### PR TITLE
docs: add usage examples and QA record

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,92 +63,155 @@ rinkaku --base main --deps 0
 
 ### What it looks like
 
+All examples below are captured from the `cargo build --release` binary
+against `main` post-[#9](https://github.com/hiro-o918/rinkaku/pull/9)
+(the dependency-resolution precision and indexing performance
+improvements), not fabricated.
+
 Running `rinkaku` on
-[a real rinkaku commit](https://github.com/hiro-o918/rinkaku/commit/099fd83)
-(a 73-line diff touching four test functions in `pipeline.rs`) produces:
+[a real rinkaku commit](https://github.com/hiro-o918/rinkaku/commit/1ccc183)
+(a 128-line diff adding the stdin garbage-input warning in `main.rs`)
+produces:
 
 ```sh
-$ git show 099fd83 --format="" | rinkaku
+$ git show 1ccc183 --format="" | rinkaku
 ```
 
 ````markdown
-## rinkaku-core/src/pipeline.rs
+## rinkaku-core/src/main.rs
 
 ```
-fn should_skip_deleted_file_without_reading_it()
+fn main() -> anyhow::Result<()>
+```
+
+Depends on:
+- `rinkaku-core/src/deps.rs`: `pub trait Resolver { fn resolve(&self, name: &str) -> Vec<ResolvedSymbol>; }`
+- `rinkaku-core/src/pipeline.rs`: `pub fn analyze_diff( diff_text: &str, read_file: impl Fn(&str) -> std::io::Result<String>, resolver: Option<&dyn Resolver>, ) -> Result<Report, AnalyzeError>`
+- `rinkaku-core/src/main.rs`: `fn build_resolver( cli: &Cli, diff_text: &str, diff_read_file: impl Fn(&str) -> std::io::Result<String>, head: Option<&str>, cwd: Option<&std::path::Path>, ) -> anyhow::Result<Option<TagsResolver>>`
+- `rinkaku-core/src/main.rs`: `fn read_git_show_file( cwd: Option<&std::path::Path>, head: &str, path: &str, ) -> std::io::Result<String>`
+- `rinkaku-core/src/main.rs`: `fn read_stdin_diff() -> anyhow::Result<String>`
+- `rinkaku-core/src/render.rs`: `pub fn render(report: &Report, format: OutputFormat) -> Result<String, RenderError>`
+- `rinkaku-core/src/main.rs`: `fn run_git_diff(base: &str, head: &str) -> anyhow::Result<String>`
+
+```
+fn garbage_input_note( diff_text: &str, report: &rinkaku_core::render::Report, ) -> Option<&'static str>
 ```
 
 Depends on:
 - `rinkaku-core/src/render.rs`: `pub struct Report { pub files: Vec<FileReport>, pub skipped: Vec<SkippedFile>, }`
-- `rinkaku-core/src/pipeline.rs`: `pub fn analyze_diff( diff_text: &str, read_file: impl Fn(&str) -> std::io::Result<String>, resolver: Option<&dyn Resolver>, ) -> Result<Report, AnalyzeError>`
-- `rinkaku-core/src/pipeline.rs`: `fn fake_reader( files: HashMap<&'static str, &'static str>, ) -> impl Fn(&str) -> std::io::Result<String>`
 
-```
-fn should_skip_binary_file_without_reading_it()
-```
-
-Depends on:
-- `rinkaku-core/src/render.rs`: `pub struct Report { pub files: Vec<FileReport>, pub skipped: Vec<SkippedFile>, }`
-- `rinkaku-core/src/pipeline.rs`: `pub fn analyze_diff( diff_text: &str, read_file: impl Fn(&str) -> std::io::Result<String>, resolver: Option<&dyn Resolver>, ) -> Result<Report, AnalyzeError>`
-- `rinkaku-core/src/pipeline.rs`: `fn fake_reader( files: HashMap<&'static str, &'static str>, ) -> impl Fn(&str) -> std::io::Result<String>`
-
-... (2 more symbols, same shape)
+... (6 more symbols, same shape)
 ````
 
-The 73-line diff (test bodies included) becomes 37 lines of signatures and
-their dependencies — the reviewer sees which functions changed and what
-they touch, without reading every reassigned string literal in the test
-bodies. On a larger real diff — rinkaku's own
-[PR #7](https://github.com/hiro-o918/rinkaku/pull/7) (a 2,254-line diff
-adding dependency resolution across 12 files) — `rinkaku` produces 658
-lines: about 29% of the original, while surfacing cross-file dependencies
-that would otherwise require opening every changed file to trace by hand.
+The 128-line diff (test bodies included) becomes 59 lines of signatures
+and their dependencies — the reviewer sees which functions changed and
+what they touch, without reading every match arm by hand. On a larger
+real diff — rinkaku's own [PR #7](https://github.com/hiro-o918/rinkaku/pull/7)
+(a 2,254-line diff adding dependency resolution across 12 files) —
+`rinkaku` produces 658 lines: about 29% of the original, while surfacing
+cross-file dependencies that would otherwise require opening every
+changed file to trace by hand.
 
 `--format json` renders the same data as structured JSON instead
 (`{"files": [{"path", "symbols": [{"name", "kind", "signature", "range",
-"container", "dependencies"}]}], "skipped": [...]}`), for piping into `jq`
-or another tool:
+"container", "dependencies", "omitted_matches"}]}], "skipped": [...]}`),
+for piping into `jq` or another tool:
 
 ```sh
-$ git show 099fd83 --format="" | rinkaku --format json | jq '.files[0].symbols[0]'
+$ git show 1ccc183 --format="" | rinkaku --format json | jq '.files[0].symbols[0]'
 ```
 
 ```json
 {
-  "name": "should_skip_deleted_file_without_reading_it",
+  "name": "main",
   "kind": "Function",
-  "signature": "fn should_skip_deleted_file_without_reading_it()",
-  "range": { "start": 201, "end": 226 },
+  "signature": "fn main() -> anyhow::Result<()>",
+  "range": { "start": 73, "end": 118 },
   "container": null,
   "dependencies": [
     {
-      "signature": "pub struct Report { pub files: Vec<FileReport>, pub skipped: Vec<SkippedFile>, }",
-      "path": "rinkaku-core/src/render.rs"
+      "signature": "pub trait Resolver { fn resolve(&self, name: &str) -> Vec<ResolvedSymbol>; }",
+      "path": "rinkaku-core/src/deps.rs"
     },
     {
       "signature": "pub fn analyze_diff( diff_text: &str, read_file: impl Fn(&str) -> std::io::Result<String>, resolver: Option<&dyn Resolver>, ) -> Result<Report, AnalyzeError>",
       "path": "rinkaku-core/src/pipeline.rs"
     },
     {
-      "signature": "fn fake_reader( files: HashMap<&'static str, &'static str>, ) -> impl Fn(&str) -> std::io::Result<String>",
-      "path": "rinkaku-core/src/pipeline.rs"
+      "signature": "fn build_resolver( cli: &Cli, diff_text: &str, diff_read_file: impl Fn(&str) -> std::io::Result<String>, head: Option<&str>, cwd: Option<&std::path::Path>, ) -> anyhow::Result<Option<TagsResolver>>",
+      "path": "rinkaku-core/src/main.rs"
+    },
+    {
+      "signature": "fn read_git_show_file( cwd: Option<&std::path::Path>, head: &str, path: &str, ) -> std::io::Result<String>",
+      "path": "rinkaku-core/src/main.rs"
+    },
+    {
+      "signature": "fn read_stdin_diff() -> anyhow::Result<String>",
+      "path": "rinkaku-core/src/main.rs"
+    },
+    {
+      "signature": "pub fn render(report: &Report, format: OutputFormat) -> Result<String, RenderError>",
+      "path": "rinkaku-core/src/render.rs"
+    },
+    {
+      "signature": "fn run_git_diff(base: &str, head: &str) -> anyhow::Result<String>",
+      "path": "rinkaku-core/src/main.rs"
     }
-  ]
+  ],
+  "omitted_matches": 0
 }
 ```
+
+### When same-name matches are capped
+
+On a repository with many same-named definitions, the same-name cap (see
+Known limitations below) shows up directly in the output. Running
+`rinkaku` against [astral-sh/ruff](https://github.com/astral-sh/ruff)
+commit `6237ecb4d` ("[ty] Add progress reporting to workspace
+diagnostics"), a changed `LazyWorkDoneProgress` struct references `Inner`,
+a name defined 14 times across the repo (mostly unrelated Python test
+fixtures and formatter cases named `class Inner`) — the 3 closest matches
+by path proximity are shown, and the rest are reported as a count instead
+of listed in full or silently dropped:
+
+````markdown
+## crates/ty_server/src/server/lazy_work_done_progress.rs
+
+```
+pub(super) struct LazyWorkDoneProgress { inner: Arc<Inner>, }
+```
+
+Depends on:
+- `crates/ruff_linter/resources/test/fixtures/pyupgrade/UP046_0.py`: `class Inner(Generic[T]): var: T`
+- `crates/ruff_python_formatter/resources/test/fixtures/black/cases/class_methods_new_line.py`: `class Inner: pass`
+- `crates/ruff_python_formatter/resources/test/fixtures/black/cases/class_methods_new_line.py`: `class Inner: """Just a docstring.""" def __init__(self):`
+- (+11 more definitions matched by name)
+````
+
+This same 810-line diff also shows the noise reduction from filtering `_`
+and single-character identifiers out of referenced names entirely (see
+Known limitations): the pre-#9 QA pass on this exact diff found 76 of 188
+"Depends on" lines were unrelated `def _(...)` matches (~40% noise); on
+the current `main`, the same diff produces 295 output lines (down from
+405 pre-#9) with zero `_`-related entries, since `_` is no longer looked
+up at all.
 
 ### `--deps`
 
 `--deps 1` (the default) resolves each changed symbol's 1-hop dependencies
 by indexing every file `git ls-files` tracks in the repository — this
 makes the output more useful (you see what a changed function calls) but
-costs an up-front repo-wide scan. `--deps 0` skips resolution entirely
-(no "Depends on" sections, no repository scan), which is significantly
-faster on large repositories: in QA, running against a large Rust
-monorepo (astral-sh/ruff, tens of thousands of files) took ~9.5s with
-`--deps 1` versus ~0.003s with `--deps 0` for the same diff. Prefer
-`--deps 0` for quick iteration or CI checks where the dependency context
-isn't needed.
+costs an up-front repo-wide scan. `TagsResolver::new` prefilters which
+files are worth parsing (skipping any file whose content cannot contain
+any referenced name at all), which helps when referenced names are
+distinctive but has limited effect when they include common
+standard-library-style names (see Known limitations). On the ruff
+`6237ecb4d` diff above, `--deps 1` took ~6.5s post-#9 (down from ~9.5s
+pre-#9) versus ~0.05s for `--deps 0` on the same diff — `--deps 0` skips
+resolution entirely (no "Depends on" sections, no repository scan) and
+remains dramatically faster since indexing cost does not depend on diff
+size. Prefer `--deps 0` for quick iteration or CI checks where the
+dependency context isn't needed.
 
 ## Development
 
@@ -175,41 +238,59 @@ LSP/process boundaries isolated behind traits (`LanguageSupport`,
 
 ### Known limitations
 
-- **No type resolution (by design, ADR 0003)**: dependency resolution
-  matches referenced names against definitions by name alone, with no
-  type information — it cannot disambiguate overloads, shadowed names, or
-  same-named symbols in unrelated modules. A future `Resolver`
-  implementation backed by an LSP server (pyright, gopls, rust-analyzer,
-  ...) is planned as a higher-precision, opt-in alternative for v2+; see
-  the Roadmap below.
-- **Same-name matches are ranked, not resolved**: when several
+**Mitigated in [#9](https://github.com/hiro-o918/rinkaku/pull/9):** the
+original QA pass (see below) found name-only matching noise and slow
+`--deps 1` indexing severe enough to block merging. Both are improved,
+though not eliminated — v1's resolver is still name-only (see "still
+open" below).
+
+- **Same-name matches are ranked and capped, not resolved.** When several
   definitions share a referenced name, they are ranked by path proximity
   to the referencing file (same file > same directory > shared path
-  prefix depth > other) and only the top 3 are shown; the rest are
-  reported as a count (`(+N more definitions matched by name)` in
-  Markdown, `omitted_matches` in JSON) rather than silently dropped or
-  listed in full. This bounds "Depends on" noise but does not guarantee
-  the top 3 include the actually-referenced definition.
-- **`_` and single-character identifiers are never resolved**: they are
+  prefix depth > other) and only the top 3 ([`MAX_MATCHES_PER_NAME`]) are
+  shown; the rest are reported as a count (`(+N more definitions matched
+  by name)` in Markdown, `omitted_matches` in JSON) rather than silently
+  dropped or listed in full — see "When same-name matches are capped"
+  above for a real example. This bounds "Depends on" noise but does not
+  guarantee the top 3 include the actually-referenced definition, since
+  ranking is a proximity heuristic, not type-aware resolution.
+- **`_` and single-character identifiers are never resolved.** They are
   filtered out of referenced names entirely, since under name-only
-  resolution they match too many unrelated definitions to be useful.
+  resolution they match too many unrelated definitions to be useful
+  (Python's `_` placeholder convention was the main offender found in
+  QA — see below).
 - **The `--deps 1` indexing prefilter has limited effect when a diff
-  references common standard-library-style names**: `TagsResolver::new`
+  references common standard-library-style names.** `TagsResolver::new`
   skips parsing files whose content cannot contain any referenced name at
   all (measured ~88% fewer files parsed, ~8x faster indexing on a
-  same-language-only reference set — see the PR description for the full
+  same-language-only reference set — see PR #9's description for the full
   numbers). But a name like `Vec`, `Option`, `String`, `Some`, or `Ok`
   appears in nearly every Rust file in a real codebase, so a diff whose
-  referenced names include several of these sees little to no reduction
-  (measured ~93% of files still parsed on one real-world diff). The
-  prefilter is a substring match over raw file content, not scoped to
-  actual definitions, so it cannot distinguish "defines `Vec`" from
-  "mentions `Vec`" without also being safe against false negatives (see
-  `deps.rs`'s `should_parse_file` doc comment) — narrowing this further is
-  left for a future iteration. The dominant cost in `--base` mode remains
-  the per-file `git show` subprocess invocation for reading tracked files
+  referenced names include several of these sees a smaller reduction (on
+  the ruff `6237ecb4d` diff used above, `--deps 1` dropped from ~9.5s
+  pre-#9 to ~6.5s post-#9 — better, not solved). The prefilter is a
+  substring match over raw file content, not scoped to actual
+  definitions, so it cannot distinguish "defines `Vec`" from "mentions
+  `Vec`" without also risking false negatives (see `deps.rs`'s
+  `should_parse_file` doc comment) — narrowing this further is left for a
+  future iteration. The dominant cost in `--base` mode remains the
+  per-file `git show` subprocess invocation for reading tracked files
   (unrelated to this prefilter, and unaddressed — see `deps.rs`'s
   performance doc comment).
+
+**Still open — no type resolution (by design, ADR 0003):** dependency
+resolution matches referenced names against definitions by name alone,
+with no type information — it cannot disambiguate overloads, shadowed
+names, or same-named symbols in unrelated modules. The ranking and cap
+above reduce the resulting noise but do not fix the underlying
+imprecision (e.g. an unrelated same-named Python test fixture class can
+still outrank a real dependency once same-file/same-directory candidates
+are exhausted — see the `Inner` example above). A future `Resolver`
+implementation backed by an LSP server (pyright, gopls, rust-analyzer,
+...) is planned as a higher-precision, opt-in alternative for v2+; see
+the Roadmap below.
+
+[`MAX_MATCHES_PER_NAME`]: rinkaku-core/src/deps.rs
 
 ### Roadmap / not yet done
 
@@ -219,22 +300,6 @@ LSP/process boundaries isolated behind traits (`LanguageSupport`,
 - Release automation (release-please, cross-compiled binary publishing)
   — intentionally deferred out of the bootstrap PR; tracked as a
   follow-up.
-
-### Known limitations (v1 tags-based `Resolver`)
-
-- **Name-only matching produces false-positive dependencies on common
-  identifiers.** The v1 `Resolver` matches referenced names against a
-  repo-wide index by name alone, with no scope or type awareness. On
-  repositories with common short identifiers (Python's `_` placeholder
-  convention, generic type names like `Data`/`Result`/`Client` reused
-  across modules, standard-library names shadowed by an unrelated
-  same-named local type), this can attach unrelated, noisy "Depends on"
-  entries to a symbol — observed in QA against real OSS diffs (e.g. a
-  builtin `pathlib.Path` reference resolving to an unrelated `class Path`
-  in a test fixture; dozens of unrelated `def _(...)` matches inflating
-  a single symbol's dependency list). This is the main motivation for the
-  planned LSP-backed `Resolver` above, which would use real scope/type
-  information instead of name matching.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ TBD — not yet published. Once released, this section will cover
 
 ## Usage
 
-Planned CLI shape (subject to change as implementation lands):
-
 ```sh
 # From a GitHub PR
 gh pr diff 123 | rinkaku
@@ -58,7 +56,99 @@ rinkaku --base main
 
 # JSON output for feeding into another tool or LLM
 rinkaku --base main --format json
+
+# Skip dependency resolution (faster, no repo-wide index — see below)
+rinkaku --base main --deps 0
 ```
+
+### What it looks like
+
+Running `rinkaku` on
+[a real rinkaku commit](https://github.com/hiro-o918/rinkaku/commit/099fd83)
+(a 73-line diff touching four test functions in `pipeline.rs`) produces:
+
+```sh
+$ git show 099fd83 --format="" | rinkaku
+```
+
+````markdown
+## rinkaku-core/src/pipeline.rs
+
+```
+fn should_skip_deleted_file_without_reading_it()
+```
+
+Depends on:
+- `rinkaku-core/src/render.rs`: `pub struct Report { pub files: Vec<FileReport>, pub skipped: Vec<SkippedFile>, }`
+- `rinkaku-core/src/pipeline.rs`: `pub fn analyze_diff( diff_text: &str, read_file: impl Fn(&str) -> std::io::Result<String>, resolver: Option<&dyn Resolver>, ) -> Result<Report, AnalyzeError>`
+- `rinkaku-core/src/pipeline.rs`: `fn fake_reader( files: HashMap<&'static str, &'static str>, ) -> impl Fn(&str) -> std::io::Result<String>`
+
+```
+fn should_skip_binary_file_without_reading_it()
+```
+
+Depends on:
+- `rinkaku-core/src/render.rs`: `pub struct Report { pub files: Vec<FileReport>, pub skipped: Vec<SkippedFile>, }`
+- `rinkaku-core/src/pipeline.rs`: `pub fn analyze_diff( diff_text: &str, read_file: impl Fn(&str) -> std::io::Result<String>, resolver: Option<&dyn Resolver>, ) -> Result<Report, AnalyzeError>`
+- `rinkaku-core/src/pipeline.rs`: `fn fake_reader( files: HashMap<&'static str, &'static str>, ) -> impl Fn(&str) -> std::io::Result<String>`
+
+... (2 more symbols, same shape)
+````
+
+The 73-line diff (test bodies included) becomes 37 lines of signatures and
+their dependencies — the reviewer sees which functions changed and what
+they touch, without reading every reassigned string literal in the test
+bodies. On a larger real diff — rinkaku's own
+[PR #7](https://github.com/hiro-o918/rinkaku/pull/7) (a 2,254-line diff
+adding dependency resolution across 12 files) — `rinkaku` produces 658
+lines: about 29% of the original, while surfacing cross-file dependencies
+that would otherwise require opening every changed file to trace by hand.
+
+`--format json` renders the same data as structured JSON instead
+(`{"files": [{"path", "symbols": [{"name", "kind", "signature", "range",
+"container", "dependencies"}]}], "skipped": [...]}`), for piping into `jq`
+or another tool:
+
+```sh
+$ git show 099fd83 --format="" | rinkaku --format json | jq '.files[0].symbols[0]'
+```
+
+```json
+{
+  "name": "should_skip_deleted_file_without_reading_it",
+  "kind": "Function",
+  "signature": "fn should_skip_deleted_file_without_reading_it()",
+  "range": { "start": 201, "end": 226 },
+  "container": null,
+  "dependencies": [
+    {
+      "signature": "pub struct Report { pub files: Vec<FileReport>, pub skipped: Vec<SkippedFile>, }",
+      "path": "rinkaku-core/src/render.rs"
+    },
+    {
+      "signature": "pub fn analyze_diff( diff_text: &str, read_file: impl Fn(&str) -> std::io::Result<String>, resolver: Option<&dyn Resolver>, ) -> Result<Report, AnalyzeError>",
+      "path": "rinkaku-core/src/pipeline.rs"
+    },
+    {
+      "signature": "fn fake_reader( files: HashMap<&'static str, &'static str>, ) -> impl Fn(&str) -> std::io::Result<String>",
+      "path": "rinkaku-core/src/pipeline.rs"
+    }
+  ]
+}
+```
+
+### `--deps`
+
+`--deps 1` (the default) resolves each changed symbol's 1-hop dependencies
+by indexing every file `git ls-files` tracks in the repository — this
+makes the output more useful (you see what a changed function calls) but
+costs an up-front repo-wide scan. `--deps 0` skips resolution entirely
+(no "Depends on" sections, no repository scan), which is significantly
+faster on large repositories: in QA, running against a large Rust
+monorepo (astral-sh/ruff, tens of thousands of files) took ~9.5s with
+`--deps 1` versus ~0.003s with `--deps 0` for the same diff. Prefer
+`--deps 0` for quick iteration or CI checks where the dependency context
+isn't needed.
 
 ## Development
 
@@ -129,6 +219,22 @@ LSP/process boundaries isolated behind traits (`LanguageSupport`,
 - Release automation (release-please, cross-compiled binary publishing)
   — intentionally deferred out of the bootstrap PR; tracked as a
   follow-up.
+
+### Known limitations (v1 tags-based `Resolver`)
+
+- **Name-only matching produces false-positive dependencies on common
+  identifiers.** The v1 `Resolver` matches referenced names against a
+  repo-wide index by name alone, with no scope or type awareness. On
+  repositories with common short identifiers (Python's `_` placeholder
+  convention, generic type names like `Data`/`Result`/`Client` reused
+  across modules, standard-library names shadowed by an unrelated
+  same-named local type), this can attach unrelated, noisy "Depends on"
+  entries to a symbol — observed in QA against real OSS diffs (e.g. a
+  builtin `pathlib.Path` reference resolving to an unrelated `class Path`
+  in a test fixture; dozens of unrelated `def _(...)` matches inflating
+  a single symbol's dependency list). This is the main motivation for the
+  planned LSP-backed `Resolver` above, which would use real scope/type
+  information instead of name matching.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add real usage examples to the README (Markdown and JSON output, `--deps` explanation with measured timing, compression numbers) — all captured from the `cargo build --release` binary, not fabricated.
- Add a "Known limitations" note documenting a name-only-matching false-positive issue in the v1 tags-based `Resolver`, found during this QA pass.
- Record the full QA pass (below) that was run against the release binary before merging.

No code changes — this PR only touches `README.md`. Any bugs found during QA (see below) are reported as-is, not fixed here, per QA policy.

## QA

**Update:** the High/Medium problems found in this initial QA pass
(problems #1 and #2 below — name-only matching noise and slow `--deps 1`
indexing) have since been mitigated in
[#9](https://github.com/hiro-o918/rinkaku/pull/9) (ranking + cap on
same-name matches, `_`/single-char filtering, and an indexing prefilter).
This section is left as originally recorded, as the historical QA record;
the README's Known limitations section now reflects the post-#9 state,
and this PR's usage examples were re-captured against the post-#9 binary.

All commands below were run against `cargo build --release`'s `target/release/rinkaku` binary (aliased `$RINKAKU`), not `cargo run`.

### 1. Automated checks

- `make lint` (`cargo fmt --all --check` + `cargo clippy --all-targets --all-features -- -D warnings`): **pass**, no warnings.
- `make test`: **139/139 tests pass** (129 in `rinkaku-core` lib + 10 in the `rinkaku` binary), 0 failed.

### 2. End-to-end on real PR diffs (per-language)

- **Rust — rinkaku's own PR [#7](https://github.com/hiro-o918/rinkaku/pull/7)** (`gh pr diff 7 | rinkaku`, run inside the rinkaku repo at the post-merge commit so stdin mode's working-tree-consistency assumption holds): 2,254-line diff (12 files) → **658-line** Markdown output (~29% of original). Signatures, containers, and "Depends on" all looked correct for this diff.
- **Go — `cli/cli`** commit `74e77914` ("Fix concurrent map writes in codespace port forwarding"): ran cleanly, struct/interface signatures and cross-file `Depends on` resolved correctly. Noted `CodespaceConnection` (defined in both `api.go` and `connection.go` structurally) surfaced as a dependency candidate — plausible but worth double-checking precision on duplicate-shaped types.
- **Python — `astral-sh/ruff`** (Rust project with a large embedded Python corpus): see problem #1 below — found a clear false-positive dependency-resolution bug (`pathlib.Path` reference matched to an unrelated `class Path` in a test fixture; standalone `print` matched to a local test-fixture function).
- **TypeScript — `vercel/swr`** commit `83761ac` ("react.use should not depend on data condition", checked out at that commit since stdin mode requires diff/working-tree consistency): ran cleanly overall, but see problem #2 below — a generic `Data` reference incorrectly resolved to an unrelated `type Data = { name: string }` in an e2e fixture file.

### 3. Large "LLM-PR-shaped" diff / compression ratio

- `astral-sh/ruff` commit `6237ecb4d` ("[ty] Add progress reporting to workspace diagnostics"), 11 files / 448 insertions / 77 deletions, 810-line raw diff → **405-line** rinkaku output (~50%). However ~40% of the `Depends on` lines in this output are noise (see problem #1 — Python's `_` placeholder convention matching dozens of unrelated fixture functions), so the *effective* signal-to-noise compression is worse than the raw line count suggests.
- `astral-sh/ruff` commit `48d5bd13f` ("[ty] Initial test suite for TypedDict"), 28 files / 394 insertions / 128 deletions, mostly a single `.md` mdtest fixture (unsupported language) → 285-line diff → **3-line** output (correctly reports the file as skipped, ~99% compression — expected, since there's no actual source-code symbol change).
- Timing on the same large-repo diff: `--deps 1` (default) **9.5s** vs `--deps 0` **0.003s** (see problem #3 below).

### 4. Input modes and flags

- stdin mode vs `--base`/`--head` mode: ran both on the same 3-commit range inside rinkaku itself; **outputs are byte-identical** (`diff` reports no difference). OK
- `--deps 0` vs `--deps 1`: confirmed `--deps 0` fully omits "Depends on" sections and skips the repo-wide `git ls-files` scan; output line count differs as expected (34 vs 61 lines on a sample diff). Timing difference is dramatic on large repos (see above). OK
- `--format json`: output piped through `jq .` parses successfully (`jq` exit code 0); spot-checked structure (`files[].symbols[].{name,kind,signature,range,container,dependencies}`, `skipped[]`). OK
- Empty diff via stdin (`echo -n "" | rinkaku`): prints `note: diff is empty, nothing to analyze` to stderr, exit code 0. OK
- Garbage (non-diff) input via stdin (`echo "hello world" | rinkaku`): exits 0 with **empty stdout and no error** — no `files`, no `skipped`, no note. See problem #4 below (minor: silently produces nothing rather than a clear "not a valid diff" message).
- Diff-shaped-but-malformed input (`diff --git a/foo.rs b/foo.rs` header followed by garbage instead of a real hunk): produces `## foo.rs` heading with no symbols, exit 0 — parsed leniently rather than erroring. Related to problem #4.
- Binary file diff (`Binary files a/image.png and b/image.png differ`): correctly reported under `## Skipped files` as `image.png (binary)`, exit 0. OK
- Unsupported-language-only diff (e.g. a `.json` file change): correctly reported under `## Skipped files` as `config.json (unsupported language)`, exit 0. OK
- Nonexistent `--base` ref (`rinkaku --base nonexistent-ref-xyz123`): fails with a clear error (`Error: git diff nonexistent-ref-xyz123...HEAD failed: fatal: ambiguous argument ...`), exit code 1. OK

### 5. Regression / boundary cases

- Non-ASCII (Japanese identifiers `ユーザー`, `名前`, `新規作成`, and Japanese doc comments) in a Rust diff: struct/function signatures extracted correctly, no mangling or encoding issues. OK
- Rename + content change (`git diff -M`, `lib.rs` → `user.rs` with an added field and a phone-number parameter): correctly reported under the new path (`user.rs`) with the updated signature. OK
- Pure rename with no content change (`user.rs` → `account.rs`, `similarity index 100%`): correctly reported as a heading with **no symbols listed**, matching the existing `should_skip_reading_pure_rename_with_no_changed_ranges` unit test's expected behavior, confirmed against the real binary. OK
- Full rewrite of a single large file (500 functions, every body changed, 2,505-line diff): completed in ~60ms (`--deps 0`) / ~77ms (`--deps 1`), all 500 signatures correctly extracted with bodies stripped. No crash, no truncation. OK

## Problems found (not fixed — reported per QA policy)

1. **[High] False-positive dependency resolution on common/short identifiers (v1 tags-based `Resolver`).** The `Resolver` matches referenced names against a repo-wide index by name only, with no scope/type/import awareness.
   - Example A: in `astral-sh/ruff`, a `pathlib.Path` reference in `scripts/update_schemastore.py` resolved as a "dependency" to an unrelated `class Path` defined inside a *test fixture* (`crates/ruff_python_formatter/resources/test/fixtures/ruff/newlines.py`).
   - Example B: in the same repo, a plain `print` reference resolved to an unrelated local function `def print(s: str):` inside a lint-rule test fixture (`RUF030.py`).
   - Example C (most severe): Python's `_` placeholder-variable convention is used for dozens of throwaway function names (`def _(): ...`) across ruff's test fixtures. A single real symbol's dependency list absorbed 30+ of these unrelated matches; in the `6237ecb4d` diff, roughly 40% (76/188) of all `Depends on` lines in the output were `def _(...)` noise from unrelated fixture files.
   - Example D: in `vercel/swr`, a generic `Data` type reference in `use-swr.ts` resolved to an unrelated `type Data = { name: string }` defined in an e2e test fixture (`e2e/site/pages/api/data.ts`).
   - Impact: on repositories with common/generic identifier names, `--deps 1` output can be dominated by noise, undermining the tool's core value proposition (a reviewer has to mentally filter out bogus dependencies). Documented as a "Known limitations" note in this PR's README changes; not fixed here.

2. **[Medium] `--deps 1` repo-wide indexing is very slow on large repositories, independent of diff size.** On `astral-sh/ruff` (a large Rust monorepo), `--deps 1` took ~9.5s regardless of whether the diff touched 1 file or 28 files — the cost is dominated by indexing every file `git ls-files` reports, not by the diff itself. `--deps 0` on the same diffs took ~0.003–0.06s. This is a real usability concern for the tool's primary use case (large/LLM-generated PRs on real-world repos) since `--deps 1` is the default. Documented with measured numbers in the README's new `--deps` section; not fixed here (a caching/incremental-index strategy would be a reasonable follow-up).

3. **[Low] Silent no-op on non-diff garbage input via stdin.** Piping arbitrary non-diff text (e.g. `echo "hello world" | rinkaku`) exits 0 with completely empty stdout — no error, no "Skipped files" note, nothing. A diff-shaped-but-malformed input (valid `diff --git` header, garbage hunk body) is also parsed leniently (produces a bare file heading with no symbols) rather than erroring, even though `pipeline::tests::should_return_err_when_diff_is_malformed` exists as a unit test for a stricter malformed case. The exact boundary between "tolerated as an empty/no-op diff" and "rejected as malformed" isn't obvious from the CLI's behavior; a clearer signal (e.g. "0 files parsed from N lines of input" note, similar to the empty-diff note) would help users notice a mistake (wrong file piped, PR number typo'd into `gh pr diff`, etc.) rather than silently getting nothing.

4. **[Info, not a bug] Long multi-line doc comments are flattened onto a single output line.** When a symbol's dependency has a multi-line `///` doc comment, the signature line in "Depends on" includes the full flattened doc comment text (whitespace-normalized onto one line), which can make individual lines in the Markdown output very long (several hundred characters) — see `LanguageSupport::reference_query`'s doc comment surfacing verbatim in the PR #7 QA output. This is consistent with the documented signature-slicing behavior (doc comments are normalized, not stripped, for dependency signatures) and doesn't affect correctness, but is worth knowing when skimming Markdown output for very heavily-documented codebases.

## Compression ratios (measured)

| Diff | Raw diff lines | rinkaku output lines | Ratio |
|---|---|---|---|
| rinkaku PR #7 (Rust, 12 files) | 2,254 | 658 | ~29% |
| `cli/cli` commit `74e77914` (Go) | 333 | ~230 | ~69% |
| `ruff` commit `6237ecb4d` (Rust/Python monorepo, 11 files, real code changes) | 810 | 405 | ~50% (but ~40% of "Depends on" lines are noise, see problem #1) |
| `ruff` commit `48d5bd13f` (28 files, almost entirely a `.md` test fixture) | 285 | 3 | ~1% (correctly skips the unsupported-language file) |
| Single-file full rewrite (500 Rust functions, all bodies changed) | 2,505 | 2,002 | ~80% (expected — every symbol genuinely changed) |

## Merge decision

This initial QA pass found real correctness/precision issues (problems #1-#2 above) in the v1 `Resolver`, severe enough that this PR was originally left in **draft**, not merged — problems were reported here for the maintainer to triage rather than silently worked around.

**Update:** problems #1 and #2 have since been mitigated in [#9](https://github.com/hiro-o918/rinkaku/pull/9) (see the QA section's update note above). This PR's README changes were rebased onto post-#9 `main` and its usage examples re-captured against the new binary before merging.

