### PR TITLE
docs: cross-reference README's Release section from self_update.rs

### DIFF
--- a/rinkaku/src/self_update.rs
+++ b/rinkaku/src/self_update.rs
@@ -8,6 +8,9 @@
 //! process/network IO tied to how *this specific binary* is distributed
 //! (GitHub Releases asset naming), not part of the pure diff-condensation
 //! core.
+//!
+//! See README's Release section for how `rinkaku` and `rinkaku-core` are
+//! versioned and tagged independently.
 
 use anyhow::{Context, Result};
 use std::io::IsTerminal;


### PR DESCRIPTION
## Summary
- Small doc pointer from `self_update.rs` to README's Release section.
- Also serves as a verification commit for #25 (separate-pull-requests fix): merging this should produce a normal release-please PR titled with an actual version, and merging that PR should tag/release automatically without manual intervention.

## Test plan
- [x] `make lint` clean