### PR TITLE
feat: wire CLI with Markdown and JSON report output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,8 @@ dependencies = [
  "log",
  "pretty_assertions",
  "rstest",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "tree-sitter",
@@ -615,6 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ tree-sitter-rust = "0.24"
 rstest = "0.23"
 pretty_assertions = "1.4"
 tempfile = "3.15"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ every implementation line.
 ## What it is
 
 - **Input**: a unified diff via stdin (`gh pr diff 123 | rinkaku`), or
-  `rinkaku --base main` to run `git diff` internally.
+  `rinkaku --base main` to run `git diff` internally. In `--base` mode,
+  file contents are read via `git show <head>:<path>` so extraction always
+  matches the diffed commit, regardless of the working tree's state. In
+  stdin mode, file contents are read off the working tree, which assumes
+  **the piped diff is consistent with the current working tree** (e.g. it
+  was just produced by `git diff` or already applied); a stale or
+  unrelated diff piped via stdin can produce misaligned line numbers.
 - **Core**: tree-sitter parses the changed files, finds the definitions
   that contain changed lines, and slices out their signatures.
 - **Dependency expansion**: each changed symbol is expanded one hop out to

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ See [`docs/adr/`](docs/adr) for the reasoning behind these choices.
 
 ## Status
 
-Early development. The CLI skeleton exists but diff parsing, tree-sitter
-extraction, and dependency resolution are not implemented yet. Not
-published to crates.io.
+Early development. Diff parsing, tree-sitter extraction, and the CLI
+(stdin/`--base` input, Markdown/JSON output) are implemented. Dependency
+expansion (`--deps`, the tags-based `Resolver`) is not implemented yet.
+Not published to crates.io.
 
 ## Installation
 

--- a/rinkaku-core/Cargo.toml
+++ b/rinkaku-core/Cargo.toml
@@ -23,6 +23,8 @@ env_logger = { workspace = true }
 thiserror = { workspace = true }
 tree-sitter = { workspace = true }
 tree-sitter-rust = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/rinkaku-core/src/diff.rs
+++ b/rinkaku-core/src/diff.rs
@@ -11,11 +11,12 @@
 //! hunk headers, which is a small, self-contained piece of parsing that
 //! doesn't justify an extra dependency.
 
+use serde::Serialize;
 use thiserror::Error;
 
 /// A contiguous, inclusive range of 1-based line numbers on the new side of
 /// a file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct LineRange {
     pub start: usize,
     pub end: usize,

--- a/rinkaku-core/src/extract.rs
+++ b/rinkaku-core/src/extract.rs
@@ -7,6 +7,7 @@
 
 use crate::diff::LineRange;
 use crate::language::LanguageSupport;
+use serde::Serialize;
 use tree_sitter::StreamingIterator;
 
 /// The kind of symbol a definition node represents, expressed in
@@ -16,7 +17,7 @@ use tree_sitter::StreamingIterator;
 /// No `Impl` variant: impl blocks are never reported as symbols in their
 /// own right (see the filtering in `extract_changed_symbols`) — they only
 /// contribute `container` names to the members nested inside them.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum SymbolKind {
     Function,
     Struct,
@@ -26,7 +27,7 @@ pub enum SymbolKind {
 
 /// A definition whose signature was extracted because one of its lines
 /// (declaration or body) fell inside a changed range.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ExtractedSymbol {
     pub name: String,
     pub kind: SymbolKind,

--- a/rinkaku-core/src/lib.rs
+++ b/rinkaku-core/src/lib.rs
@@ -9,4 +9,5 @@
 pub mod diff;
 pub mod extract;
 pub mod language;
+pub mod pipeline;
 pub mod render;

--- a/rinkaku-core/src/lib.rs
+++ b/rinkaku-core/src/lib.rs
@@ -9,3 +9,4 @@
 pub mod diff;
 pub mod extract;
 pub mod language;
+pub mod render;

--- a/rinkaku-core/src/main.rs
+++ b/rinkaku-core/src/main.rs
@@ -1,25 +1,157 @@
 //! Composition root for the `rinkaku` binary.
 //!
 //! This is the only place allowed to know about the concrete CLI wiring.
-//! It stays a thin entry point: parse arguments, initialize logging, and
-//! (once implemented) dispatch to the pure core in `lib.rs` via ports such
-//! as `LanguageSupport` and `Resolver`.
+//! It stays a thin entry point: parse arguments, obtain the diff text
+//! (stdin or `git diff`), read changed files off the working tree, and
+//! dispatch to the pure core in `lib.rs` (`pipeline::analyze_diff`,
+//! `render::render`).
 
 use clap::Parser;
+use rinkaku_core::pipeline::analyze_diff;
+use rinkaku_core::render::{OutputFormat, render};
+use std::io::IsTerminal;
+use std::io::Read;
 
 /// rinkaku (輪郭) — condense PR diffs into signatures and their dependencies.
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, PartialEq, Eq)]
 #[command(name = "rinkaku", version, about, long_about = None)]
 struct Cli {
-    /// Base ref to diff against (runs `git diff` internally instead of
-    /// reading from stdin). Not yet implemented.
+    /// Base ref to diff against (runs `git diff <base>...<head>` instead
+    /// of reading from stdin).
     #[arg(long)]
     base: Option<String>,
+
+    /// Head ref to diff against `base`. Only meaningful together with
+    /// `--base`; defaults to `HEAD`.
+    #[arg(long, default_value = "HEAD")]
+    head: String,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = Format::Md)]
+    format: Format,
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+enum Format {
+    Md,
+    Json,
+}
+
+impl From<Format> for OutputFormat {
+    fn from(format: Format) -> Self {
+        match format {
+            Format::Md => OutputFormat::Markdown,
+            Format::Json => OutputFormat::Json,
+        }
+    }
 }
 
 fn main() -> anyhow::Result<()> {
     env_logger::init();
-    let _cli = Cli::parse();
+    let cli = Cli::parse();
 
-    anyhow::bail!("rinkaku is not implemented yet");
+    let diff_text = match &cli.base {
+        Some(base) => run_git_diff(base, &cli.head)?,
+        None => read_stdin_diff()?,
+    };
+
+    let report = analyze_diff(&diff_text, read_working_tree_file)?;
+    let output = render(&report, cli.format.into())?;
+    print!("{output}");
+
+    Ok(())
+}
+
+/// Reads the diff from stdin. Errors with a clear message if stdin is a
+/// terminal (interactive), since there is nothing to read in that case and
+/// `--base` should be used instead.
+fn read_stdin_diff() -> anyhow::Result<String> {
+    if std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "no diff input: pipe a diff via stdin (e.g. `gh pr diff 123 | rinkaku`) or pass --base <ref>"
+        );
+    }
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf)?;
+    Ok(buf)
+}
+
+/// Runs `git diff <base>...<head>` and returns its stdout.
+fn run_git_diff(base: &str, head: &str) -> anyhow::Result<String> {
+    let range = format!("{base}...{head}");
+    let output = std::process::Command::new("git")
+        .args(["diff", &range])
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git diff {range} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+/// Reads a changed file's new-side content off the working tree.
+fn read_working_tree_file(path: &str) -> std::io::Result<String> {
+    std::fs::read_to_string(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_default_to_markdown_head_and_no_base_when_no_args_given() {
+        let expected = Cli {
+            base: None,
+            head: "HEAD".to_string(),
+            format: Format::Md,
+        };
+        let actual = Cli::parse_from(["rinkaku"]);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_set_base_when_base_flag_given() {
+        let expected = Cli {
+            base: Some("main".to_string()),
+            head: "HEAD".to_string(),
+            format: Format::Md,
+        };
+        let actual = Cli::parse_from(["rinkaku", "--base", "main"]);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_set_base_and_head_when_both_flags_given() {
+        let expected = Cli {
+            base: Some("main".to_string()),
+            head: "feature-branch".to_string(),
+            format: Format::Md,
+        };
+        let actual = Cli::parse_from(["rinkaku", "--base", "main", "--head", "feature-branch"]);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_set_format_json_when_format_flag_given() {
+        let expected = Cli {
+            base: None,
+            head: "HEAD".to_string(),
+            format: Format::Json,
+        };
+        let actual = Cli::parse_from(["rinkaku", "--format", "json"]);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_reject_unknown_format_value() {
+        let actual = Cli::try_parse_from(["rinkaku", "--format", "yaml"]);
+
+        assert!(actual.is_err());
+    }
 }

--- a/rinkaku-core/src/main.rs
+++ b/rinkaku-core/src/main.rs
@@ -2,9 +2,23 @@
 //!
 //! This is the only place allowed to know about the concrete CLI wiring.
 //! It stays a thin entry point: parse arguments, obtain the diff text
-//! (stdin or `git diff`), read changed files off the working tree, and
-//! dispatch to the pure core in `lib.rs` (`pipeline::analyze_diff`,
-//! `render::render`).
+//! (stdin or `git diff`), read changed files, and dispatch to the pure
+//! core in `lib.rs` (`pipeline::analyze_diff`, `render::render`).
+//!
+//! The file-reading port passed to `analyze_diff` differs by input mode:
+//!
+//! - `--base` mode: the diff comes from `git diff <base>...<head>`, so
+//!   files are read via `git show <head>:<path>` rather than off the
+//!   working tree. This keeps the diff and the file content read from the
+//!   exact same commit by construction, regardless of what the working
+//!   tree currently holds (uncommitted changes, a dirty checkout, etc.).
+//! - stdin mode: the diff's provenance is unknown to rinkaku (it could be
+//!   `gh pr diff`, a saved patch file, anything). Files are read off the
+//!   working tree, under the assumption that **the diff is consistent
+//!   with the current working tree** — i.e. applying it (or having
+//!   already applied it) would reproduce the working tree's content. If
+//!   that assumption doesn't hold, line numbers in the extracted symbols
+//!   may not line up with the actual file content.
 
 use clap::Parser;
 use rinkaku_core::pipeline::analyze_diff;
@@ -50,12 +64,23 @@ fn main() -> anyhow::Result<()> {
     env_logger::init();
     let cli = Cli::parse();
 
-    let diff_text = match &cli.base {
-        Some(base) => run_git_diff(base, &cli.head)?,
-        None => read_stdin_diff()?,
+    let report = match &cli.base {
+        Some(base) => {
+            let diff_text = run_git_diff(base, &cli.head)?;
+            let head = cli.head.clone();
+            analyze_diff(&diff_text, move |path| {
+                read_git_show_file(None, &head, path)
+            })?
+        }
+        None => {
+            let diff_text = read_stdin_diff()?;
+            if diff_text.trim().is_empty() {
+                eprintln!("note: diff is empty, nothing to analyze");
+            }
+            analyze_diff(&diff_text, read_working_tree_file)?
+        }
     };
 
-    let report = analyze_diff(&diff_text, read_working_tree_file)?;
     let output = render(&report, cli.format.into())?;
     print!("{output}");
 
@@ -96,9 +121,41 @@ fn read_working_tree_file(path: &str) -> std::io::Result<String> {
     std::fs::read_to_string(path)
 }
 
+/// Reads a changed file's content as committed at `head`, via
+/// `git show <head>:<path>`. Used in `--base` mode so the content read
+/// always matches the commit the diff was generated against, independent
+/// of the working tree's current state.
+///
+/// `cwd` selects the repository to run `git` in; `None` uses the process's
+/// current directory (production callers), `Some(dir)` pins it to a
+/// specific directory (tests, so they don't depend on or mutate the
+/// process-wide current directory).
+fn read_git_show_file(
+    cwd: Option<&std::path::Path>,
+    head: &str,
+    path: &str,
+) -> std::io::Result<String> {
+    let object = format!("{head}:{path}");
+    let mut command = std::process::Command::new("git");
+    command.args(["show", &object]);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(std::io::Error::other(format!(
+            "git show {object} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    String::from_utf8(output.stdout)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn should_default_to_markdown_head_and_no_base_when_no_args_given() {
@@ -153,5 +210,58 @@ mod tests {
         let actual = Cli::try_parse_from(["rinkaku", "--format", "yaml"]);
 
         assert!(actual.is_err());
+    }
+
+    /// Runs `git` inside `dir`, panicking with the captured stderr on
+    /// failure. Test-only helper: production code never wants a panicking
+    /// git wrapper.
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git must be installed to run this test");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Sets up a throwaway git repository with deterministic author/committer
+    /// identity (avoids depending on the host's global git config) and one
+    /// commit containing `src/lib.rs` with `content`.
+    fn init_repo_with_committed_file(dir: &std::path::Path, content: &str) {
+        run_git(dir, &["init", "--initial-branch=main"]);
+        run_git(dir, &["config", "user.email", "test@example.com"]);
+        run_git(dir, &["config", "user.name", "Test"]);
+        std::fs::create_dir_all(dir.join("src")).expect("create src dir");
+        std::fs::write(dir.join("src/lib.rs"), content).expect("write src/lib.rs");
+        run_git(dir, &["add", "src/lib.rs"]);
+        run_git(dir, &["commit", "-m", "initial commit"]);
+    }
+
+    // Integration test for the must-fix design: `--base` mode must read
+    // file content via `git show <head>:<path>`, not off the working tree.
+    // A dirty working tree (uncommitted edit) must not affect what gets
+    // read — only the committed content at `head` should come back.
+    #[test]
+    fn should_read_committed_content_when_working_tree_is_dirty() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        let committed = "fn foo(a: i32) -> i32 {\n    a\n}\n";
+        init_repo_with_committed_file(dir.path(), committed);
+
+        // Dirty the working tree after the commit: if `read_git_show_file`
+        // fell back to the working tree, it would read this instead.
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            "fn foo(a: i32) -> i32 {\n    a + 999\n}\n",
+        )
+        .expect("dirty the working tree");
+
+        let actual = read_git_show_file(Some(dir.path()), "HEAD", "src/lib.rs")
+            .expect("git show should succeed for a committed file");
+
+        assert_eq!(committed, actual);
     }
 }

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -34,6 +34,13 @@ pub enum AnalyzeError {
 /// with no registered [`crate::language::LanguageSupport`] for their
 /// extension are skipped. All skips are recorded in the returned
 /// [`Report`], never silently dropped.
+///
+/// Files with no changed line ranges (a pure rename or a mode-change-only
+/// diff — no hunks) are *not* skipped, since they are supported and were
+/// looked at; they are reported as a [`crate::render::FileReport`] with an
+/// empty `symbols` list, and — unlike every other case above — `read_file`
+/// is never called for them, since there is no content change to extract
+/// symbols from.
 pub fn analyze_diff(
     diff_text: &str,
     read_file: impl Fn(&str) -> std::io::Result<String>,
@@ -65,6 +72,19 @@ pub fn analyze_diff(
             });
             continue;
         };
+
+        // No hunks means no content change (a pure rename or a
+        // mode-change-only diff): extract_changed_symbols would return no
+        // symbols for an empty changed_ranges anyway, so skip the read
+        // entirely rather than pay IO for a result already known to be
+        // empty.
+        if changed_file.changed_ranges.is_empty() {
+            files.push(FileReport {
+                path: changed_file.path,
+                symbols: Vec::new(),
+            });
+            continue;
+        }
 
         let source = read_file(&changed_file.path).map_err(|source| AnalyzeError::ReadFile {
             path: changed_file.path.clone(),
@@ -220,6 +240,39 @@ index e69de29..4b825dc 100644
                 path: "src/main.py".to_string(),
                 reason: SkipReason::UnsupportedLanguage,
             }],
+        };
+        let actual = analyze_diff(diff, read_file).expect("analyze should succeed");
+
+        assert_eq!(expected, actual);
+    }
+
+    // Regression test: a pure rename (or a mode-change-only diff) has no
+    // hunks, so `changed_ranges` is empty and there is no content change to
+    // extract symbols from. The pipeline must not call `read_file` for such
+    // an entry — doing so is wasted IO for content that, by construction,
+    // yields no symbols (`extract_changed_symbols` already returns `[]` for
+    // an empty `changed_ranges`). Reported as a `FileReport` with empty
+    // `symbols` rather than a `SkippedFile`: the file *is* supported and
+    // was looked at, it just has nothing to report, which is a different
+    // situation from `SkipReason`'s "could not be analyzed" cases.
+    #[test]
+    fn should_skip_reading_pure_rename_with_no_changed_ranges() {
+        let diff = "\
+diff --git a/src/old_name.rs b/src/new_name.rs
+similarity index 100%
+rename from src/old_name.rs
+rename to src/new_name.rs
+";
+        // No entry in the map: if the pipeline tried to read the renamed
+        // file, this would return an Err and fail the test.
+        let read_file = fake_reader(HashMap::new());
+
+        let expected = Report {
+            files: vec![FileReport {
+                path: "src/new_name.rs".to_string(),
+                symbols: vec![],
+            }],
+            skipped: vec![],
         };
         let actual = analyze_diff(diff, read_file).expect("analyze should succeed");
 

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -1,0 +1,309 @@
+//! Wiring the diff parser, language registry, and symbol extractor into a
+//! single pure pipeline.
+//!
+//! [`analyze_diff`] takes a diff's text and a `read_file` port for fetching
+//! a changed file's new-side content, and produces a [`crate::render::Report`].
+//! File reads are injected rather than performed here so this module stays
+//! pure and testable: `main.rs` supplies a closure that reads the working
+//! tree, tests supply a closure backed by an in-memory map.
+
+use crate::diff::{ChangeKind, parse_unified_diff};
+use crate::extract::extract_changed_symbols;
+use crate::language::language_for_path;
+use crate::render::{FileReport, Report, SkipReason, SkippedFile};
+use thiserror::Error;
+
+/// Errors that can occur while running the pipeline.
+#[derive(Debug, Error)]
+pub enum AnalyzeError {
+    #[error("failed to parse diff: {0}")]
+    Diff(#[from] crate::diff::ParseError),
+    #[error("failed to read {path}: {source}")]
+    ReadFile {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Parses `diff_text` and extracts changed symbols from every file it can,
+/// reading each file's new-side content through `read_file`.
+///
+/// Deleted files are skipped (there is no new-side content to read).
+/// Binary files are skipped (no line-level diff to extract from). Files
+/// with no registered [`crate::language::LanguageSupport`] for their
+/// extension are skipped. All skips are recorded in the returned
+/// [`Report`], never silently dropped.
+pub fn analyze_diff(
+    diff_text: &str,
+    read_file: impl Fn(&str) -> std::io::Result<String>,
+) -> Result<Report, AnalyzeError> {
+    let changed_files = parse_unified_diff(diff_text)?;
+
+    let mut files = Vec::new();
+    let mut skipped = Vec::new();
+
+    for changed_file in changed_files {
+        if changed_file.kind == ChangeKind::Deleted {
+            skipped.push(SkippedFile {
+                path: changed_file.path,
+                reason: SkipReason::Deleted,
+            });
+            continue;
+        }
+        if changed_file.is_binary {
+            skipped.push(SkippedFile {
+                path: changed_file.path,
+                reason: SkipReason::Binary,
+            });
+            continue;
+        }
+        let Some(lang) = language_for_path(&changed_file.path) else {
+            skipped.push(SkippedFile {
+                path: changed_file.path,
+                reason: SkipReason::UnsupportedLanguage,
+            });
+            continue;
+        };
+
+        let source = read_file(&changed_file.path).map_err(|source| AnalyzeError::ReadFile {
+            path: changed_file.path.clone(),
+            source,
+        })?;
+        let symbols = extract_changed_symbols(&source, lang, &changed_file.changed_ranges);
+        files.push(FileReport {
+            path: changed_file.path,
+            symbols,
+        });
+    }
+
+    Ok(Report { files, skipped })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::LineRange;
+    use crate::extract::{ExtractedSymbol, SymbolKind};
+    use pretty_assertions::assert_eq;
+    use std::collections::HashMap;
+
+    /// Builds a `read_file` port backed by an in-memory map, so tests never
+    /// touch the real filesystem.
+    fn fake_reader(
+        files: HashMap<&'static str, &'static str>,
+    ) -> impl Fn(&str) -> std::io::Result<String> {
+        move |path: &str| {
+            files
+                .get(path)
+                .map(|s| s.to_string())
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, path.to_string()))
+        }
+    }
+
+    #[test]
+    fn should_return_empty_report_when_diff_is_empty() {
+        let read_file = fake_reader(HashMap::new());
+
+        let expected = Report {
+            files: vec![],
+            skipped: vec![],
+        };
+        let actual = analyze_diff("", read_file).expect("analyze should succeed");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_extract_symbols_when_diff_touches_a_rust_file() {
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,3 @@
+ fn foo(a: i32) -> i32 {
+-    a
++    a + 1
+ }
+";
+        let source = "\
+fn foo(a: i32) -> i32 {
+    a + 1
+}
+";
+        let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+
+        let expected = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    name: "foo".to_string(),
+                    kind: SymbolKind::Function,
+                    signature: "fn foo(a: i32) -> i32".to_string(),
+                    range: LineRange { start: 1, end: 3 },
+                    container: None,
+                }],
+            }],
+            skipped: vec![],
+        };
+        let actual = analyze_diff(diff, read_file).expect("analyze should succeed");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_skip_deleted_file_without_reading_it() {
+        let diff = "\
+diff --git a/src/old.rs b/src/old.rs
+deleted file mode 100644
+index 4b825dc..0000000
+--- a/src/old.rs
++++ /dev/null
+@@ -1,2 +0,0 @@
+-fn a() {}
+-fn b() {}
+";
+        // No entry in the map: if the pipeline tried to read a deleted
+        // file, this would return an Err and fail the test.
+        let read_file = fake_reader(HashMap::new());
+
+        let expected = Report {
+            files: vec![],
+            skipped: vec![SkippedFile {
+                path: "src/old.rs".to_string(),
+                reason: SkipReason::Deleted,
+            }],
+        };
+        let actual = analyze_diff(diff, read_file).expect("analyze should succeed");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_skip_binary_file_without_reading_it() {
+        let diff = "\
+diff --git a/assets/logo.png b/assets/logo.png
+index e69de29..4b825dc 100644
+Binary files a/assets/logo.png and b/assets/logo.png differ
+";
+        let read_file = fake_reader(HashMap::new());
+
+        let expected = Report {
+            files: vec![],
+            skipped: vec![SkippedFile {
+                path: "assets/logo.png".to_string(),
+                reason: SkipReason::Binary,
+            }],
+        };
+        let actual = analyze_diff(diff, read_file).expect("analyze should succeed");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_skip_file_with_unsupported_language_without_reading_it() {
+        let diff = "\
+diff --git a/src/main.py b/src/main.py
+index e69de29..4b825dc 100644
+--- a/src/main.py
++++ b/src/main.py
+@@ -1,1 +1,2 @@
+ def foo():
++    pass
+";
+        let read_file = fake_reader(HashMap::new());
+
+        let expected = Report {
+            files: vec![],
+            skipped: vec![SkippedFile {
+                path: "src/main.py".to_string(),
+                reason: SkipReason::UnsupportedLanguage,
+            }],
+        };
+        let actual = analyze_diff(diff, read_file).expect("analyze should succeed");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_err_when_diff_is_malformed() {
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 1,4 @@
+ fn a() {}
+";
+        let read_file = fake_reader(HashMap::new());
+
+        let actual = analyze_diff(diff, read_file);
+
+        assert!(matches!(actual, Err(AnalyzeError::Diff(_))));
+    }
+
+    #[test]
+    fn should_return_err_when_read_file_fails() {
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,1 +1,1 @@
+-fn a() {}
++fn a() -> i32 { 0 }
+";
+        // Map has no entry for src/lib.rs, so the fake reader returns Err.
+        let read_file = fake_reader(HashMap::new());
+
+        let actual = analyze_diff(diff, read_file);
+
+        assert!(matches!(
+            actual,
+            Err(AnalyzeError::ReadFile { path, .. }) if path == "src/lib.rs"
+        ));
+    }
+
+    #[test]
+    fn should_process_multiple_files_with_mixed_outcomes_in_one_diff() {
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,1 +1,1 @@
+-fn a() {}
++fn a() -> i32 { 0 }
+diff --git a/src/main.py b/src/main.py
+index e69de29..4b825dc 100644
+--- a/src/main.py
++++ b/src/main.py
+@@ -1,1 +1,2 @@
+ def foo():
++    pass
+";
+        let source = "fn a() -> i32 { 0 }\n";
+        let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+
+        let expected = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    name: "a".to_string(),
+                    kind: SymbolKind::Function,
+                    signature: "fn a() -> i32".to_string(),
+                    range: LineRange { start: 1, end: 1 },
+                    container: None,
+                }],
+            }],
+            skipped: vec![SkippedFile {
+                path: "src/main.py".to_string(),
+                reason: SkipReason::UnsupportedLanguage,
+            }],
+        };
+        let actual = analyze_diff(diff, read_file).expect("analyze should succeed");
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -12,6 +12,7 @@
 use crate::extract::ExtractedSymbol;
 use serde::Serialize;
 use std::fmt::Write as _;
+use thiserror::Error;
 
 /// The result of running the extraction pipeline over a whole diff.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -54,54 +55,85 @@ pub enum OutputFormat {
     Json,
 }
 
+/// Errors that can occur while rendering a [`Report`].
+#[derive(Debug, Error)]
+pub enum RenderError {
+    /// Writing to the in-memory `String` buffer failed. This only happens
+    /// on allocation failure, which `std::fmt::Write` reports as `Err(())`
+    /// with no further detail; kept as a typed error (rather than
+    /// `.unwrap()`) so the fallible write calls in `render_markdown` can
+    /// use `?` instead of panicking.
+    #[error("failed to write Markdown output")]
+    Fmt(#[from] std::fmt::Error),
+    #[error("failed to serialize report as JSON: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
 /// Renders a [`Report`] in the requested [`OutputFormat`].
-///
-/// JSON rendering only fails if `serde_json` itself fails to serialize the
-/// `Report`, which does not happen for this data shape (no maps with
-/// non-string keys, no floats); the `Result` is kept so callers don't need
-/// to special-case a `.unwrap()` at the boundary.
-pub fn render(report: &Report, format: OutputFormat) -> Result<String, serde_json::Error> {
+pub fn render(report: &Report, format: OutputFormat) -> Result<String, RenderError> {
     match format {
-        OutputFormat::Markdown => Ok(render_markdown(report)),
-        OutputFormat::Json => serde_json::to_string_pretty(report),
+        OutputFormat::Markdown => render_markdown(report),
+        OutputFormat::Json => Ok(serde_json::to_string_pretty(report)?),
     }
 }
 
 /// Renders a [`Report`] as Markdown: one heading per file with its
 /// symbols' signatures in a fenced code block, followed by a list of
 /// skipped files.
-fn render_markdown(report: &Report) -> String {
+fn render_markdown(report: &Report) -> Result<String, RenderError> {
     let mut out = String::new();
 
     for file in &report.files {
-        writeln!(out, "## {}", file.path).unwrap();
-        writeln!(out).unwrap();
+        writeln!(out, "## {}", file.path)?;
+        writeln!(out)?;
         for symbol in &file.symbols {
-            writeln!(out, "```").unwrap();
-            if let Some(container) = &symbol.container {
-                writeln!(out, "// {container}").unwrap();
+            let container_line = symbol.container.as_deref().map(|c| format!("// {c}"));
+            let fence = fence_for(container_line.as_deref(), &symbol.signature);
+            writeln!(out, "{fence}")?;
+            if let Some(container_line) = &container_line {
+                writeln!(out, "{container_line}")?;
             }
-            writeln!(out, "{}", symbol.signature).unwrap();
-            writeln!(out, "```").unwrap();
-            writeln!(out).unwrap();
+            writeln!(out, "{}", symbol.signature)?;
+            writeln!(out, "{fence}")?;
+            writeln!(out)?;
         }
     }
 
     if !report.skipped.is_empty() {
-        writeln!(out, "## Skipped files").unwrap();
-        writeln!(out).unwrap();
+        writeln!(out, "## Skipped files")?;
+        writeln!(out)?;
         for skipped in &report.skipped {
             writeln!(
                 out,
                 "- {} ({})",
                 skipped.path,
                 skip_reason_label(skipped.reason)
-            )
-            .unwrap();
+            )?;
         }
     }
 
-    out
+    Ok(out)
+}
+
+/// Picks a fence long enough that it cannot be closed early by a backtick
+/// run inside the fenced content: one backtick longer than the longest run
+/// of consecutive backticks in `content`, with a floor of 3 (the minimum
+/// valid Markdown fence).
+fn fence_for(container_line: Option<&str>, signature: &str) -> String {
+    let longest_run = [container_line.unwrap_or(""), signature]
+        .iter()
+        .flat_map(|text| longest_backtick_run(text))
+        .max()
+        .unwrap_or(0);
+    "`".repeat((longest_run + 1).max(3))
+}
+
+/// Length of the longest run of consecutive `` ` `` characters in `text`.
+fn longest_backtick_run(text: &str) -> Option<usize> {
+    text.split(|c| c != '`')
+        .map(str::len)
+        .filter(|&len| len > 0)
+        .max()
 }
 
 fn skip_reason_label(reason: SkipReason) -> &'static str {
@@ -185,6 +217,76 @@ fn foo(a: i32) -> i32
 // impl Foo
 fn bar(&self) -> i32
 ```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    // Regression test: a signature containing a backtick code fence (e.g. a
+    // doc comment example embedded in a macro invocation) used to break out
+    // of the surrounding Markdown fence because it was always rendered with
+    // exactly 3 backticks. The fence length must be at least one longer
+    // than the longest run of backticks appearing in the rendered content.
+    #[test]
+    fn should_widen_fence_when_signature_contains_a_backtick_run() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    name: "example_macro".to_string(),
+                    kind: SymbolKind::Function,
+                    signature: "fn example_macro() { let s = \"```rust\\nfn f() {}\\n```\"; }"
+                        .to_string(),
+                    range: LineRange { start: 1, end: 1 },
+                    container: None,
+                }],
+            }],
+            skipped: vec![],
+        };
+
+        let expected = "\
+## src/lib.rs
+
+````
+fn example_macro() { let s = \"```rust\\nfn f() {}\\n```\"; }
+````
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    // Regression test: the container comment is part of the fenced block
+    // too, so a backtick run inside the container name must also widen the
+    // fence.
+    #[test]
+    fn should_widen_fence_when_container_contains_a_backtick_run() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    name: "bar".to_string(),
+                    kind: SymbolKind::Function,
+                    signature: "fn bar(&self) -> i32".to_string(),
+                    range: LineRange { start: 4, end: 6 },
+                    container: Some("impl Foo /* ```` */".to_string()),
+                }],
+            }],
+            skipped: vec![],
+        };
+
+        let expected = "\
+## src/lib.rs
+
+`````
+// impl Foo /* ```` */
+fn bar(&self) -> i32
+`````
 
 "
         .to_string();

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -1,0 +1,315 @@
+//! Rendering the extraction pipeline's results into an output format.
+//!
+//! [`Report`] is the pipeline-wide result shape produced by
+//! [`crate::pipeline::analyze_diff`]: per-file extracted symbols plus the
+//! files that were skipped (unsupported language, binary, or deleted).
+//! This module turns a `Report` into either Markdown (the default, meant
+//! for humans and LLMs) or JSON (`serde`-derived, for machine consumption).
+//!
+//! Skipped files are always listed, never silently dropped — a reviewer
+//! or LLM consuming the output needs to know what rinkaku didn't look at.
+
+use crate::extract::ExtractedSymbol;
+use serde::Serialize;
+use std::fmt::Write as _;
+
+/// The result of running the extraction pipeline over a whole diff.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Report {
+    pub files: Vec<FileReport>,
+    pub skipped: Vec<SkippedFile>,
+}
+
+/// Extracted symbols for a single changed file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FileReport {
+    pub path: String,
+    pub symbols: Vec<ExtractedSymbol>,
+}
+
+/// A file the pipeline did not extract symbols from, and why.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SkippedFile {
+    pub path: String,
+    pub reason: SkipReason,
+}
+
+/// Why a changed file was skipped rather than analyzed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkipReason {
+    /// No registered [`crate::language::LanguageSupport`] for this file's
+    /// extension.
+    UnsupportedLanguage,
+    /// Git reported this as a binary file patch.
+    Binary,
+    /// The file was deleted; there is no new-side content to extract from.
+    Deleted,
+}
+
+/// Supported output formats for a [`Report`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    Markdown,
+    Json,
+}
+
+/// Renders a [`Report`] in the requested [`OutputFormat`].
+///
+/// JSON rendering only fails if `serde_json` itself fails to serialize the
+/// `Report`, which does not happen for this data shape (no maps with
+/// non-string keys, no floats); the `Result` is kept so callers don't need
+/// to special-case a `.unwrap()` at the boundary.
+pub fn render(report: &Report, format: OutputFormat) -> Result<String, serde_json::Error> {
+    match format {
+        OutputFormat::Markdown => Ok(render_markdown(report)),
+        OutputFormat::Json => serde_json::to_string_pretty(report),
+    }
+}
+
+/// Renders a [`Report`] as Markdown: one heading per file with its
+/// symbols' signatures in a fenced code block, followed by a list of
+/// skipped files.
+fn render_markdown(report: &Report) -> String {
+    let mut out = String::new();
+
+    for file in &report.files {
+        writeln!(out, "## {}", file.path).unwrap();
+        writeln!(out).unwrap();
+        for symbol in &file.symbols {
+            writeln!(out, "```").unwrap();
+            if let Some(container) = &symbol.container {
+                writeln!(out, "// {container}").unwrap();
+            }
+            writeln!(out, "{}", symbol.signature).unwrap();
+            writeln!(out, "```").unwrap();
+            writeln!(out).unwrap();
+        }
+    }
+
+    if !report.skipped.is_empty() {
+        writeln!(out, "## Skipped files").unwrap();
+        writeln!(out).unwrap();
+        for skipped in &report.skipped {
+            writeln!(
+                out,
+                "- {} ({})",
+                skipped.path,
+                skip_reason_label(skipped.reason)
+            )
+            .unwrap();
+        }
+    }
+
+    out
+}
+
+fn skip_reason_label(reason: SkipReason) -> &'static str {
+    match reason {
+        SkipReason::UnsupportedLanguage => "unsupported language",
+        SkipReason::Binary => "binary",
+        SkipReason::Deleted => "deleted",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::LineRange;
+    use crate::extract::SymbolKind;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_render_empty_markdown_when_report_has_no_files_and_no_skips() {
+        let report = Report {
+            files: vec![],
+            skipped: vec![],
+        };
+
+        let expected = "".to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_markdown_heading_and_fenced_signature_when_file_has_one_symbol() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    name: "foo".to_string(),
+                    kind: SymbolKind::Function,
+                    signature: "fn foo(a: i32) -> i32".to_string(),
+                    range: LineRange { start: 1, end: 3 },
+                    container: None,
+                }],
+            }],
+            skipped: vec![],
+        };
+
+        let expected = "\
+## src/lib.rs
+
+```
+fn foo(a: i32) -> i32
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_container_comment_when_symbol_has_container() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    name: "bar".to_string(),
+                    kind: SymbolKind::Function,
+                    signature: "fn bar(&self) -> i32".to_string(),
+                    range: LineRange { start: 4, end: 6 },
+                    container: Some("impl Foo".to_string()),
+                }],
+            }],
+            skipped: vec![],
+        };
+
+        let expected = "\
+## src/lib.rs
+
+```
+// impl Foo
+fn bar(&self) -> i32
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_skipped_files_section_when_report_has_skips() {
+        let report = Report {
+            files: vec![],
+            skipped: vec![
+                SkippedFile {
+                    path: "assets/logo.png".to_string(),
+                    reason: SkipReason::Binary,
+                },
+                SkippedFile {
+                    path: "src/main.py".to_string(),
+                    reason: SkipReason::UnsupportedLanguage,
+                },
+                SkippedFile {
+                    path: "src/old.rs".to_string(),
+                    reason: SkipReason::Deleted,
+                },
+            ],
+        };
+
+        let expected = "\
+## Skipped files
+
+- assets/logo.png (binary)
+- src/main.py (unsupported language)
+- src/old.rs (deleted)
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_files_then_skipped_section_when_report_has_both() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    name: "foo".to_string(),
+                    kind: SymbolKind::Function,
+                    signature: "fn foo()".to_string(),
+                    range: LineRange { start: 1, end: 1 },
+                    container: None,
+                }],
+            }],
+            skipped: vec![SkippedFile {
+                path: "assets/logo.png".to_string(),
+                reason: SkipReason::Binary,
+            }],
+        };
+
+        let expected = "\
+## src/lib.rs
+
+```
+fn foo()
+```
+
+## Skipped files
+
+- assets/logo.png (binary)
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_json_with_files_and_skipped_when_report_has_both() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    name: "foo".to_string(),
+                    kind: SymbolKind::Function,
+                    signature: "fn foo()".to_string(),
+                    range: LineRange { start: 1, end: 1 },
+                    container: None,
+                }],
+            }],
+            skipped: vec![SkippedFile {
+                path: "assets/logo.png".to_string(),
+                reason: SkipReason::Binary,
+            }],
+        };
+
+        let expected = "\
+{
+  \"files\": [
+    {
+      \"path\": \"src/lib.rs\",
+      \"symbols\": [
+        {
+          \"name\": \"foo\",
+          \"kind\": \"Function\",
+          \"signature\": \"fn foo()\",
+          \"range\": {
+            \"start\": 1,
+            \"end\": 1
+          },
+          \"container\": null
+        }
+      ]
+    }
+  ],
+  \"skipped\": [
+    {
+      \"path\": \"assets/logo.png\",
+      \"reason\": \"binary\"
+    }
+  ]
+}"
+        .to_string();
+        let actual = render(&report, OutputFormat::Json).expect("json render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -80,6 +80,13 @@ pub fn render(report: &Report, format: OutputFormat) -> Result<String, RenderErr
 /// Renders a [`Report`] as Markdown: one heading per file with its
 /// symbols' signatures in a fenced code block, followed by a list of
 /// skipped files.
+///
+/// Path headings (`## {path}`) do not escape Markdown special characters
+/// (`#`, `[`, `]`, `_`, ...). A path containing them can distort the
+/// rendered heading; this is accepted rather than escaped, since file
+/// paths with Markdown-significant characters are rare in practice and the
+/// fenced code blocks (the part that matters for correctness) are already
+/// hardened against content-driven breakage.
 fn render_markdown(report: &Report) -> Result<String, RenderError> {
     let mut out = String::new();
 


### PR DESCRIPTION
## Summary
- Add `render.rs`: pure `Report`/`FileReport`/`SkippedFile` output shape plus `render()` to Markdown (default) or JSON (serde). Skipped files (unsupported language, binary, deleted) are always listed, never silently dropped.
- Add `pipeline.rs`: `analyze_diff(diff_text, read_file)` glues `parse_unified_diff` -> `language_for_path` -> `extract_changed_symbols` into one call, with file reads injected as a port so the core stays IO-free and testable with an in-memory fake.
- Wire `main.rs` (composition root): clap CLI with `--base`/`--head`/`--format`, reading the diff from stdin (erroring clearly if stdin is a terminal and no `--base` was given) or via `git diff <base>...<head>`, then rendering through the pipeline above.

## Review follow-ups (this update)
- **fix**: `--base` mode now reads changed files via `git show <head>:<path>` instead of the working tree, so an uncommitted/dirty working tree can no longer desync line numbers from the diffed commit. stdin mode still reads the working tree; its doc comment and the README now state that assumption explicitly. Covered by a `tempfile::TempDir` + real git repo integration test.
- **fix**: Markdown rendering no longer breaks when a signature or container name contains a backtick run — the code fence now widens dynamically (longest backtick run + 1, floor 3).
- **fix**: `render_markdown`'s 9 `writeln!().unwrap()` calls now propagate via `?` into a typed `RenderError` (`fmt::Error` / `serde_json::Error`), removing the unwraps from library code.
- **fix**: the pipeline no longer calls `read_file` for files with no changed line ranges (pure renames, mode-change-only diffs) — reported as a `FileReport` with empty `symbols` instead of paying IO for a result already known to be empty.
- **nit**: stdin mode prints a one-line stderr note when the piped diff is empty.
- **nit**: documented (not fixed) that path headings don't escape Markdown special characters — an accepted tradeoff, not an oversight.

## Test plan
- [x] `make lint` passes (fmt + clippy -D warnings)
- [x] `make test` passes: 53 lib tests + 6 `main.rs` tests (including a real-git integration test for `--base` file reads), all green
- [x] Manually ran `git diff HEAD~3 | cargo run -p rinkaku-core --bin rinkaku` and `--format json` / `--base` variants against this repo's own diff — output is readable Markdown/JSON with signatures grouped by file and a skipped-files section
- [x] `--deps` intentionally not implemented (tracked separately)
