### PR TITLE
fix: set push-to explicitly for homebrew formula bump

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -133,10 +133,21 @@ jobs:
 
       # x86_64-apple-darwin is the tarball macOS Homebrew installs from
       # (see awsctx's homebrew-release.yml, same convention).
+      #
+      # push-to is set explicitly to hiro-o918/homebrew-tap: without it,
+      # the action decides whether to fork by checking
+      # `repos.get(homebrew-tap).permissions.push` on the token, and a
+      # GitHub App installation token doesn't populate that field the
+      # way the action expects. That made it treat the token as
+      # read-only and attempt `POST /repos/.../forks`, which the App
+      # isn't permitted to do (HTTP 403). Declaring push-to short-
+      # circuits that permission probe and pushes directly, matching
+      # the actual (write) access the token has.
       - uses: mislav/bump-homebrew-formula-action@v3
         with:
           formula-name: rinkaku
           formula-path: Formula/rinkaku.rb
+          push-to: hiro-o918/homebrew-tap
           homebrew-tap: hiro-o918/homebrew-tap
           base-branch: main
           tag-name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

`publish-homebrew` failed on the v0.1.0 release
(https://github.com/hiro-o918/rinkaku/actions/runs/29174139826):

```
POST /repos/hiro-o918/homebrew-tap/forks - 403
HttpError: Resource not accessible by integration
```

## Root cause

`mislav/bump-homebrew-formula-action` decides whether to fork
`homebrew-tap` (vs. pushing directly) by calling
`repos.get(homebrew-tap)` and checking `.data.permissions.push` on the
token, *unless* `push-to` is explicitly set (source:
[`edit-github-blob.ts`](https://github.com/mislav/bump-homebrew-formula-action/blob/main/src/edit-github-blob.ts)).
The action does auto-skip this fork check when `homebrew-tap` is the
*same* repo the workflow runs in — but here `rinkaku` and
`homebrew-tap` are separate repos, so that shortcut doesn't apply.

The GitHub App installation token minted by
`actions/create-github-app-token` (scoped to `homebrew-tap` with
Contents: write) doesn't populate `permissions.push` the way the
action expects when hitting `repos.get`, so the action treated it as
read-only and attempted `repos.createFork`, which the App isn't
permitted to do — hence the 403.

## Fix

Set `push-to: hiro-o918/homebrew-tap` explicitly on the
`mislav/bump-homebrew-formula-action` step. This matches `pushTo` to
`homebrew-tap` itself, which short-circuits the permission probe in
the action entirely and pushes directly using the token's actual
(write) access.

## Verification

- `actionlint .github/workflows/build-and-publish.yaml` — same 2
  pre-existing shellcheck warnings as on `main` (SC2086, unrelated
  lines 42/55), nothing new introduced by this change.
- No Rust source changed.