### PR TITLE
feat: render output as entry-point trees over the changed-symbol graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,103 +146,103 @@ rinkaku --base main --deps 0
 ### What it looks like
 
 All examples below are captured from the `cargo build --release` binary
-against `main` post-[#9](https://github.com/hiro-o918/rinkaku/pull/9)
-(the dependency-resolution precision and indexing performance
-improvements), not fabricated.
+against `main` post-[ADR 0008](docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md)
+(entry-point tree rendering), not fabricated.
 
 Running `rinkaku` on
-[a real rinkaku commit](https://github.com/hiro-o918/rinkaku/commit/1ccc183)
-(a 128-line diff adding the stdin garbage-input warning in `main.rs`)
-produces:
+[a real rinkaku commit](https://github.com/hiro-o918/rinkaku/commit/aa7ca34)
+(a 35-line diff adding stderr progress logging to `main.rs`) produces:
 
 ```sh
-$ git show 1ccc183 --format="" | rinkaku
+$ git show aa7ca34 --format="" | rinkaku --deps 0
 ```
 
 ````markdown
-## rinkaku-core/src/main.rs
+## Change graph
+
+- fn main (rinkaku/src/main.rs)
+  - fn build_resolver (rinkaku/src/main.rs)
+  - fn resolve_pr_workdir (rinkaku/src/main.rs)
+  - fn run_base_pipeline (rinkaku/src/main.rs)
+    - fn build_resolver (rinkaku/src/main.rs) (see above)
+
+## Definitions
+
+### fn main (rinkaku/src/main.rs)
 
 ```
 fn main() -> anyhow::Result<()>
 ```
 
-Depends on:
-- `rinkaku-core/src/deps.rs`: `pub trait Resolver { fn resolve(&self, name: &str) -> Vec<ResolvedSymbol>; }`
-- `rinkaku-core/src/pipeline.rs`: `pub fn analyze_diff( diff_text: &str, read_file: impl Fn(&str) -> std::io::Result<String>, resolver: Option<&dyn Resolver>, ) -> Result<Report, AnalyzeError>`
-- `rinkaku-core/src/main.rs`: `fn build_resolver( cli: &Cli, diff_text: &str, diff_read_file: impl Fn(&str) -> std::io::Result<String>, head: Option<&str>, cwd: Option<&std::path::Path>, ) -> anyhow::Result<Option<TagsResolver>>`
-- `rinkaku-core/src/main.rs`: `fn read_git_show_file( cwd: Option<&std::path::Path>, head: &str, path: &str, ) -> std::io::Result<String>`
-- `rinkaku-core/src/main.rs`: `fn read_stdin_diff() -> anyhow::Result<String>`
-- `rinkaku-core/src/render.rs`: `pub fn render(report: &Report, format: OutputFormat) -> Result<String, RenderError>`
-- `rinkaku-core/src/main.rs`: `fn run_git_diff(base: &str, head: &str) -> anyhow::Result<String>`
+### fn build_resolver (rinkaku/src/main.rs)
 
 ```
-fn garbage_input_note( diff_text: &str, report: &rinkaku_core::render::Report, ) -> Option<&'static str>
+fn build_resolver( cli: &Cli, diff_text: &str, diff_read_file: impl Fn(&str) -> std::io::Result<String>, head: Option<&str>, cwd: Option<&std::path::Path>, ) -> anyhow::Result<Option<TagsResolver>>
 ```
 
-Depends on:
-- `rinkaku-core/src/render.rs`: `pub struct Report { pub files: Vec<FileReport>, pub skipped: Vec<SkippedFile>, }`
+### fn resolve_pr_workdir (rinkaku/src/main.rs)
 
-... (6 more symbols, same shape)
+```
+fn resolve_pr_workdir(parsed: &PrArg) -> anyhow::Result<Option<std::path::PathBuf>>
+```
+
+### fn run_base_pipeline (rinkaku/src/main.rs)
+
+```
+fn run_base_pipeline( cli: &Cli, base: &str, head: &str, cwd: Option<&std::path::Path>, ) -> anyhow::Result<rinkaku_core::render::Report>
+```
+
 ````
 
-The 128-line diff (test bodies included) becomes 59 lines of signatures
-and their dependencies — the reviewer sees which functions changed and
-what they touch, without reading every match arm by hand. On a larger
-real diff — rinkaku's own [PR #7](https://github.com/hiro-o918/rinkaku/pull/7)
-(a 2,254-line diff adding dependency resolution across 12 files) —
-`rinkaku` produces 658 lines: about 29% of the original, while surfacing
-cross-file dependencies that would otherwise require opening every
-changed file to trace by hand.
+"Change graph" reads top-down in call-hierarchy order: `main` is the only
+entry point (nothing else changed in this diff calls it), and every
+function it reaches is nested beneath it. `build_resolver` is reachable
+from both `main` and `run_base_pipeline`; it is rendered in full once,
+under `main` (the first place it's reached), and referenced by name only
+(`(see above)`) the second time — so a reviewer never sees the same
+signature twice. When two changed symbols depend on each other (a
+mutual-recursion cycle), the edge that closes the loop is marked
+`⚠️ ... — dependency cycle, see above` instead of being walked into again;
+see [ADR 0008](docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md)
+for the full rationale.
+
+Unchanged 1-hop dependencies (ADR 0003) — functions/types the diff touches
+but did not itself change — still show up as a `Depends on:` list under
+each definition, same as before ADR 0008; they're omitted from the example
+above (`--deps 0`) to keep it focused on the tree shape.
 
 `--format json` renders the same data as structured JSON instead
-(`{"files": [{"path", "symbols": [{"name", "kind", "signature", "range",
-"container", "dependencies", "omitted_matches"}]}], "skipped": [...]}`),
-for piping into `jq` or another tool:
+(`{"files": [...], "skipped": [...], "graph": {"nodes", "edges", "roots"}}`),
+for piping into `jq` or another tool. The `graph` field is the same
+call-graph data "Change graph" renders as a tree, so JSON consumers don't
+need to recompute it from `referenced_names`:
 
 ```sh
-$ git show 1ccc183 --format="" | rinkaku --format json | jq '.files[0].symbols[0]'
+$ git show aa7ca34 --format="" | rinkaku --format json --deps 0 | jq '.graph'
 ```
 
 ```json
 {
-  "name": "main",
-  "kind": "Function",
-  "signature": "fn main() -> anyhow::Result<()>",
-  "range": { "start": 73, "end": 118 },
-  "container": null,
-  "dependencies": [
-    {
-      "signature": "pub trait Resolver { fn resolve(&self, name: &str) -> Vec<ResolvedSymbol>; }",
-      "path": "rinkaku-core/src/deps.rs"
-    },
-    {
-      "signature": "pub fn analyze_diff( diff_text: &str, read_file: impl Fn(&str) -> std::io::Result<String>, resolver: Option<&dyn Resolver>, ) -> Result<Report, AnalyzeError>",
-      "path": "rinkaku-core/src/pipeline.rs"
-    },
-    {
-      "signature": "fn build_resolver( cli: &Cli, diff_text: &str, diff_read_file: impl Fn(&str) -> std::io::Result<String>, head: Option<&str>, cwd: Option<&std::path::Path>, ) -> anyhow::Result<Option<TagsResolver>>",
-      "path": "rinkaku-core/src/main.rs"
-    },
-    {
-      "signature": "fn read_git_show_file( cwd: Option<&std::path::Path>, head: &str, path: &str, ) -> std::io::Result<String>",
-      "path": "rinkaku-core/src/main.rs"
-    },
-    {
-      "signature": "fn read_stdin_diff() -> anyhow::Result<String>",
-      "path": "rinkaku-core/src/main.rs"
-    },
-    {
-      "signature": "pub fn render(report: &Report, format: OutputFormat) -> Result<String, RenderError>",
-      "path": "rinkaku-core/src/render.rs"
-    },
-    {
-      "signature": "fn run_git_diff(base: &str, head: &str) -> anyhow::Result<String>",
-      "path": "rinkaku-core/src/main.rs"
-    }
+  "nodes": [
+    { "id": "rinkaku/src/main.rs::main", "path": "rinkaku/src/main.rs", "name": "main" },
+    { "id": "rinkaku/src/main.rs::resolve_pr_workdir", "path": "rinkaku/src/main.rs", "name": "resolve_pr_workdir" },
+    { "id": "rinkaku/src/main.rs::run_base_pipeline", "path": "rinkaku/src/main.rs", "name": "run_base_pipeline" },
+    { "id": "rinkaku/src/main.rs::build_resolver", "path": "rinkaku/src/main.rs", "name": "build_resolver" }
   ],
-  "omitted_matches": 0
+  "edges": [
+    { "from": "rinkaku/src/main.rs::main", "to": "rinkaku/src/main.rs::build_resolver", "is_cycle": false },
+    { "from": "rinkaku/src/main.rs::main", "to": "rinkaku/src/main.rs::resolve_pr_workdir", "is_cycle": false },
+    { "from": "rinkaku/src/main.rs::main", "to": "rinkaku/src/main.rs::run_base_pipeline", "is_cycle": false },
+    { "from": "rinkaku/src/main.rs::run_base_pipeline", "to": "rinkaku/src/main.rs::build_resolver", "is_cycle": false }
+  ],
+  "roots": ["rinkaku/src/main.rs::main"]
 }
 ```
+
+Each symbol in `files[].symbols` also carries an `id` field matching its
+`graph` node's `id`, so a consumer can join a symbol's full signature back
+to its position in the graph without recomputing the `{path}::{name}` id
+scheme itself.
 
 ### When same-name matches are capped
 
@@ -257,7 +257,7 @@ by path proximity are shown, and the rest are reported as a count instead
 of listed in full or silently dropped:
 
 ````markdown
-## crates/ty_server/src/server/lazy_work_done_progress.rs
+### struct LazyWorkDoneProgress (crates/ty_server/src/server/lazy_work_done_progress.rs)
 
 ```
 pub(super) struct LazyWorkDoneProgress { inner: Arc<Inner>, }
@@ -274,7 +274,8 @@ This same 810-line diff also shows the noise reduction from filtering `_`
 and single-character identifiers out of referenced names entirely (see
 Known limitations): the pre-#9 QA pass on this exact diff found 76 of 188
 "Depends on" lines were unrelated `def _(...)` matches (~40% noise); on
-the current `main`, the same diff produces 295 output lines (down from
+the current `main`, the same diff produces 384 output lines (up from 295
+pre-ADR-0008 due to the added "Change graph" tree section, and down from
 405 pre-#9) with zero `_`-related entries, since `_` is no longer looked
 up at all.
 

--- a/docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md
+++ b/docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md
@@ -1,0 +1,58 @@
+# 0008. Entry-point tree rendering for changed symbols
+
+- Status: accepted
+- Date: 2026-07-12
+
+## Context
+
+The current Markdown output lists changed symbols flat, in git file order,
+each with its 1-hop dependencies (ADR 0003). Two things make this hard for
+humans to read. First, there is no obvious place to start reading — file
+order carries no meaning. Second, `resolve_dependencies` deliberately
+excludes symbols that are themselves part of the diff, so the relationships
+*between* changed symbols — the most interesting edges in a review — are
+invisible, and the reader has to reconstruct the call graph mentally.
+
+The data to fix this already exists: each `ExtractedSymbol` keeps its raw
+`referenced_names`, and the tags index can match those names against the
+other changed symbols.
+
+## Decision
+
+Build a directed graph over the changed symbols (edges from
+`referenced_names` matched against the changed-symbol set) and render
+Markdown as trees rooted at auto-detected entry points: changed symbols
+that no other changed symbol references. Unchanged 1-hop dependencies
+remain leaf annotations as today. A symbol reachable from multiple roots
+is rendered in full once and referenced by name afterwards. Cycles among
+changed symbols are broken at the back edge and rendered with an explicit
+warning marker, since a dependency cycle usually signals a design smell
+the reviewer should see. The JSON output gains the same edge information;
+this is a breaking change to both output formats.
+
+## Alternatives
+
+- **User-specified entry point (`--entry <symbol>`)**: requires the user
+  to already know the change's structure, which is exactly what the tool
+  should surface. Graph roots give the same starting points for free. May
+  still be added later as a *filter* on top of this rendering.
+- **Keep the flat list and append a separate call-graph section**: avoids
+  a breaking change, but duplicates every symbol and still forces readers
+  to join two sections mentally.
+- **Split human (tree) and LLM (flat) formats behind a flag**: structure
+  helps LLM consumers too, and maintaining two Markdown renderers doubles
+  the surface for every future change. Revisit only if LLM consumption
+  measurably degrades.
+
+## Consequences
+
+- Markdown reads top-down in call-hierarchy order: entry points first,
+  callees nested beneath, giving reviewers a natural reading order.
+- Dependency cycles among changed code become visible as warnings instead
+  of being silently flattened away.
+- Name-based edges inherit the imprecision of tags resolution (ADR 0003):
+  a false match now distorts tree shape, not just a dependency list, so
+  wrong edges are more visible — acceptable while the `Resolver` trait
+  allows a precise LSP-backed upgrade later.
+- Both output formats break; downstream consumers must adapt. Acceptable
+  pre-1.0.

--- a/rinkaku-core/src/deps.rs
+++ b/rinkaku-core/src/deps.rs
@@ -632,6 +632,7 @@ mod tests {
 
         fn symbol(name: &str, referenced_names: Vec<&str>) -> ExtractedSymbol {
             ExtractedSymbol {
+                id: String::new(),
                 name: name.to_string(),
                 kind: SymbolKind::Function,
                 signature: format!("fn {name}()"),

--- a/rinkaku-core/src/extract.rs
+++ b/rinkaku-core/src/extract.rs
@@ -44,6 +44,14 @@ pub enum SymbolKind {
 /// (declaration or body) fell inside a changed range.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ExtractedSymbol {
+    /// Stable identifier matching this symbol's [`crate::graph::Node::id`]
+    /// once graph-building has run, so JSON consumers can correlate a
+    /// symbol with the graph's `nodes`/`edges`/`roots` without recomputing
+    /// the `{path}::{name}` scheme themselves. Empty until
+    /// [`crate::graph::build_graph`] populates it (mirrors `dependencies`
+    /// and `omitted_dependency_matches`, both populated post-extraction by
+    /// a later pipeline stage rather than by `build_symbol`).
+    pub id: String,
     pub name: String,
     pub kind: SymbolKind,
     /// Declaration text without its body, whitespace-normalized. Doc
@@ -252,6 +260,9 @@ fn build_symbol(
     let referenced_names = collect_referenced_names(node, source, reference_query);
 
     Some(ExtractedSymbol {
+        // Populated later by `graph::build_graph`, once node IDs are
+        // assigned across the whole diff (see the field's doc comment).
+        id: String::new(),
         name,
         kind,
         signature,
@@ -588,6 +599,7 @@ struct Point {
 
         let expected = vec![
             ExtractedSymbol {
+                id: String::new(),
                 name: "helper".to_string(),
                 kind: SymbolKind::Function,
                 signature: "fn helper(x: i32) -> i32".to_string(),
@@ -598,6 +610,7 @@ struct Point {
                 omitted_dependency_matches: 0,
             },
             ExtractedSymbol {
+                id: String::new(),
                 name: "Point".to_string(),
                 kind: SymbolKind::Struct,
                 signature: "struct Point { x: i32, }".to_string(),
@@ -634,6 +647,7 @@ fn foo() -> i32 {
         // `_` local names) as noise unlikely to resolve to a meaningful,
         // uniquely named definition.
         let expected = vec![ExtractedSymbol {
+            id: String::new(),
             name: "foo".to_string(),
             kind: SymbolKind::Function,
             signature: "fn foo() -> i32".to_string(),
@@ -672,6 +686,7 @@ fn foo(a: i32) -> i32 {
         let changed_ranges = vec![LineRange { start: 2, end: 2 }];
 
         let expected = vec![ExtractedSymbol {
+            id: String::new(),
             name: "foo".to_string(),
             kind: SymbolKind::Function,
             signature: "fn foo(a: i32) -> i32".to_string(),
@@ -698,6 +713,7 @@ fn foo(a: i32, c: i32) -> i32 {
         let changed_ranges = vec![LineRange { start: 1, end: 1 }];
 
         let expected = vec![ExtractedSymbol {
+            id: String::new(),
             name: "foo".to_string(),
             kind: SymbolKind::Function,
             signature: "fn foo(a: i32, c: i32) -> i32".to_string(),
@@ -725,6 +741,7 @@ struct Point {
         let changed_ranges = vec![LineRange { start: 3, end: 3 }];
 
         let expected = vec![ExtractedSymbol {
+            id: String::new(),
             name: "Point".to_string(),
             kind: SymbolKind::Struct,
             signature: "struct Point { x: i32, y: i32, }".to_string(),
@@ -759,6 +776,7 @@ impl Foo {
         let changed_ranges = vec![LineRange { start: 5, end: 5 }];
 
         let expected = vec![ExtractedSymbol {
+            id: String::new(),
             name: "bar".to_string(),
             kind: SymbolKind::Function,
             signature: "fn bar(&self) -> i32".to_string(),
@@ -789,6 +807,7 @@ impl Foo {
         let changed_ranges = vec![LineRange { start: 4, end: 4 }];
 
         let expected = vec![ExtractedSymbol {
+            id: String::new(),
             name: "bar".to_string(),
             kind: SymbolKind::Function,
             signature: "fn bar(&self, extra: i32) -> i32".to_string(),
@@ -817,6 +836,7 @@ enum Color {
         let changed_ranges = vec![LineRange { start: 3, end: 3 }];
 
         let expected = vec![ExtractedSymbol {
+            id: String::new(),
             name: "Color".to_string(),
             kind: SymbolKind::Enum,
             signature: "enum Color { Red, Green, Blue, }".to_string(),
@@ -848,6 +868,7 @@ trait Greeter {
         // rather than the whole trait body — same "narrowest enclosing
         // definition" rule used for impl methods.
         let expected = vec![ExtractedSymbol {
+            id: String::new(),
             name: "greet".to_string(),
             kind: SymbolKind::Function,
             signature: "fn greet(&self) -> String;".to_string(),
@@ -875,6 +896,7 @@ trait Greeter {
         let changed_ranges = vec![LineRange { start: 1, end: 1 }];
 
         let expected = vec![ExtractedSymbol {
+            id: String::new(),
             name: "Greeter".to_string(),
             kind: SymbolKind::Trait,
             signature: "trait Greeter { fn greet(&self) -> String; }".to_string(),
@@ -912,6 +934,7 @@ const X: i32 = 1;
     #[case::should_extract_only_the_touched_function_when_two_functions_exist(
         vec![LineRange { start: 2, end: 2 }],
         vec![ExtractedSymbol {
+            id: String::new(),
             name: "first".to_string(),
             kind: SymbolKind::Function,
             signature: "fn first()".to_string(),
@@ -971,6 +994,7 @@ fn foo(a: i32) -> i32 {
         let lang = language_for_path(&changed_file.path).expect("*.rs should resolve to Rust");
 
         let expected = vec![ExtractedSymbol {
+            id: String::new(),
             name: "foo".to_string(),
             kind: SymbolKind::Function,
             signature: "fn foo(a: i32) -> i32".to_string(),
@@ -1017,6 +1041,7 @@ func foo(a int) int {
             let changed_ranges = vec![LineRange { start: 4, end: 4 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "foo".to_string(),
                 kind: SymbolKind::Function,
                 signature: "func foo(a int) int".to_string(),
@@ -1048,6 +1073,7 @@ func foo(a int, c int) int {
             let changed_ranges = vec![LineRange { start: 3, end: 3 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "foo".to_string(),
                 kind: SymbolKind::Function,
                 signature: "func foo(a int, c int) int".to_string(),
@@ -1077,6 +1103,7 @@ type Repo struct {
             let changed_ranges = vec![LineRange { start: 5, end: 5 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Repo".to_string(),
                 kind: SymbolKind::Struct,
                 signature: "Repo struct { Name string Size int }".to_string(),
@@ -1109,6 +1136,7 @@ type Fetcher interface {
             let changed_ranges = vec![LineRange { start: 4, end: 4 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Fetcher".to_string(),
                 kind: SymbolKind::Interface,
                 signature: "Fetcher interface { Fetch(id string) (string, error) }".to_string(),
@@ -1166,6 +1194,7 @@ func (r *Repo) Save(id string) error {
             let changed_ranges = vec![LineRange { start: 8, end: 8 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Save".to_string(),
                 kind: SymbolKind::Function,
                 signature: "func (r *Repo) Save(id string) error".to_string(),
@@ -1206,6 +1235,7 @@ func (r Repo) Label() string {
             let changed_ranges = vec![LineRange { start: 7, end: 7 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Label".to_string(),
                 kind: SymbolKind::Function,
                 signature: "func (r Repo) Label() string".to_string(),
@@ -1275,6 +1305,7 @@ func (r *Repo) Save(id string) error {
             let lang = language_for_path(&changed_file.path).expect("*.go should resolve to Go");
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Save".to_string(),
                 kind: SymbolKind::Function,
                 signature: "func (r *Repo) Save(id string) error".to_string(),
@@ -1311,6 +1342,7 @@ def foo(a):
             let changed_ranges = vec![LineRange { start: 2, end: 2 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "foo".to_string(),
                 kind: SymbolKind::Function,
                 signature: "def foo(a):".to_string(),
@@ -1335,6 +1367,7 @@ def foo(a, c):
             let changed_ranges = vec![LineRange { start: 1, end: 1 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "foo".to_string(),
                 kind: SymbolKind::Function,
                 signature: "def foo(a, c):".to_string(),
@@ -1367,6 +1400,7 @@ def top_level(a, b):
             // walks past it and finds nothing (see extract.rs doc comment
             // on `find_container`).
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "inner".to_string(),
                 kind: SymbolKind::Function,
                 signature: "def inner(c):".to_string(),
@@ -1411,6 +1445,7 @@ def decorated(a):
             let changed_ranges = vec![LineRange { start: 3, end: 3 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "decorated".to_string(),
                 kind: SymbolKind::Function,
                 signature: "def decorated(a):".to_string(),
@@ -1442,6 +1477,7 @@ class Point:
             let changed_ranges = vec![LineRange { start: 3, end: 3 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Point".to_string(),
                 kind: SymbolKind::Class,
                 signature: "class Point: x: int y: int def __init__(self, x, y):".to_string(),
@@ -1470,6 +1506,7 @@ class Point:
             let changed_ranges = vec![LineRange { start: 3, end: 3 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "__init__".to_string(),
                 kind: SymbolKind::Function,
                 signature: "def __init__(self, x):".to_string(),
@@ -1496,6 +1533,7 @@ class Point:
             let changed_ranges = vec![LineRange { start: 2, end: 2 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "__init__".to_string(),
                 kind: SymbolKind::Function,
                 signature: "def __init__(self, x):".to_string(),
@@ -1525,6 +1563,7 @@ class Point:
             let changed_ranges = vec![LineRange { start: 6, end: 6 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "label".to_string(),
                 kind: SymbolKind::Function,
                 signature: "def label(self):".to_string(),
@@ -1592,6 +1631,7 @@ class Point:
                 language_for_path(&changed_file.path).expect("*.py should resolve to Python");
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "__init__".to_string(),
                 kind: SymbolKind::Function,
                 signature: "def __init__(self, x):".to_string(),
@@ -1624,6 +1664,7 @@ function foo(a: number): number {
             let changed_ranges = vec![LineRange { start: 2, end: 2 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "foo".to_string(),
                 kind: SymbolKind::Function,
                 signature: "function foo(a: number): number".to_string(),
@@ -1649,6 +1690,7 @@ function foo(a: number, c: number): number {
             let changed_ranges = vec![LineRange { start: 1, end: 1 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "foo".to_string(),
                 kind: SymbolKind::Function,
                 signature: "function foo(a: number, c: number): number".to_string(),
@@ -1675,6 +1717,7 @@ const arrow = (a: number): number => {
             let changed_ranges = vec![LineRange { start: 2, end: 2 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "arrow".to_string(),
                 kind: SymbolKind::Function,
                 signature: "arrow = (a: number): number =>".to_string(),
@@ -1721,6 +1764,7 @@ interface Shape {
             let changed_ranges = vec![LineRange { start: 3, end: 3 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Shape".to_string(),
                 kind: SymbolKind::Interface,
                 signature: "interface Shape { area(): number; perimeter(): number; }".to_string(),
@@ -1752,6 +1796,7 @@ type Point = {
             let changed_ranges = vec![LineRange { start: 3, end: 3 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Point".to_string(),
                 kind: SymbolKind::TypeAlias,
                 signature: "type Point = { x: number; y: number; };".to_string(),
@@ -1780,6 +1825,7 @@ enum Color {
             let changed_ranges = vec![LineRange { start: 3, end: 3 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Color".to_string(),
                 kind: SymbolKind::Enum,
                 signature: "enum Color { Red, Green, Blue, }".to_string(),
@@ -1811,6 +1857,7 @@ class Circle {
             let changed_ranges = vec![LineRange { start: 2, end: 2 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Circle".to_string(),
                 kind: SymbolKind::Class,
                 signature: "class Circle { radius: number; area(): number }".to_string(),
@@ -1841,6 +1888,7 @@ class Circle {
             let changed_ranges = vec![LineRange { start: 5, end: 5 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "area".to_string(),
                 kind: SymbolKind::Function,
                 signature: "area(): number".to_string(),
@@ -1871,6 +1919,7 @@ class Circle {
             let changed_ranges = vec![LineRange { start: 4, end: 4 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "area".to_string(),
                 kind: SymbolKind::Function,
                 signature: "area(): number".to_string(),
@@ -1903,6 +1952,7 @@ class Circle {
             let changed_ranges = vec![LineRange { start: 7, end: 7 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "area".to_string(),
                 kind: SymbolKind::Function,
                 signature: "area(): number".to_string(),
@@ -1965,6 +2015,7 @@ function foo(a: number): number {
                 language_for_path(&changed_file.path).expect("*.ts should resolve to TypeScript");
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "foo".to_string(),
                 kind: SymbolKind::Function,
                 signature: "function foo(a: number): number".to_string(),
@@ -1997,6 +2048,7 @@ abstract class Shape {
             let changed_ranges = vec![LineRange { start: 3, end: 3 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "perimeter".to_string(),
                 kind: SymbolKind::Function,
                 signature: "abstract perimeter(): number".to_string(),
@@ -2025,6 +2077,7 @@ abstract class Shape {
             let changed_ranges = vec![LineRange { start: 1, end: 1 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Shape".to_string(),
                 kind: SymbolKind::Class,
                 signature:
@@ -2061,6 +2114,7 @@ class Circle {
             let changed_ranges = vec![LineRange { start: 2, end: 2 }];
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Circle".to_string(),
                 kind: SymbolKind::Class,
                 signature: "class Circle { radius: number; area = (): number => ; }".to_string(),
@@ -2095,6 +2149,7 @@ const Component = () => {
             let lang = language_for_path("src/Component.tsx").expect("*.tsx should resolve to TSX");
 
             let expected = vec![ExtractedSymbol {
+                id: String::new(),
                 name: "Component".to_string(),
                 kind: SymbolKind::Function,
                 signature: "Component = () =>".to_string(),

--- a/rinkaku-core/src/graph.rs
+++ b/rinkaku-core/src/graph.rs
@@ -178,6 +178,20 @@ fn collect_edges(files: &[FileReport], nodes: &[Node]) -> Vec<Edge> {
     edges
 }
 
+/// Maps each node's [`NodeId`] to its position in `nodes`, letting the
+/// index-based algorithms below (`find_roots`'s SCC condensation,
+/// `mark_cycle_edges`'s back-edge DFS) translate an [`Edge`]'s
+/// string-keyed `from`/`to` into array indices without a linear scan per
+/// lookup. Shared by both rather than each rebuilding its own copy from
+/// `nodes`.
+fn node_index_map(nodes: &[Node]) -> HashMap<&str, usize> {
+    nodes
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.id.as_str(), i))
+        .collect()
+}
+
 /// Computes entry points as the representative nodes of in-degree-0 SCCs in
 /// the condensation graph, so at least one root always exists even if every
 /// node participates in some cycle (a pure raw in-degree-0 test would find
@@ -193,11 +207,7 @@ fn find_roots(nodes: &[Node], edges: &[Edge]) -> Vec<NodeId> {
         return Vec::new();
     }
 
-    let index_of: HashMap<&str, usize> = nodes
-        .iter()
-        .enumerate()
-        .map(|(i, n)| (n.id.as_str(), i))
-        .collect();
+    let index_of = node_index_map(nodes);
 
     let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); nodes.len()];
     for edge in edges {
@@ -266,11 +276,7 @@ fn mark_cycle_edges(nodes: &[Node], roots: &[NodeId], edges: &mut [Edge]) {
         return;
     }
 
-    let index_of: HashMap<&str, usize> = nodes
-        .iter()
-        .enumerate()
-        .map(|(i, n)| (n.id.as_str(), i))
-        .collect();
+    let index_of = node_index_map(nodes);
 
     let mut adjacency: Vec<Vec<(usize, usize)>> = vec![Vec::new(); nodes.len()]; // (target, edge_index)
     for (edge_index, edge) in edges.iter().enumerate() {

--- a/rinkaku-core/src/graph.rs
+++ b/rinkaku-core/src/graph.rs
@@ -1,0 +1,662 @@
+//! Directed graph over changed symbols, for entry-point tree rendering
+//! (ADR 0008).
+//!
+//! [`build_graph`] takes every changed symbol across a diff (already
+//! extracted by [`crate::extract`], with `referenced_names` still intact)
+//! and builds a [`SymbolGraph`]: nodes are changed symbols, edges are
+//! name-matches from one symbol's `referenced_names` to another changed
+//! symbol's name. Entry points ("roots") are auto-detected rather than
+//! user-specified — see the module-level rationale in the ADR for why.
+//!
+//! Cycles among changed symbols are expected (e.g. mutual recursion) and
+//! must not prevent every node from having *some* root to hang off of, so
+//! roots are computed on the strongly-connected-component (SCC) condensation
+//! of the graph rather than the raw graph: an SCC with in-degree 0 always
+//! exists in a finite DAG (the condensation is always a DAG), so at least
+//! one root always exists, even when literally every node participates in
+//! some cycle.
+
+use crate::render::FileReport;
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Stable identifier for a graph node: `{path}::{name}`, disambiguated with
+/// `@{start_line}` only when a report contains more than one symbol sharing
+/// that `(path, name)` pair (e.g. overloaded free functions in a language
+/// that allows them, or two same-named symbols in different containers).
+pub type NodeId = String;
+
+/// One changed symbol, as a graph node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Node {
+    pub id: NodeId,
+    pub path: String,
+    pub name: String,
+}
+
+/// A directed edge from one changed symbol to another, both identified by
+/// [`NodeId`]. `is_cycle` marks a back edge discovered by the DFS used to
+/// detect cycles (see `build_graph`'s doc comment) — a cycle edge is still
+/// a real edge (kept in `SymbolGraph::edges`), just annotated so rendering
+/// can show a warning instead of infinitely recursing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Edge {
+    pub from: NodeId,
+    pub to: NodeId,
+    pub is_cycle: bool,
+}
+
+/// A directed graph over a diff's changed symbols, plus its auto-detected
+/// entry points.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SymbolGraph {
+    pub nodes: Vec<Node>,
+    pub edges: Vec<Edge>,
+    /// Entry points: nodes with no incoming non-cycle edge from another
+    /// changed symbol, chosen so that a DFS from `roots` reaches every node
+    /// (see `build_graph`'s doc comment on SCC-based root selection).
+    pub roots: Vec<NodeId>,
+}
+
+/// Builds a [`SymbolGraph`] over every symbol in `files`.
+///
+/// Node order (and therefore `nodes`, tie-breaks in `roots`, and DFS
+/// exploration order downstream in rendering) follows `files`' own order,
+/// then each file's symbol order — i.e. source appearance order, which is
+/// already how `pipeline::analyze_diff` assembles `files`. Determinism
+/// downstream (rendering) depends on this.
+pub fn build_graph(files: &[FileReport]) -> SymbolGraph {
+    let nodes = collect_nodes(files);
+    let mut edges = collect_edges(files, &nodes);
+    let roots = find_roots(&nodes, &edges);
+    mark_cycle_edges(&nodes, &roots, &mut edges);
+
+    SymbolGraph {
+        nodes,
+        edges,
+        roots,
+    }
+}
+
+/// Assigns a stable [`NodeId`] to every symbol in source order. A `(path,
+/// name)` pair disambiguates with `@{start_line}` only when it is not
+/// already unique within `files` — the common case (no duplicate names)
+/// gets the short `{path}::{name}` form.
+fn collect_nodes(files: &[FileReport]) -> Vec<Node> {
+    let mut name_counts: HashMap<(&str, &str), usize> = HashMap::new();
+    for file in files {
+        for symbol in &file.symbols {
+            *name_counts
+                .entry((file.path.as_str(), symbol.name.as_str()))
+                .or_default() += 1;
+        }
+    }
+
+    let mut nodes = Vec::new();
+    for file in files {
+        for symbol in &file.symbols {
+            let is_duplicate = name_counts[&(file.path.as_str(), symbol.name.as_str())] > 1;
+            let id = if is_duplicate {
+                format!("{}::{}@{}", file.path, symbol.name, symbol.range.start)
+            } else {
+                format!("{}::{}", file.path, symbol.name)
+            };
+            nodes.push(Node {
+                id,
+                path: file.path.clone(),
+                name: symbol.name.clone(),
+            });
+        }
+    }
+    nodes
+}
+
+/// Builds edges from each symbol's `referenced_names` to every changed
+/// symbol whose name matches, across the whole diff (not just within one
+/// file) — mirroring how `deps::resolve_dependencies` matches by name
+/// alone. Self-references (a node referencing its own name, e.g. a
+/// struct's name appearing inside its own definition — see
+/// `extract::collect_referenced_names`'s doc comment) are excluded, same
+/// rationale as `deps::resolve_dependencies`'s self-reference exclusion.
+/// A referenced name matching more than one changed symbol (possible once
+/// duplicate `(path, name)` pairs get distinct node IDs) produces an edge
+/// to each match, not just one — the caller has no way to disambiguate
+/// under v1's name-only matching (ADR 0003), so all plausible edges are
+/// kept rather than arbitrarily picking one.
+fn collect_edges(files: &[FileReport], nodes: &[Node]) -> Vec<Edge> {
+    let mut nodes_by_name: HashMap<&str, Vec<&Node>> = HashMap::new();
+    for node in nodes {
+        nodes_by_name
+            .entry(node.name.as_str())
+            .or_default()
+            .push(node);
+    }
+
+    let mut edges = Vec::new();
+    let mut node_index = 0;
+    for file in files {
+        for symbol in &file.symbols {
+            let from = &nodes[node_index];
+            for referenced_name in &symbol.referenced_names {
+                if let Some(targets) = nodes_by_name.get(referenced_name.as_str()) {
+                    for target in targets {
+                        if target.id != from.id {
+                            edges.push(Edge {
+                                from: from.id.clone(),
+                                to: target.id.clone(),
+                                is_cycle: false,
+                            });
+                        }
+                    }
+                }
+            }
+            node_index += 1;
+        }
+    }
+    edges
+}
+
+/// Computes entry points as the representative nodes of in-degree-0 SCCs in
+/// the condensation graph, so at least one root always exists even if every
+/// node participates in some cycle (a pure raw in-degree-0 test would find
+/// none in that case). Representative = the SCC member that appears first
+/// in `nodes`' source order.
+///
+/// Uses Tarjan's algorithm (`tarjan_sccs`) rather than pulling in a graph
+/// crate: this is the only graph algorithm the codebase needs today (see
+/// CLAUDE.md's guidance against speculative shared abstractions), and a
+/// from-scratch implementation keeps the core dependency-free.
+fn find_roots(nodes: &[Node], edges: &[Edge]) -> Vec<NodeId> {
+    if nodes.is_empty() {
+        return Vec::new();
+    }
+
+    let index_of: HashMap<&str, usize> = nodes
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.id.as_str(), i))
+        .collect();
+
+    let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); nodes.len()];
+    for edge in edges {
+        if let (Some(&from), Some(&to)) = (
+            index_of.get(edge.from.as_str()),
+            index_of.get(edge.to.as_str()),
+        ) {
+            adjacency[from].push(to);
+        }
+    }
+
+    let sccs = tarjan_sccs(&adjacency);
+    // scc_of[node_index] = index into `sccs` of the SCC containing it.
+    let mut scc_of = vec![0usize; nodes.len()];
+    for (scc_index, scc) in sccs.iter().enumerate() {
+        for &node_index in scc {
+            scc_of[node_index] = scc_index;
+        }
+    }
+
+    let mut scc_has_incoming = vec![false; sccs.len()];
+    for edge in edges {
+        if let (Some(&from), Some(&to)) = (
+            index_of.get(edge.from.as_str()),
+            index_of.get(edge.to.as_str()),
+        ) {
+            let (from_scc, to_scc) = (scc_of[from], scc_of[to]);
+            if from_scc != to_scc {
+                scc_has_incoming[to_scc] = true;
+            }
+        }
+    }
+
+    let mut roots = Vec::new();
+    for (scc_index, scc) in sccs.iter().enumerate() {
+        if scc_has_incoming[scc_index] {
+            continue;
+        }
+        // Representative = earliest in source order (smallest node index).
+        let representative = *scc.iter().min().expect("an SCC always has >=1 member");
+        roots.push(nodes[representative].id.clone());
+    }
+
+    // sccs are discovered in reverse-postorder-ish order depending on the
+    // implementation; sort roots by node source order for deterministic
+    // output regardless of that internal detail.
+    roots.sort_by_key(|id| index_of[id.as_str()]);
+    roots
+}
+
+/// Marks every back edge discovered by a pre-order DFS starting at `roots`
+/// (in order) as `is_cycle = true`. A back edge — one pointing to an
+/// ancestor still on the current DFS path — is the standard graph-theory
+/// signature of a cycle; marking it (rather than the whole SCC) pinpoints
+/// exactly which edge closes the loop, which is what rendering needs to
+/// show a warning at the right spot in the tree (ADR 0008).
+///
+/// DFS starts from `roots` so cycle marking agrees with the traversal
+/// order `render.rs` will use to walk the tree. `roots` is guaranteed to
+/// reach every node (see `find_roots`'s doc comment), so the fallback loop
+/// over all remaining unvisited nodes only guards against future changes
+/// to `find_roots` breaking that guarantee — not expected to trigger in
+/// practice.
+fn mark_cycle_edges(nodes: &[Node], roots: &[NodeId], edges: &mut [Edge]) {
+    if nodes.is_empty() {
+        return;
+    }
+
+    let index_of: HashMap<&str, usize> = nodes
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.id.as_str(), i))
+        .collect();
+
+    let mut adjacency: Vec<Vec<(usize, usize)>> = vec![Vec::new(); nodes.len()]; // (target, edge_index)
+    for (edge_index, edge) in edges.iter().enumerate() {
+        if let (Some(&from), Some(&to)) = (
+            index_of.get(edge.from.as_str()),
+            index_of.get(edge.to.as_str()),
+        ) {
+            adjacency[from].push((to, edge_index));
+        }
+    }
+
+    let mut visited = vec![false; nodes.len()];
+    let mut on_path = vec![false; nodes.len()];
+    let mut cycle_edge_indices: Vec<usize> = Vec::new();
+
+    let start_indices: Vec<usize> = roots
+        .iter()
+        .filter_map(|id| index_of.get(id.as_str()).copied())
+        .chain((0..nodes.len()).filter(|i| !visited[*i]))
+        .collect();
+
+    for start in start_indices {
+        if visited[start] {
+            continue;
+        }
+        dfs_mark_back_edges(
+            start,
+            &adjacency,
+            &mut visited,
+            &mut on_path,
+            &mut cycle_edge_indices,
+        );
+    }
+
+    for edge_index in cycle_edge_indices {
+        edges[edge_index].is_cycle = true;
+    }
+}
+
+/// Iterative pre-order DFS from `start`, recording the edge index of every
+/// back edge (an edge to a node currently `on_path`, i.e. an ancestor in
+/// the DFS tree) into `cycle_edge_indices`. Iterative rather than recursive
+/// for the same stack-depth reason as `tarjan_sccs`.
+fn dfs_mark_back_edges(
+    start: usize,
+    adjacency: &[Vec<(usize, usize)>],
+    visited: &mut [bool],
+    on_path: &mut [bool],
+    cycle_edge_indices: &mut Vec<usize>,
+) {
+    // Explicit work-stack entries: (node, next child index to visit).
+    let mut work: Vec<(usize, usize)> = vec![(start, 0)];
+    visited[start] = true;
+    on_path[start] = true;
+
+    while let Some(&(v, child_i)) = work.last() {
+        if child_i < adjacency[v].len() {
+            let (w, edge_index) = adjacency[v][child_i];
+            work.last_mut().unwrap().1 += 1;
+
+            if on_path[w] {
+                cycle_edge_indices.push(edge_index);
+            } else if !visited[w] {
+                visited[w] = true;
+                on_path[w] = true;
+                work.push((w, 0));
+            }
+            // `visited[w] && !on_path[w]`: a cross/forward edge to an
+            // already-fully-explored node — not a cycle, nothing to mark.
+        } else {
+            on_path[v] = false;
+            work.pop();
+        }
+    }
+}
+
+/// Tarjan's strongly-connected-components algorithm, iterative (not
+/// recursive) to avoid stack overflow on pathologically deep call chains in
+/// a large diff. Returns each SCC as a `Vec<usize>` of node indices;
+/// singleton SCCs (a node with no cycle through itself) are included too,
+/// same as any other SCC — the caller does not need to special-case them.
+fn tarjan_sccs(adjacency: &[Vec<usize>]) -> Vec<Vec<usize>> {
+    let n = adjacency.len();
+    let mut index_counter = 0usize;
+    let mut indices: Vec<Option<usize>> = vec![None; n];
+    let mut lowlink: Vec<usize> = vec![0; n];
+    let mut on_stack: Vec<bool> = vec![false; n];
+    let mut stack: Vec<usize> = Vec::new();
+    let mut sccs: Vec<Vec<usize>> = Vec::new();
+
+    // Explicit work-stack entries: (node, next child index to visit).
+    for start in 0..n {
+        if indices[start].is_some() {
+            continue;
+        }
+        let mut work: Vec<(usize, usize)> = vec![(start, 0)];
+
+        while let Some(&(v, child_i)) = work.last() {
+            if child_i == 0 {
+                indices[v] = Some(index_counter);
+                lowlink[v] = index_counter;
+                index_counter += 1;
+                stack.push(v);
+                on_stack[v] = true;
+            }
+
+            if child_i < adjacency[v].len() {
+                let w = adjacency[v][child_i];
+                work.last_mut().unwrap().1 += 1;
+
+                if indices[w].is_none() {
+                    work.push((w, 0));
+                } else if on_stack[w] {
+                    lowlink[v] = lowlink[v].min(indices[w].unwrap());
+                }
+            } else {
+                work.pop();
+                if let Some(&(parent, _)) = work.last() {
+                    lowlink[parent] = lowlink[parent].min(lowlink[v]);
+                }
+
+                if lowlink[v] == indices[v].unwrap() {
+                    let mut component = Vec::new();
+                    loop {
+                        let w = stack.pop().expect("stack must contain v's SCC members");
+                        on_stack[w] = false;
+                        component.push(w);
+                        if w == v {
+                            break;
+                        }
+                    }
+                    sccs.push(component);
+                }
+            }
+        }
+    }
+
+    sccs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::LineRange;
+    use crate::extract::{ExtractedSymbol, SymbolKind};
+    use pretty_assertions::assert_eq;
+
+    /// Builds an `ExtractedSymbol` with a given `name`/`referenced_names`,
+    /// filling every other field with a fixed placeholder — these tests
+    /// only care about the graph-building fields.
+    fn symbol(name: &str, referenced_names: Vec<&str>) -> ExtractedSymbol {
+        ExtractedSymbol {
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature: format!("fn {name}()"),
+            range: LineRange { start: 1, end: 1 },
+            container: None,
+            referenced_names: referenced_names.into_iter().map(str::to_string).collect(),
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+        }
+    }
+
+    #[test]
+    fn should_return_empty_graph_when_no_files() {
+        let files: Vec<FileReport> = vec![];
+
+        let expected = SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        };
+        let actual = build_graph(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_build_single_node_graph_with_itself_as_root_when_one_symbol_and_no_references() {
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol("foo", vec![])],
+        }];
+
+        let expected = SymbolGraph {
+            nodes: vec![Node {
+                id: "src/lib.rs::foo".to_string(),
+                path: "src/lib.rs".to_string(),
+                name: "foo".to_string(),
+            }],
+            edges: vec![],
+            roots: vec!["src/lib.rs::foo".to_string()],
+        };
+        let actual = build_graph(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_build_edge_when_symbol_references_another_changed_symbol_by_name() {
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol("foo", vec!["bar"]), symbol("bar", vec![])],
+        }];
+
+        let expected = SymbolGraph {
+            nodes: vec![
+                Node {
+                    id: "src/lib.rs::foo".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "foo".to_string(),
+                },
+                Node {
+                    id: "src/lib.rs::bar".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "bar".to_string(),
+                },
+            ],
+            edges: vec![Edge {
+                from: "src/lib.rs::foo".to_string(),
+                to: "src/lib.rs::bar".to_string(),
+                is_cycle: false,
+            }],
+            roots: vec!["src/lib.rs::foo".to_string()],
+        };
+        let actual = build_graph(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_exclude_self_reference_edge_when_symbol_references_its_own_name() {
+        // A struct's own name is captured as a `referenced_names` entry by
+        // the extractor (see `extract::collect_referenced_names`'s doc
+        // comment on self-references) — this must not produce a self-loop
+        // edge.
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol("Point", vec!["Point"])],
+        }];
+
+        let expected = SymbolGraph {
+            nodes: vec![Node {
+                id: "src/lib.rs::Point".to_string(),
+                path: "src/lib.rs".to_string(),
+                name: "Point".to_string(),
+            }],
+            edges: vec![],
+            roots: vec!["src/lib.rs::Point".to_string()],
+        };
+        let actual = build_graph(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_disambiguate_node_id_with_start_line_when_duplicate_path_and_name() {
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    range: LineRange { start: 1, end: 2 },
+                    ..symbol("foo", vec![])
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 10, end: 12 },
+                    ..symbol("foo", vec![])
+                },
+            ],
+        }];
+
+        let expected_ids = vec![
+            "src/lib.rs::foo@1".to_string(),
+            "src/lib.rs::foo@10".to_string(),
+        ];
+        let actual = build_graph(&files);
+        let actual_ids: Vec<NodeId> = actual.nodes.iter().map(|n| n.id.clone()).collect();
+
+        assert_eq!(expected_ids, actual_ids);
+    }
+
+    #[test]
+    fn should_find_root_via_scc_representative_when_two_symbols_reference_each_other() {
+        // `foo` and `bar` reference each other (mutual recursion): neither
+        // has an in-degree-0 raw node, but their SCC as a whole has no
+        // incoming edge from outside, so the SCC's first-in-source-order
+        // member ("foo") becomes the root.
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol("foo", vec!["bar"]), symbol("bar", vec!["foo"])],
+        }];
+
+        let expected_roots = vec!["src/lib.rs::foo".to_string()];
+        let actual = build_graph(&files);
+
+        assert_eq!(expected_roots, actual.roots);
+    }
+
+    #[test]
+    fn should_mark_back_edge_as_cycle_when_two_symbols_reference_each_other() {
+        // "foo" -> "bar" is the forward (tree) edge from the DFS root
+        // ("foo"); "bar" -> "foo" is the back edge that closes the loop and
+        // must be marked `is_cycle: true`. The forward edge is a normal
+        // dependency edge, not a cycle edge itself.
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol("foo", vec!["bar"]), symbol("bar", vec!["foo"])],
+        }];
+
+        let expected_edges = vec![
+            Edge {
+                from: "src/lib.rs::foo".to_string(),
+                to: "src/lib.rs::bar".to_string(),
+                is_cycle: false,
+            },
+            Edge {
+                from: "src/lib.rs::bar".to_string(),
+                to: "src/lib.rs::foo".to_string(),
+                is_cycle: true,
+            },
+        ];
+        let actual = build_graph(&files);
+
+        assert_eq!(expected_edges, actual.edges);
+    }
+
+    #[test]
+    fn should_mark_self_referencing_cycle_edge_when_three_symbols_form_a_cycle() {
+        // foo -> bar -> baz -> foo: a 3-node cycle. DFS starts at "foo"
+        // (its only root, since the whole SCC has no incoming edge from
+        // outside), walks foo -> bar -> baz, and baz -> foo is the back
+        // edge.
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                symbol("foo", vec!["bar"]),
+                symbol("bar", vec!["baz"]),
+                symbol("baz", vec!["foo"]),
+            ],
+        }];
+
+        let expected_edges = vec![
+            Edge {
+                from: "src/lib.rs::foo".to_string(),
+                to: "src/lib.rs::bar".to_string(),
+                is_cycle: false,
+            },
+            Edge {
+                from: "src/lib.rs::bar".to_string(),
+                to: "src/lib.rs::baz".to_string(),
+                is_cycle: false,
+            },
+            Edge {
+                from: "src/lib.rs::baz".to_string(),
+                to: "src/lib.rs::foo".to_string(),
+                is_cycle: true,
+            },
+        ];
+        let actual = build_graph(&files);
+
+        assert_eq!(expected_edges, actual.edges);
+    }
+
+    #[test]
+    fn should_not_mark_edge_as_cycle_when_two_roots_both_reach_a_shared_node() {
+        // "shared" is reachable from both "foo" and "bar" (a diamond, not a
+        // cycle): the second edge into "shared" is a cross/forward edge in
+        // DFS terms, not a back edge, so it must stay `is_cycle: false`.
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                symbol("foo", vec!["shared"]),
+                symbol("bar", vec!["shared"]),
+                symbol("shared", vec![]),
+            ],
+        }];
+
+        let expected_edges = vec![
+            Edge {
+                from: "src/lib.rs::foo".to_string(),
+                to: "src/lib.rs::shared".to_string(),
+                is_cycle: false,
+            },
+            Edge {
+                from: "src/lib.rs::bar".to_string(),
+                to: "src/lib.rs::shared".to_string(),
+                is_cycle: false,
+            },
+        ];
+        let actual = build_graph(&files);
+
+        assert_eq!(expected_edges, actual.edges);
+    }
+
+    #[test]
+    fn should_find_multiple_roots_when_two_independent_entry_points_exist() {
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                symbol("foo", vec!["shared"]),
+                symbol("bar", vec!["shared"]),
+                symbol("shared", vec![]),
+            ],
+        }];
+
+        let expected_roots = vec!["src/lib.rs::foo".to_string(), "src/lib.rs::bar".to_string()];
+        let actual = build_graph(&files);
+
+        assert_eq!(expected_roots, actual.roots);
+    }
+}

--- a/rinkaku-core/src/graph.rs
+++ b/rinkaku-core/src/graph.rs
@@ -78,6 +78,28 @@ pub fn build_graph(files: &[FileReport]) -> SymbolGraph {
     }
 }
 
+/// Assigns each symbol in `files` its [`ExtractedSymbol::id`] to match the
+/// [`NodeId`] `build_graph` gave its corresponding [`Node`] (ADR 0008: JSON
+/// consumers need to correlate a symbol with `SymbolGraph`'s
+/// `nodes`/`edges`/`roots` without recomputing the `{path}::{name}` scheme
+/// themselves). Iterates `files` in the same source order `collect_nodes`
+/// used to build `graph.nodes`, so `graph.nodes[i]` and the i-th symbol
+/// encountered here always correspond to the same definition — this
+/// ordering coupling is why `stamp_ids` takes the already-built `graph`
+/// rather than recomputing IDs independently, which could drift out of
+/// sync if the two ID-assignment schemes were ever edited separately.
+pub fn stamp_ids(files: &mut [FileReport], graph: &SymbolGraph) {
+    let mut node_index = 0;
+    for file in files.iter_mut() {
+        for symbol in file.symbols.iter_mut() {
+            if let Some(node) = graph.nodes.get(node_index) {
+                symbol.id = node.id.clone();
+            }
+            node_index += 1;
+        }
+    }
+}
+
 /// Assigns a stable [`NodeId`] to every symbol in source order. A `(path,
 /// name)` pair disambiguates with `@{start_line}` only when it is not
 /// already unique within `files` — the common case (no duplicate names)
@@ -401,6 +423,7 @@ mod tests {
     /// only care about the graph-building fields.
     fn symbol(name: &str, referenced_names: Vec<&str>) -> ExtractedSymbol {
         ExtractedSymbol {
+            id: String::new(),
             name: name.to_string(),
             kind: SymbolKind::Function,
             signature: format!("fn {name}()"),
@@ -658,5 +681,60 @@ mod tests {
         let actual = build_graph(&files);
 
         assert_eq!(expected_roots, actual.roots);
+    }
+
+    #[test]
+    fn should_stamp_each_symbol_id_when_graph_has_no_duplicate_names() {
+        let mut files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol("foo", vec!["bar"]), symbol("bar", vec![])],
+        }];
+        let graph = build_graph(&files);
+
+        stamp_ids(&mut files, &graph);
+
+        let expected = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    id: "src/lib.rs::foo".to_string(),
+                    ..symbol("foo", vec!["bar"])
+                },
+                ExtractedSymbol {
+                    id: "src/lib.rs::bar".to_string(),
+                    ..symbol("bar", vec![])
+                },
+            ],
+        }];
+
+        assert_eq!(expected, files);
+    }
+
+    #[test]
+    fn should_stamp_disambiguated_id_when_duplicate_path_and_name() {
+        let mut files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    range: LineRange { start: 1, end: 2 },
+                    ..symbol("foo", vec![])
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 10, end: 12 },
+                    ..symbol("foo", vec![])
+                },
+            ],
+        }];
+        let graph = build_graph(&files);
+
+        stamp_ids(&mut files, &graph);
+
+        let expected_ids = vec![
+            "src/lib.rs::foo@1".to_string(),
+            "src/lib.rs::foo@10".to_string(),
+        ];
+        let actual_ids: Vec<String> = files[0].symbols.iter().map(|s| s.id.clone()).collect();
+
+        assert_eq!(expected_ids, actual_ids);
     }
 }

--- a/rinkaku-core/src/graph.rs
+++ b/rinkaku-core/src/graph.rs
@@ -587,6 +587,41 @@ mod tests {
     }
 
     #[test]
+    fn should_disambiguate_every_node_id_when_three_symbols_share_path_and_name() {
+        // Guards against an off-by-one in the "more than 2" case: a naive
+        // implementation could special-case pairs (e.g. compare only the
+        // first two) and mishandle a third or later duplicate. All three
+        // must get a distinct `@{start_line}`-suffixed id.
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    range: LineRange { start: 1, end: 2 },
+                    ..symbol("foo", vec![])
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 10, end: 12 },
+                    ..symbol("foo", vec![])
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 20, end: 22 },
+                    ..symbol("foo", vec![])
+                },
+            ],
+        }];
+
+        let expected_ids = vec![
+            "src/lib.rs::foo@1".to_string(),
+            "src/lib.rs::foo@10".to_string(),
+            "src/lib.rs::foo@20".to_string(),
+        ];
+        let actual = build_graph(&files);
+        let actual_ids: Vec<NodeId> = actual.nodes.iter().map(|n| n.id.clone()).collect();
+
+        assert_eq!(expected_ids, actual_ids);
+    }
+
+    #[test]
     fn should_find_root_via_scc_representative_when_two_symbols_reference_each_other() {
         // `foo` and `bar` reference each other (mutual recursion): neither
         // has an in-degree-0 raw node, but their SCC as a whole has no

--- a/rinkaku-core/src/graph.rs
+++ b/rinkaku-core/src/graph.rs
@@ -247,8 +247,15 @@ fn find_roots(nodes: &[Node], edges: &[Edge]) -> Vec<NodeId> {
             continue;
         }
         // Representative = earliest in source order (smallest node index).
-        let representative = *scc.iter().min().expect("an SCC always has >=1 member");
-        roots.push(nodes[representative].id.clone());
+        // `tarjan_sccs` never produces an empty component (each `component`
+        // it pushes starts from a freshly-visited node and is only pushed
+        // after collecting at least that node), so `min()` always finds a
+        // value in practice; `if let` avoids asserting that invariant via
+        // `.expect()` in library code and simply skips a component that
+        // somehow turned out empty rather than panicking.
+        if let Some(&representative) = scc.iter().min() {
+            roots.push(nodes[representative].id.clone());
+        }
     }
 
     // sccs are discovered in reverse-postorder-ish order depending on the
@@ -332,10 +339,10 @@ fn dfs_mark_back_edges(
     visited[start] = true;
     on_path[start] = true;
 
-    while let Some(&(v, child_i)) = work.last() {
-        if child_i < adjacency[v].len() {
-            let (w, edge_index) = adjacency[v][child_i];
-            work.last_mut().unwrap().1 += 1;
+    while let Some(&mut (v, ref mut child_i)) = work.last_mut() {
+        if *child_i < adjacency[v].len() {
+            let (w, edge_index) = adjacency[v][*child_i];
+            *child_i += 1;
 
             if on_path[w] {
                 cycle_edge_indices.push(edge_index);
@@ -383,14 +390,26 @@ fn tarjan_sccs(adjacency: &[Vec<usize>]) -> Vec<Vec<usize>> {
                 on_stack[v] = true;
             }
 
+            let Some(frame) = work.last_mut() else {
+                // Unreachable in practice (the `while let Some(...) =
+                // work.last()` guard above just matched this same frame),
+                // but avoiding `.unwrap()` here keeps this library function
+                // panic-free even if that invariant is ever broken by a
+                // future edit — an empty `work` simply ends the loop for
+                // this `start` rather than panicking.
+                break;
+            };
+
             if child_i < adjacency[v].len() {
                 let w = adjacency[v][child_i];
-                work.last_mut().unwrap().1 += 1;
+                frame.1 += 1;
 
-                if indices[w].is_none() {
-                    work.push((w, 0));
-                } else if on_stack[w] {
-                    lowlink[v] = lowlink[v].min(indices[w].unwrap());
+                match indices[w] {
+                    None => work.push((w, 0)),
+                    Some(w_index) if on_stack[w] => {
+                        lowlink[v] = lowlink[v].min(w_index);
+                    }
+                    Some(_) => {}
                 }
             } else {
                 work.pop();
@@ -398,13 +417,21 @@ fn tarjan_sccs(adjacency: &[Vec<usize>]) -> Vec<Vec<usize>> {
                     lowlink[parent] = lowlink[parent].min(lowlink[v]);
                 }
 
-                if lowlink[v] == indices[v].unwrap() {
+                // `indices[v]` was set to `Some(_)` unconditionally above
+                // (at `child_i == 0`, the first time `v` was visited) and
+                // is never cleared afterward, so it is always `Some` here;
+                // `if let` reads that invariant without asserting it via
+                // `.expect()`. A `None` (unreachable in practice) simply
+                // skips emitting an SCC for `v` instead of panicking.
+                if let Some(v_index) = indices[v]
+                    && lowlink[v] == v_index
+                {
                     let mut component = Vec::new();
-                    loop {
-                        let w = stack.pop().expect("stack must contain v's SCC members");
+                    while let Some(w) = stack.pop() {
                         on_stack[w] = false;
+                        let is_v = w == v;
                         component.push(w);
-                        if w == v {
+                        if is_v {
                             break;
                         }
                     }

--- a/rinkaku-core/src/lib.rs
+++ b/rinkaku-core/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod deps;
 pub mod diff;
 pub mod extract;
+pub mod graph;
 pub mod language;
 pub mod pipeline;
 pub mod render;

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -10,6 +10,7 @@
 use crate::deps::{Resolver, resolve_dependencies};
 use crate::diff::{ChangeKind, parse_unified_diff};
 use crate::extract::extract_changed_symbols;
+use crate::graph::{build_graph, stamp_ids};
 use crate::language::language_for_path;
 use crate::render::{FileReport, Report, SkipReason, SkippedFile};
 use thiserror::Error;
@@ -115,12 +116,24 @@ pub fn analyze_diff(
         });
     }
 
-    let files = match resolver {
+    let mut files = match resolver {
         Some(resolver) => resolve_dependencies(files, resolver),
         None => files,
     };
 
-    Ok(Report { files, skipped })
+    // Built last, over the final `files`: the graph's node IDs must match
+    // whatever symbols actually end up in the report (dependency
+    // resolution does not add/remove/reorder symbols, but building the
+    // graph from the post-resolution list rather than an intermediate one
+    // avoids relying on that invariant holding forever).
+    let graph = build_graph(&files);
+    stamp_ids(&mut files, &graph);
+
+    Ok(Report {
+        files,
+        skipped,
+        graph,
+    })
 }
 
 /// Parses `diff_text` and collects every name referenced by any changed
@@ -194,6 +207,15 @@ mod tests {
         }
     }
 
+    /// An empty `SymbolGraph`, for tests where no changed symbols exist.
+    fn empty_graph() -> crate::graph::SymbolGraph {
+        crate::graph::SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        }
+    }
+
     #[test]
     fn should_return_empty_report_when_diff_is_empty() {
         let read_file = fake_reader(HashMap::new());
@@ -201,6 +223,7 @@ mod tests {
         let expected = Report {
             files: vec![],
             skipped: vec![],
+            graph: empty_graph(),
         };
         let actual = analyze_diff("", read_file, None).expect("analyze should succeed");
 
@@ -231,6 +254,7 @@ fn foo(a: i32) -> i32 {
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
+                    id: "src/lib.rs::foo".to_string(),
                     name: "foo".to_string(),
                     kind: SymbolKind::Function,
                     signature: "fn foo(a: i32) -> i32".to_string(),
@@ -242,6 +266,15 @@ fn foo(a: i32) -> i32 {
                 }],
             }],
             skipped: vec![],
+            graph: crate::graph::SymbolGraph {
+                nodes: vec![crate::graph::Node {
+                    id: "src/lib.rs::foo".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "foo".to_string(),
+                }],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
         };
         let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
 
@@ -270,6 +303,7 @@ index 4b825dc..0000000
                 path: "src/old.rs".to_string(),
                 reason: SkipReason::Deleted,
             }],
+            graph: empty_graph(),
         };
         let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
 
@@ -291,6 +325,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
                 path: "assets/logo.png".to_string(),
                 reason: SkipReason::Binary,
             }],
+            graph: empty_graph(),
         };
         let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
 
@@ -320,6 +355,7 @@ index e69de29..4b825dc 100644
                 path: "src/main.rb".to_string(),
                 reason: SkipReason::UnsupportedLanguage,
             }],
+            graph: empty_graph(),
         };
         let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
 
@@ -353,6 +389,7 @@ rename to src/new_name.rs
                 symbols: vec![],
             }],
             skipped: vec![],
+            graph: empty_graph(),
         };
         let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
 
@@ -425,6 +462,7 @@ index e69de29..4b825dc 100644
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
+                    id: "src/lib.rs::a".to_string(),
                     name: "a".to_string(),
                     kind: SymbolKind::Function,
                     signature: "fn a() -> i32".to_string(),
@@ -439,6 +477,15 @@ index e69de29..4b825dc 100644
                 path: "src/main.rb".to_string(),
                 reason: SkipReason::UnsupportedLanguage,
             }],
+            graph: crate::graph::SymbolGraph {
+                nodes: vec![crate::graph::Node {
+                    id: "src/lib.rs::a".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "a".to_string(),
+                }],
+                edges: vec![],
+                roots: vec!["src/lib.rs::a".to_string()],
+            },
         };
         let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
 

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -143,14 +143,15 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
     }
 
     let lookup = SymbolLookup::build(&report.files);
-    let visit_order = dfs_pre_order(&report.graph);
+    let children = children_by_node(&report.graph);
+    let visit_order = dfs_pre_order(&report.graph, &children);
 
     let mut out = String::new();
 
     if !report.graph.nodes.is_empty() {
         writeln!(out, "## Change graph")?;
         writeln!(out)?;
-        render_change_graph(&mut out, &report.graph, &lookup)?;
+        render_change_graph(&mut out, &report.graph, &children, &lookup)?;
         writeln!(out)?;
 
         writeln!(out, "## Definitions")?;
@@ -200,13 +201,13 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
 fn render_change_graph(
     out: &mut String,
     graph: &SymbolGraph,
+    children: &HashMap<&str, Vec<(&str, bool)>>,
     lookup: &SymbolLookup,
 ) -> Result<(), RenderError> {
-    let children = children_by_node(graph);
     let mut printed: HashSet<String> = HashSet::new();
 
     for root in &graph.roots {
-        render_tree_node(out, root, &children, lookup, &mut printed, 0)?;
+        render_tree_node(out, root, children, lookup, &mut printed, 0)?;
     }
     Ok(())
 }
@@ -367,22 +368,24 @@ fn symbol_kind_prefix(kind: SymbolKind) -> &'static str {
 /// non-cycle edges only (a cycle edge is rendered as a warning reference in
 /// `render_change_graph`, never walked into) and never revisiting a node.
 /// Used by `render_markdown` to decide "Definitions"' order, matching the
-/// order symbols first appear in the "Change graph" tree above it.
+/// order symbols first appear in the "Change graph" tree above it. Takes
+/// the already-built `children` lookup (built once by `render_markdown` and
+/// shared with `render_change_graph`) rather than rebuilding it from
+/// `graph.edges` itself.
 ///
 /// Falls back to visiting any node no root reaches (defensive: `roots` is
 /// documented to always cover every node via SCC condensation, see
 /// `graph::find_roots`, so this branch is not expected to trigger in
 /// practice, only guarding against that guarantee being broken later).
-fn dfs_pre_order(graph: &SymbolGraph) -> Vec<NodeId> {
-    let children = children_by_node(graph);
+fn dfs_pre_order(graph: &SymbolGraph, children: &HashMap<&str, Vec<(&str, bool)>>) -> Vec<NodeId> {
     let mut visited: HashSet<String> = HashSet::new();
     let mut order: Vec<NodeId> = Vec::new();
 
     for root in &graph.roots {
-        visit_from(root, &children, &mut visited, &mut order);
+        visit_from(root, children, &mut visited, &mut order);
     }
     for node in &graph.nodes {
-        visit_from(node.id.as_str(), &children, &mut visited, &mut order);
+        visit_from(node.id.as_str(), children, &mut visited, &mut order);
     }
 
     order

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -322,12 +322,28 @@ fn render_definition(
 /// e.g. `fn handle_pr (src/main.rs)`. The prefix comes from
 /// [`symbol_kind_prefix`], fixed per [`SymbolKind`] rather than derived
 /// from the signature text, so it stays stable across languages.
+///
+/// When `symbol.id` was disambiguated by line number (`graph::collect_nodes`
+/// appends `@{start_line}` whenever a report contains more than one symbol
+/// sharing the same `(path, name)` pair, e.g. two overloaded free
+/// functions), the label includes that line number too —
+/// `{prefix} {name} ({path}:{start_line})` — so the otherwise-identical
+/// entries stay distinguishable in "Change graph"/"Definitions". Detected
+/// by comparing `symbol.id` against the plain (non-disambiguated) form
+/// rather than parsing the id string, since `symbol.range.start` is the
+/// exact same line number `collect_nodes` used to build it.
 fn tree_label(path: &str, symbol: &ExtractedSymbol) -> String {
+    let plain_id = format!("{path}::{}", symbol.name);
+    let location = if symbol.id == plain_id {
+        path.to_string()
+    } else {
+        format!("{path}:{}", symbol.range.start)
+    };
     format!(
         "{} {} ({})",
         symbol_kind_prefix(symbol.kind),
         symbol.name,
-        path
+        location
     )
 }
 
@@ -654,6 +670,79 @@ fn foo()
 
 ```
 fn foo(a: i32) -> i32
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_include_start_line_in_label_when_node_id_is_disambiguated_by_line() {
+        // `graph::collect_nodes` appends `@{start_line}` to a node's id only
+        // when its `(path, name)` pair is not unique in the report (e.g.
+        // two overloaded free functions sharing a name). Without a visible
+        // line number, "Change graph"/"Definitions" would show two
+        // identical-looking `fn foo (src/lib.rs)` entries with no way to
+        // tell them apart.
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![
+                    ExtractedSymbol {
+                        range: LineRange { start: 1, end: 3 },
+                        ..symbol(
+                            "src/lib.rs::foo@1",
+                            "foo",
+                            SymbolKind::Function,
+                            "fn foo(a: i32)",
+                        )
+                    },
+                    ExtractedSymbol {
+                        range: LineRange { start: 10, end: 12 },
+                        ..symbol(
+                            "src/lib.rs::foo@10",
+                            "foo",
+                            SymbolKind::Function,
+                            "fn foo(a: i32, b: i32)",
+                        )
+                    },
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("src/lib.rs::foo@1", "src/lib.rs", "foo"),
+                    node("src/lib.rs::foo@10", "src/lib.rs", "foo"),
+                ],
+                edges: vec![],
+                roots: vec![
+                    "src/lib.rs::foo@1".to_string(),
+                    "src/lib.rs::foo@10".to_string(),
+                ],
+            },
+        };
+
+        let expected = "\
+## Change graph
+
+- fn foo (src/lib.rs:1)
+- fn foo (src/lib.rs:10)
+
+## Definitions
+
+### fn foo (src/lib.rs:1)
+
+```
+fn foo(a: i32)
+```
+
+### fn foo (src/lib.rs:10)
+
+```
+fn foo(a: i32, b: i32)
 ```
 
 "

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -1544,6 +1544,127 @@ fn foo()
         assert_eq!(expected, actual);
     }
 
+    // NOTE: these three tests hand-build a `Report` whose `graph` refers to
+    // node ids that have no corresponding `ExtractedSymbol` in `files` — an
+    // inconsistency `pipeline::analyze_diff` never actually produces (the
+    // graph is always built from, and ids stamped onto, the very same
+    // `files` list), but exercised here defensively so the lookup-miss
+    // fallback branches (`SymbolLookup::get` returning `None`) have direct
+    // coverage rather than being unreachable-in-practice dead code.
+
+    #[test]
+    fn should_skip_definitions_entry_when_visit_order_id_has_no_matching_symbol() {
+        // `dfs_pre_order`'s `visit_order` is derived from `graph.nodes`, not
+        // `files`, so a node with no matching `ExtractedSymbol` reaches the
+        // `let Some(..) = lookup.get(id) else { continue }` branch in the
+        // "Definitions" loop; the malformed root must simply be skipped
+        // rather than panicking or emitting a broken heading.
+        let report = Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::ghost", "src/lib.rs", "ghost")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::ghost".to_string()],
+            },
+        };
+
+        let expected = "\
+## Change graph
+
+
+## Definitions
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_nothing_for_root_when_root_id_has_no_matching_symbol() {
+        // Same lookup miss as above, but hit inside `render_tree_node`'s
+        // own `let Some(..) = lookup.get(id) else { return Ok(()) }` guard
+        // (the "Change graph" tree-line branch) rather than the
+        // "Definitions" loop.
+        let report = Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::ghost", "src/lib.rs", "ghost")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::ghost".to_string()],
+            },
+        };
+
+        let expected = "\
+## Change graph
+
+
+## Definitions
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        // Both malformed-root branches (the "Change graph" line and the
+        // "Definitions" entry) are exercised by the same minimal report;
+        // asserted together since there is no simpler input that isolates
+        // only one of the two lookups.
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_omit_cycle_warning_line_when_cycle_target_id_has_no_matching_symbol() {
+        // A cycle edge whose `to` id has no matching symbol hits
+        // `render_tree_node`'s inner `let Some(..) = lookup.get(child_id)
+        // else { continue }` guard (the cycle-warning branch specifically,
+        // as opposed to the two tests above which exercise the
+        // non-cycle-edge lookups) — the warning line is simply omitted
+        // rather than rendering a broken label.
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    SymbolKind::Function,
+                    "fn foo()",
+                )],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![Edge {
+                    from: "src/lib.rs::foo".to_string(),
+                    to: "src/lib.rs::ghost".to_string(),
+                    is_cycle: true,
+                }],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
+        };
+
+        let expected = "\
+## Change graph
+
+- fn foo (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo()
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
     #[test]
     fn should_render_json_with_graph_files_and_skipped_when_report_has_all_three() {
         let report = Report {

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -117,7 +117,9 @@ impl<'a> SymbolLookup<'a> {
 
 /// Renders a [`Report`] as Markdown: a "Change graph" tree of entry points
 /// (ADR 0008), a "Definitions" section with each changed symbol's signature
-/// in the same tree order, and a list of skipped files.
+/// in the same tree order, an "Other changed files" section for files that
+/// were analyzed but contributed no symbol (e.g. a pure rename — see
+/// `pipeline::analyze_diff`'s doc comment), and a list of skipped files.
 ///
 /// Path headings and tree labels (`{prefix} {name} ({path})`) do not escape
 /// Markdown special characters (`#`, `[`, `]`, `_`, ...). A path containing
@@ -126,7 +128,17 @@ impl<'a> SymbolLookup<'a> {
 /// in practice and the fenced code blocks (the part that matters for
 /// correctness) are already hardened against content-driven breakage.
 fn render_markdown(report: &Report) -> Result<String, RenderError> {
-    if report.graph.nodes.is_empty() && report.skipped.is_empty() {
+    let files_with_no_symbols: Vec<&str> = report
+        .files
+        .iter()
+        .filter(|file| file.symbols.is_empty())
+        .map(|file| file.path.as_str())
+        .collect();
+
+    if report.graph.nodes.is_empty()
+        && files_with_no_symbols.is_empty()
+        && report.skipped.is_empty()
+    {
         return Ok(String::new());
     }
 
@@ -149,6 +161,15 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
             };
             render_definition(&mut out, path, symbol)?;
         }
+    }
+
+    if !files_with_no_symbols.is_empty() {
+        writeln!(out, "## Other changed files")?;
+        writeln!(out)?;
+        for path in &files_with_no_symbols {
+            writeln!(out, "- {path}")?;
+        }
+        writeln!(out)?;
     }
 
     if !report.skipped.is_empty() {
@@ -474,6 +495,129 @@ mod tests {
         };
 
         let expected = "".to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    // Regression test: a pure rename (or mode-change-only diff) is reported
+    // as a `FileReport` with an empty `symbols` list (see
+    // `pipeline::analyze_diff`'s doc comment) rather than a `SkippedFile` —
+    // the file *was* looked at, it just had no symbol-level changes. Before
+    // this fix, such a file was silently dropped from Markdown output
+    // entirely (the empty-output guard fired because `graph.nodes` and
+    // `skipped` were both empty, even though `files` was not), which is a
+    // regression from the pre-ADR-0008 renderer that always emitted a `##
+    // {path}` heading for every entry in `report.files`.
+    #[test]
+    fn should_list_file_with_no_symbols_under_other_changed_files_when_report_has_no_graph_nodes() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/new_name.rs".to_string(),
+                symbols: vec![],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+        };
+
+        let expected = "\
+## Other changed files
+
+- src/new_name.rs
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_list_file_with_no_symbols_after_definitions_when_report_has_graph_nodes_too() {
+        // A diff with one file that has a changed symbol (feeds the
+        // "Change graph"/"Definitions" sections) alongside a pure-rename
+        // file with no symbols at all — the pure rename must still show up,
+        // in its own section after "Definitions".
+        let report = Report {
+            files: vec![
+                FileReport {
+                    path: "src/lib.rs".to_string(),
+                    symbols: vec![symbol(
+                        "src/lib.rs::foo",
+                        "foo",
+                        SymbolKind::Function,
+                        "fn foo()",
+                    )],
+                },
+                FileReport {
+                    path: "src/new_name.rs".to_string(),
+                    symbols: vec![],
+                },
+            ],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
+        };
+
+        let expected = "\
+## Change graph
+
+- fn foo (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo()
+```
+
+## Other changed files
+
+- src/new_name.rs
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_other_changed_files_before_skipped_files_when_report_has_both() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/new_name.rs".to_string(),
+                symbols: vec![],
+            }],
+            skipped: vec![SkippedFile {
+                path: "assets/logo.png".to_string(),
+                reason: SkipReason::Binary,
+            }],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+        };
+
+        let expected = "\
+## Other changed files
+
+- src/new_name.rs
+
+## Skipped files
+
+- assets/logo.png (binary)
+"
+        .to_string();
         let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
 
         assert_eq!(expected, actual);

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -2,15 +2,25 @@
 //!
 //! [`Report`] is the pipeline-wide result shape produced by
 //! [`crate::pipeline::analyze_diff`]: per-file extracted symbols plus the
-//! files that were skipped (unsupported language, binary, or deleted).
+//! files that were skipped (unsupported language, binary, or deleted), plus
+//! the [`crate::graph::SymbolGraph`] built over those symbols (ADR 0008).
 //! This module turns a `Report` into either Markdown (the default, meant
 //! for humans and LLMs) or JSON (`serde`-derived, for machine consumption).
+//!
+//! Markdown renders as two sections: a "Change graph" tree (names only,
+//! rooted at the graph's auto-detected entry points) giving the reader a
+//! call-hierarchy reading order, followed by "Definitions" — the full
+//! signature of every changed symbol, in the same tree order, each shown
+//! exactly once (ADR 0008's decision to avoid duplicating a symbol
+//! reachable from multiple roots).
 //!
 //! Skipped files are always listed, never silently dropped — a reviewer
 //! or LLM consuming the output needs to know what rinkaku didn't look at.
 
-use crate::extract::ExtractedSymbol;
+use crate::extract::{ExtractedSymbol, SymbolKind};
+use crate::graph::{NodeId, SymbolGraph};
 use serde::Serialize;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 use thiserror::Error;
 
@@ -19,6 +29,10 @@ use thiserror::Error;
 pub struct Report {
     pub files: Vec<FileReport>,
     pub skipped: Vec<SkippedFile>,
+    /// The dependency graph over `files`' symbols (ADR 0008): edges and
+    /// entry points used to render "Change graph" in Markdown, exposed here
+    /// too so JSON consumers get the same structure without recomputing it.
+    pub graph: SymbolGraph,
 }
 
 /// Extracted symbols for a single changed file.
@@ -77,56 +91,63 @@ pub fn render(report: &Report, format: OutputFormat) -> Result<String, RenderErr
     }
 }
 
-/// Renders a [`Report`] as Markdown: one heading per file with its
-/// symbols' signatures in a fenced code block, followed by a list of
-/// skipped files.
+/// A changed symbol paired with the path of the file it lives in, keyed by
+/// [`NodeId`] — the lookup table rendering needs to go from a graph node
+/// back to the full [`ExtractedSymbol`] (signature, container,
+/// dependencies) it represents.
+struct SymbolLookup<'a> {
+    by_id: HashMap<&'a str, (&'a str, &'a ExtractedSymbol)>,
+}
+
+impl<'a> SymbolLookup<'a> {
+    fn build(files: &'a [FileReport]) -> Self {
+        let mut by_id = HashMap::new();
+        for file in files {
+            for symbol in &file.symbols {
+                by_id.insert(symbol.id.as_str(), (file.path.as_str(), symbol));
+            }
+        }
+        Self { by_id }
+    }
+
+    fn get(&self, id: &str) -> Option<(&'a str, &'a ExtractedSymbol)> {
+        self.by_id.get(id).copied()
+    }
+}
+
+/// Renders a [`Report`] as Markdown: a "Change graph" tree of entry points
+/// (ADR 0008), a "Definitions" section with each changed symbol's signature
+/// in the same tree order, and a list of skipped files.
 ///
-/// Path headings (`## {path}`) do not escape Markdown special characters
-/// (`#`, `[`, `]`, `_`, ...). A path containing them can distort the
-/// rendered heading; this is accepted rather than escaped, since file
-/// paths with Markdown-significant characters are rare in practice and the
-/// fenced code blocks (the part that matters for correctness) are already
-/// hardened against content-driven breakage.
+/// Path headings and tree labels (`{prefix} {name} ({path})`) do not escape
+/// Markdown special characters (`#`, `[`, `]`, `_`, ...). A path containing
+/// them can distort the rendered heading; this is accepted rather than
+/// escaped, since file paths with Markdown-significant characters are rare
+/// in practice and the fenced code blocks (the part that matters for
+/// correctness) are already hardened against content-driven breakage.
 fn render_markdown(report: &Report) -> Result<String, RenderError> {
+    if report.graph.nodes.is_empty() && report.skipped.is_empty() {
+        return Ok(String::new());
+    }
+
+    let lookup = SymbolLookup::build(&report.files);
+    let visit_order = dfs_pre_order(&report.graph);
+
     let mut out = String::new();
 
-    for file in &report.files {
-        writeln!(out, "## {}", file.path)?;
+    if !report.graph.nodes.is_empty() {
+        writeln!(out, "## Change graph")?;
         writeln!(out)?;
-        for symbol in &file.symbols {
-            let container_line = symbol.container.as_deref().map(|c| format!("// {c}"));
-            let fence = fence_for(container_line.as_deref(), &symbol.signature);
-            writeln!(out, "{fence}")?;
-            if let Some(container_line) = &container_line {
-                writeln!(out, "{container_line}")?;
-            }
-            writeln!(out, "{}", symbol.signature)?;
-            writeln!(out, "{fence}")?;
-            writeln!(out)?;
-            if !symbol.dependencies.is_empty() || symbol.omitted_dependency_matches > 0 {
-                writeln!(out, "Depends on:")?;
-                for dependency in &symbol.dependencies {
-                    // Inline code spans (not a fenced block): a
-                    // dependency list entry is one line per dependency,
-                    // so a fence per entry would be noisy. Path and
-                    // signature are not hardened against embedded
-                    // backticks the way the fenced blocks above are — a
-                    // signature is unlikely to contain a backtick run
-                    // long enough to break out of a single backtick span,
-                    // and this is a cosmetic-only failure mode (unlike
-                    // the fenced blocks, which without widening could
-                    // make later content render as code).
-                    writeln!(out, "- `{}`: `{}`", dependency.path, dependency.signature)?;
-                }
-                if symbol.omitted_dependency_matches > 0 {
-                    writeln!(
-                        out,
-                        "- (+{} more definitions matched by name)",
-                        symbol.omitted_dependency_matches
-                    )?;
-                }
-                writeln!(out)?;
-            }
+        render_change_graph(&mut out, &report.graph, &lookup)?;
+        writeln!(out)?;
+
+        writeln!(out, "## Definitions")?;
+        writeln!(out)?;
+        for id in &visit_order {
+            let Some((path, symbol)) = lookup.get(id) else {
+                continue;
+            };
+            render_definition(&mut out, path, symbol)?;
         }
     }
 
@@ -144,6 +165,222 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
     }
 
     Ok(out)
+}
+
+/// Renders the "Change graph" section: an indented, names-only tree rooted
+/// at `graph.roots`, in root order. Each root starts its own top-level DFS;
+/// a node already printed earlier in the tree is re-shown by name only,
+/// suffixed `(see above)`, and not expanded again — this is what keeps a
+/// symbol reachable from multiple roots from being duplicated in full (ADR
+/// 0008). Cycle edges (`Edge::is_cycle`) are rendered as an explicit
+/// warning line instead of being walked into (walking into one would loop
+/// forever, since a cycle edge points back to an ancestor already on the
+/// current path).
+fn render_change_graph(
+    out: &mut String,
+    graph: &SymbolGraph,
+    lookup: &SymbolLookup,
+) -> Result<(), RenderError> {
+    let children = children_by_node(graph);
+    let mut printed: HashSet<String> = HashSet::new();
+
+    for root in &graph.roots {
+        render_tree_node(out, root, &children, lookup, &mut printed, 0)?;
+    }
+    Ok(())
+}
+
+/// Groups `graph.edges` by their `from` node, each target annotated with
+/// whether reaching it crosses a cycle edge. Preserves `edges`' own order
+/// (source appearance order, per `graph::collect_edges`'s doc comment), so
+/// a node's children are visited in a deterministic, diff-order-derived
+/// sequence.
+fn children_by_node(graph: &SymbolGraph) -> HashMap<&str, Vec<(&str, bool)>> {
+    let mut children: HashMap<&str, Vec<(&str, bool)>> = HashMap::new();
+    for edge in &graph.edges {
+        children
+            .entry(edge.from.as_str())
+            .or_default()
+            .push((edge.to.as_str(), edge.is_cycle));
+    }
+    children
+}
+
+/// Writes one tree line for `id` at `depth`, then recurses into its
+/// children (unless `id` was already printed earlier in the tree, in which
+/// case it is shown as a `(see above)` reference and not expanded).
+fn render_tree_node(
+    out: &mut String,
+    id: &str,
+    children: &HashMap<&str, Vec<(&str, bool)>>,
+    lookup: &SymbolLookup,
+    printed: &mut HashSet<String>,
+    depth: usize,
+) -> Result<(), RenderError> {
+    let indent = "  ".repeat(depth);
+    let Some((path, symbol)) = lookup.get(id) else {
+        return Ok(());
+    };
+    let label = tree_label(path, symbol);
+
+    if !printed.insert(id.to_string()) {
+        writeln!(out, "{indent}- {label} (see above)")?;
+        return Ok(());
+    }
+    writeln!(out, "{indent}- {label}")?;
+
+    if let Some(kids) = children.get(id) {
+        for &(child_id, is_cycle) in kids {
+            if is_cycle {
+                let Some((child_path, child_symbol)) = lookup.get(child_id) else {
+                    continue;
+                };
+                let child_label = tree_label(child_path, child_symbol);
+                writeln!(
+                    out,
+                    "{}  - ⚠️ {child_label} — dependency cycle, see above",
+                    indent
+                )?;
+                continue;
+            }
+            render_tree_node(out, child_id, children, lookup, printed, depth + 1)?;
+        }
+    }
+    Ok(())
+}
+
+/// Renders one symbol's "Definitions" entry: a `###` heading using the same
+/// label as the tree, the fenced signature (container comment included, as
+/// in the pre-ADR-0008 rendering), and its unchanged 1-hop `dependencies`
+/// under "Depends on:".
+fn render_definition(
+    out: &mut String,
+    path: &str,
+    symbol: &ExtractedSymbol,
+) -> Result<(), RenderError> {
+    writeln!(out, "### {}", tree_label(path, symbol))?;
+    writeln!(out)?;
+
+    let container_line = symbol.container.as_deref().map(|c| format!("// {c}"));
+    let fence = fence_for(container_line.as_deref(), &symbol.signature);
+    writeln!(out, "{fence}")?;
+    if let Some(container_line) = &container_line {
+        writeln!(out, "{container_line}")?;
+    }
+    writeln!(out, "{}", symbol.signature)?;
+    writeln!(out, "{fence}")?;
+    writeln!(out)?;
+
+    if !symbol.dependencies.is_empty() || symbol.omitted_dependency_matches > 0 {
+        writeln!(out, "Depends on:")?;
+        for dependency in &symbol.dependencies {
+            // Inline code spans (not a fenced block): a dependency list
+            // entry is one line per dependency, so a fence per entry would
+            // be noisy. Path and signature are not hardened against
+            // embedded backticks the way the fenced blocks above are — a
+            // signature is unlikely to contain a backtick run long enough
+            // to break out of a single backtick span, and this is a
+            // cosmetic-only failure mode (unlike the fenced blocks, which
+            // without widening could make later content render as code).
+            writeln!(out, "- `{}`: `{}`", dependency.path, dependency.signature)?;
+        }
+        if symbol.omitted_dependency_matches > 0 {
+            writeln!(
+                out,
+                "- (+{} more definitions matched by name)",
+                symbol.omitted_dependency_matches
+            )?;
+        }
+        writeln!(out)?;
+    }
+
+    Ok(())
+}
+
+/// Builds a tree/heading label for `symbol`: `{prefix} {name} ({path})`,
+/// e.g. `fn handle_pr (src/main.rs)`. The prefix comes from
+/// [`symbol_kind_prefix`], fixed per [`SymbolKind`] rather than derived
+/// from the signature text, so it stays stable across languages.
+fn tree_label(path: &str, symbol: &ExtractedSymbol) -> String {
+    format!(
+        "{} {} ({})",
+        symbol_kind_prefix(symbol.kind),
+        symbol.name,
+        path
+    )
+}
+
+/// Maps a [`SymbolKind`] to the short, lowercase word used as a tree/heading
+/// label prefix. Not tied to any one language's keyword set (`SymbolKind`
+/// is already language-neutral, see its own doc comment) — chosen to read
+/// naturally for the concept each variant represents.
+fn symbol_kind_prefix(kind: SymbolKind) -> &'static str {
+    match kind {
+        SymbolKind::Function => "fn",
+        SymbolKind::Struct => "struct",
+        SymbolKind::Enum => "enum",
+        SymbolKind::Trait => "trait",
+        SymbolKind::Class => "class",
+        SymbolKind::Interface => "interface",
+        SymbolKind::TypeAlias => "type",
+    }
+}
+
+/// Pre-order DFS over `graph` starting at `roots`, in root order, following
+/// non-cycle edges only (a cycle edge is rendered as a warning reference in
+/// `render_change_graph`, never walked into) and never revisiting a node.
+/// Used by `render_markdown` to decide "Definitions"' order, matching the
+/// order symbols first appear in the "Change graph" tree above it.
+///
+/// Falls back to visiting any node no root reaches (defensive: `roots` is
+/// documented to always cover every node via SCC condensation, see
+/// `graph::find_roots`, so this branch is not expected to trigger in
+/// practice, only guarding against that guarantee being broken later).
+fn dfs_pre_order(graph: &SymbolGraph) -> Vec<NodeId> {
+    let children = children_by_node(graph);
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut order: Vec<NodeId> = Vec::new();
+
+    for root in &graph.roots {
+        visit_from(root, &children, &mut visited, &mut order);
+    }
+    for node in &graph.nodes {
+        visit_from(node.id.as_str(), &children, &mut visited, &mut order);
+    }
+
+    order
+}
+
+/// Iterative pre-order DFS from `start`, appending every newly-visited node
+/// to `order` and following non-cycle edges only. Shared by `dfs_pre_order`
+/// for both its `roots` pass and its defensive fallback pass over every
+/// node.
+fn visit_from(
+    start: &str,
+    children: &HashMap<&str, Vec<(&str, bool)>>,
+    visited: &mut HashSet<String>,
+    order: &mut Vec<NodeId>,
+) {
+    if !visited.insert(start.to_string()) {
+        return;
+    }
+    // Explicit stack rather than recursion, to match the style used
+    // elsewhere in the graph/render modules for unbounded-depth walks.
+    let mut stack = vec![start];
+    order.push(start.to_string());
+    while let Some(current) = stack.pop() {
+        if let Some(kids) = children.get(current) {
+            // Push in reverse so children are visited in edge order (a
+            // `Vec`-backed stack pops last-in-first-out).
+            for &(child, is_cycle) in kids.iter().rev() {
+                if is_cycle || !visited.insert(child.to_string()) {
+                    continue;
+                }
+                order.push(child.to_string());
+                stack.push(child);
+            }
+        }
+    }
 }
 
 /// Picks a fence long enough that it cannot be closed early by a backtick
@@ -180,13 +417,45 @@ mod tests {
     use super::*;
     use crate::diff::LineRange;
     use crate::extract::SymbolKind;
+    use crate::graph::{Edge, Node};
     use pretty_assertions::assert_eq;
+
+    /// Builds an `ExtractedSymbol` for rendering tests, with `id` set (the
+    /// graph-building pipeline stage this module assumes already ran) and
+    /// every other field defaulted to something inert unless overridden via
+    /// struct-update syntax at the call site.
+    fn symbol(id: &str, name: &str, kind: SymbolKind, signature: &str) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind,
+            signature: signature.to_string(),
+            range: LineRange { start: 1, end: 1 },
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+        }
+    }
+
+    fn node(id: &str, path: &str, name: &str) -> Node {
+        Node {
+            id: id.to_string(),
+            path: path.to_string(),
+            name: name.to_string(),
+        }
+    }
 
     #[test]
     fn should_render_empty_markdown_when_report_has_no_files_and_no_skips() {
         let report = Report {
             files: vec![],
             skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
         };
 
         let expected = "".to_string();
@@ -196,29 +465,354 @@ mod tests {
     }
 
     #[test]
-    fn should_render_markdown_heading_and_fenced_signature_when_file_has_one_symbol() {
+    fn should_render_change_graph_and_definitions_when_report_has_one_symbol() {
         let report = Report {
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
-                symbols: vec![ExtractedSymbol {
-                    name: "foo".to_string(),
-                    kind: SymbolKind::Function,
-                    signature: "fn foo(a: i32) -> i32".to_string(),
-                    range: LineRange { start: 1, end: 3 },
-                    container: None,
-                    referenced_names: vec![],
-                    dependencies: vec![],
-                    omitted_dependency_matches: 0,
-                }],
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    SymbolKind::Function,
+                    "fn foo(a: i32) -> i32",
+                )],
             }],
             skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
         };
 
         let expected = "\
-## src/lib.rs
+## Change graph
+
+- fn foo (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
 
 ```
 fn foo(a: i32) -> i32
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_nest_callee_under_caller_in_change_graph_when_symbol_references_another() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/main.rs".to_string(),
+                symbols: vec![
+                    symbol(
+                        "src/main.rs::handle_pr",
+                        "handle_pr",
+                        SymbolKind::Function,
+                        "fn handle_pr(args: PrArgs) -> Result<()>",
+                    ),
+                    symbol(
+                        "src/main.rs::resolve_pr_base_sha",
+                        "resolve_pr_base_sha",
+                        SymbolKind::Function,
+                        "fn resolve_pr_base_sha() -> Result<String>",
+                    ),
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("src/main.rs::handle_pr", "src/main.rs", "handle_pr"),
+                    node(
+                        "src/main.rs::resolve_pr_base_sha",
+                        "src/main.rs",
+                        "resolve_pr_base_sha",
+                    ),
+                ],
+                edges: vec![Edge {
+                    from: "src/main.rs::handle_pr".to_string(),
+                    to: "src/main.rs::resolve_pr_base_sha".to_string(),
+                    is_cycle: false,
+                }],
+                roots: vec!["src/main.rs::handle_pr".to_string()],
+            },
+        };
+
+        let expected = "\
+## Change graph
+
+- fn handle_pr (src/main.rs)
+  - fn resolve_pr_base_sha (src/main.rs)
+
+## Definitions
+
+### fn handle_pr (src/main.rs)
+
+```
+fn handle_pr(args: PrArgs) -> Result<()>
+```
+
+### fn resolve_pr_base_sha (src/main.rs)
+
+```
+fn resolve_pr_base_sha() -> Result<String>
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_mark_see_above_when_symbol_reachable_from_multiple_roots() {
+        // Both "foo" and "bar" reference "shared": it must be rendered in
+        // full once (under "foo", the first root in source order) and
+        // referenced by name only under "bar" (ADR 0008).
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![
+                    symbol("src/lib.rs::foo", "foo", SymbolKind::Function, "fn foo()"),
+                    symbol("src/lib.rs::bar", "bar", SymbolKind::Function, "fn bar()"),
+                    symbol(
+                        "src/lib.rs::shared",
+                        "shared",
+                        SymbolKind::Function,
+                        "fn shared()",
+                    ),
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                    node("src/lib.rs::bar", "src/lib.rs", "bar"),
+                    node("src/lib.rs::shared", "src/lib.rs", "shared"),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "src/lib.rs::foo".to_string(),
+                        to: "src/lib.rs::shared".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "src/lib.rs::bar".to_string(),
+                        to: "src/lib.rs::shared".to_string(),
+                        is_cycle: false,
+                    },
+                ],
+                roots: vec!["src/lib.rs::foo".to_string(), "src/lib.rs::bar".to_string()],
+            },
+        };
+
+        let expected = "\
+## Change graph
+
+- fn foo (src/lib.rs)
+  - fn shared (src/lib.rs)
+- fn bar (src/lib.rs)
+  - fn shared (src/lib.rs) (see above)
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo()
+```
+
+### fn shared (src/lib.rs)
+
+```
+fn shared()
+```
+
+### fn bar (src/lib.rs)
+
+```
+fn bar()
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_cycle_warning_when_edge_is_marked_as_cycle() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/git.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/git.rs::resolve_pr_base_sha",
+                    "resolve_pr_base_sha",
+                    SymbolKind::Function,
+                    "fn resolve_pr_base_sha()",
+                )],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node(
+                    "src/git.rs::resolve_pr_base_sha",
+                    "src/git.rs",
+                    "resolve_pr_base_sha",
+                )],
+                edges: vec![Edge {
+                    from: "src/git.rs::resolve_pr_base_sha".to_string(),
+                    to: "src/git.rs::resolve_pr_base_sha".to_string(),
+                    is_cycle: true,
+                }],
+                roots: vec!["src/git.rs::resolve_pr_base_sha".to_string()],
+            },
+        };
+
+        let expected = "\
+## Change graph
+
+- fn resolve_pr_base_sha (src/git.rs)
+  - ⚠️ fn resolve_pr_base_sha (src/git.rs) — dependency cycle, see above
+
+## Definitions
+
+### fn resolve_pr_base_sha (src/git.rs)
+
+```
+fn resolve_pr_base_sha()
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_full_cycle_example_with_two_root_functions_and_a_dependency_cycle() {
+        // The scenario from the ADR walkthrough: `handle_pr` calls
+        // `resolve_pr_base_sha`, which calls `fetch_base_branch` and also
+        // (a design smell the tool should surface) calls back into
+        // itself. `Config` is an unrelated, independent root.
+        let report = Report {
+            files: vec![
+                FileReport {
+                    path: "src/main.rs".to_string(),
+                    symbols: vec![symbol(
+                        "src/main.rs::handle_pr",
+                        "handle_pr",
+                        SymbolKind::Function,
+                        "fn handle_pr(args: PrArgs) -> Result<()>",
+                    )],
+                },
+                FileReport {
+                    path: "src/git.rs".to_string(),
+                    symbols: vec![
+                        symbol(
+                            "src/git.rs::resolve_pr_base_sha",
+                            "resolve_pr_base_sha",
+                            SymbolKind::Function,
+                            "fn resolve_pr_base_sha() -> Result<String>",
+                        ),
+                        symbol(
+                            "src/git.rs::fetch_base_branch",
+                            "fetch_base_branch",
+                            SymbolKind::Function,
+                            "fn fetch_base_branch() -> Result<()>",
+                        ),
+                    ],
+                },
+                FileReport {
+                    path: "src/config.rs".to_string(),
+                    symbols: vec![symbol(
+                        "src/config.rs::Config",
+                        "Config",
+                        SymbolKind::Struct,
+                        "struct Config { path: String }",
+                    )],
+                },
+            ],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("src/main.rs::handle_pr", "src/main.rs", "handle_pr"),
+                    node(
+                        "src/git.rs::resolve_pr_base_sha",
+                        "src/git.rs",
+                        "resolve_pr_base_sha",
+                    ),
+                    node(
+                        "src/git.rs::fetch_base_branch",
+                        "src/git.rs",
+                        "fetch_base_branch",
+                    ),
+                    node("src/config.rs::Config", "src/config.rs", "Config"),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "src/main.rs::handle_pr".to_string(),
+                        to: "src/git.rs::resolve_pr_base_sha".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "src/git.rs::resolve_pr_base_sha".to_string(),
+                        to: "src/git.rs::fetch_base_branch".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "src/git.rs::resolve_pr_base_sha".to_string(),
+                        to: "src/git.rs::resolve_pr_base_sha".to_string(),
+                        is_cycle: true,
+                    },
+                ],
+                roots: vec![
+                    "src/main.rs::handle_pr".to_string(),
+                    "src/config.rs::Config".to_string(),
+                ],
+            },
+        };
+
+        let expected = "\
+## Change graph
+
+- fn handle_pr (src/main.rs)
+  - fn resolve_pr_base_sha (src/git.rs)
+    - fn fetch_base_branch (src/git.rs)
+    - ⚠️ fn resolve_pr_base_sha (src/git.rs) — dependency cycle, see above
+- struct Config (src/config.rs)
+
+## Definitions
+
+### fn handle_pr (src/main.rs)
+
+```
+fn handle_pr(args: PrArgs) -> Result<()>
+```
+
+### fn resolve_pr_base_sha (src/git.rs)
+
+```
+fn resolve_pr_base_sha() -> Result<String>
+```
+
+### fn fetch_base_branch (src/git.rs)
+
+```
+fn fetch_base_branch() -> Result<()>
+```
+
+### struct Config (src/config.rs)
+
+```
+struct Config { path: String }
 ```
 
 "
@@ -234,21 +828,31 @@ fn foo(a: i32) -> i32
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
-                    name: "bar".to_string(),
-                    kind: SymbolKind::Function,
-                    signature: "fn bar(&self) -> i32".to_string(),
-                    range: LineRange { start: 4, end: 6 },
                     container: Some("impl Foo".to_string()),
-                    referenced_names: vec![],
-                    dependencies: vec![],
-                    omitted_dependency_matches: 0,
+                    ..symbol(
+                        "src/lib.rs::bar",
+                        "bar",
+                        SymbolKind::Function,
+                        "fn bar(&self) -> i32",
+                    )
                 }],
             }],
             skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::bar", "src/lib.rs", "bar")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::bar".to_string()],
+            },
         };
 
         let expected = "\
-## src/lib.rs
+## Change graph
+
+- fn bar (src/lib.rs)
+
+## Definitions
+
+### fn bar (src/lib.rs)
 
 ```
 // impl Foo
@@ -268,24 +872,34 @@ fn bar(&self) -> i32
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
-                    name: "foo".to_string(),
-                    kind: SymbolKind::Function,
-                    signature: "fn foo(p: Point) -> i32".to_string(),
-                    range: LineRange { start: 1, end: 3 },
-                    container: None,
-                    referenced_names: vec!["Point".to_string()],
                     dependencies: vec![crate::deps::ResolvedSymbol {
                         signature: "struct Point { x: i32, y: i32 }".to_string(),
                         path: "src/point.rs".to_string(),
                     }],
-                    omitted_dependency_matches: 0,
+                    ..symbol(
+                        "src/lib.rs::foo",
+                        "foo",
+                        SymbolKind::Function,
+                        "fn foo(p: Point) -> i32",
+                    )
                 }],
             }],
             skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
         };
 
         let expected = "\
-## src/lib.rs
+## Change graph
+
+- fn foo (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
 
 ```
 fn foo(p: Point) -> i32
@@ -307,12 +921,6 @@ Depends on:
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
-                    name: "foo".to_string(),
-                    kind: SymbolKind::Function,
-                    signature: "fn foo(p: Point) -> i32".to_string(),
-                    range: LineRange { start: 1, end: 3 },
-                    container: None,
-                    referenced_names: vec!["Point".to_string()],
                     dependencies: vec![
                         crate::deps::ResolvedSymbol {
                             signature: "struct Point { x: i32 }".to_string(),
@@ -323,14 +931,30 @@ Depends on:
                             path: "src/b.rs".to_string(),
                         },
                     ],
-                    omitted_dependency_matches: 0,
+                    ..symbol(
+                        "src/lib.rs::foo",
+                        "foo",
+                        SymbolKind::Function,
+                        "fn foo(p: Point) -> i32",
+                    )
                 }],
             }],
             skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
         };
 
         let expected = "\
-## src/lib.rs
+## Change graph
+
+- fn foo (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
 
 ```
 fn foo(p: Point) -> i32
@@ -353,24 +977,35 @@ Depends on:
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
-                    name: "foo".to_string(),
-                    kind: SymbolKind::Function,
-                    signature: "fn foo(p: Point) -> i32".to_string(),
-                    range: LineRange { start: 1, end: 3 },
-                    container: None,
-                    referenced_names: vec!["Point".to_string()],
                     dependencies: vec![crate::deps::ResolvedSymbol {
                         signature: "struct Point { x: i32 }".to_string(),
                         path: "src/a.rs".to_string(),
                     }],
                     omitted_dependency_matches: 2,
+                    ..symbol(
+                        "src/lib.rs::foo",
+                        "foo",
+                        SymbolKind::Function,
+                        "fn foo(p: Point) -> i32",
+                    )
                 }],
             }],
             skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
         };
 
         let expected = "\
-## src/lib.rs
+## Change graph
+
+- fn foo (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
 
 ```
 fn foo(p: Point) -> i32
@@ -397,23 +1032,33 @@ Depends on:
         let report = Report {
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
-                symbols: vec![ExtractedSymbol {
-                    name: "example_macro".to_string(),
-                    kind: SymbolKind::Function,
-                    signature: "fn example_macro() { let s = \"```rust\\nfn f() {}\\n```\"; }"
-                        .to_string(),
-                    range: LineRange { start: 1, end: 1 },
-                    container: None,
-                    referenced_names: vec![],
-                    dependencies: vec![],
-                    omitted_dependency_matches: 0,
-                }],
+                symbols: vec![symbol(
+                    "src/lib.rs::example_macro",
+                    "example_macro",
+                    SymbolKind::Function,
+                    "fn example_macro() { let s = \"```rust\\nfn f() {}\\n```\"; }",
+                )],
             }],
             skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node(
+                    "src/lib.rs::example_macro",
+                    "src/lib.rs",
+                    "example_macro",
+                )],
+                edges: vec![],
+                roots: vec!["src/lib.rs::example_macro".to_string()],
+            },
         };
 
         let expected = "\
-## src/lib.rs
+## Change graph
+
+- fn example_macro (src/lib.rs)
+
+## Definitions
+
+### fn example_macro (src/lib.rs)
 
 ````
 fn example_macro() { let s = \"```rust\\nfn f() {}\\n```\"; }
@@ -435,21 +1080,31 @@ fn example_macro() { let s = \"```rust\\nfn f() {}\\n```\"; }
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
-                    name: "bar".to_string(),
-                    kind: SymbolKind::Function,
-                    signature: "fn bar(&self) -> i32".to_string(),
-                    range: LineRange { start: 4, end: 6 },
                     container: Some("impl Foo /* ```` */".to_string()),
-                    referenced_names: vec![],
-                    dependencies: vec![],
-                    omitted_dependency_matches: 0,
+                    ..symbol(
+                        "src/lib.rs::bar",
+                        "bar",
+                        SymbolKind::Function,
+                        "fn bar(&self) -> i32",
+                    )
                 }],
             }],
             skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::bar", "src/lib.rs", "bar")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::bar".to_string()],
+            },
         };
 
         let expected = "\
-## src/lib.rs
+## Change graph
+
+- fn bar (src/lib.rs)
+
+## Definitions
+
+### fn bar (src/lib.rs)
 
 `````
 // impl Foo /* ```` */
@@ -481,6 +1136,11 @@ fn bar(&self) -> i32
                     reason: SkipReason::Deleted,
                 },
             ],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
         };
 
         let expected = "\
@@ -497,29 +1157,36 @@ fn bar(&self) -> i32
     }
 
     #[test]
-    fn should_render_files_then_skipped_section_when_report_has_both() {
+    fn should_render_change_graph_then_skipped_section_when_report_has_both() {
         let report = Report {
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
-                symbols: vec![ExtractedSymbol {
-                    name: "foo".to_string(),
-                    kind: SymbolKind::Function,
-                    signature: "fn foo()".to_string(),
-                    range: LineRange { start: 1, end: 1 },
-                    container: None,
-                    referenced_names: vec![],
-                    dependencies: vec![],
-                    omitted_dependency_matches: 0,
-                }],
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    SymbolKind::Function,
+                    "fn foo()",
+                )],
             }],
             skipped: vec![SkippedFile {
                 path: "assets/logo.png".to_string(),
                 reason: SkipReason::Binary,
             }],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
         };
 
         let expected = "\
-## src/lib.rs
+## Change graph
+
+- fn foo (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
 
 ```
 fn foo()
@@ -536,25 +1203,26 @@ fn foo()
     }
 
     #[test]
-    fn should_render_json_with_files_and_skipped_when_report_has_both() {
+    fn should_render_json_with_graph_files_and_skipped_when_report_has_all_three() {
         let report = Report {
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
-                symbols: vec![ExtractedSymbol {
-                    name: "foo".to_string(),
-                    kind: SymbolKind::Function,
-                    signature: "fn foo()".to_string(),
-                    range: LineRange { start: 1, end: 1 },
-                    container: None,
-                    referenced_names: vec![],
-                    dependencies: vec![],
-                    omitted_dependency_matches: 0,
-                }],
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    SymbolKind::Function,
+                    "fn foo()",
+                )],
             }],
             skipped: vec![SkippedFile {
                 path: "assets/logo.png".to_string(),
                 reason: SkipReason::Binary,
             }],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
         };
 
         let expected = "\
@@ -564,6 +1232,7 @@ fn foo()
       \"path\": \"src/lib.rs\",
       \"symbols\": [
         {
+          \"id\": \"src/lib.rs::foo\",
           \"name\": \"foo\",
           \"kind\": \"Function\",
           \"signature\": \"fn foo()\",
@@ -583,63 +1252,20 @@ fn foo()
       \"path\": \"assets/logo.png\",
       \"reason\": \"binary\"
     }
-  ]
-}"
-        .to_string();
-        let actual = render(&report, OutputFormat::Json).expect("json render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_render_json_with_nonzero_omitted_matches_when_dependency_matches_were_capped() {
-        let report = Report {
-            files: vec![FileReport {
-                path: "src/lib.rs".to_string(),
-                symbols: vec![ExtractedSymbol {
-                    name: "foo".to_string(),
-                    kind: SymbolKind::Function,
-                    signature: "fn foo(p: Point) -> i32".to_string(),
-                    range: LineRange { start: 1, end: 3 },
-                    container: None,
-                    referenced_names: vec!["Point".to_string()],
-                    dependencies: vec![crate::deps::ResolvedSymbol {
-                        signature: "struct Point { x: i32 }".to_string(),
-                        path: "src/a.rs".to_string(),
-                    }],
-                    omitted_dependency_matches: 2,
-                }],
-            }],
-            skipped: vec![],
-        };
-
-        let expected = "\
-{
-  \"files\": [
-    {
-      \"path\": \"src/lib.rs\",
-      \"symbols\": [
-        {
-          \"name\": \"foo\",
-          \"kind\": \"Function\",
-          \"signature\": \"fn foo(p: Point) -> i32\",
-          \"range\": {
-            \"start\": 1,
-            \"end\": 3
-          },
-          \"container\": null,
-          \"dependencies\": [
-            {
-              \"signature\": \"struct Point { x: i32 }\",
-              \"path\": \"src/a.rs\"
-            }
-          ],
-          \"omitted_matches\": 2
-        }
-      ]
-    }
   ],
-  \"skipped\": []
+  \"graph\": {
+    \"nodes\": [
+      {
+        \"id\": \"src/lib.rs::foo\",
+        \"path\": \"src/lib.rs\",
+        \"name\": \"foo\"
+      }
+    ],
+    \"edges\": [],
+    \"roots\": [
+      \"src/lib.rs::foo\"
+    ]
+  }
 }"
         .to_string();
         let actual = render(&report, OutputFormat::Json).expect("json render succeeds");

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -352,9 +352,22 @@ fn dfs_pre_order(graph: &SymbolGraph) -> Vec<NodeId> {
 }
 
 /// Iterative pre-order DFS from `start`, appending every newly-visited node
-/// to `order` and following non-cycle edges only. Shared by `dfs_pre_order`
-/// for both its `roots` pass and its defensive fallback pass over every
-/// node.
+/// to `order` in true pre-order (a node is only appended once every node
+/// before it in DFS order has already been fully appended — i.e. the same
+/// order `render_tree_node`'s recursive walk visits nodes in) and following
+/// non-cycle edges only. Shared by `dfs_pre_order` for both its `roots` pass
+/// and its defensive fallback pass over every node.
+///
+/// Explicit work-stack of `(node, remaining children)` rather than a plain
+/// node stack: a plain node stack that appends to `order` when a node is
+/// *pushed* (rather than when it is fully descended into) produces the
+/// wrong order whenever a node has more than one child and the first child
+/// itself has children — e.g. `A -> B, A -> C, B -> D` would wrongly order
+/// `A, C, B, D` (C, pushed right after A, gets appended before B's subtree
+/// is even explored) instead of the correct `A, B, D, C`. Tracking each
+/// stack frame's own child cursor mirrors `render_tree_node`'s recursion
+/// without recursing (unbounded-depth walks in this module use an explicit
+/// stack, see `tarjan_sccs`/`dfs_mark_back_edges` in `graph.rs`).
 fn visit_from(
     start: &str,
     children: &HashMap<&str, Vec<(&str, bool)>>,
@@ -364,22 +377,24 @@ fn visit_from(
     if !visited.insert(start.to_string()) {
         return;
     }
-    // Explicit stack rather than recursion, to match the style used
-    // elsewhere in the graph/render modules for unbounded-depth walks.
-    let mut stack = vec![start];
     order.push(start.to_string());
-    while let Some(current) = stack.pop() {
-        if let Some(kids) = children.get(current) {
-            // Push in reverse so children are visited in edge order (a
-            // `Vec`-backed stack pops last-in-first-out).
-            for &(child, is_cycle) in kids.iter().rev() {
-                if is_cycle || !visited.insert(child.to_string()) {
-                    continue;
-                }
-                order.push(child.to_string());
-                stack.push(child);
-            }
+
+    // Each frame is (node, index of the next child to consider).
+    let mut stack: Vec<(&str, usize)> = vec![(start, 0)];
+    while let Some(frame) = stack.last_mut() {
+        let (node, child_i) = (frame.0, frame.1);
+        let kids = children.get(node).map(Vec::as_slice).unwrap_or(&[]);
+        let Some(&(child, is_cycle)) = kids.get(child_i) else {
+            stack.pop();
+            continue;
+        };
+        frame.1 += 1;
+
+        if is_cycle || !visited.insert(child.to_string()) {
+            continue;
         }
+        order.push(child.to_string());
+        stack.push((child, 0));
     }
 }
 
@@ -561,6 +576,97 @@ fn handle_pr(args: PrArgs) -> Result<()>
 
 ```
 fn resolve_pr_base_sha() -> Result<String>
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_order_definitions_in_true_pre_order_when_first_child_has_its_own_child() {
+        // A -> B, A -> C (B before C in edge order), B -> D. True pre-order
+        // DFS visits A, then descends fully into B's subtree (B, D) before
+        // moving on to C: A, B, D, C. A naive "append to order when a node
+        // is pushed onto the stack" (rather than when it is actually
+        // visited/popped) would instead produce A, C, B, D, because C gets
+        // pushed onto the stack right after A even though B is visited
+        // first — this test pins the correct DFS order down as the full
+        // rendered string so both the "Change graph" tree and "Definitions"
+        // order are asserted together.
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![
+                    symbol("src/lib.rs::a", "a", SymbolKind::Function, "fn a()"),
+                    symbol("src/lib.rs::b", "b", SymbolKind::Function, "fn b()"),
+                    symbol("src/lib.rs::c", "c", SymbolKind::Function, "fn c()"),
+                    symbol("src/lib.rs::d", "d", SymbolKind::Function, "fn d()"),
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("src/lib.rs::a", "src/lib.rs", "a"),
+                    node("src/lib.rs::b", "src/lib.rs", "b"),
+                    node("src/lib.rs::c", "src/lib.rs", "c"),
+                    node("src/lib.rs::d", "src/lib.rs", "d"),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "src/lib.rs::a".to_string(),
+                        to: "src/lib.rs::b".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "src/lib.rs::a".to_string(),
+                        to: "src/lib.rs::c".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "src/lib.rs::b".to_string(),
+                        to: "src/lib.rs::d".to_string(),
+                        is_cycle: false,
+                    },
+                ],
+                roots: vec!["src/lib.rs::a".to_string()],
+            },
+        };
+
+        let expected = "\
+## Change graph
+
+- fn a (src/lib.rs)
+  - fn b (src/lib.rs)
+    - fn d (src/lib.rs)
+  - fn c (src/lib.rs)
+
+## Definitions
+
+### fn a (src/lib.rs)
+
+```
+fn a()
+```
+
+### fn b (src/lib.rs)
+
+```
+fn b()
+```
+
+### fn d (src/lib.rs)
+
+```
+fn d()
+```
+
+### fn c (src/lib.rs)
+
+```
+fn c()
 ```
 
 "

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -332,6 +332,11 @@ fn run_base_pipeline(
         return Ok(rinkaku_core::render::Report {
             files: Vec::new(),
             skipped: Vec::new(),
+            graph: rinkaku_core::graph::SymbolGraph {
+                nodes: Vec::new(),
+                edges: Vec::new(),
+                roots: Vec::new(),
+            },
         });
     }
 
@@ -2357,6 +2362,11 @@ mod tests {
             rinkaku_core::render::Report {
                 files: Vec::new(),
                 skipped: Vec::new(),
+                graph: rinkaku_core::graph::SymbolGraph {
+                    nodes: Vec::new(),
+                    edges: Vec::new(),
+                    roots: Vec::new(),
+                },
             },
             actual.expect("empty diff must not touch the repository-wide index scan")
         );
@@ -2367,10 +2377,19 @@ mod tests {
         use pretty_assertions::assert_eq;
         use rinkaku_core::render::Report;
 
+        fn empty_graph() -> rinkaku_core::graph::SymbolGraph {
+            rinkaku_core::graph::SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            }
+        }
+
         fn empty_report() -> Report {
             Report {
                 files: vec![],
                 skipped: vec![],
+                graph: empty_graph(),
             }
         }
 
@@ -2381,6 +2400,7 @@ mod tests {
                     symbols: vec![],
                 }],
                 skipped: vec![],
+                graph: empty_graph(),
             }
         }
 
@@ -2423,6 +2443,7 @@ mod tests {
                     path: "assets/logo.png".to_string(),
                     reason: rinkaku_core::render::SkipReason::Binary,
                 }],
+                graph: empty_graph(),
             };
 
             let actual = garbage_input_note("some diff text", &report);


### PR DESCRIPTION
## Why

The Markdown output listed changed symbols flat in git file order, which is hard for humans to read: there is no obvious place to start, and the relationships *between* changed symbols were invisible because dependency resolution deliberately excludes diff-internal symbols. Reviewers had to reconstruct the call graph mentally. See ADR 0008 for the full decision record.

## What

- **Symbol graph** (`rinkaku-core/src/graph.rs`, new): builds a directed graph over changed symbols from their `referenced_names`, with stable node ids (`{path}::{name}`, `@{line}` on collision). Entry points are auto-detected as roots of the SCC condensation (hand-rolled iterative Tarjan, no new dependency), so roots exist even when everything is cyclic. Back edges found via DFS are marked as cycle edges.
- **Markdown format** (breaking): output is now a `## Change graph` section (indented name-only tree, DFS pre-order from entry points, `(see above)` on revisits) followed by `## Definitions` (each symbol's full signature exactly once, in tree order). Dependency cycles among changed symbols render an explicit `⚠️ … — dependency cycle, see above` warning, since a cycle usually signals a design smell worth the reviewer's attention. Direct self-recursion is intentionally not flagged. Files with no extracted symbols (e.g. pure renames) are listed under `## Other changed files`.
- **JSON format** (breaking, additive): `Report` gains a `graph` field (`nodes` / `edges` with `is_cycle` / `roots`), and each symbol gains an `id`.
- README examples regenerated from real command output.

## QA

- `make test` (281 tests) and `make lint` (fmt + clippy `-D warnings`) pass.
- Dogfooded on this branch's own diff (`cargo run -- --base main`, Markdown + JSON): tree ordering, `(see above)` dedup, duplicate-name `:line` disambiguation, `Other changed files`, and `graph` JSON all verified on real data; cycle warning verified via unit tests and a synthetic mutual-recursion repo.