### PR TITLE
chore: remove release-as pin and harden build-and-publish for re-runs

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -42,12 +42,10 @@
   ],
   "packages": {
     "rinkaku-core": {
-      "component": "rinkaku-core",
-      "release-as": "0.1.0"
+      "component": "rinkaku-core"
     },
     "rinkaku": {
-      "component": "rinkaku",
-      "release-as": "0.1.0"
+      "component": "rinkaku"
     }
   },
   "plugins": [

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -4,6 +4,20 @@ on:
   push:
     tags:
       - "v*"
+  # Manual re-run, e.g. when only publish-homebrew failed and needs
+  # retrying without repeating publish-crates. Trigger against the tag
+  # itself (`gh workflow run build-and-publish.yaml --ref v0.1.0`) so
+  # the default checkout ref is already correct; the `tag` input only
+  # documents/records which release this dispatch is for.
+  # publish-crates guards itself against re-publishing a version that's
+  # already on crates.io, so a full re-run is safe even after a partial
+  # success.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag being (re-)published, e.g. v0.1.0 -- must match the ref this workflow is dispatched against"
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}--${{ github.ref }}
@@ -86,8 +100,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # --clobber makes this safe to re-run via workflow_dispatch
+          # against a tag whose assets were already uploaded.
           gh release upload "${{ github.ref_name }}" dist/* \
-            --repo "${{ github.repository }}"
+            --repo "${{ github.repository }}" \
+            --clobber
 
   publish-crates:
     needs: [rust-test]
@@ -100,18 +117,53 @@ jobs:
         with:
           key: publish-crates
 
+      # Makes this job idempotent so workflow_dispatch (or a build
+      # rerun) can safely repeat it after a partial release failure:
+      # crates.io rejects re-publishing an existing version, so skip
+      # ahead instead of letting `cargo publish` fail the whole job.
+      - name: Check whether rinkaku-core is already published
+        id: check-core
+        run: |
+          version=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "rinkaku-core") | .version')
+          status=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://crates.io/api/v1/crates/rinkaku-core/${version}")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if [ "$status" = "200" ]; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # rinkaku-core must publish first: rinkaku depends on it by version,
       # and crates.io resolves that dependency from the registry, not the
       # workspace's local path.
       - name: Publish rinkaku-core
+        if: steps.check-core.outputs.already_published == 'false'
         run: cargo publish -p rinkaku-core --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
 
       # crates.io needs a short window to index rinkaku-core before
-      # rinkaku's publish can resolve it as a dependency.
+      # rinkaku's publish can resolve it as a dependency. Only needed
+      # right after an actual publish, not when we skipped above.
       - name: Wait for rinkaku-core to be indexed
+        if: steps.check-core.outputs.already_published == 'false'
         run: sleep 30
 
+      - name: Check whether rinkaku is already published
+        id: check-bin
+        run: |
+          version=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "rinkaku") | .version')
+          status=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://crates.io/api/v1/crates/rinkaku/${version}")
+          if [ "$status" = "200" ]; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish rinkaku
+        if: steps.check-bin.outputs.already_published == 'false'
         run: cargo publish -p rinkaku --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
 
   publish-homebrew:


### PR DESCRIPTION
## Summary

Three follow-ups after shipping v0.1.0 (tag/release/crates.io succeeded;
publish-homebrew initially failed and was recovered by hand -- see
below):

### 1. Remove the `release-as: "0.1.0"` pins

Added in #13 to force the first release PR to compute as `0.1.0` instead
of depending on how release-please derives an initial version from an
empty manifest. Now that v0.1.0 is tagged and released, these pins are
removed so future releases resume normal conventional-commit-driven
version calculation instead of being pinned forever.

### 2. Add `workflow_dispatch` to build-and-publish.yaml

The v0.1.0 run's `publish-homebrew` job failed
(`mislav/bump-homebrew-formula-action` needed `push-to` set explicitly,
fixed in #15) after `publish-crates`, `build`, and `publish-release` had
already succeeded. There was no way to re-run just the fixed workflow
against the existing `v0.1.0` tag -- `gh run rerun` uses the workflow
definition from when the run was originally triggered, not the current
one, and the only trigger was `push: tags: v*`, so re-running would have
meant deleting and re-pushing the tag (which would also re-trigger
`publish-crates` against an already-published version).

`workflow_dispatch` (with a `tag` input, used only for documentation/
logging -- the actual ref comes from `--ref` on dispatch) lets a
maintainer re-trigger the whole pipeline directly:
`gh workflow run build-and-publish.yaml --ref v0.1.0`.

(For the record: v0.1.0's homebrew formula was fixed by hand via the
Contents API in the interim, since this workflow_dispatch path didn't
exist yet.)

### 3. Make `publish-crates` idempotent

Checks crates.io for each package's current `Cargo.toml` version before
publishing, skipping `cargo publish` (and the indexing wait) if that
version is already there. This is what actually makes a
`workflow_dispatch` re-run -- or a plain job rerun -- safe after a
partial release failure, since crates.io rejects re-publishing an
existing version outright and would otherwise fail the whole job again.

Also added `--clobber` to the release-asset upload in `publish-release`
so re-running against a tag whose assets are already uploaded doesn't
fail either.

## Verification

- `actionlint .github/workflows/build-and-publish.yaml` -- same 2
  pre-existing shellcheck warnings as on `main` (SC2086, unrelated
  lines), nothing new from this change.
- `ruby -ryaml` / `python3 -m json` -- both changed files parse.
- `make lint` -- green (no Rust source changed).