### PR TITLE
fix: use separate release-please PRs per package

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -3,6 +3,7 @@
   "release-type": "rust",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
+  "separate-pull-requests": true,
   "changelog-sections": [
     {
       "type": "feat",

--- a/README.md
+++ b/README.md
@@ -383,6 +383,21 @@ release tag (`v{version}`, no component prefix) triggers
 (`rinkaku-core-v{version}`) so a `rinkaku-core`-only release doesn't spin
 up the binary build/publish pipeline.
 
+`separate-pull-requests: true` is set for a reason that isn't obvious
+from the config alone: with more than one non-root `packages` entry (no
+`.` path), release-please's PR-merging step can't find a "root" release
+candidate to base the combined PR's title on, and falls back to a title
+that omits the version entirely (`chore: release main`). That title
+doesn't match what the *next* run expects when looking up the
+already-merged PR to tag, so tagging silently finds nothing to do and
+`release-main.yaml` aborts with "untagged, merged release PRs
+outstanding" -- this bit us for both the v0.2.0 and v0.3.0 releases,
+each requiring a manual `gh release create` + relabeling the PR
+`autorelease: tagged` to recover. `separate-pull-requests: true` sidesteps
+this entirely: each package gets its own PR (and its own title, correctly
+including that package's version), so there's no combined-PR title to
+compute in the first place.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Both v0.2.0 and v0.3.0 releases hit `release-main.yaml` aborting with `⚠ There are untagged, merged release PRs outstanding - aborting`, requiring manual `gh release create` + relabeling recovery each time.
- Root cause (traced through release-please's source): with two non-root `packages` entries (`rinkaku-core`, `rinkaku`) and no `.` path, the `Merge` plugin that combines them into one PR has no "root" release candidate to base the combined title on (`rootRelease` is always `null` when no package is at path `.`). It falls back to a title that omits the version entirely: `chore: release main`. The *next* run, when looking up this already-merged PR to tag it, can't extract a version from that title, and the manifest-level bookkeeping ends up inconsistent enough that tagging silently produces nothing -- aborting instead of creating the release.
- This is independent of the `linked-versions` plugin (already removed in #21) and of the per-component tag scheme (also already fixed) -- it's specific to having 2+ non-root packages combined into a single PR.

## Fix
- `separate-pull-requests: true`: each package now gets its own release PR instead of being merged into one. Each PR's title is built directly from that package's own strategy, which always has a version to work with -- no combined-PR title computation, no fallback, no mismatch.
- Documented the reasoning in README's Release section so it isn't a mystery next time someone looks at this config.

## Trade-off
A commit set touching both `rinkaku` and `rinkaku-core` in the same PR would now open two release PRs instead of one. Acceptable here since the two crates already version independently and rarely change together.

## Test plan
- [x] `make lint` -- clean (config/docs-only change)
- [ ] After merge: verify the next release-please run creates a normal, correctly-titled PR per changed package, and that merging it produces a tag/release without manual intervention