### PR TITLE
chore: slow down version bumps while pre-1.0

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -4,6 +4,8 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "separate-pull-requests": true,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
## Summary

Every `feat:` commit currently bumps the minor version, which moves 0.x versions faster than the project's actual API maturity. This PR adds release-please's pre-major bump options so version bumps stay conservative until 1.0.0.

## Changes

Added to `.github/release-please/config.json`:

- `bump-minor-pre-major: true` — breaking changes bump **minor** instead of major while <1.0.0
- `bump-patch-for-minor-pre-major: true` — `feat:` commits bump **patch** instead of minor while <1.0.0

## Behavior change (while <1.0.0)

| Commit | Before | After |
|---|---|---|
| `feat:` | minor (0.5.0) | patch (0.4.1) |
| `fix:` | patch | patch |
| `feat!:` / `BREAKING CHANGE` | major | minor (0.5.0) |

Once the project reaches 1.0.0, standard semver behavior resumes automatically. No workflow changes needed — the cargo-workspace plugin and CHANGELOG generation are unaffected.