### PR TITLE
fix: base --pr diffs on baseRefOid so merged PRs produce output

### DIFF
--- a/docs/adr/0007-base-pr-diffs-on-baserefoid.md
+++ b/docs/adr/0007-base-pr-diffs-on-baserefoid.md
@@ -47,15 +47,23 @@ particular, ADR 0005/0006, may not have fetched recently):
    branch has been fetched at all.
 2. If not, fetch the base branch by name (as before) and re-check —
    `baseRefOid` is normally reachable from the base branch's history, so
-   an ordinary branch fetch usually retrieves it.
+   an ordinary branch fetch usually retrieves it. A failure at this step
+   (the base branch itself was renamed or deleted after the PR merged) is
+   treated as soft: log a warning and fall through to step 3 rather than
+   aborting, since step 3 is exactly the recovery path for a base branch
+   that no longer leads to the commit.
 3. If still not found (e.g. the base branch was force-pushed past that
-   commit, or deleted after merge), fetch the oid directly
-   (`git fetch origin <oid>`) — works against GitHub as long as the
-   commit hasn't been actually garbage-collected server-side.
-4. If that also fails, fall back to the fetched base branch tip (today's
-   behavior) and print a `log::warn!` — better a possibly-wrong-for-merged-
-   PRs diff with a warning than a hard failure, since this only degrades
-   back to the pre-fix behavior rather than introducing a new failure mode.
+   commit, deleted after merge, or step 2 itself failed to fetch),
+   fetch the oid directly (`git fetch origin <oid>`) — works against
+   GitHub as long as the commit hasn't been actually garbage-collected
+   server-side.
+4. If that also fails, fall back to the base branch's tip (today's
+   pre-ADR-0007 behavior) and print a `log::warn!` — better a
+   possibly-wrong-for-merged-PRs diff with a warning than a hard failure,
+   since this only degrades back to the pre-fix behavior rather than
+   introducing a new failure mode. Reuses step 2's fetched tip when step 2
+   succeeded, rather than fetching the base branch a second time; only
+   fetches again here if step 2 itself failed.
 
 ## Alternatives
 

--- a/docs/adr/0007-base-pr-diffs-on-baserefoid.md
+++ b/docs/adr/0007-base-pr-diffs-on-baserefoid.md
@@ -1,0 +1,85 @@
+# 0007. Base `--pr` diffs on `baseRefOid` instead of the fetched branch tip
+
+- Status: accepted
+- Date: 2026-07-12
+
+## Context
+
+`--pr` mode (ADR 0004) resolves the PR's base branch name via `gh pr view`,
+fetches that branch's current tip with `git fetch`, and runs
+`git diff <fetched-base-tip>...<head>` through the same pipeline as
+`--base` mode. This works for an open PR, whose base branch tip has not
+advanced past what the PR was opened against in any way that matters for
+a triple-dot diff. For a **merged** PR, however, the base branch tip has
+by definition advanced to include the PR's own commits (the merge itself),
+so the PR's head is now an ancestor of the base branch tip. A triple-dot
+diff against an ancestor produces an empty diff — `git diff` succeeds and
+prints nothing, `analyze_diff` returns an empty `Report`, `render` returns
+an empty string, and rinkaku exits 0 having silently done nothing. There is
+also no diagnostic today in this code path (see the companion fix that adds
+one), which makes the silence particularly confusing: the command runs
+successfully and produces no output for what looks like a normal review
+request.
+
+## Decision
+
+Resolve `--pr` mode's diff base from the PR's `baseRefOid` — the base
+branch's tip *at the time `gh pr view` reports it* — instead of fetching
+the base branch by name and using whatever its tip happens to be right
+now. `gh pr view --json ...,baseRefOid` already reports this alongside the
+existing `baseRefName`/`headRefOid` fields, so this is an additive field on
+the same API call, not a new one.
+
+For an open PR, `baseRefOid` and the base branch's current tip are the
+same commit (nothing has landed on top since the PR was opened), so this
+is behavior-preserving for the common case. For a merged PR, `baseRefOid`
+stays pinned to the commit the PR was actually diffed against at merge
+time, so `git diff <baseRefOid>...<head>` reproduces the original PR diff
+regardless of how far the base branch has moved since.
+
+Getting the commit object for `baseRefOid` locally follows a small
+availability cascade, since a commit reachable today from the base branch
+tip may not yet be reachable from a stale local clone (a cache clone in
+particular, ADR 0005/0006, may not have fetched recently):
+
+1. Check whether the object already exists locally
+   (`git cat-file -e <oid>^{commit}`) — the common case once the base
+   branch has been fetched at all.
+2. If not, fetch the base branch by name (as before) and re-check —
+   `baseRefOid` is normally reachable from the base branch's history, so
+   an ordinary branch fetch usually retrieves it.
+3. If still not found (e.g. the base branch was force-pushed past that
+   commit, or deleted after merge), fetch the oid directly
+   (`git fetch origin <oid>`) — works against GitHub as long as the
+   commit hasn't been actually garbage-collected server-side.
+4. If that also fails, fall back to the fetched base branch tip (today's
+   behavior) and print a `log::warn!` — better a possibly-wrong-for-merged-
+   PRs diff with a warning than a hard failure, since this only degrades
+   back to the pre-fix behavior rather than introducing a new failure mode.
+
+## Alternatives
+
+- **Diff against the merge commit's first parent**: only meaningful once
+  a PR is known to be merged, which means branching the `--pr` code path
+  on PR state and handling rebase-merges (where there is no single merge
+  commit) as a separate case. Rejected for the extra branching and
+  ambiguity; `baseRefOid` covers both open and merged PRs uniformly
+  through the same field and the same diff command.
+- **Use `gh pr diff` output directly instead of local `git diff`**: would
+  need a separate parse path and loses the property ADR 0004 established —
+  that the diff and the `git show`-based file reads (both for changed
+  files and for the dependency index) are pinned to commits verified to
+  exist in the local clone, not merely trusted from `gh`'s own diff
+  rendering.
+
+## Consequences
+
+- `rinkaku --pr <url>` on a merged PR now reproduces the original PR diff
+  instead of silently producing nothing.
+- Open-PR behavior is unchanged: `baseRefOid` equals the base branch's
+  current tip in the common case.
+- `--pr` mode gains an availability cascade with a fetch-the-oid-directly
+  step and a warn-and-fall-back last resort, both new failure/degradation
+  modes worth knowing about when debugging an unexpected diff base.
+- `PrInfo` grows a `base_ref_oid` field; `fetch_branch_head` (still used
+  for the fallback step) is unchanged.

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -282,6 +282,17 @@ fn resolve_pr_workdir(parsed: &PrArg) -> anyhow::Result<Option<std::path::PathBu
 /// fetched from the PR, see ADR 0004) — `--pr` is a resolution step in
 /// front of this same pipeline, not a separate read strategy.
 ///
+/// An empty (or whitespace-only) diff — most commonly a `--base`/`--pr`
+/// range with no actual changes, e.g. `base == head` — returns the empty
+/// `Report` immediately, printing the same "diff is empty" note the stdin
+/// path prints, and **without calling `build_resolver`**: indexing every
+/// tracked file for dependency resolution is pointless work when there is
+/// nothing to resolve dependencies for, and on a large repository it is
+/// also the single slowest part of a run (one `git show`/`cat-file` per
+/// tracked file). A non-empty diff that nonetheless yields zero entries
+/// (garbage input) still gets its own note via `garbage_input_note` after
+/// the full pipeline runs, same as stdin mode.
+///
 /// `cwd` selects which repository every subprocess in this call runs in
 /// (same rationale as `read_git_show_file`'s `cwd`: `None` uses the
 /// process's current directory for `--base` and cwd-clone `--pr` runs,
@@ -293,18 +304,30 @@ fn run_base_pipeline(
     cwd: Option<&std::path::Path>,
 ) -> anyhow::Result<rinkaku_core::render::Report> {
     let diff_text = run_git_diff(base, head, cwd)?;
+    if diff_text.trim().is_empty() {
+        eprintln!("note: diff is empty, nothing to analyze");
+        return Ok(rinkaku_core::render::Report {
+            files: Vec::new(),
+            skipped: Vec::new(),
+        });
+    }
+
     let read_file = {
         let head = head.to_string();
         move |path: &str| read_git_show_file(cwd, &head, path)
     };
     let resolver = build_resolver(cli, &diff_text, &read_file, Some(head), cwd)?;
-    Ok(analyze_diff(
+    let report = analyze_diff(
         &diff_text,
         read_file,
         resolver
             .as_ref()
             .map(|r| r as &dyn rinkaku_core::deps::Resolver),
-    )?)
+    )?;
+    if let Some(note) = garbage_input_note(&diff_text, &report) {
+        eprintln!("{note}");
+    }
+    Ok(report)
 }
 
 /// Returns a warning note for stdin input that is garbage rather than a
@@ -1740,6 +1763,60 @@ mod tests {
         let actual = build_resolver(&cli, "", read_file, None, Some(dir.path()));
 
         assert!(actual.is_err());
+    }
+
+    // Regression test for the must-fix performance/correctness bug: an
+    // empty diff (base == head, e.g. `--pr` on an already-merged PR before
+    // ADR 0007's fix, or `--base main --head main`) must return the empty
+    // `Report` directly, without ever invoking `build_resolver`'s
+    // repository-wide `git ls-files` scan. Unlike `deps == 0`'s sibling
+    // tests above (which call `build_resolver` directly and can simply
+    // point `cwd` at a non-git directory), `run_base_pipeline` calls
+    // `run_git_diff` unconditionally first — a non-git `cwd` would make
+    // that fail too, before the empty-diff branch is ever reached. So this
+    // test instead uses a real repository (required for `run_git_diff` to
+    // succeed) and revokes read permission on `.git/index` specifically:
+    // `git diff <base>...<head>` (a tree-to-tree comparison between two
+    // commits) never opens the index, but `git ls-files` always does — so
+    // if `build_resolver` were reached, `list_git_files` would fail and
+    // this test would observe `Err` instead of the expected `Ok`.
+    #[test]
+    fn should_skip_repository_scan_when_diff_is_empty() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        init_repo_with_committed_file(dir.path(), "fn foo() {}\n");
+        let index_path = dir.path().join(".git/index");
+        let mut permissions = std::fs::metadata(&index_path)
+            .expect("read .git/index metadata")
+            .permissions();
+        let original_mode = std::os::unix::fs::PermissionsExt::mode(&permissions);
+        std::os::unix::fs::PermissionsExt::set_mode(&mut permissions, 0o000);
+        std::fs::set_permissions(&index_path, permissions).expect("revoke .git/index read access");
+
+        let cli = Cli {
+            command: None,
+            base: None,
+            head: "HEAD".to_string(),
+            pr: None,
+            format: Format::Md,
+            deps: 1,
+        };
+        let actual = run_base_pipeline(&cli, "HEAD", "HEAD", Some(dir.path()));
+
+        // Restore permissions before asserting so a failed assertion
+        // doesn't leave an unreadable file behind for the tempdir cleanup.
+        let mut permissions = std::fs::metadata(&index_path)
+            .expect("re-read .git/index metadata")
+            .permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut permissions, original_mode);
+        std::fs::set_permissions(&index_path, permissions).expect("restore .git/index permissions");
+
+        assert_eq!(
+            rinkaku_core::render::Report {
+                files: Vec::new(),
+                skipped: Vec::new(),
+            },
+            actual.expect("empty diff must not touch the repository-wide index scan")
+        );
     }
 
     mod garbage_input_note_tests {

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -136,7 +136,13 @@ impl From<Format> for OutputFormat {
 }
 
 fn main() -> anyhow::Result<()> {
-    env_logger::init();
+    // Default to `info`-level progress output on stderr (env_logger's own
+    // default is error-only, which meant `--pr`/`--base` runs — the ones
+    // slow enough to want a heartbeat, see the dependency-index build
+    // below — gave no feedback at all while running). `RUST_LOG` still
+    // overrides this, same as any other `env_logger::Builder::from_env`
+    // setup.
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let cli = Cli::parse();
 
     if let Some(Command::SelfUpdate { yes }) = cli.command {
@@ -150,8 +156,11 @@ fn main() -> anyhow::Result<()> {
         let parsed = parse_pr_arg(pr_arg)?;
         let number = parsed.number();
         let workdir = resolve_pr_workdir(&parsed)?;
+        log::info!("resolving PR #{number} via gh");
         let pr_info = fetch_pr_info(pr_arg.trim())?;
-        let head_sha = fetch_pr_head(number, workdir.as_deref())?;
+        let cwd = workdir.as_deref();
+        log::info!("fetching PR #{number} head");
+        let head_sha = fetch_pr_head(number, cwd)?;
         if head_sha != pr_info.head_ref_oid {
             anyhow::bail!(
                 "fetched PR #{number} head ({head_sha}) does not match `gh`'s reported head \
@@ -161,7 +170,7 @@ fn main() -> anyhow::Result<()> {
                 expected = pr_info.head_ref_oid,
             );
         }
-        let cwd = workdir.as_deref();
+        log::info!("resolving PR #{number} base commit");
         let (base_sha, used_fallback) = resolve_pr_base_sha(
             &pr_info.base_ref_oid,
             |oid| object_exists_locally(cwd, oid),
@@ -178,7 +187,7 @@ fn main() -> anyhow::Result<()> {
                 base_branch = pr_info.base_ref_name,
             );
         }
-        run_base_pipeline(&cli, &base_sha, &head_sha, workdir.as_deref())?
+        run_base_pipeline(&cli, &base_sha, &head_sha, cwd)?
     } else if let Some(base) = &cli.base {
         run_base_pipeline(&cli, base, &cli.head, None)?
     } else {
@@ -187,6 +196,7 @@ fn main() -> anyhow::Result<()> {
             eprintln!("note: diff is empty, nothing to analyze");
         }
         let resolver = build_resolver(&cli, &diff_text, read_working_tree_file, None, None)?;
+        log::info!("analyzing diff");
         let report = analyze_diff(
             &diff_text,
             read_working_tree_file,
@@ -241,6 +251,7 @@ fn resolve_pr_workdir(parsed: &PrArg) -> anyhow::Result<Option<std::path::PathBu
     if let Some(origin) = git_remote_origin_url(None)?
         && github_remote_matches(&origin, owner, repo)
     {
+        log::info!("using the current directory as a clone of {owner}/{repo}");
         return Ok(None);
     }
 
@@ -251,6 +262,10 @@ fn resolve_pr_workdir(parsed: &PrArg) -> anyhow::Result<Option<std::path::PathBu
         owner,
         repo,
     ) {
+        log::info!(
+            "using ghq-managed clone of {owner}/{repo} at {}",
+            discovered.display()
+        );
         return Ok(Some(discovered));
     }
 
@@ -271,7 +286,13 @@ fn resolve_pr_workdir(parsed: &PrArg) -> anyhow::Result<Option<std::path::PathBu
                 dir.display()
             )
         })?;
+        log::info!(
+            "cloning {owner}/{repo} into cache at {} (first run against this repository)",
+            dir.display()
+        );
         clone_repo_into_cache(owner, repo, &dir)?;
+    } else {
+        log::info!("using cache clone of {owner}/{repo} at {}", dir.display());
     }
     Ok(Some(dir))
 }
@@ -305,6 +326,7 @@ fn run_base_pipeline(
     head: &str,
     cwd: Option<&std::path::Path>,
 ) -> anyhow::Result<rinkaku_core::render::Report> {
+    log::info!("diffing {base}...{head}");
     let diff_text = run_git_diff(base, head, cwd)?;
     if diff_text.trim().is_empty() {
         eprintln!("note: diff is empty, nothing to analyze");
@@ -319,6 +341,7 @@ fn run_base_pipeline(
         move |path: &str| read_git_show_file(cwd, &head, path)
     };
     let resolver = build_resolver(cli, &diff_text, &read_file, Some(head), cwd)?;
+    log::info!("analyzing diff");
     let report = analyze_diff(
         &diff_text,
         read_file,
@@ -404,6 +427,10 @@ fn build_resolver(
         rinkaku_core::pipeline::collect_referenced_names(diff_text, diff_read_file)?;
 
     let paths = list_git_files(cwd)?;
+    log::info!(
+        "building dependency index over {} tracked files",
+        paths.len()
+    );
     let files: Vec<(String, String)> = match head {
         // One `git cat-file --batch` child process serves every path
         // (see `read_git_show_files_batch`'s doc comment for why this

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -13,20 +13,24 @@
 //!   working tree. This keeps the diff and the file content read from the
 //!   exact same commit by construction, regardless of what the working
 //!   tree currently holds (uncommitted changes, a dirty checkout, etc.).
-//! - `--pr` mode (ADR 0004, ADR 0005, ADR 0006): the PR's base branch and
-//!   head commit are resolved via `gh pr view`, both are fetched with
-//!   `git fetch`, and the resulting base/head SHAs are handed to exactly
-//!   the same `git show`-backed read strategy as `--base` mode — `--pr`
-//!   is a resolution step in front of the `--base` pipeline, not a
-//!   separate read strategy. A bare PR number requires running inside a
-//!   local clone of the target repository. A PR URL also uses the
-//!   current directory when its `origin` matches the URL's repository;
-//!   otherwise it prefers an existing `ghq`-managed clone of the
-//!   repository when one is found (ADR 0006), and only falls back to
-//!   auto-cloning a blobless partial clone into a per-repository cache
-//!   directory (ADR 0005) if neither the cwd nor `ghq` has one — so URL
-//!   input works from any directory either way. `gh` must be installed
-//!   and authenticated either way.
+//! - `--pr` mode (ADR 0004, ADR 0005, ADR 0006, ADR 0007): the PR's base
+//!   branch, base commit (`baseRefOid`), and head commit are resolved via
+//!   `gh pr view`; the head is fetched with `git fetch`, and the base
+//!   commit is resolved via `baseRefOid` rather than the base branch's
+//!   current tip (ADR 0007) — this is what makes `--pr` work on a merged
+//!   PR, whose base branch has since advanced past the PR's own commits.
+//!   The resulting base/head SHAs are handed to exactly the same
+//!   `git show`-backed read strategy as `--base` mode — `--pr` is a
+//!   resolution step in front of the `--base` pipeline, not a separate
+//!   read strategy. A bare PR number requires running inside a local
+//!   clone of the target repository. A PR URL also uses the current
+//!   directory when its `origin` matches the URL's repository; otherwise
+//!   it prefers an existing `ghq`-managed clone of the repository when one
+//!   is found (ADR 0006), and only falls back to auto-cloning a blobless
+//!   partial clone into a per-repository cache directory (ADR 0005) if
+//!   neither the cwd nor `ghq` has one — so URL input works from any
+//!   directory either way. `gh` must be installed and authenticated
+//!   either way.
 //! - stdin mode: the diff's provenance is unknown to rinkaku (it could be
 //!   `gh pr diff`, a saved patch file, anything). Files are read off the
 //!   working tree, under the assumption that **the diff is consistent
@@ -155,7 +159,23 @@ fn main() -> anyhow::Result<()> {
                 expected = pr_info.head_ref_oid,
             );
         }
-        let base_sha = fetch_branch_head(&pr_info.base_ref_name, workdir.as_deref())?;
+        let cwd = workdir.as_deref();
+        let (base_sha, used_fallback) = resolve_pr_base_sha(
+            &pr_info.base_ref_oid,
+            |oid| object_exists_locally(cwd, oid),
+            || fetch_branch_head(&pr_info.base_ref_name, cwd).map(|_| ()),
+            |oid| fetch_oid(cwd, oid),
+            || fetch_branch_head(&pr_info.base_ref_name, cwd),
+        )?;
+        if used_fallback {
+            log::warn!(
+                "could not resolve PR #{number}'s base commit ({base_oid}) locally; falling \
+                 back to the current tip of {base_branch}, which may not reproduce the original \
+                 PR diff for a merged PR",
+                base_oid = pr_info.base_ref_oid,
+                base_branch = pr_info.base_ref_name,
+            );
+        }
         run_base_pipeline(&cli, &base_sha, &head_sha, workdir.as_deref())?
     } else if let Some(base) = &cli.base {
         run_base_pipeline(&cli, base, &cli.head, None)?
@@ -434,16 +454,20 @@ fn run_git_diff(base: &str, head: &str, cwd: Option<&std::path::Path>) -> anyhow
     Ok(String::from_utf8(output.stdout)?)
 }
 
-/// The subset of `gh pr view --json number,baseRefName,headRefOid` this
-/// binary needs to drive `--pr` mode (ADR 0004): which PR, what its base
-/// branch is called, and the exact commit its head is expected to be at
-/// (checked against what `git fetch` actually retrieves, see
+/// The subset of `gh pr view --json number,baseRefName,baseRefOid,
+/// headRefOid` this binary needs to drive `--pr` mode (ADR 0004, ADR
+/// 0007): which PR, what its base branch is called (fallback path),
+/// the commit its base was pinned to at PR time (`base_ref_oid`,
+/// preferred — see ADR 0007), and the exact commit its head is expected
+/// to be at (checked against what `git fetch` actually retrieves, see
 /// `main`'s mismatch check).
 #[derive(Debug, PartialEq, Eq, serde::Deserialize)]
 struct PrInfo {
     number: u64,
     #[serde(rename = "baseRefName")]
     base_ref_name: String,
+    #[serde(rename = "baseRefOid")]
+    base_ref_oid: String,
     #[serde(rename = "headRefOid")]
     head_ref_oid: String,
 }
@@ -599,15 +623,15 @@ fn cache_repo_dir(
     Ok(root.join("repos").join("github.com").join(owner).join(repo))
 }
 
-/// Parses `gh pr view --json number,baseRefName,headRefOid`'s stdout.
-/// Split out from `fetch_pr_info` so the JSON shape can be unit-tested
-/// without shelling out to `gh`.
+/// Parses `gh pr view --json number,baseRefName,baseRefOid,headRefOid`'s
+/// stdout. Split out from `fetch_pr_info` so the JSON shape can be
+/// unit-tested without shelling out to `gh`.
 fn parse_pr_view_json(json: &str) -> anyhow::Result<PrInfo> {
     Ok(serde_json::from_str(json)?)
 }
 
-/// Runs `gh pr view <arg> --json number,baseRefName,headRefOid` and parses
-/// the result.
+/// Runs `gh pr view <arg> --json number,baseRefName,baseRefOid,headRefOid`
+/// and parses the result.
 ///
 /// Takes the user's original `--pr` argument (URL or bare number) rather
 /// than the number `parse_pr_arg` extracts from it, and this is load-bearing
@@ -624,7 +648,13 @@ fn parse_pr_view_json(json: &str) -> anyhow::Result<PrInfo> {
 /// which repository they resolved against.
 fn fetch_pr_info(arg: &str) -> anyhow::Result<PrInfo> {
     let output = std::process::Command::new("gh")
-        .args(["pr", "view", arg, "--json", "number,baseRefName,headRefOid"])
+        .args([
+            "pr",
+            "view",
+            arg,
+            "--json",
+            "number,baseRefName,baseRefOid,headRefOid",
+        ])
         .output()?;
     if !output.status.success() {
         anyhow::bail!(
@@ -648,6 +678,90 @@ fn fetch_pr_head(number: u64, cwd: Option<&std::path::Path>) -> anyhow::Result<S
 /// the base branch name `gh pr view` reports.
 fn fetch_branch_head(name: &str, cwd: Option<&std::path::Path>) -> anyhow::Result<String> {
     run_git_fetch(name, cwd)
+}
+
+/// Resolves `--pr` mode's diff base commit following ADR 0007's
+/// availability cascade, preferring `base_ref_oid` (pinned to the PR-time
+/// base, correct for both open and merged PRs) over the base branch's
+/// current tip (correct only for open PRs, since a merged PR's base
+/// branch has since advanced past it).
+///
+/// Cascade, each step only taken if the previous one didn't already
+/// resolve `base_ref_oid` locally:
+///
+/// 1. `object_exists` (`git cat-file -e <oid>^{commit}`) — already have it.
+/// 2. `fetch_base_branch` (`git fetch origin <base_ref_name>`) then
+///    re-check `object_exists` — an ordinary branch fetch usually retrieves
+///    it, since `base_ref_oid` is normally reachable from the base
+///    branch's history.
+/// 3. `fetch_oid` (`git fetch origin <oid>`) then re-check `object_exists`
+///    — covers a base branch that has since been force-pushed past it or
+///    deleted.
+/// 4. Fall back to `branch_tip` (today's pre-ADR-0007 behavior, e.g. an
+///    already-fetched `fetch_branch_head` result) with `used_fallback`
+///    signaling the caller should warn — the commit is unreachable by any
+///    means available, so this degrades rather than fails the whole run.
+///
+/// Every IO step is injected as a closure so this decision logic is
+/// unit-testable without shelling out to `git`, following the same
+/// pattern as `select_matching_clone` elsewhere in this file.
+///
+/// Returns the resolved SHA and whether the fallback (step 4) was used.
+fn resolve_pr_base_sha(
+    base_ref_oid: &str,
+    mut object_exists: impl FnMut(&str) -> bool,
+    mut fetch_base_branch: impl FnMut() -> anyhow::Result<()>,
+    mut fetch_oid: impl FnMut(&str) -> anyhow::Result<()>,
+    branch_tip: impl FnOnce() -> anyhow::Result<String>,
+) -> anyhow::Result<(String, bool)> {
+    if object_exists(base_ref_oid) {
+        return Ok((base_ref_oid.to_string(), false));
+    }
+
+    fetch_base_branch()?;
+    if object_exists(base_ref_oid) {
+        return Ok((base_ref_oid.to_string(), false));
+    }
+
+    if fetch_oid(base_ref_oid).is_ok() && object_exists(base_ref_oid) {
+        return Ok((base_ref_oid.to_string(), false));
+    }
+
+    Ok((branch_tip()?, true))
+}
+
+/// Runs `git cat-file -e <oid>^{commit}` in `cwd`, i.e. whether `oid`
+/// already exists locally as a commit object — the cheap first check in
+/// `resolve_pr_base_sha`'s cascade, run before attempting any fetch.
+fn object_exists_locally(cwd: Option<&std::path::Path>, oid: &str) -> bool {
+    let mut command = std::process::Command::new("git");
+    command.args(["cat-file", "-e", &format!("{oid}^{{commit}}")]);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    command.output().is_ok_and(|output| output.status.success())
+}
+
+/// Runs `git fetch origin <oid>` in `cwd` — the direct-oid step of
+/// `resolve_pr_base_sha`'s cascade, tried only when the base branch itself
+/// (already fetched by the caller) didn't bring the commit in, e.g. after
+/// a force-push past it. Unlike `run_git_fetch`, this doesn't need
+/// `FETCH_HEAD` afterwards: the caller re-checks `object_exists_locally`
+/// instead, since fetching a bare oid doesn't update any ref.
+fn fetch_oid(cwd: Option<&std::path::Path>, oid: &str) -> anyhow::Result<()> {
+    let mut command = std::process::Command::new("git");
+    command.args(["fetch", "origin", oid]);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let output = command.output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git fetch origin {oid} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
 }
 
 /// Runs `git fetch origin <refspec>` then `git rev-parse FETCH_HEAD` in
@@ -1294,9 +1408,145 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
+    mod resolve_pr_base_sha_tests {
+        use super::*;
+        use pretty_assertions::assert_eq;
+        use std::cell::RefCell;
+
+        #[test]
+        fn should_return_base_ref_oid_when_it_already_exists_locally() {
+            let fetch_base_branch_calls = RefCell::new(0);
+            let fetch_oid_calls = RefCell::new(0);
+
+            let actual = resolve_pr_base_sha(
+                "base789",
+                |_oid| true,
+                || {
+                    *fetch_base_branch_calls.borrow_mut() += 1;
+                    Ok(())
+                },
+                |_oid| {
+                    *fetch_oid_calls.borrow_mut() += 1;
+                    Ok(())
+                },
+                || panic!("branch_tip must not be called when base_ref_oid already exists"),
+            )
+            .expect("should resolve without error");
+
+            assert_eq!(("base789".to_string(), false), actual);
+            assert_eq!(0, *fetch_base_branch_calls.borrow());
+            assert_eq!(0, *fetch_oid_calls.borrow());
+        }
+
+        #[test]
+        fn should_return_base_ref_oid_when_fetching_the_base_branch_makes_it_available() {
+            let exists_calls = RefCell::new(0);
+            let object_exists = |_oid: &str| {
+                let mut calls = exists_calls.borrow_mut();
+                *calls += 1;
+                // First check (before any fetch) fails; the check right
+                // after `fetch_base_branch` succeeds.
+                *calls > 1
+            };
+
+            let actual = resolve_pr_base_sha(
+                "base789",
+                object_exists,
+                || Ok(()),
+                |_oid| panic!("fetch_oid must not be called when the base branch fetch sufficed"),
+                || panic!("branch_tip must not be called when the base branch fetch sufficed"),
+            )
+            .expect("should resolve without error");
+
+            assert_eq!(("base789".to_string(), false), actual);
+        }
+
+        #[test]
+        fn should_return_base_ref_oid_when_fetching_the_oid_directly_makes_it_available() {
+            let exists_calls = RefCell::new(0);
+            let object_exists = |_oid: &str| {
+                let mut calls = exists_calls.borrow_mut();
+                *calls += 1;
+                // Neither the initial check nor the one after the base
+                // branch fetch succeed; only the one after `fetch_oid`
+                // does (third call).
+                *calls > 2
+            };
+
+            let actual = resolve_pr_base_sha(
+                "base789",
+                object_exists,
+                || Ok(()),
+                |_oid| Ok(()),
+                || panic!("branch_tip must not be called when fetch_oid sufficed"),
+            )
+            .expect("should resolve without error");
+
+            assert_eq!(("base789".to_string(), false), actual);
+        }
+
+        #[test]
+        fn should_fall_back_to_branch_tip_when_the_oid_is_unreachable_by_any_means() {
+            let actual = resolve_pr_base_sha(
+                "base789",
+                |_oid| false,
+                || Ok(()),
+                |_oid| anyhow::bail!("simulated: base789 not found on the remote"),
+                || Ok("branch-tip-sha".to_string()),
+            )
+            .expect("should fall back rather than error");
+
+            assert_eq!(("branch-tip-sha".to_string(), true), actual);
+        }
+
+        #[test]
+        fn should_fall_back_to_branch_tip_when_fetch_oid_succeeds_but_object_still_missing() {
+            // `git fetch origin <oid>` can itself succeed (e.g. the remote
+            // accepts the request) while the object is still not resolvable
+            // locally afterwards — covered separately from the "fetch_oid
+            // errors outright" case above.
+            let actual = resolve_pr_base_sha(
+                "base789",
+                |_oid| false,
+                || Ok(()),
+                |_oid| Ok(()),
+                || Ok("branch-tip-sha".to_string()),
+            )
+            .expect("should fall back rather than error");
+
+            assert_eq!(("branch-tip-sha".to_string(), true), actual);
+        }
+
+        #[test]
+        fn should_propagate_error_when_fetching_the_base_branch_fails() {
+            let actual = resolve_pr_base_sha(
+                "base789",
+                |_oid| false,
+                || anyhow::bail!("simulated: git fetch origin main failed"),
+                |_oid| Ok(()),
+                || Ok("branch-tip-sha".to_string()),
+            );
+
+            assert!(actual.is_err());
+        }
+
+        #[test]
+        fn should_propagate_error_when_the_branch_tip_fallback_itself_fails() {
+            let actual = resolve_pr_base_sha(
+                "base789",
+                |_oid| false,
+                || Ok(()),
+                |_oid| anyhow::bail!("simulated: base789 not found on the remote"),
+                || anyhow::bail!("simulated: git fetch origin main failed"),
+            );
+
+            assert!(actual.is_err());
+        }
+    }
+
     #[test]
     fn should_parse_pr_view_json_into_pr_info() {
-        let json = r#"{"number":123,"baseRefName":"main","headRefOid":"abc123def456"}"#;
+        let json = r#"{"number":123,"baseRefName":"main","baseRefOid":"base789","headRefOid":"abc123def456"}"#;
 
         let actual = parse_pr_view_json(json).expect("expected valid JSON to parse");
 
@@ -1304,6 +1554,7 @@ mod tests {
             PrInfo {
                 number: 123,
                 base_ref_name: "main".to_string(),
+                base_ref_oid: "base789".to_string(),
                 head_ref_oid: "abc123def456".to_string(),
             },
             actual

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -46,8 +46,10 @@ use rinkaku_core::deps::TagsResolver;
 use rinkaku_core::language::language_for_path;
 use rinkaku_core::pipeline::analyze_diff;
 use rinkaku_core::render::{OutputFormat, render};
+use std::io::BufRead;
 use std::io::IsTerminal;
 use std::io::Read;
+use std::io::Write;
 
 /// rinkaku (輪郭) — condense PR diffs into signatures and their dependencies.
 #[derive(Parser, Debug, PartialEq, Eq)]
@@ -373,11 +375,12 @@ fn garbage_input_note(
 /// parsing changed files a second time for its index.
 ///
 /// `head`, when `Some`, matches `--base` mode's read strategy: file
-/// content is read via `git show <head>:<path>` rather than the working
-/// tree, so the index and the diff being analyzed are consistent with the
-/// same commit regardless of the working tree's state (same rationale as
-/// `read_git_show_file`, applied here to the whole repo rather than just
-/// the changed files).
+/// content is read via a single `git cat-file --batch` process
+/// (`read_git_show_files_batch` — one process for every tracked file,
+/// rather than one `git show` subprocess per file) so the index and the
+/// diff being analyzed are consistent with the same commit regardless of
+/// the working tree's state (same rationale as `read_git_show_file`,
+/// applied here to the whole repo rather than just the changed files).
 /// `cwd` selects the repository `list_git_files` runs `git ls-files` in
 /// (same rationale as `read_git_show_file`'s `cwd`: `None` uses the
 /// process's current directory for production callers, `Some(dir)` pins
@@ -401,18 +404,25 @@ fn build_resolver(
         rinkaku_core::pipeline::collect_referenced_names(diff_text, diff_read_file)?;
 
     let paths = list_git_files(cwd)?;
-    let files = paths.into_iter().filter_map(|path| {
-        let content = match head {
-            Some(head) => read_git_show_file(cwd, head, &path),
-            None => read_working_tree_file(&path),
-        };
-        // A file listed by `git ls-files` can still fail to read (e.g.
-        // deleted in the working tree but not yet staged, a submodule
-        // gitlink entry) — skipped rather than failing the whole run,
-        // since the resolver's index is a best-effort aid, not a
-        // correctness-critical input.
-        content.ok().map(|content| (path, content))
-    });
+    let files: Vec<(String, String)> = match head {
+        // One `git cat-file --batch` child process serves every path
+        // (see `read_git_show_files_batch`'s doc comment for why this
+        // replaces a `git show` subprocess per file).
+        Some(head) => read_git_show_files_batch(cwd, head, paths)?,
+        None => paths
+            .into_iter()
+            .filter_map(|path| {
+                // A file listed by `git ls-files` can still fail to read
+                // (e.g. deleted in the working tree but not yet staged, a
+                // submodule gitlink entry) — skipped rather than failing
+                // the whole run, since the resolver's index is a
+                // best-effort aid, not a correctness-critical input.
+                read_working_tree_file(&path)
+                    .ok()
+                    .map(|content| (path, content))
+            })
+            .collect(),
+    };
     Ok(Some(TagsResolver::new(
         files,
         language_for_path,
@@ -987,6 +997,142 @@ fn read_git_show_file(
     }
     String::from_utf8(output.stdout)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+/// Reads every path in `paths` at `head` (`git show <head>:<path>`'s
+/// content, for each path) via a single long-lived `git cat-file --batch`
+/// child process, instead of spawning one `git show` subprocess per path
+/// (`read_git_show_file`'s approach — fine for the handful of files a diff
+/// actually changes, but prohibitively slow for `build_resolver`'s
+/// repository-wide index, which reads every tracked file: a repository
+/// with a few thousand tracked files previously meant a few thousand
+/// process spawns just to build the dependency index).
+///
+/// Protocol: `git cat-file --batch` reads `<object>\n` requests from
+/// stdin and writes one of two response shapes to stdout per request,
+/// documented in `git help cat-file`:
+/// - found: `<oid> <type> <size>\n` followed by exactly `size` content
+///   bytes and a trailing `\n`;
+/// - not found: `<object> missing\n`.
+///
+/// Requests and responses are sent one at a time (write a request, then
+/// immediately read its response) rather than writing every request up
+/// front: `git cat-file --batch`'s stdout is a pipe with a bounded OS
+/// buffer, and with ~thousands of paths the parent could deadlock writing
+/// requests while the child blocks trying to write responses into an
+/// already-full pipe that nobody is draining. One-at-a-time interleaving
+/// avoids that entirely while still cutting the process count from one
+/// per file to exactly one for the whole index — the actual cost this
+/// change targets.
+///
+/// A path that doesn't resolve (`missing` — e.g. a submodule gitlink
+/// entry `git ls-files` still lists) or whose content isn't valid UTF-8
+/// (a binary tracked file) is skipped rather than failing the whole call,
+/// matching `build_resolver`'s existing best-effort handling of
+/// `read_git_show_file` failures for the working-tree read path.
+fn read_git_show_files_batch(
+    cwd: Option<&std::path::Path>,
+    head: &str,
+    paths: Vec<String>,
+) -> anyhow::Result<Vec<(String, String)>> {
+    let mut command = std::process::Command::new("git");
+    command
+        .args(["cat-file", "--batch"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let mut child = command
+        .spawn()
+        .map_err(|source| anyhow::anyhow!("failed to start git cat-file --batch: {source}"))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .expect("stdin is piped, so it must be present");
+    let stdout = child
+        .stdout
+        .take()
+        .expect("stdout is piped, so it must be present");
+    let mut reader = std::io::BufReader::new(stdout);
+
+    let mut files = Vec::with_capacity(paths.len());
+    for path in paths {
+        let object = format!("{head}:{path}");
+        writeln!(stdin, "{object}").map_err(|source| {
+            anyhow::anyhow!("failed to write to git cat-file --batch: {source}")
+        })?;
+        stdin.flush().map_err(|source| {
+            anyhow::anyhow!("failed to flush git cat-file --batch stdin: {source}")
+        })?;
+
+        match read_cat_file_batch_response(&mut reader, &object)? {
+            Some(content) => files.push((path, content)),
+            None => continue,
+        }
+    }
+
+    // Dropping `stdin` here (end of scope) closes the pipe, which is what
+    // makes `git cat-file --batch` exit; `wait()` then just reaps it.
+    drop(stdin);
+    let status = child
+        .wait()
+        .map_err(|source| anyhow::anyhow!("failed to wait on git cat-file --batch: {source}"))?;
+    if !status.success() {
+        anyhow::bail!("git cat-file --batch exited with {status}");
+    }
+    Ok(files)
+}
+
+/// Reads and parses one `git cat-file --batch` response for `object`
+/// (`<head>:<path>`, used only for the "missing" line's exact echo). See
+/// `read_git_show_files_batch`'s doc comment for the two response shapes.
+///
+/// `Ok(None)` for a `missing` response or non-UTF-8 content (both treated
+/// as "skip this path", matching the working-tree read path's `.ok()`
+/// handling); `Err` only for a genuinely malformed/unexpected response,
+/// which would mean the batch stream itself has desynchronized and every
+/// subsequent read in the loop would be garbage.
+fn read_cat_file_batch_response(
+    reader: &mut impl BufRead,
+    object: &str,
+) -> anyhow::Result<Option<String>> {
+    let mut header = String::new();
+    reader.read_line(&mut header).map_err(|source| {
+        anyhow::anyhow!("failed to read git cat-file --batch header: {source}")
+    })?;
+    let header = header.trim_end_matches('\n');
+
+    if header == format!("{object} missing") {
+        return Ok(None);
+    }
+
+    // Found: "<oid> <type> <size>".
+    let size: usize = header
+        .rsplit(' ')
+        .next()
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| {
+            anyhow::anyhow!("unexpected git cat-file --batch response for {object}: {header:?}")
+        })?;
+
+    let mut content = vec![0u8; size];
+    reader.read_exact(&mut content).map_err(|source| {
+        anyhow::anyhow!("failed to read git cat-file --batch content: {source}")
+    })?;
+    // Every found response is followed by exactly one trailing newline
+    // after the content bytes, regardless of whether the content itself
+    // ends in one.
+    let mut trailing_newline = [0u8; 1];
+    reader.read_exact(&mut trailing_newline).map_err(|source| {
+        anyhow::anyhow!("failed to read git cat-file --batch trailing newline: {source}")
+    })?;
+
+    match String::from_utf8(content) {
+        Ok(content) => Ok(Some(content)),
+        Err(_) => Ok(None),
+    }
 }
 
 #[cfg(test)]
@@ -1644,6 +1790,118 @@ mod tests {
             .expect("git show should succeed for a committed file");
 
         assert_eq!(committed, actual);
+    }
+
+    // Integration test for the perf fix: a single `git cat-file --batch`
+    // process must return the same content `read_git_show_file` would
+    // have returned per-file, for every tracked path in one pass.
+    #[test]
+    fn should_read_every_path_via_a_single_cat_file_batch_process() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        run_git(dir.path(), &["init", "--initial-branch=main"]);
+        run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+        run_git(dir.path(), &["config", "user.name", "Test"]);
+        std::fs::write(dir.path().join("a.rs"), "fn a() {}\n").expect("write a.rs");
+        std::fs::write(dir.path().join("b.rs"), "fn b() {}\n").expect("write b.rs");
+        run_git(dir.path(), &["add", "a.rs", "b.rs"]);
+        run_git(dir.path(), &["commit", "-m", "initial commit"]);
+
+        let mut actual = read_git_show_files_batch(
+            Some(dir.path()),
+            "HEAD",
+            vec!["a.rs".to_string(), "b.rs".to_string()],
+        )
+        .expect("git cat-file --batch should succeed for tracked files");
+        actual.sort();
+
+        assert_eq!(
+            vec![
+                ("a.rs".to_string(), "fn a() {}\n".to_string()),
+                ("b.rs".to_string(), "fn b() {}\n".to_string()),
+            ],
+            actual
+        );
+    }
+
+    // Sibling case: a dirty working tree must not affect what the batch
+    // read returns, same guarantee `read_git_show_file` already provides
+    // per-file (`should_read_committed_content_when_working_tree_is_dirty`
+    // above).
+    #[test]
+    fn should_read_committed_content_via_batch_when_working_tree_is_dirty() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        let committed = "fn foo(a: i32) -> i32 {\n    a\n}\n";
+        init_repo_with_committed_file(dir.path(), committed);
+
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            "fn foo(a: i32) -> i32 {\n    a + 999\n}\n",
+        )
+        .expect("dirty the working tree");
+
+        let actual =
+            read_git_show_files_batch(Some(dir.path()), "HEAD", vec!["src/lib.rs".to_string()])
+                .expect("git cat-file --batch should succeed for a committed file");
+
+        assert_eq!(
+            vec![("src/lib.rs".to_string(), committed.to_string())],
+            actual
+        );
+    }
+
+    // A path `git ls-files` lists but that doesn't resolve to a blob at
+    // `head` (e.g. a submodule gitlink entry, or here simply a path that
+    // was never committed) must be skipped rather than failing the whole
+    // batch — matching `build_resolver`'s existing best-effort handling of
+    // per-file read failures.
+    #[test]
+    fn should_skip_missing_paths_when_reading_via_batch() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        init_repo_with_committed_file(dir.path(), "fn foo() {}\n");
+
+        let actual = read_git_show_files_batch(
+            Some(dir.path()),
+            "HEAD",
+            vec!["src/lib.rs".to_string(), "does/not/exist.rs".to_string()],
+        )
+        .expect("git cat-file --batch should succeed even with a missing path");
+
+        assert_eq!(
+            vec![("src/lib.rs".to_string(), "fn foo() {}\n".to_string())],
+            actual
+        );
+    }
+
+    // A tracked file whose committed content isn't valid UTF-8 (a binary
+    // file) must be skipped rather than failing the batch or the whole
+    // resolver build — matching `build_resolver`'s existing best-effort
+    // handling (content.ok() drops read failures, and a `String::from_utf8`
+    // failure is exactly the same kind of "can't use this as source text"
+    // situation).
+    #[test]
+    fn should_skip_non_utf8_content_when_reading_via_batch() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        run_git(dir.path(), &["init", "--initial-branch=main"]);
+        run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+        run_git(dir.path(), &["config", "user.name", "Test"]);
+        std::fs::write(dir.path().join("text.rs"), "fn ok() {}\n").expect("write text.rs");
+        std::fs::write(dir.path().join("binary.dat"), [0xff_u8, 0xfe, 0x00, 0x01])
+            .expect("write binary.dat");
+        run_git(dir.path(), &["add", "text.rs", "binary.dat"]);
+        run_git(dir.path(), &["commit", "-m", "initial commit"]);
+
+        let mut actual = read_git_show_files_batch(
+            Some(dir.path()),
+            "HEAD",
+            vec!["text.rs".to_string(), "binary.dat".to_string()],
+        )
+        .expect("git cat-file --batch should succeed even with binary content present");
+        actual.sort();
+
+        assert_eq!(
+            vec![("text.rs".to_string(), "fn ok() {}\n".to_string())],
+            actual
+        );
     }
 
     // Integration test for `--pr` URL mode's cwd-vs-cache decision (ADR

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -174,9 +174,8 @@ fn main() -> anyhow::Result<()> {
         let (base_sha, used_fallback) = resolve_pr_base_sha(
             &pr_info.base_ref_oid,
             |oid| object_exists_locally(cwd, oid),
-            || fetch_branch_head(&pr_info.base_ref_name, cwd).map(|_| ()),
-            |oid| fetch_oid(cwd, oid),
             || fetch_branch_head(&pr_info.base_ref_name, cwd),
+            |oid| fetch_oid(cwd, oid),
         )?;
         if used_fallback {
             log::warn!(
@@ -750,17 +749,25 @@ fn fetch_branch_head(name: &str, cwd: Option<&std::path::Path>) -> anyhow::Resul
 /// resolve `base_ref_oid` locally:
 ///
 /// 1. `object_exists` (`git cat-file -e <oid>^{commit}`) — already have it.
-/// 2. `fetch_base_branch` (`git fetch origin <base_ref_name>`) then
-///    re-check `object_exists` — an ordinary branch fetch usually retrieves
-///    it, since `base_ref_oid` is normally reachable from the base
-///    branch's history.
+/// 2. `fetch_base_branch` (`git fetch origin <base_ref_name>`, returning
+///    the fetched tip's SHA) then re-check `object_exists` — an ordinary
+///    branch fetch usually retrieves it, since `base_ref_oid` is normally
+///    reachable from the base branch's history. A failure here (e.g. the
+///    base branch was deleted after the PR merged, or renamed) is soft:
+///    `log::warn!` and fall through to step 3 rather than aborting the
+///    whole run — step 3 is exactly the recovery path for a base branch
+///    that no longer leads to `base_ref_oid`, so a step-2 failure must not
+///    short-circuit past it.
 /// 3. `fetch_oid` (`git fetch origin <oid>`) then re-check `object_exists`
-///    — covers a base branch that has since been force-pushed past it or
-///    deleted.
-/// 4. Fall back to `branch_tip` (today's pre-ADR-0007 behavior, e.g. an
-///    already-fetched `fetch_branch_head` result) with `used_fallback`
-///    signaling the caller should warn — the commit is unreachable by any
-///    means available, so this degrades rather than fails the whole run.
+///    — covers a base branch that has since been force-pushed past it,
+///    renamed, or deleted (including the case where step 2 itself failed
+///    to fetch at all).
+/// 4. Fall back to the base branch's tip with `used_fallback` signaling
+///    the caller should warn — the commit is unreachable by any means
+///    available, so this degrades rather than fails the whole run. Reuses
+///    step 2's fetched tip when step 2 succeeded, rather than fetching the
+///    same branch a second time; only calls `fetch_base_branch` again here
+///    if step 2 itself failed (so there is no tip yet to reuse).
 ///
 /// Every IO step is injected as a closure so this decision logic is
 /// unit-testable without shelling out to `git`, following the same
@@ -770,24 +777,38 @@ fn fetch_branch_head(name: &str, cwd: Option<&std::path::Path>) -> anyhow::Resul
 fn resolve_pr_base_sha(
     base_ref_oid: &str,
     mut object_exists: impl FnMut(&str) -> bool,
-    mut fetch_base_branch: impl FnMut() -> anyhow::Result<()>,
+    mut fetch_base_branch: impl FnMut() -> anyhow::Result<String>,
     mut fetch_oid: impl FnMut(&str) -> anyhow::Result<()>,
-    branch_tip: impl FnOnce() -> anyhow::Result<String>,
 ) -> anyhow::Result<(String, bool)> {
     if object_exists(base_ref_oid) {
         return Ok((base_ref_oid.to_string(), false));
     }
 
-    fetch_base_branch()?;
-    if object_exists(base_ref_oid) {
-        return Ok((base_ref_oid.to_string(), false));
-    }
+    let branch_tip = match fetch_base_branch() {
+        Ok(tip) => {
+            if object_exists(base_ref_oid) {
+                return Ok((base_ref_oid.to_string(), false));
+            }
+            Some(tip)
+        }
+        Err(source) => {
+            log::warn!(
+                "fetching the base branch failed, continuing the base-commit resolution \
+                 cascade: {source}"
+            );
+            None
+        }
+    };
 
     if fetch_oid(base_ref_oid).is_ok() && object_exists(base_ref_oid) {
         return Ok((base_ref_oid.to_string(), false));
     }
 
-    Ok((branch_tip()?, true))
+    let branch_tip = match branch_tip {
+        Some(tip) => tip,
+        None => fetch_base_branch()?,
+    };
+    Ok((branch_tip, true))
 }
 
 /// Runs `git cat-file -e <oid>^{commit}` in `cwd`, i.e. whether `oid`
@@ -1619,13 +1640,12 @@ mod tests {
                 |_oid| true,
                 || {
                     *fetch_base_branch_calls.borrow_mut() += 1;
-                    Ok(())
+                    Ok("branch-tip-sha".to_string())
                 },
                 |_oid| {
                     *fetch_oid_calls.borrow_mut() += 1;
                     Ok(())
                 },
-                || panic!("branch_tip must not be called when base_ref_oid already exists"),
             )
             .expect("should resolve without error");
 
@@ -1648,9 +1668,8 @@ mod tests {
             let actual = resolve_pr_base_sha(
                 "base789",
                 object_exists,
-                || Ok(()),
+                || Ok("branch-tip-sha".to_string()),
                 |_oid| panic!("fetch_oid must not be called when the base branch fetch sufficed"),
-                || panic!("branch_tip must not be called when the base branch fetch sufficed"),
             )
             .expect("should resolve without error");
 
@@ -1672,9 +1691,8 @@ mod tests {
             let actual = resolve_pr_base_sha(
                 "base789",
                 object_exists,
-                || Ok(()),
+                || Ok("branch-tip-sha".to_string()),
                 |_oid| Ok(()),
-                || panic!("branch_tip must not be called when fetch_oid sufficed"),
             )
             .expect("should resolve without error");
 
@@ -1686,9 +1704,8 @@ mod tests {
             let actual = resolve_pr_base_sha(
                 "base789",
                 |_oid| false,
-                || Ok(()),
-                |_oid| anyhow::bail!("simulated: base789 not found on the remote"),
                 || Ok("branch-tip-sha".to_string()),
+                |_oid| anyhow::bail!("simulated: base789 not found on the remote"),
             )
             .expect("should fall back rather than error");
 
@@ -1704,36 +1721,114 @@ mod tests {
             let actual = resolve_pr_base_sha(
                 "base789",
                 |_oid| false,
-                || Ok(()),
-                |_oid| Ok(()),
                 || Ok("branch-tip-sha".to_string()),
+                |_oid| Ok(()),
             )
             .expect("should fall back rather than error");
 
             assert_eq!(("branch-tip-sha".to_string(), true), actual);
         }
 
+        // Regression test for the must-fix correctness bug: a step-2
+        // fetch failure (e.g. the base branch was deleted or renamed after
+        // the PR merged) must not abort the whole cascade — step 3 (fetch
+        // the oid directly) is exactly the recovery path for this
+        // situation, so it must still run and can still resolve
+        // `base_ref_oid` even though step 2 failed.
         #[test]
-        fn should_propagate_error_when_fetching_the_base_branch_fails() {
+        fn should_fall_through_to_fetch_oid_when_fetching_the_base_branch_fails() {
+            let exists_calls = RefCell::new(0);
+            let object_exists = |_oid: &str| {
+                let mut calls = exists_calls.borrow_mut();
+                *calls += 1;
+                // Only the initial check happens before the failed branch
+                // fetch (which does not re-check); the check after
+                // `fetch_oid` (second call) succeeds.
+                *calls > 1
+            };
+
+            let actual = resolve_pr_base_sha(
+                "base789",
+                object_exists,
+                || anyhow::bail!("simulated: base branch was deleted"),
+                |_oid| Ok(()),
+            )
+            .expect("a step-2 failure must not abort the cascade");
+
+            assert_eq!(("base789".to_string(), false), actual);
+        }
+
+        // Sibling case: if step 3 also can't resolve the oid after a
+        // step-2 failure, the cascade must still fall back (step 4) rather
+        // than propagating the step-2 error — step 2's failure was already
+        // handled by falling through, not by failing the whole call.
+        #[test]
+        fn should_fetch_branch_tip_for_fallback_when_step_two_failed_and_fetch_oid_also_fails() {
+            let fetch_base_branch_calls = RefCell::new(0);
+
             let actual = resolve_pr_base_sha(
                 "base789",
                 |_oid| false,
-                || anyhow::bail!("simulated: git fetch origin main failed"),
-                |_oid| Ok(()),
-                || Ok("branch-tip-sha".to_string()),
-            );
+                || {
+                    let mut calls = fetch_base_branch_calls.borrow_mut();
+                    *calls += 1;
+                    if *calls == 1 {
+                        anyhow::bail!("simulated: base branch was deleted")
+                    } else {
+                        // Step 4 must re-fetch since step 2 never produced
+                        // a tip to reuse.
+                        Ok("branch-tip-sha".to_string())
+                    }
+                },
+                |_oid| anyhow::bail!("simulated: base789 not found on the remote"),
+            )
+            .expect("should fall back rather than error");
 
-            assert!(actual.is_err());
+            assert_eq!(("branch-tip-sha".to_string(), true), actual);
+            assert_eq!(2, *fetch_base_branch_calls.borrow());
+        }
+
+        // Regression test for the must-fix cleanup: when step 2 succeeded
+        // (returned a tip) but didn't make `base_ref_oid` resolvable, and
+        // step 3 also fails, step 4's fallback must reuse step 2's tip
+        // rather than fetching the same base branch a second time.
+        #[test]
+        fn should_reuse_step_two_tip_for_fallback_without_refetching() {
+            let fetch_base_branch_calls = RefCell::new(0);
+
+            let actual = resolve_pr_base_sha(
+                "base789",
+                |_oid| false,
+                || {
+                    *fetch_base_branch_calls.borrow_mut() += 1;
+                    Ok("branch-tip-sha".to_string())
+                },
+                |_oid| anyhow::bail!("simulated: base789 not found on the remote"),
+            )
+            .expect("should fall back rather than error");
+
+            assert_eq!(("branch-tip-sha".to_string(), true), actual);
+            assert_eq!(
+                1,
+                *fetch_base_branch_calls.borrow(),
+                "fetch_base_branch must only be called once (by step 2); step 4 must reuse its \
+                 result instead of fetching the base branch again"
+            );
         }
 
         #[test]
         fn should_propagate_error_when_the_branch_tip_fallback_itself_fails() {
+            let fetch_base_branch_calls = RefCell::new(0);
+
             let actual = resolve_pr_base_sha(
                 "base789",
                 |_oid| false,
-                || Ok(()),
+                || {
+                    let mut calls = fetch_base_branch_calls.borrow_mut();
+                    *calls += 1;
+                    anyhow::bail!("simulated: git fetch origin main failed")
+                },
                 |_oid| anyhow::bail!("simulated: base789 not found on the remote"),
-                || anyhow::bail!("simulated: git fetch origin main failed"),
             );
 
             assert!(actual.is_err());

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -433,7 +433,12 @@ fn build_resolver(
     let files: Vec<(String, String)> = match head {
         // One `git cat-file --batch` child process serves every path
         // (see `read_git_show_files_batch`'s doc comment for why this
-        // replaces a `git show` subprocess per file).
+        // replaces a `git show` subprocess per file). A single
+        // unresolvable path is isolated inside that call (same
+        // best-effort skip as the working-tree branch below); the `?`
+        // here only ever fires for a genuinely unrecoverable failure
+        // (the child process itself failing to start, or the batch
+        // stream desyncing), which cannot be isolated to one path.
         Some(head) => read_git_show_files_batch(cwd, head, paths)?,
         None => paths
             .into_iter()
@@ -1057,11 +1062,13 @@ fn read_git_show_file(
 /// process spawns just to build the dependency index).
 ///
 /// Protocol: `git cat-file --batch` reads `<object>\n` requests from
-/// stdin and writes one of two response shapes to stdout per request,
-/// documented in `git help cat-file`:
-/// - found: `<oid> <type> <size>\n` followed by exactly `size` content
-///   bytes and a trailing `\n`;
-/// - not found: `<object> missing\n`.
+/// stdin and writes a response to stdout per request, documented in
+/// `git help cat-file`'s BATCH OUTPUT section — mainly the "found" shape
+/// (`<oid> <type> <size>\n` followed by exactly `size` content bytes and
+/// a trailing `\n`) and several single-line, no-content shapes
+/// (`<object> missing`, `<object> ambiguous`, `<oid> submodule`, ...);
+/// see `read_cat_file_batch_response`'s doc comment for exactly which
+/// shapes are treated as "skip this path" versus a hard failure.
 ///
 /// Requests and responses are sent one at a time (write a request, then
 /// immediately read its response) rather than writing every request up
@@ -1071,13 +1078,10 @@ fn read_git_show_file(
 /// already-full pipe that nobody is draining. One-at-a-time interleaving
 /// avoids that entirely while still cutting the process count from one
 /// per file to exactly one for the whole index — the actual cost this
-/// change targets.
-///
-/// A path that doesn't resolve (`missing` — e.g. a submodule gitlink
-/// entry `git ls-files` still lists) or whose content isn't valid UTF-8
-/// (a binary tracked file) is skipped rather than failing the whole call,
-/// matching `build_resolver`'s existing best-effort handling of
-/// `read_git_show_file` failures for the working-tree read path.
+/// change targets. stderr is drained concurrently on a dedicated thread
+/// for the same reason (see the inline comment where it's spawned) — a
+/// verbose enough diagnostic on stderr could otherwise fill that pipe too
+/// and deadlock the same way.
 fn read_git_show_files_batch(
     cwd: Option<&std::path::Path>,
     head: &str,
@@ -1103,7 +1107,26 @@ fn read_git_show_files_batch(
         .stdout
         .take()
         .expect("stdout is piped, so it must be present");
+    let stderr = child
+        .stderr
+        .take()
+        .expect("stderr is piped, so it must be present");
     let mut reader = std::io::BufReader::new(stdout);
+
+    // Drained on a dedicated thread rather than read after `wait()`: this
+    // call writes/reads stdin and stdout on the main thread in lockstep,
+    // so nothing here would otherwise ever read stderr. If `git` writes
+    // enough diagnostics to fill the OS pipe buffer, the child would block
+    // writing to stderr while this thread blocks reading stdout — an
+    // indefinite mutual stall neither side can break out of. A concurrent
+    // reader keeps that pipe draining regardless of what the main thread
+    // is doing.
+    let stderr_reader = std::thread::spawn(move || {
+        let mut stderr = stderr;
+        let mut buf = Vec::new();
+        let _ = stderr.read_to_end(&mut buf);
+        buf
+    });
 
     let mut files = Vec::with_capacity(paths.len());
     for path in paths {
@@ -1127,21 +1150,46 @@ fn read_git_show_files_batch(
     let status = child
         .wait()
         .map_err(|source| anyhow::anyhow!("failed to wait on git cat-file --batch: {source}"))?;
+    // The child has exited, so its stderr end is closed and this join
+    // cannot block indefinitely waiting for more output.
+    let stderr_output = stderr_reader
+        .join()
+        .unwrap_or_else(|_| b"<failed to read stderr: reader thread panicked>".to_vec());
     if !status.success() {
-        anyhow::bail!("git cat-file --batch exited with {status}");
+        anyhow::bail!(
+            "git cat-file --batch exited with {status}: {}",
+            String::from_utf8_lossy(&stderr_output)
+        );
     }
     Ok(files)
 }
 
 /// Reads and parses one `git cat-file --batch` response for `object`
-/// (`<head>:<path>`, used only for the "missing" line's exact echo). See
-/// `read_git_show_files_batch`'s doc comment for the two response shapes.
+/// (`<head>:<path>`). See `read_git_show_files_batch`'s doc comment for
+/// the "found" response shape.
 ///
-/// `Ok(None)` for a `missing` response or non-UTF-8 content (both treated
-/// as "skip this path", matching the working-tree read path's `.ok()`
-/// handling); `Err` only for a genuinely malformed/unexpected response,
-/// which would mean the batch stream itself has desynchronized and every
-/// subsequent read in the loop would be garbage.
+/// `git cat-file --batch` has more single-line, no-content-body response
+/// shapes than just `<object> missing` — `git help cat-file`'s BATCH
+/// OUTPUT section also documents `<object> ambiguous` (an ambiguous short
+/// name — not reachable through this call's `<head>:<path>` requests,
+/// which are never short/ambiguous, but defended against anyway) and
+/// `<oid> submodule` (a gitlink entry whose target commit isn't present
+/// in the repository). Any header line that isn't the `<oid> <type>
+/// <size>` "found" shape is therefore treated the same way as `missing`:
+/// skip this single path, since a single line was already fully consumed
+/// by `read_line` and the stream position is well-defined regardless of
+/// what that line actually said — there is nothing to desync.
+///
+/// `Ok(None)` for any such skippable single-line response, or for
+/// found-but-non-UTF-8 content (both "skip this path", matching the
+/// working-tree read path's `.ok()` handling and restoring the same
+/// per-file isolation `read_git_show_file` had before batching). `Err`
+/// only for an IO failure reading the header line, the exact-size content
+/// bytes, or the trailing newline after a "found" header — those are the
+/// only points where the stream's position becomes genuinely unknown
+/// (a partial read of `size` content bytes, in particular, means there is
+/// no way to know where the next response begins), so recovery for later
+/// paths in the same batch is not possible and the whole call must fail.
 fn read_cat_file_batch_response(
     reader: &mut impl BufRead,
     object: &str,
@@ -1152,29 +1200,31 @@ fn read_cat_file_batch_response(
     })?;
     let header = header.trim_end_matches('\n');
 
-    if header == format!("{object} missing") {
-        return Ok(None);
-    }
-
-    // Found: "<oid> <type> <size>".
-    let size: usize = header
+    // "Found" shape: "<oid> <type> <size>", the size being the last
+    // whitespace-separated token. Anything else (missing, ambiguous,
+    // submodule, or any other single-line shape this code doesn't
+    // specifically know about) is a skip, not a hard error — see the doc
+    // comment above for why that's safe.
+    let Some(size) = header
         .rsplit(' ')
         .next()
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| {
-            anyhow::anyhow!("unexpected git cat-file --batch response for {object}: {header:?}")
-        })?;
+        .and_then(|s| s.parse::<usize>().ok())
+    else {
+        return Ok(None);
+    };
 
     let mut content = vec![0u8; size];
     reader.read_exact(&mut content).map_err(|source| {
-        anyhow::anyhow!("failed to read git cat-file --batch content: {source}")
+        anyhow::anyhow!("failed to read git cat-file --batch content for {object}: {source}")
     })?;
     // Every found response is followed by exactly one trailing newline
     // after the content bytes, regardless of whether the content itself
     // ends in one.
     let mut trailing_newline = [0u8; 1];
     reader.read_exact(&mut trailing_newline).map_err(|source| {
-        anyhow::anyhow!("failed to read git cat-file --batch trailing newline: {source}")
+        anyhow::anyhow!(
+            "failed to read git cat-file --batch trailing newline for {object}: {source}"
+        )
     })?;
 
     match String::from_utf8(content) {
@@ -2023,6 +2073,119 @@ mod tests {
         assert_eq!(
             vec![("text.rs".to_string(), "fn ok() {}\n".to_string())],
             actual
+        );
+    }
+
+    mod read_cat_file_batch_response_tests {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn should_return_content_when_response_is_found() {
+            let mut reader = std::io::Cursor::new(b"abc123 blob 5\nhello\n".to_vec());
+
+            let actual = read_cat_file_batch_response(&mut reader, "HEAD:a.rs")
+                .expect("a well-formed found response must parse");
+
+            assert_eq!(Some("hello".to_string()), actual);
+        }
+
+        #[test]
+        fn should_return_none_when_response_is_missing() {
+            let mut reader = std::io::Cursor::new(b"HEAD:a.rs missing\n".to_vec());
+
+            let actual = read_cat_file_batch_response(&mut reader, "HEAD:a.rs")
+                .expect("a missing response must not be a hard error");
+
+            assert_eq!(None, actual);
+        }
+
+        // `git help cat-file`'s BATCH OUTPUT section documents this shape
+        // for an ambiguous short name. Not reachable in practice through
+        // this codebase's `<head>:<path>` requests (never a short/
+        // ambiguous name by construction), but must still be treated as a
+        // skip rather than a hard error if git ever emitted it — it's a
+        // single line with no content body, so there is nothing to
+        // desync on.
+        #[test]
+        fn should_return_none_when_response_is_ambiguous() {
+            let mut reader = std::io::Cursor::new(b"abc1 ambiguous\n".to_vec());
+
+            let actual = read_cat_file_batch_response(&mut reader, "abc1")
+                .expect("an ambiguous response must not be a hard error");
+
+            assert_eq!(None, actual);
+        }
+
+        // `git help cat-file`'s BATCH OUTPUT section documents this shape
+        // for a gitlink (submodule) entry whose target commit isn't
+        // present in the repository — exactly the kind of single-file
+        // condition the regression this test guards against used to turn
+        // into a hard failure for the whole batch (the "<size>" parse
+        // used to require the header be an exact `missing` match or
+        // parse as `<oid> <type> <size>`; anything else, including this
+        // shape, fell into an `Err`).
+        #[test]
+        fn should_return_none_when_response_is_a_submodule_entry() {
+            let mut reader = std::io::Cursor::new(
+                b"3eb8e680cc28d03641be1d2af8e098e8ac6a42f8 submodule\n".to_vec(),
+            );
+
+            let actual = read_cat_file_batch_response(&mut reader, "HEAD:sub")
+                .expect("a submodule response must not be a hard error");
+
+            assert_eq!(None, actual);
+        }
+
+        #[test]
+        fn should_return_none_when_found_content_is_not_valid_utf8() {
+            let mut reader = std::io::Cursor::new(
+                [
+                    b"abc123 blob 4\n".as_slice(),
+                    &[0xff, 0xfe, 0x00, 0x01],
+                    b"\n",
+                ]
+                .concat(),
+            );
+
+            let actual = read_cat_file_batch_response(&mut reader, "HEAD:binary.dat")
+                .expect("non-UTF-8 content must not be a hard error");
+
+            assert_eq!(None, actual);
+        }
+
+        // Regression guard for the opposite direction of the fix above:
+        // a genuine stream desync (here, content truncated shorter than
+        // the declared size) must still be a hard error — it cannot be
+        // isolated to a single path, unlike the skippable shapes above.
+        #[test]
+        fn should_return_error_when_content_is_truncated() {
+            let mut reader = std::io::Cursor::new(b"abc123 blob 100\nshort\n".to_vec());
+
+            let actual = read_cat_file_batch_response(&mut reader, "HEAD:a.rs");
+
+            assert!(actual.is_err());
+        }
+    }
+
+    // Regression test for the must-fix cleanup: the exit-status error
+    // message must include the child's stderr, matching every other
+    // subprocess call in this file. Also exercises the concurrent
+    // stderr-draining thread end to end (rather than only reasoning about
+    // it): a non-git `cwd` makes `git cat-file --batch` write a `fatal:
+    // not a git repository...` diagnostic to stderr and exit non-zero,
+    // and that diagnostic must show up in the returned error.
+    #[test]
+    fn should_include_stderr_in_error_when_git_cat_file_batch_exits_non_zero() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+
+        let actual = read_git_show_files_batch(Some(dir.path()), "HEAD", vec!["a.rs".to_string()]);
+
+        let error = actual.expect_err("a non-git cwd must fail rather than silently succeed");
+        let message = error.to_string();
+        assert!(
+            message.contains("not a git repository"),
+            "expected the child's stderr to be included in the error, got: {message:?}"
         );
     }
 


### PR DESCRIPTION
## Why

Running `rinkaku --pr <url>` against a merged PR printed nothing and still took a long time:

- `--pr` mode diffed against the base branch's **current tip**. Once a PR is merged, its head is an ancestor of that tip, so the triple-dot diff is empty — rinkaku exited 0 with zero output and zero diagnostics.
- Even with an empty diff, the dependency index was still built by spawning one `git show` subprocess per tracked file (~1,500 processes on a large repository), so the run was slow despite producing nothing.
- No progress was logged, so the long silence was undiagnosable.

## What

- **Base PR diffs on `baseRefOid`** (ADR 0007): resolve the diff base from the PR's `baseRefOid` reported by `gh pr view` instead of the fetched branch tip. For open PRs this is identical to the branch tip; for merged PRs it is pinned to the PR-time base, so the original PR diff is reproduced. Availability cascade: local object check → fetch base branch → fetch the oid directly → fall back to the branch tip with a warning (soft failures fall through; the branch tip fetched in step 2 is reused by the fallback without a second fetch).
- **Report empty diffs and skip indexing**: `--base`/`--pr` now print the same "diff is empty" / garbage-input notes stdin mode already had, and skip the dependency index entirely when the diff is empty.
- **Read the dependency index via a single `git cat-file --batch` process** instead of one `git show` per tracked file (index build on a ~1,500-file repository drops from tens of seconds to ~2s). Per-file failures (`missing`, non-UTF8, unparsable headers) skip that file only, matching the previous best-effort behavior; the child's stderr is drained concurrently to avoid pipe-buffer deadlock and is included in error messages.
- **Log progress to stderr by default**: `env_logger` now defaults to `info` (still overridable via `RUST_LOG`), with progress lines for workdir selection (cwd / ghq / cache clone), PR resolution, fetches, diffing, and dependency-index construction.

## Verification

- `make test` (146 core + 111 rinkaku unit tests) and `make lint` pass.
- End-to-end against a real merged PR on a large private repository: previously silent-empty in tens of seconds; now produces the full report (32 changed files) in ~6s with progress logged to stderr, and the output is stable across runs.