### PR TITLE
fix: declare explicit crate versions for release-please compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ resolver = "2"
 members = ["rinkaku-core", "rinkaku"]
 
 [workspace.package]
-version = "0.1.0"
 edition = "2024"
 authors = ["Hironori Yamamoto"]
 license = "MIT"

--- a/rinkaku-core/Cargo.toml
+++ b/rinkaku-core/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "rinkaku-core"
-version.workspace = true
+# release-please's cargo-workspace plugin reads `package.version` as a
+# literal string; `version.workspace = true` resolves to a TOML table
+# rather than a string and is rejected as invalid. Declare it directly
+# here (and in rinkaku/Cargo.toml) while other fields stay inherited.
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/rinkaku/Cargo.toml
+++ b/rinkaku/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "rinkaku"
-version.workspace = true
+# See rinkaku-core/Cargo.toml for why this is a literal version instead
+# of `version.workspace = true`.
+version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

`release-main.yaml`'s release-please step failed after PR #10 merged:

```
##[error]release-please failed: cargo-workspace (hiro-o918/rinkaku):
package manifest at rinkaku-core/Cargo.toml has an invalid [package.version]
```

release-please's `cargo-workspace` plugin reads each workspace member's
`package.version` as a literal string (see
[`cargo-workspace.ts`](https://github.com/googleapis/release-please/blob/main/src/plugins/cargo-workspace.ts#L140-L157)).
`version.workspace = true` resolves to a TOML table (`{ workspace: true }`)
rather than a string, so it fails `typeof version !== 'string'` and is
rejected — the plugin does not support Cargo's workspace version
inheritance syntax.

## Fix

- `rinkaku-core/Cargo.toml` and `rinkaku/Cargo.toml` now declare
  `version = "0.1.0"` directly instead of `version.workspace = true`.
  Other fields (`edition`, `authors`, `license`, `repository`) stay
  inherited via `.workspace = true` — release-please only inspects
  `package.version`.
- `[workspace.package].version` is dropped from the root `Cargo.toml`
  since nothing references it anymore, avoiding future drift between a
  workspace-level version and the per-crate ones release-please now owns.
- `rinkaku`'s internal dependency on `rinkaku-core` keeps its existing
  literal `version = "0.1.0"` (already compatible; needed so the
  cargo-workspace plugin can bump it on release).

## Verification

- `cargo build --all-features`
- `make lint` (fmt + clippy, no warnings)
- `make test` (146 passed)