### PR TITLE
feat: auto-clone PR URL repos into a cache when outside a clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ every implementation line.
   file contents are read via `git show <head>:<path>` so extraction always
   matches the diffed commit, regardless of the working tree's state.
   `--pr` mode resolves the PR's base and head via `gh pr view`, fetches
-  both into the local clone, and reuses the same `git show`-backed read
-  strategy as `--base` — it requires running inside a local clone of the
-  target repository, and `gh` installed and authenticated (see
-  [ADR 0004](docs/adr/0004-pr-input-mode-via-gh-in-local-clone.md)). In
+  both, and reuses the same `git show`-backed read strategy as `--base`
+  (see [ADR 0004](docs/adr/0004-pr-input-mode-via-gh-in-local-clone.md)).
+  A bare PR number requires running inside a local clone of the target
+  repository; a URL also works from any directory by auto-cloning a
+  blobless copy into a cache (see
+  [ADR 0005](docs/adr/0005-auto-clone-into-cache-for-pr-urls.md)). `gh`
+  must be installed and authenticated either way. In
   stdin mode, file contents are read off the working tree, which assumes
   **the piped diff is consistent with the current working tree** (e.g. it
   was just produced by `git diff` or already applied); a stale or
@@ -115,9 +118,16 @@ not given, `self-update` refuses to run rather than silently proceeding.
 # From a GitHub PR (stdin, no local clone required)
 gh pr diff 123 | rinkaku
 
-# From a GitHub PR, run inside a local clone of the target repository
-# (fetches the PR via `gh`/`git`; requires `gh` installed and authenticated)
+# From a GitHub PR by number: run inside a local clone of the target
+# repository (fetches the PR via `gh`/`git`; requires `gh` installed and
+# authenticated)
 rinkaku --pr 123
+
+# From a GitHub PR URL: works from any directory. If the cwd isn't already
+# a clone of that repository, rinkaku auto-clones a blobless copy into
+# $RINKAKU_CACHE_DIR / $XDG_CACHE_HOME/rinkaku / ~/.cache/rinkaku and runs
+# there instead (see ADR 0005). Private repos need `gh auth setup-git` so
+# the cache clone's later `git fetch`s can authenticate too.
 rinkaku --pr https://github.com/octocat/hello-world/pull/123
 
 # From a local git diff against a base branch

--- a/docs/adr/0005-auto-clone-into-cache-for-pr-urls.md
+++ b/docs/adr/0005-auto-clone-into-cache-for-pr-urls.md
@@ -1,0 +1,63 @@
+# 0005. Auto-clone into a cache for PR URLs outside a local clone
+
+- Status: accepted
+- Date: 2026-07-12
+
+## Context
+
+ADR 0004's `--pr` mode requires running inside a local clone whose
+`origin` is the PR's repository: `gh pr view` itself works anywhere when
+given a URL, but the subsequent `git fetch`, `git show`-based file reads,
+and the dependency resolver's `git ls-files` index all need a local git
+repository. A PR URL, however, carries everything needed to identify the
+repository — only a bare PR number is inherently ambiguous. ADR 0004
+rejected a clone-less mode built on the GitHub HTTP API; that rejection
+was about the API approach (HTTP client, token handling, per-file fetch
+cost), not about the goal of working outside a clone.
+
+## Decision
+
+When `--pr` is given a URL and the current directory is not a clone of
+that URL's repository (its `origin` does not match, or it is not a git
+repository at all), rinkaku clones the repository as a blobless partial
+clone (`--filter=blob:none`) into a per-repository cache directory
+(`$RINKAKU_CACHE_DIR`, falling back to `$XDG_CACHE_HOME/rinkaku`, then
+`~/.cache/rinkaku`) and runs the existing `--pr` pipeline with that
+directory as the working repository. An existing cache entry is reused
+and updated with `git fetch`. Cloning is delegated to `gh repo clone`
+so authentication stays with `gh` (ADR 0004's auth stance). A bare PR
+number keeps requiring a local clone, and a URL matching the current
+clone keeps using it — behavior inside a matching clone is unchanged.
+
+## Alternatives
+
+- **GitHub HTTP API for diff and file contents**: rejected in ADR 0004;
+  the reasons (new HTTP client, token handling, rate-limit-prohibitive
+  per-file fetches for the dependency index) still hold. The git
+  protocol via a partial clone avoids all three.
+- **Discover an existing local clone (ghq or a `--repo-dir` flag)**:
+  helps only users who already have a clone and couples rinkaku to a
+  workspace-layout convention; the cache clone covers everyone,
+  including CI. A found matching clone in the cwd is still preferred.
+- **Full or shallow (`--depth`) clone into the cache**: a full clone
+  pays the whole history up front for large repositories; a shallow
+  clone breaks `git diff <base>...<head>` merge-base computation and
+  fetch-deepening semantics. Blobless keeps the full DAG (correct
+  merge-bases) while fetching blobs lazily only as `git show` needs
+  them.
+
+## Consequences
+
+- `rinkaku --pr <URL>` works from any directory; the first run against a
+  repository pays a tree-only clone, later runs pay a fetch.
+- The dependency resolver (`--deps 1`) triggers lazy blob downloads in a
+  cache clone — slower than a warm local clone; `--deps 0` stays cheap.
+- rinkaku gains a managed cache directory; entries are plain git repos
+  the user can delete freely. No eviction policy for now — revisit if
+  cache growth becomes a real complaint.
+- Private repositories need `gh` auth for the clone and `git` credentials
+  for later fetches (`gh auth setup-git` covers both); documented in the
+  README rather than handled specially.
+- ADR 0004's "requires running inside a local clone" constraint is
+  narrowed to bare-number arguments; its rejection of the HTTP API
+  approach stands.

--- a/docs/adr/0006-prefer-ghq-managed-clones-over-cache.md
+++ b/docs/adr/0006-prefer-ghq-managed-clones-over-cache.md
@@ -1,0 +1,58 @@
+# 0006. Prefer existing ghq-managed clones over the cache clone
+
+- Status: accepted
+- Date: 2026-07-12
+
+## Context
+
+ADR 0005 makes `--pr <URL>` work from any directory by falling back to a
+blobless clone in rinkaku's cache. Users who manage their repositories
+with [ghq](https://github.com/x-motemen/ghq) usually already have a full
+clone of the repository they are reviewing; cloning it again into the
+cache duplicates disk usage and grows the cache with every new
+repository. ADR 0005 rejected local-clone discovery as the *sole*
+mechanism because it cannot help users who have no clone at all — that
+reasoning does not apply to using discovery as a preference layer in
+front of the cache fallback.
+
+## Decision
+
+When resolving the working repository for a PR URL, probe in order:
+
+1. the current directory, when its `origin` matches the URL's
+   owner/repo (unchanged from ADR 0004/0005);
+2. an existing clone reported by `ghq list --full-path --exact
+   <owner>/<repo>`, when `ghq` is on `PATH` — the first hit whose
+   `origin` matches the URL's repository is used;
+3. the cache blobless clone (ADR 0005).
+
+ghq being absent, returning no hit, or returning only clones whose
+`origin` does not match all fall through silently to the cache. rinkaku
+never mutates a discovered clone beyond what `git fetch` does (updating
+`FETCH_HEAD` and remote-tracking refs); the working tree is untouched.
+This partially supersedes ADR 0005's rejection of clone discovery, which
+now stands only against discovery *as the sole mechanism*.
+
+## Alternatives
+
+- **A generic search-path setting (e.g. `RINKAKU_REPO_ROOTS`)**: more
+  configuration surface for a need ghq already expresses; can be added
+  later without conflicting with this decision if non-ghq users ask.
+- **Defaulting the cache location to the ghq root**: would plant
+  rinkaku-owned blobless clones inside a directory layout ghq believes
+  it manages, surprising both tools.
+- **Requiring ghq (no cache fallback)**: rejected in ADR 0005 already;
+  leaves users without a clone stranded.
+
+## Consequences
+
+- ghq users get zero cache growth for repositories they already have;
+  first-run latency drops to a `git fetch` against their existing clone.
+- Discovered clones see their remote-tracking refs advance as a side
+  effect of the fetch — the same effect any manual `git fetch` has, but
+  worth knowing when a user wonders why `origin/<branch>` moved.
+- ghq becomes an opportunistic, optional runtime dependency: its absence
+  changes nothing, so CI and non-ghq users are unaffected.
+- The probe order (cwd, ghq, cache) is fixed and documented; if other
+  clone managers need supporting, they slot in as additional probes
+  rather than reshaping the flow.

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -13,14 +13,18 @@
 //!   working tree. This keeps the diff and the file content read from the
 //!   exact same commit by construction, regardless of what the working
 //!   tree currently holds (uncommitted changes, a dirty checkout, etc.).
-//! - `--pr` mode (ADR 0004): the PR's base branch and head commit are
-//!   resolved via `gh pr view`, both are fetched into the local clone
-//!   with `git fetch`, and the resulting base/head SHAs are handed to
-//!   exactly the same `git show`-backed read strategy as `--base` mode —
-//!   `--pr` is a resolution step in front of the `--base` pipeline, not a
-//!   separate read strategy. Requires running inside a local clone whose
-//!   `origin` remote is the target repository, and requires `gh` to be
-//!   installed and authenticated.
+//! - `--pr` mode (ADR 0004, ADR 0005): the PR's base branch and head
+//!   commit are resolved via `gh pr view`, both are fetched with
+//!   `git fetch`, and the resulting base/head SHAs are handed to exactly
+//!   the same `git show`-backed read strategy as `--base` mode — `--pr`
+//!   is a resolution step in front of the `--base` pipeline, not a
+//!   separate read strategy. A bare PR number requires running inside a
+//!   local clone of the target repository. A PR URL also uses the
+//!   current directory when its `origin` matches the URL's repository;
+//!   otherwise (ADR 0005) it auto-clones a blobless partial clone into a
+//!   per-repository cache directory and runs there instead, so URL input
+//!   works from any directory. `gh` must be installed and authenticated
+//!   either way.
 //! - stdin mode: the diff's provenance is unknown to rinkaku (it could be
 //!   `gh pr diff`, a saved patch file, anything). Files are read off the
 //!   working tree, under the assumption that **the diff is consistent
@@ -67,9 +71,12 @@ struct Cli {
 
     /// GitHub PR to review, as a URL
     /// (`https://github.com/<owner>/<repo>/pull/<number>`) or a bare PR
-    /// number (`76`). Must be run inside a local clone of the target
-    /// repository, with `gh` installed and authenticated.
-    // See ADR 0004 for the resolve-then-fetch design this drives in `main`.
+    /// number (`76`). A bare number must be run inside a local clone of
+    /// the target repository; a URL also works from any other directory
+    /// by auto-cloning into a cache. Requires `gh` installed and
+    /// authenticated.
+    // See ADR 0004 for the resolve-then-fetch design and ADR 0005 for the
+    // auto-clone-into-cache behavior this drives in `main`.
     #[arg(long)]
     pr: Option<String>,
 
@@ -132,22 +139,24 @@ fn main() -> anyhow::Result<()> {
         // Validate the arg and derive the fetch refspec's PR number, but
         // pass the original (trimmed) value — not the parsed number — to
         // `gh pr view` (see that function's doc comment for why).
-        let number = parse_pr_arg(pr_arg)?;
+        let parsed = parse_pr_arg(pr_arg)?;
+        let number = parsed.number();
+        let workdir = resolve_pr_workdir(&parsed)?;
         let pr_info = fetch_pr_info(pr_arg.trim())?;
-        let head_sha = fetch_pr_head(number)?;
+        let head_sha = fetch_pr_head(number, workdir.as_deref())?;
         if head_sha != pr_info.head_ref_oid {
             anyhow::bail!(
                 "fetched PR #{number} head ({head_sha}) does not match `gh`'s reported head \
                  ({expected}); this usually means the PR belongs to a different repository than \
-                 this clone's `origin` remote, or the PR was updated between resolving it and \
-                 fetching it — verify `origin` points at the PR's repository and re-run",
+                 the target clone's `origin` remote, or the PR was updated between resolving it \
+                 and fetching it — verify `origin` points at the PR's repository and re-run",
                 expected = pr_info.head_ref_oid,
             );
         }
-        let base_sha = fetch_branch_head(&pr_info.base_ref_name)?;
-        run_base_pipeline(&cli, &base_sha, &head_sha)?
+        let base_sha = fetch_branch_head(&pr_info.base_ref_name, workdir.as_deref())?;
+        run_base_pipeline(&cli, &base_sha, &head_sha, workdir.as_deref())?
     } else if let Some(base) = &cli.base {
-        run_base_pipeline(&cli, base, &cli.head)?
+        run_base_pipeline(&cli, base, &cli.head, None)?
     } else {
         let diff_text = read_stdin_diff()?;
         if diff_text.trim().is_empty() {
@@ -173,6 +182,56 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Determines which repository `--pr` mode should run its `git` commands
+/// in (ADR 0005), and clones one into the cache if needed.
+///
+/// `PrArg::Number` always uses the process's current directory (`None`,
+/// meaning "no override" to the `cwd` parameters downstream) — a bare
+/// number carries no repository information, so ADR 0004's "run inside a
+/// local clone" requirement is unchanged for it.
+///
+/// `PrArg::Url` first checks whether the current directory is already a
+/// clone of that repository (`git remote get-url origin` matching
+/// `owner`/`repo`, case-insensitively via `github_remote_matches`); if so
+/// it also returns `None`, reusing the cwd exactly like `PrArg::Number`
+/// does today. Otherwise it resolves the per-repository cache directory
+/// (`cache_repo_dir`, reading the real environment here at the boundary)
+/// and clones into it if it doesn't exist yet — an existing cache entry
+/// is left alone here and refreshed by the `git fetch` calls `main` makes
+/// afterwards, not re-cloned.
+fn resolve_pr_workdir(parsed: &PrArg) -> anyhow::Result<Option<std::path::PathBuf>> {
+    let PrArg::Url { owner, repo, .. } = parsed else {
+        return Ok(None);
+    };
+
+    if let Some(origin) = git_remote_origin_url(None)?
+        && github_remote_matches(&origin, owner, repo)
+    {
+        return Ok(None);
+    }
+
+    let dir = cache_repo_dir(
+        std::env::var("RINKAKU_CACHE_DIR").ok().as_deref(),
+        std::env::var("XDG_CACHE_HOME").ok().as_deref(),
+        std::env::var("HOME").ok().as_deref(),
+        owner,
+        repo,
+    )?;
+    if !dir.exists() {
+        // Create the parent (`.../repos/github.com/<owner>/`) only, not
+        // `dir` itself: `gh repo clone` (like `git clone`) creates its
+        // destination directory and fails if it already exists.
+        std::fs::create_dir_all(dir.parent().unwrap_or(&dir)).map_err(|source| {
+            anyhow::anyhow!(
+                "failed to create cache directory for {}: {source}",
+                dir.display()
+            )
+        })?;
+        clone_repo_into_cache(owner, repo, &dir)?;
+    }
+    Ok(Some(dir))
+}
+
 /// Runs `git diff <base>...<head>` and analyzes the result, reading file
 /// content via `git show <head>:<path>` (ADR: keeps the diff and file
 /// reads pinned to the same commit regardless of the working tree's
@@ -180,17 +239,23 @@ fn main() -> anyhow::Result<()> {
 /// user passed) and `--pr` mode (`base`/`head` are the SHAs resolved and
 /// fetched from the PR, see ADR 0004) — `--pr` is a resolution step in
 /// front of this same pipeline, not a separate read strategy.
+///
+/// `cwd` selects which repository every subprocess in this call runs in
+/// (same rationale as `read_git_show_file`'s `cwd`: `None` uses the
+/// process's current directory for `--base` and cwd-clone `--pr` runs,
+/// `Some(dir)` targets a cache clone (ADR 0005) or a test fixture).
 fn run_base_pipeline(
     cli: &Cli,
     base: &str,
     head: &str,
+    cwd: Option<&std::path::Path>,
 ) -> anyhow::Result<rinkaku_core::render::Report> {
-    let diff_text = run_git_diff(base, head)?;
+    let diff_text = run_git_diff(base, head, cwd)?;
     let read_file = {
         let head = head.to_string();
-        move |path: &str| read_git_show_file(None, &head, path)
+        move |path: &str| read_git_show_file(cwd, &head, path)
     };
-    let resolver = build_resolver(cli, &diff_text, &read_file, Some(head), None)?;
+    let resolver = build_resolver(cli, &diff_text, &read_file, Some(head), cwd)?;
     Ok(analyze_diff(
         &diff_text,
         read_file,
@@ -326,11 +391,18 @@ fn read_stdin_diff() -> anyhow::Result<String> {
 }
 
 /// Runs `git diff <base>...<head>` and returns its stdout.
-fn run_git_diff(base: &str, head: &str) -> anyhow::Result<String> {
+///
+/// `cwd` selects the repository to run `git` in; `None` uses the process's
+/// current directory (production `--base`/cwd-clone `--pr` callers),
+/// `Some(dir)` pins it (cache clones, tests).
+fn run_git_diff(base: &str, head: &str, cwd: Option<&std::path::Path>) -> anyhow::Result<String> {
     let range = format!("{base}...{head}");
-    let output = std::process::Command::new("git")
-        .args(["diff", &range])
-        .output()?;
+    let mut command = std::process::Command::new("git");
+    command.args(["diff", &range]);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let output = command.output()?;
     if !output.status.success() {
         anyhow::bail!(
             "git diff {range} failed: {}",
@@ -354,37 +426,155 @@ struct PrInfo {
     head_ref_oid: String,
 }
 
-/// Extracts a PR number from `--pr`'s value: either a bare number
-/// (`"76"`) or a GitHub PR URL
+/// A validated `--pr` argument. `Url` carries `owner`/`repo` (not just the
+/// PR number) so callers can decide, per ADR 0005, whether the current
+/// directory's clone matches the PR's repository or a cache clone is
+/// needed — information a bare `Number` inherently cannot provide, which
+/// is exactly why `Number` still requires running inside a local clone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PrArg {
+    Number(u64),
+    Url {
+        owner: String,
+        repo: String,
+        number: u64,
+    },
+}
+
+impl PrArg {
+    /// The PR number, regardless of which variant this is. Used to build
+    /// the `refs/pull/<number>/head` fetch refspec, which only needs the
+    /// number even for `Url`.
+    fn number(&self) -> u64 {
+        match self {
+            PrArg::Number(number) => *number,
+            PrArg::Url { number, .. } => *number,
+        }
+    }
+}
+
+/// Extracts a validated `--pr` argument: either a bare number (`"76"`) or
+/// a GitHub PR URL
 /// (`https://github.com/<owner>/<repo>/pull/<number>`, tolerating a
 /// trailing slash or extra path segments like `/files`).
 ///
 /// `0` is rejected even though it parses as a `u64`: GitHub PR numbers
 /// are 1-indexed, so `0` can only be a typo, and failing fast here beats
 /// a confusing `gh pr view 0` error downstream.
-fn parse_pr_arg(value: &str) -> anyhow::Result<u64> {
-    let candidate = match value.trim().strip_prefix("https://github.com/") {
+fn parse_pr_arg(value: &str) -> anyhow::Result<PrArg> {
+    match value.trim().strip_prefix("https://github.com/") {
         Some(rest) => {
             // Expect `<owner>/<repo>/pull/<number>[/...]`.
             let segments: Vec<&str> = rest.split('/').filter(|s| !s.is_empty()).collect();
             match segments.as_slice() {
-                [_owner, _repo, "pull", number, ..] => *number,
+                [owner, repo, "pull", number, ..] => Ok(PrArg::Url {
+                    owner: owner.to_string(),
+                    repo: repo.to_string(),
+                    number: parse_positive_pr_number(number, value)?,
+                }),
                 _ => anyhow::bail!(
                     "--pr URL must look like https://github.com/<owner>/<repo>/pull/<number>, \
                      got: {value}"
                 ),
             }
         }
-        None => value.trim(),
-    };
+        None => Ok(PrArg::Number(parse_positive_pr_number(
+            value.trim(),
+            value,
+        )?)),
+    }
+}
 
+/// Parses `candidate` as a positive `u64` PR number, reporting errors
+/// against the original (untrimmed/un-extracted) `--pr` value so the user
+/// sees what they actually typed.
+fn parse_positive_pr_number(candidate: &str, original_value: &str) -> anyhow::Result<u64> {
     let number: u64 = candidate.parse().map_err(|_| {
-        anyhow::anyhow!("--pr must be a PR number or a GitHub PR URL, got: {value}")
+        anyhow::anyhow!("--pr must be a PR number or a GitHub PR URL, got: {original_value}")
     })?;
     if number == 0 {
-        anyhow::bail!("--pr must be a positive PR number, got: {value}");
+        anyhow::bail!("--pr must be a positive PR number, got: {original_value}");
     }
     Ok(number)
+}
+
+/// Extracts `(owner, repo)` from a git remote URL, if it points at
+/// GitHub. Accepts the forms `git remote get-url` can return for a GitHub
+/// remote: `https://github.com/<owner>/<repo>`, the same with a `.git`
+/// suffix, the scp-like SSH form `git@github.com:<owner>/<repo>(.git)`,
+/// and the explicit `ssh://` form `ssh://git@github.com/<owner>/<repo>
+/// (.git)`. Any other host, or a string that doesn't parse as one of
+/// these forms, yields `None` — used by `main` to decide whether the
+/// current directory's `origin` matches a `--pr` URL's repository (ADR
+/// 0005), where "not GitHub" and "malformed" are both simply "no match".
+fn parse_github_remote(url: &str) -> Option<(String, String)> {
+    let url = url.trim();
+    let rest = url
+        .strip_prefix("https://github.com/")
+        .or_else(|| url.strip_prefix("ssh://git@github.com/"))
+        .or_else(|| url.strip_prefix("git@github.com:"))?;
+    let rest = rest.strip_suffix(".git").unwrap_or(rest);
+
+    let segments: Vec<&str> = rest.split('/').filter(|s| !s.is_empty()).collect();
+    match segments.as_slice() {
+        [owner, repo] => Some((owner.to_string(), repo.to_string())),
+        _ => None,
+    }
+}
+
+/// Whether `remote_url` (as returned by `git remote get-url origin`)
+/// points at the same GitHub repository as `owner`/`repo`. GitHub
+/// owner/repo names are case-insensitive, so the comparison is too — a
+/// clone whose `origin` is `.../Octocat/Hello-World` must still be
+/// recognized as matching a `--pr` URL spelled `.../octocat/hello-world`.
+/// A `remote_url` that isn't a GitHub remote at all (`parse_github_remote`
+/// returns `None`) never matches.
+fn github_remote_matches(remote_url: &str, owner: &str, repo: &str) -> bool {
+    match parse_github_remote(remote_url) {
+        Some((remote_owner, remote_repo)) => {
+            remote_owner.eq_ignore_ascii_case(owner) && remote_repo.eq_ignore_ascii_case(repo)
+        }
+        None => false,
+    }
+}
+
+/// Resolves the root cache directory for `--pr` URL auto-clones (ADR
+/// 0005), then the per-repository clone path under it.
+///
+/// Precedence for the root, evaluated in order: `rinkaku_cache_dir`
+/// (`$RINKAKU_CACHE_DIR`) if set, else `<xdg_cache_home>/rinkaku`
+/// (`$XDG_CACHE_HOME/rinkaku`) if set, else `<home>/.cache/rinkaku`. An
+/// error if none of the three inputs is available — there is then no
+/// sane place to put the cache. All three are taken as arguments rather
+/// than read from the environment here, so this stays a pure function the
+/// precedence order can be unit-tested against directly; `main` is the
+/// only place that reads the actual environment.
+///
+/// Repo layout under the root: `repos/github.com/<owner>/<repo>`, so
+/// different git hosts (a future extension) could share one cache root
+/// without path collisions, and so the cache directory's own contents
+/// read as self-explanatory if a user goes looking (`~/.cache/rinkaku/
+/// repos/github.com/octocat/hello-world`).
+fn cache_repo_dir(
+    rinkaku_cache_dir: Option<&str>,
+    xdg_cache_home: Option<&str>,
+    home: Option<&str>,
+    owner: &str,
+    repo: &str,
+) -> anyhow::Result<std::path::PathBuf> {
+    let root = if let Some(dir) = rinkaku_cache_dir {
+        std::path::PathBuf::from(dir)
+    } else if let Some(dir) = xdg_cache_home {
+        std::path::PathBuf::from(dir).join("rinkaku")
+    } else if let Some(dir) = home {
+        std::path::PathBuf::from(dir).join(".cache").join("rinkaku")
+    } else {
+        anyhow::bail!(
+            "cannot determine a cache directory for --pr: set $RINKAKU_CACHE_DIR, \
+             $XDG_CACHE_HOME, or $HOME"
+        );
+    };
+    Ok(root.join("repos").join("github.com").join(owner).join(repo))
 }
 
 /// Parses `gh pr view --json number,baseRefName,headRefOid`'s stdout.
@@ -423,27 +613,37 @@ fn fetch_pr_info(arg: &str) -> anyhow::Result<PrInfo> {
     parse_pr_view_json(&String::from_utf8(output.stdout)?)
 }
 
-/// Fetches PR `number`'s head ref into the local clone and returns the
-/// fetched commit's SHA, via `git fetch origin refs/pull/<number>/head`
-/// followed by `git rev-parse FETCH_HEAD`.
-fn fetch_pr_head(number: u64) -> anyhow::Result<String> {
-    run_git_fetch(&format!("refs/pull/{number}/head"))
+/// Fetches PR `number`'s head ref into the repository at `cwd` and
+/// returns the fetched commit's SHA, via
+/// `git fetch origin refs/pull/<number>/head` followed by
+/// `git rev-parse FETCH_HEAD`.
+fn fetch_pr_head(number: u64, cwd: Option<&std::path::Path>) -> anyhow::Result<String> {
+    run_git_fetch(&format!("refs/pull/{number}/head"), cwd)
 }
 
-/// Fetches branch `name` into the local clone and returns the fetched
-/// commit's SHA. Used to resolve `--pr` mode's base commit from the base
-/// branch name `gh pr view` reports.
-fn fetch_branch_head(name: &str) -> anyhow::Result<String> {
-    run_git_fetch(name)
+/// Fetches branch `name` into the repository at `cwd` and returns the
+/// fetched commit's SHA. Used to resolve `--pr` mode's base commit from
+/// the base branch name `gh pr view` reports.
+fn fetch_branch_head(name: &str, cwd: Option<&std::path::Path>) -> anyhow::Result<String> {
+    run_git_fetch(name, cwd)
 }
 
-/// Runs `git fetch origin <refspec>` then `git rev-parse FETCH_HEAD`,
-/// returning the resulting SHA. Shared by `fetch_pr_head` and
-/// `fetch_branch_head`, which differ only in what refspec they fetch.
-fn run_git_fetch(refspec: &str) -> anyhow::Result<String> {
-    let fetch_output = std::process::Command::new("git")
-        .args(["fetch", "origin", refspec])
-        .output()?;
+/// Runs `git fetch origin <refspec>` then `git rev-parse FETCH_HEAD` in
+/// the repository at `cwd`, returning the resulting SHA. Shared by
+/// `fetch_pr_head` and `fetch_branch_head`, which differ only in what
+/// refspec they fetch.
+///
+/// `cwd` selects the repository to run `git` in; `None` uses the
+/// process's current directory (production cwd-clone callers),
+/// `Some(dir)` pins it (cache clones, tests) — same rationale as
+/// `read_git_show_file`'s `cwd`.
+fn run_git_fetch(refspec: &str, cwd: Option<&std::path::Path>) -> anyhow::Result<String> {
+    let mut fetch_command = std::process::Command::new("git");
+    fetch_command.args(["fetch", "origin", refspec]);
+    if let Some(cwd) = cwd {
+        fetch_command.current_dir(cwd);
+    }
+    let fetch_output = fetch_command.output()?;
     if !fetch_output.status.success() {
         anyhow::bail!(
             "git fetch origin {refspec} failed: {}",
@@ -451,9 +651,12 @@ fn run_git_fetch(refspec: &str) -> anyhow::Result<String> {
         );
     }
 
-    let rev_parse_output = std::process::Command::new("git")
-        .args(["rev-parse", "FETCH_HEAD"])
-        .output()?;
+    let mut rev_parse_command = std::process::Command::new("git");
+    rev_parse_command.args(["rev-parse", "FETCH_HEAD"]);
+    if let Some(cwd) = cwd {
+        rev_parse_command.current_dir(cwd);
+    }
+    let rev_parse_output = rev_parse_command.output()?;
     if !rev_parse_output.status.success() {
         anyhow::bail!(
             "git rev-parse FETCH_HEAD failed after fetching {refspec}: {}",
@@ -463,6 +666,52 @@ fn run_git_fetch(refspec: &str) -> anyhow::Result<String> {
     Ok(String::from_utf8(rev_parse_output.stdout)?
         .trim()
         .to_string())
+}
+
+/// Runs `git remote get-url origin` in `cwd` (or the process's current
+/// directory when `None`) and returns its stdout, trimmed. `Ok(None)`
+/// (rather than an `Err`) when the command fails — not being inside a git
+/// repository, or a repository with no `origin` remote, are both
+/// expected, ordinary situations for `--pr` URL mode (ADR 0005): they
+/// simply mean "the current directory doesn't match, use the cache"
+/// rather than a fatal error worth surfacing to the user.
+fn git_remote_origin_url(cwd: Option<&std::path::Path>) -> anyhow::Result<Option<String>> {
+    let mut command = std::process::Command::new("git");
+    command.args(["remote", "get-url", "origin"]);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let output = command.output()?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    Ok(Some(String::from_utf8(output.stdout)?.trim().to_string()))
+}
+
+/// Clones `owner/repo` as a blobless partial clone (`--filter=blob:none`,
+/// ADR 0005) into `dir` via `gh repo clone`, delegating authentication to
+/// `gh` (ADR 0004's stance, applied to cloning too). Only called when
+/// `dir` does not already exist — an existing cache entry is refreshed by
+/// the ordinary `git fetch` calls in `main` instead of being re-cloned.
+fn clone_repo_into_cache(owner: &str, repo: &str, dir: &std::path::Path) -> anyhow::Result<()> {
+    let slug = format!("{owner}/{repo}");
+    let output = std::process::Command::new("gh")
+        .args([
+            "repo",
+            "clone",
+            &slug,
+            &dir.to_string_lossy(),
+            "--",
+            "--filter=blob:none",
+        ])
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "gh repo clone {slug} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
 }
 
 /// Reads a changed file's new-side content off the working tree.
@@ -686,19 +935,34 @@ mod tests {
     }
 
     #[rstest]
-    #[case::should_parse_bare_number("76", 76)]
-    #[case::should_parse_number_with_surrounding_whitespace(" 76 ", 76)]
-    #[case::should_parse_pull_url("https://github.com/octocat/hello-world/pull/123", 123)]
+    #[case::should_parse_bare_number("76", PrArg::Number(76))]
+    #[case::should_parse_number_with_surrounding_whitespace(" 76 ", PrArg::Number(76))]
+    #[case::should_parse_pull_url(
+        "https://github.com/octocat/hello-world/pull/123",
+        PrArg::Url {
+            owner: "octocat".to_string(),
+            repo: "hello-world".to_string(),
+            number: 123,
+        }
+    )]
     #[case::should_parse_pull_url_with_trailing_slash(
         "https://github.com/octocat/hello-world/pull/123/",
-        123
+        PrArg::Url {
+            owner: "octocat".to_string(),
+            repo: "hello-world".to_string(),
+            number: 123,
+        }
     )]
     #[case::should_parse_pull_url_with_extra_path_segment(
         "https://github.com/octocat/hello-world/pull/123/files",
-        123
+        PrArg::Url {
+            owner: "octocat".to_string(),
+            repo: "hello-world".to_string(),
+            number: 123,
+        }
     )]
-    fn should_parse_pr_arg_when_input_is_valid(#[case] input: &str, #[case] expected: u64) {
-        let actual = parse_pr_arg(input).expect("expected a valid PR number");
+    fn should_parse_pr_arg_when_input_is_valid(#[case] input: &str, #[case] expected: PrArg) {
+        let actual = parse_pr_arg(input).expect("expected a valid PR arg");
 
         assert_eq!(expected, actual);
     }
@@ -715,6 +979,134 @@ mod tests {
         let actual = parse_pr_arg(input);
 
         assert!(actual.is_err(), "expected an error for input: {input}");
+    }
+
+    #[rstest]
+    #[case::should_parse_https_url(
+        "https://github.com/octocat/hello-world",
+        Some(("octocat".to_string(), "hello-world".to_string()))
+    )]
+    #[case::should_parse_https_url_with_dot_git_suffix(
+        "https://github.com/octocat/hello-world.git",
+        Some(("octocat".to_string(), "hello-world".to_string()))
+    )]
+    #[case::should_parse_scp_like_ssh_url(
+        "git@github.com:octocat/hello-world.git",
+        Some(("octocat".to_string(), "hello-world".to_string()))
+    )]
+    #[case::should_parse_scp_like_ssh_url_without_dot_git_suffix(
+        "git@github.com:octocat/hello-world",
+        Some(("octocat".to_string(), "hello-world".to_string()))
+    )]
+    #[case::should_parse_explicit_ssh_url(
+        "ssh://git@github.com/octocat/hello-world.git",
+        Some(("octocat".to_string(), "hello-world".to_string()))
+    )]
+    #[case::should_parse_explicit_ssh_url_without_dot_git_suffix(
+        "ssh://git@github.com/octocat/hello-world",
+        Some(("octocat".to_string(), "hello-world".to_string()))
+    )]
+    #[case::should_trim_surrounding_whitespace(
+        " https://github.com/octocat/hello-world.git \n",
+        Some(("octocat".to_string(), "hello-world".to_string()))
+    )]
+    #[case::should_reject_non_github_host("https://gitlab.com/octocat/hello-world.git", None)]
+    #[case::should_reject_url_missing_repo_segment("https://github.com/octocat", None)]
+    #[case::should_reject_url_with_extra_path_segment(
+        "https://github.com/octocat/hello-world/extra",
+        None
+    )]
+    #[case::should_reject_empty_string("", None)]
+    fn should_parse_github_remote(#[case] url: &str, #[case] expected: Option<(String, String)>) {
+        let actual = parse_github_remote(url);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[rstest]
+    #[case::should_match_identical_owner_and_repo(
+        "https://github.com/octocat/hello-world.git",
+        "octocat",
+        "hello-world",
+        true
+    )]
+    #[case::should_match_case_insensitively(
+        "https://github.com/Octocat/Hello-World.git",
+        "octocat",
+        "hello-world",
+        true
+    )]
+    #[case::should_not_match_different_repo(
+        "https://github.com/octocat/hello-world.git",
+        "octocat",
+        "other-repo",
+        false
+    )]
+    #[case::should_not_match_different_owner(
+        "https://github.com/octocat/hello-world.git",
+        "someone-else",
+        "hello-world",
+        false
+    )]
+    #[case::should_not_match_non_github_remote(
+        "https://gitlab.com/octocat/hello-world.git",
+        "octocat",
+        "hello-world",
+        false
+    )]
+    fn should_check_github_remote_match(
+        #[case] remote_url: &str,
+        #[case] owner: &str,
+        #[case] repo: &str,
+        #[case] expected: bool,
+    ) {
+        let actual = github_remote_matches(remote_url, owner, repo);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[rstest]
+    #[case::should_prefer_rinkaku_cache_dir_when_set(
+        Some("/custom/cache"),
+        Some("/xdg/cache"),
+        Some("/home/user"),
+        "/custom/cache/repos/github.com/octocat/hello-world"
+    )]
+    #[case::should_fall_back_to_xdg_cache_home_when_rinkaku_cache_dir_unset(
+        None,
+        Some("/xdg/cache"),
+        Some("/home/user"),
+        "/xdg/cache/rinkaku/repos/github.com/octocat/hello-world"
+    )]
+    #[case::should_fall_back_to_home_when_neither_env_var_set(
+        None,
+        None,
+        Some("/home/user"),
+        "/home/user/.cache/rinkaku/repos/github.com/octocat/hello-world"
+    )]
+    fn should_build_cache_repo_dir(
+        #[case] rinkaku_cache_dir: Option<&str>,
+        #[case] xdg_cache_home: Option<&str>,
+        #[case] home: Option<&str>,
+        #[case] expected: &str,
+    ) {
+        let actual = cache_repo_dir(
+            rinkaku_cache_dir,
+            xdg_cache_home,
+            home,
+            "octocat",
+            "hello-world",
+        )
+        .expect("expected a cache directory to be resolved");
+
+        assert_eq!(std::path::PathBuf::from(expected), actual);
+    }
+
+    #[test]
+    fn should_fail_to_build_cache_repo_dir_when_no_env_source_is_available() {
+        let actual = cache_repo_dir(None, None, None, "octocat", "hello-world");
+
+        assert!(actual.is_err());
     }
 
     #[test]
@@ -793,6 +1185,64 @@ mod tests {
             .expect("git show should succeed for a committed file");
 
         assert_eq!(committed, actual);
+    }
+
+    // Integration test for `--pr` URL mode's cwd-vs-cache decision (ADR
+    // 0005): a real repository with an `origin` remote set must have that
+    // URL surfaced by `git_remote_origin_url` so `github_remote_matches`
+    // (already unit-tested above against arbitrary strings) can decide
+    // whether to reuse the cwd. Exercises the subprocess wrapper itself
+    // rather than `github_remote_matches`'s string logic, which is
+    // already covered directly.
+    #[test]
+    fn should_return_origin_url_when_repository_has_an_origin_remote() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        init_repo_with_committed_file(dir.path(), "fn foo() {}\n");
+        run_git(
+            dir.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/octocat/hello-world.git",
+            ],
+        );
+
+        let actual =
+            git_remote_origin_url(Some(dir.path())).expect("git remote get-url should not error");
+
+        assert_eq!(
+            Some("https://github.com/octocat/hello-world.git".to_string()),
+            actual
+        );
+    }
+
+    // Sibling case: a repository with no `origin` remote at all (rather
+    // than a missing/misconfigured one) must come back as `Ok(None)`, not
+    // an `Err` — ADR 0005 treats "doesn't match" and "isn't even a clone"
+    // identically as "use the cache", so this must not be a fatal error.
+    #[test]
+    fn should_return_none_when_repository_has_no_origin_remote() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        init_repo_with_committed_file(dir.path(), "fn foo() {}\n");
+
+        let actual = git_remote_origin_url(Some(dir.path()))
+            .expect("missing origin remote should not error");
+
+        assert_eq!(None, actual);
+    }
+
+    // Sibling case: a directory that isn't a git repository at all must
+    // also come back as `Ok(None)`, matching the "run outside any clone"
+    // scenario ADR 0005's cache path exists to handle.
+    #[test]
+    fn should_return_none_when_directory_is_not_a_git_repository() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+
+        let actual = git_remote_origin_url(Some(dir.path()))
+            .expect("a non-repository directory should not error");
+
+        assert_eq!(None, actual);
     }
 
     // Regression test for the must-fix performance bug: `build_resolver`


### PR DESCRIPTION
## Why

`--pr` (ADR 0004) required running inside a local clone of the target repository, even though a PR URL carries everything needed to identify the repository. This made the tool's primary use case — reviewing a PR — fail from any other directory. See [ADR 0005](docs/adr/0005-auto-clone-into-cache-for-pr-urls.md) for the decision and rejected alternatives (GitHub HTTP API, shallow clones).

## What

- `--pr <URL>` now works from any directory: when the cwd is not a clone of the URL's repository (origin mismatch or not a git repo), rinkaku clones it as a blobless partial clone (`--filter=blob:none`, full DAG so `git diff base...head` merge-bases stay correct) into `$RINKAKU_CACHE_DIR` / `$XDG_CACHE_HOME/rinkaku` / `~/.cache/rinkaku` via `gh repo clone`, and runs the existing pipeline there; existing cache entries are refreshed by the ordinary fetches
- Bare PR numbers keep requiring a local clone (a number carries no repository information); a URL matching the cwd's origin keeps using the cwd unchanged
- `parse_pr_arg` now returns a `PrArg` enum capturing owner/repo for URLs; new pure helpers `parse_github_remote` (https/scp-like/ssh remote forms), `github_remote_matches` (case-insensitive), and `cache_repo_dir` (env values injected as arguments) — all rstest-covered
- Also ships [ADR 0006](docs/adr/0006-prefer-ghq-managed-clones-over-cache.md) (accepted, implementation to follow in a separate PR): prefer existing ghq-managed clones over the cache to limit cache growth

## QA

- `make test` (66 bin + 146 core, 23 new tests) and `make lint` pass
- E2E from an empty directory: `rinkaku --pr <URL>` auto-cloned this repository into the cache and produced the report (~13s first run including clone; ~18s second run with `--deps 1` over lazy blobs; cache reused, no re-clone)
- E2E inside the clone with an unusable `$RINKAKU_CACHE_DIR`: succeeds, proving the cwd-match path never touches the cache
- Unwritable cache root fails with a contextual error naming the cache path