### PR TITLE
feat: exclude test symbols and generated files from output by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,13 @@ rinkaku --base main --deps 0
 
 All examples below are captured from the `cargo build --release` binary
 against `main` post-[ADR 0008](docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md)
-(entry-point tree rendering), not fabricated.
+(entry-point tree rendering), not fabricated. The example diff below
+touches no test symbols and no generated files, so it renders the same
+with or without the defaults introduced in
+[ADR 0009](docs/adr/0009-exclude-test-symbols-from-output-by-default.md)
+and [ADR 0010](docs/adr/0010-skip-files-marked-no-diff-or-generated-in-gitattributes.md)
+— see `--include-tests`/`--include-generated` below for what changes when a
+diff does touch test symbols or generated files.
 
 Running `rinkaku` on
 [a real rinkaku commit](https://github.com/hiro-o918/rinkaku/commit/aa7ca34)
@@ -244,6 +250,11 @@ Each symbol in `files[].symbols` also carries an `id` field matching its
 to its position in the graph without recomputing the `{path}::{name}` id
 scheme itself.
 
+The top-level JSON report also carries `"tests": [{"path", "symbol_count"}]`
+(ADR 0009's per-file test-symbol counts, empty unless the diff touched any)
+and `skipped[].reason` can be `"generated"` (ADR 0010) alongside the
+existing `"unsupported_language"`/`"binary"`/`"deleted"` values.
+
 ### When same-name matches are capped
 
 On a repository with many same-named definitions, the same-name cap (see
@@ -295,6 +306,47 @@ resolution entirely (no "Depends on" sections, no repository scan) and
 remains dramatically faster since indexing cost does not depend on diff
 size. Prefer `--deps 0` for quick iteration or CI checks where the
 dependency context isn't needed.
+
+### `--include-tests`
+
+By default (see [ADR 0009](docs/adr/0009-exclude-test-symbols-from-output-by-default.md)),
+test symbols are excluded from "Change graph"/"Definitions" — detected per
+language (Go's `*_test.go`, Python's `test_*.py`/`*_test.py` and `tests/`
+directories, TypeScript's `*.test.ts(x)`/`*.spec.ts(x)` and `__tests__/`,
+and Rust's `tests/` directory plus `#[cfg(test)]` modules and
+`#[test]`/`#[rstest]`/`#[tokio::test]`-attributed functions) — and
+summarized instead as a per-file count under a `## Tests` section:
+
+```markdown
+## Tests
+
+- rinkaku-core/src/pipeline.rs: 3 changed test symbols
+```
+
+This keeps the primary output focused on implementation entry points while
+still surfacing "did this change come with tests?" as a signal. Pass
+`--include-tests` to restore the previous behavior (test symbols appear in
+the graph and definitions like any other symbol, and `## Tests` is omitted).
+
+### `--include-generated`
+
+By default (see [ADR 0010](docs/adr/0010-skip-files-marked-no-diff-or-generated-in-gitattributes.md)),
+rinkaku resolves each changed file's `diff`/`linguist-generated`
+`.gitattributes` attributes via `git check-attr` and skips files marked
+`-diff` or `linguist-generated` (lockfiles, generated code — content a
+repository has already declared uninteresting to diff-review), listing them
+under "Skipped files" with reason `generated`:
+
+```markdown
+## Skipped files
+
+- Cargo.lock (generated)
+```
+
+This only applies when a local git repository is available (`--base`,
+`--pr`, or stdin piped inside a repository); outside a repository, no
+attribute filtering happens. Pass `--include-generated` to restore the
+previous behavior.
 
 ## Development
 

--- a/docs/adr/0009-exclude-test-symbols-from-output-by-default.md
+++ b/docs/adr/0009-exclude-test-symbols-from-output-by-default.md
@@ -27,6 +27,13 @@ production code). Excluded symbols are summarized as per-file counts in a
 `## Tests` section so their existence stays visible. A `--include-tests`
 flag restores the previous behavior.
 
+The same exclusion applies to `TagsResolver`'s repo-wide dependency index
+(ADR 0003), not just the diff's own graph: by default it skips whole
+test-path files and drops AST-detected test symbols the same way, so a
+changed production symbol's "Depends on:" cannot resolve to a same-named
+test helper or fixture elsewhere in the repo. `--include-tests` restores
+the previous full-index behavior for this too.
+
 ## Alternatives
 
 - **Keep including test symbols**: the status quo; makes real-world
@@ -51,3 +58,8 @@ flag restores the previous behavior.
   acceptable pre-1.0 and before announcing the format.
 - Groundwork for architecture-review features (module-level graph views)
   that assume the graph contains production symbols only.
+- Dependency resolution (ADR 0003) is more precise as a side effect: since
+  `TagsResolver`'s index excludes test symbols by the same default, a
+  production symbol's "Depends on:" no longer surfaces coincidental
+  name-matches against test helpers/fixtures — a class of false positive
+  the name-only resolver was otherwise prone to.

--- a/docs/adr/0009-exclude-test-symbols-from-output-by-default.md
+++ b/docs/adr/0009-exclude-test-symbols-from-output-by-default.md
@@ -1,0 +1,53 @@
+# 0009. Exclude test symbols from output by default
+
+- Status: accepted
+- Date: 2026-07-12
+
+## Context
+
+Dogfooding the entry-point tree rendering (ADR 0008) on a real branch of
+this repository produced 98 graph roots, most of them `should_...` test
+functions. Test symbols drown out the implementation symbols the output
+exists to surface — for both human reviewers and LLM consumers — and this
+will hold for any diff that follows the common practice of changing tests
+alongside code. The tool is also meant to support architecture-level
+review (module boundaries, separation of responsibilities), where test
+code is noise, while the *fact* that tests changed is still a signal a
+reviewer wants ("did this change come with tests?").
+
+## Decision
+
+Detect test symbols per language at extraction time and exclude them from
+the change graph and definitions by default. Detection lives in each
+`LanguageSupport` implementation: path conventions (`tests/` dirs,
+`_test.go`, `test_*.py` / `*_test.py`, `*.test.ts` / `*.spec.ts` /
+`__tests__/`) plus AST context where paths are insufficient (Rust
+`#[cfg(test)]` modules and `#[test]` functions, which are colocated with
+production code). Excluded symbols are summarized as per-file counts in a
+`## Tests` section so their existence stays visible. A `--include-tests`
+flag restores the previous behavior.
+
+## Alternatives
+
+- **Keep including test symbols**: the status quo; makes real-world
+  output unreadable, as observed.
+- **Collapse instead of exclude (render names without expansion)**:
+  still yields dozens of tree lines per file; counts convey the same
+  signal in one line.
+- **Path-only heuristics without AST context**: simpler and language-
+  agnostic, but misses Rust's in-file `#[cfg(test)]` modules — the
+  dominant case in this very repository — so per-language detection via
+  `LanguageSupport` is required anyway.
+
+## Consequences
+
+- Default output shrinks to implementation entry points and their
+  subgraph; the `## Tests` summary preserves the "tests were changed"
+  signal at one line per file.
+- Test-detection heuristics can misclassify unconventional layouts;
+  `--include-tests` is the escape hatch, and heuristics can be refined
+  per language without an output-format change.
+- Another breaking change to default output on top of ADR 0008;
+  acceptable pre-1.0 and before announcing the format.
+- Groundwork for architecture-review features (module-level graph views)
+  that assume the graph contains production symbols only.

--- a/docs/adr/0010-skip-files-marked-no-diff-or-generated-in-gitattributes.md
+++ b/docs/adr/0010-skip-files-marked-no-diff-or-generated-in-gitattributes.md
@@ -1,0 +1,44 @@
+# 0010. Skip files marked no-diff or generated in .gitattributes
+
+- Status: accepted
+- Date: 2026-07-12
+
+## Context
+
+Repositories already declare "not worth diff-reviewing" files in
+`.gitattributes`: the `-diff` attribute (git renders them as binary) and
+`linguist-generated` (GitHub collapses them in PR views). `gh pr diff`
+still emits full hunks for `linguist-generated` files, so lockfiles and
+generated code flow into rinkaku's output as noise. This complements the
+test-symbol exclusion (ADR 0009): both remove content reviewers have
+already declared uninteresting.
+
+## Decision
+
+When a local git repository is available (the `--base` and `--pr` modes,
+or stdin piped inside a repo), resolve attributes via `git check-attr`
+at the process boundary and skip files whose `diff` attribute is unset
+(`-diff`) or whose `linguist-generated` is set. Skipped files appear
+under the existing `Skipped files` section with a new `generated` skip
+reason. Without a repository, no attribute filtering happens (best
+effort). A `--include-generated` flag restores the previous behavior,
+mirroring `--include-tests`.
+
+## Alternatives
+
+- **Parse `.gitattributes` ourselves**: avoids the `git` dependency for
+  the pure-stdin case, but attribute resolution (macros, per-directory
+  files, precedence) is subtle and `git check-attr` is authoritative;
+  rinkaku already shells out to `git` in its main modes.
+- **Filter by filename heuristics (lockfile lists etc.)**: duplicates
+  what repositories already declare, and drifts per ecosystem.
+
+## Consequences
+
+- Generated/lockfile churn disappears from the output while staying
+  visible as skip entries; repositories control the behavior through
+  their own `.gitattributes`.
+- JSON consumers see a new `skipped.reason` value (`generated`) — a
+  minor breaking change for strict enum consumers, acceptable pre-1.0.
+- Pure-stdin-outside-a-repo input keeps generated files; documented
+  limitation rather than a fragile homegrown attribute parser.

--- a/rinkaku-core/src/deps.rs
+++ b/rinkaku-core/src/deps.rs
@@ -641,6 +641,7 @@ mod tests {
                 referenced_names: referenced_names.into_iter().map(str::to_string).collect(),
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }
         }
 

--- a/rinkaku-core/src/deps.rs
+++ b/rinkaku-core/src/deps.rs
@@ -108,6 +108,22 @@ impl TagsResolver {
     /// never reaching this path) indexes nothing, which is correct: no
     /// name is referenced, so no definition needs to be found.
     ///
+    /// `include_tests` mirrors `pipeline::analyze_diff`'s flag of the same
+    /// name (ADR 0009), extended to this repo-wide index: `false` (the CLI
+    /// default) excludes test symbols the same two ways `analyze_diff`
+    /// does — a whole file `language.is_test_path` considers a test file
+    /// is skipped entirely, and within every other file, only symbols
+    /// [`crate::extract::extract_all_symbols`] marked
+    /// `ExtractedSymbol::is_test` (AST context, e.g. Rust's `#[cfg(test)]`)
+    /// are dropped from indexing. Without this, a changed production
+    /// symbol's `referenced_names` could resolve to a same-named test
+    /// helper/fixture elsewhere in the repo — a name match a reviewer
+    /// would almost always read as coincidental noise in "Depends on:",
+    /// not a real dependency, since production code should not actually
+    /// depend on test-only definitions (see ADR 0009's Consequences).
+    /// `true` (`--include-tests`) indexes every symbol as before, matching
+    /// `analyze_diff`'s own `include_tests: true` behavior.
+    ///
     /// Files with no registered [`LanguageSupport`] for their extension
     /// are silently skipped, matching the pipeline's handling of
     /// unsupported files elsewhere (`pipeline::analyze_diff`).
@@ -115,6 +131,7 @@ impl TagsResolver {
         files: impl IntoIterator<Item = (String, String)>,
         language_for_path: impl Fn(&str) -> Option<&'static dyn LanguageSupport>,
         reference_names: &HashSet<String>,
+        include_tests: bool,
     ) -> Self {
         let mut index: HashMap<String, Vec<ResolvedSymbol>> = HashMap::new();
         // `AhoCorasick::new` only errors on pathological inputs this call
@@ -134,10 +151,16 @@ impl TagsResolver {
             let Some(lang) = language_for_path(&path) else {
                 continue;
             };
+            if !include_tests && lang.is_test_path(&path) {
+                continue;
+            }
             if !should_parse_file(&matcher, &content) {
                 continue;
             }
             for symbol in extract_all_symbols(&content, lang) {
+                if !include_tests && symbol.is_test {
+                    continue;
+                }
                 index.entry(symbol.name).or_default().push(ResolvedSymbol {
                     signature: symbol.signature,
                     path: path.clone(),
@@ -392,7 +415,7 @@ mod tests {
             "src/lib.rs".to_string(),
             "fn helper(x: i32) -> i32 {\n    x\n}\n".to_string(),
         )];
-        let resolver = TagsResolver::new(files, lang_for_path, &names(&["helper"]));
+        let resolver = TagsResolver::new(files, lang_for_path, &names(&["helper"]), false);
 
         let expected = vec![ResolvedSymbol {
             signature: "fn helper(x: i32) -> i32".to_string(),
@@ -409,7 +432,7 @@ mod tests {
             "src/point.rs".to_string(),
             "struct Point {\n    x: i32,\n}\n".to_string(),
         )];
-        let resolver = TagsResolver::new(files, lang_for_path, &names(&["Point"]));
+        let resolver = TagsResolver::new(files, lang_for_path, &names(&["Point"]), false);
 
         let expected = vec![ResolvedSymbol {
             signature: "struct Point { x: i32, }".to_string(),
@@ -431,7 +454,7 @@ mod tests {
         // excluded by the prefilter" — the file's content also contains
         // "i32" as a parameter/return type, so it would pass the prefilter
         // regardless, but being explicit keeps the test's intent clear.
-        let resolver = TagsResolver::new(files, lang_for_path, &names(&["helper", "i32"]));
+        let resolver = TagsResolver::new(files, lang_for_path, &names(&["helper", "i32"]), false);
 
         // Covers both a built-in type (`i32`, never indexed since it has
         // no definition anywhere) and a name from an external
@@ -456,7 +479,7 @@ mod tests {
                 "fn helper() -> i32 {\n    2\n}\n".to_string(),
             ),
         ];
-        let resolver = TagsResolver::new(files, lang_for_path, &names(&["helper"]));
+        let resolver = TagsResolver::new(files, lang_for_path, &names(&["helper"]), false);
 
         let mut expected = vec![
             ResolvedSymbol {
@@ -482,12 +505,102 @@ mod tests {
     }
 
     #[test]
+    fn should_exclude_test_path_file_from_index_by_default() {
+        let files = [(
+            "src/repo_test.go".to_string(),
+            "package main\n\nfunc TestFoo(t *testing.T) {}\n".to_string(),
+        )];
+        let resolver = TagsResolver::new(files, lang_for_path, &names(&["TestFoo"]), false);
+
+        let expected: Vec<ResolvedSymbol> = Vec::new();
+        let actual = resolver.resolve("TestFoo");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_include_test_path_file_in_index_when_include_tests_is_true() {
+        let files = [(
+            "src/repo_test.go".to_string(),
+            "package main\n\nfunc TestFoo(t *testing.T) {}\n".to_string(),
+        )];
+        let resolver = TagsResolver::new(files, lang_for_path, &names(&["TestFoo"]), true);
+
+        let expected = vec![ResolvedSymbol {
+            signature: "func TestFoo(t *testing.T)".to_string(),
+            path: "src/repo_test.go".to_string(),
+        }];
+        let actual = resolver.resolve("TestFoo");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_exclude_ast_test_definition_from_index_by_default() {
+        let files = [(
+            "src/lib.rs".to_string(),
+            "\
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn should_add_two_numbers() {}
+}
+"
+            .to_string(),
+        )];
+        let resolver = TagsResolver::new(
+            files,
+            lang_for_path,
+            &names(&["should_add_two_numbers"]),
+            false,
+        );
+
+        let expected: Vec<ResolvedSymbol> = Vec::new();
+        let actual = resolver.resolve("should_add_two_numbers");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_still_index_production_symbols_in_a_file_that_also_has_ast_test_definitions() {
+        // A file mixing production code and `#[cfg(test)] mod tests` must
+        // still index the production symbol, even with the default
+        // test-exclusion on — only the AST-detected test definitions are
+        // dropped, not the whole file (unlike a whole-file `is_test_path`
+        // match, e.g. `_test.go`).
+        let files = [(
+            "src/lib.rs".to_string(),
+            "\
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn should_add_two_numbers() {}
+}
+"
+            .to_string(),
+        )];
+        let resolver = TagsResolver::new(files, lang_for_path, &names(&["add"]), false);
+
+        let expected = vec![ResolvedSymbol {
+            signature: "fn add(a: i32, b: i32) -> i32".to_string(),
+            path: "src/lib.rs".to_string(),
+        }];
+        let actual = resolver.resolve("add");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn should_skip_file_with_unsupported_language_when_building_index() {
         let files = [(
             "src/notes.txt".to_string(),
             "helper is defined here".to_string(),
         )];
-        let resolver = TagsResolver::new(files, lang_for_path, &names(&["helper"]));
+        let resolver = TagsResolver::new(files, lang_for_path, &names(&["helper"]), false);
 
         let expected: Vec<ResolvedSymbol> = Vec::new();
         let actual = resolver.resolve("helper");
@@ -507,7 +620,7 @@ mod tests {
                 "package main\n\nfunc greet() string {\n\treturn \"hi\"\n}\n".to_string(),
             ),
         ];
-        let resolver = TagsResolver::new(files, lang_for_path, &names(&["helper", "greet"]));
+        let resolver = TagsResolver::new(files, lang_for_path, &names(&["helper", "greet"]), false);
 
         let expected = vec![ResolvedSymbol {
             signature: "func greet() string".to_string(),
@@ -531,7 +644,7 @@ mod tests {
             )];
             let reference_names: HashSet<String> = ["helper".to_string()].into_iter().collect();
 
-            let resolver = TagsResolver::new(files, lang_for_path, &reference_names);
+            let resolver = TagsResolver::new(files, lang_for_path, &reference_names, false);
 
             let expected = vec![ResolvedSymbol {
                 signature: "fn helper(x: i32) -> i32".to_string(),
@@ -555,7 +668,7 @@ mod tests {
             )];
             let reference_names: HashSet<String> = ["helper".to_string()].into_iter().collect();
 
-            let resolver = TagsResolver::new(files, lang_for_path, &reference_names);
+            let resolver = TagsResolver::new(files, lang_for_path, &reference_names, false);
 
             let expected: Vec<ResolvedSymbol> = Vec::new();
             let actual = resolver.resolve("unrelated");
@@ -580,7 +693,7 @@ mod tests {
             )];
             let reference_names: HashSet<String> = ["helper".to_string()].into_iter().collect();
 
-            let resolver = TagsResolver::new(files, lang_for_path, &reference_names);
+            let resolver = TagsResolver::new(files, lang_for_path, &reference_names, false);
 
             let expected = vec![ResolvedSymbol {
                 signature: "fn helper() -> i32".to_string(),
@@ -599,7 +712,7 @@ mod tests {
             )];
             let reference_names: HashSet<String> = HashSet::new();
 
-            let resolver = TagsResolver::new(files, lang_for_path, &reference_names);
+            let resolver = TagsResolver::new(files, lang_for_path, &reference_names, false);
 
             let expected: Vec<ResolvedSymbol> = Vec::new();
             let actual = resolver.resolve("helper");

--- a/rinkaku-core/src/extract.rs
+++ b/rinkaku-core/src/extract.rs
@@ -96,6 +96,20 @@ pub struct ExtractedSymbol {
     /// the call site.
     #[serde(rename = "omitted_matches")]
     pub omitted_dependency_matches: usize,
+    /// Whether this definition is test code by its AST context (ADR 0009),
+    /// e.g. Rust's `#[cfg(test)]` modules and `#[test]`/`#[rstest]`/
+    /// `#[tokio::test]`-attributed functions — see
+    /// [`crate::language::LanguageSupport::is_test_definition`]. `false`
+    /// for every language whose test convention is fully captured by file
+    /// path alone (`is_test_definition`'s default), which is the common
+    /// case; path-based detection happens at the file level in
+    /// `pipeline.rs`, not here, since it does not depend on any individual
+    /// node. An intermediate pipeline artifact, not part of rinkaku's
+    /// output shape (test symbols are filtered out of `files` before a
+    /// `Report` is built, see `pipeline::analyze_diff`), so excluded from
+    /// serialization like `referenced_names`.
+    #[serde(skip)]
+    pub is_test: bool,
 }
 
 /// Extracts the signatures of definitions that contain at least one
@@ -135,7 +149,7 @@ pub fn extract_changed_symbols(
                     .iter()
                     .any(|other| other != *node && is_descendant_of(*other, **node))
             })
-            .filter_map(|node| build_symbol(*node, source_bytes, reference_query))
+            .filter_map(|node| build_symbol(*node, source_bytes, reference_query, lang))
             .collect()
     })
 }
@@ -156,7 +170,7 @@ pub fn extract_all_symbols(source: &str, lang: &dyn LanguageSupport) -> Vec<Extr
     with_definition_nodes(source, lang, |all_nodes, source_bytes, reference_query| {
         all_nodes
             .iter()
-            .filter_map(|node| build_symbol(*node, source_bytes, reference_query))
+            .filter_map(|node| build_symbol(*node, source_bytes, reference_query, lang))
             .collect()
     })
 }
@@ -252,12 +266,14 @@ fn build_symbol(
     node: tree_sitter::Node,
     source: &[u8],
     reference_query: &tree_sitter::Query,
+    lang: &dyn LanguageSupport,
 ) -> Option<ExtractedSymbol> {
     let kind = symbol_kind(node)?;
     let name = definition_name(node, source)?;
     let signature = slice_signature(node, source);
     let container = find_container(node, source);
     let referenced_names = collect_referenced_names(node, source, reference_query);
+    let is_test = lang.is_test_definition(node, source);
 
     Some(ExtractedSymbol {
         // Populated later by `graph::build_graph`, once node IDs are
@@ -274,6 +290,7 @@ fn build_symbol(
         // diff-internal symbols from the resolved dependency list).
         dependencies: Vec::new(),
         omitted_dependency_matches: 0,
+        is_test,
     })
 }
 
@@ -608,6 +625,7 @@ struct Point {
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             },
             ExtractedSymbol {
                 id: String::new(),
@@ -619,6 +637,7 @@ struct Point {
                 referenced_names: vec!["Point".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             },
         ];
         let actual = extract_all_symbols(source, &lang);
@@ -656,6 +675,94 @@ fn foo() -> i32 {
             referenced_names: vec!["bar".to_string()],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
+        }];
+        let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_mark_symbol_as_test_when_nested_inside_cfg_test_mod() {
+        let source = "\
+#[cfg(test)]
+mod tests {
+    fn helper() {}
+}
+";
+        let lang = RustSupport;
+        let changed_ranges = vec![LineRange { start: 3, end: 3 }];
+
+        let expected = vec![ExtractedSymbol {
+            id: String::new(),
+            name: "helper".to_string(),
+            kind: SymbolKind::Function,
+            signature: "fn helper()".to_string(),
+            range: LineRange { start: 3, end: 3 },
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: true,
+        }];
+        let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_mark_symbol_as_test_when_function_has_test_attribute() {
+        let source = "\
+#[test]
+fn should_add_two_numbers() {
+    assert_eq!(2, 1 + 1);
+}
+";
+        let lang = RustSupport;
+        let changed_ranges = vec![LineRange { start: 2, end: 2 }];
+
+        let expected = vec![ExtractedSymbol {
+            id: String::new(),
+            name: "should_add_two_numbers".to_string(),
+            kind: SymbolKind::Function,
+            signature: "fn should_add_two_numbers()".to_string(),
+            // Note: the `function_item` node's own range starts at the
+            // `fn` line, not the `#[test]` attribute line above it — same
+            // convention as Python's decorator handling (see
+            // `should_not_detect_change_when_only_decorator_line_changed`).
+            range: LineRange { start: 2, end: 4 },
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: true,
+        }];
+        let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_not_mark_symbol_as_test_when_function_has_no_test_marker() {
+        let source = "\
+fn helper() -> i32 {
+    42
+}
+";
+        let lang = RustSupport;
+        let changed_ranges = vec![LineRange { start: 2, end: 2 }];
+
+        let expected = vec![ExtractedSymbol {
+            id: String::new(),
+            name: "helper".to_string(),
+            kind: SymbolKind::Function,
+            signature: "fn helper() -> i32".to_string(),
+            range: LineRange { start: 1, end: 3 },
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
         }];
         let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -695,6 +802,7 @@ fn foo(a: i32) -> i32 {
             referenced_names: vec![],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }];
         let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -722,6 +830,7 @@ fn foo(a: i32, c: i32) -> i32 {
             referenced_names: vec![],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }];
         let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -754,6 +863,7 @@ struct Point {
             referenced_names: vec!["Point".to_string()],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }];
         let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -785,6 +895,7 @@ impl Foo {
             referenced_names: vec![],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }];
         let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -816,6 +927,7 @@ impl Foo {
             referenced_names: vec![],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }];
         let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -847,6 +959,7 @@ enum Color {
             referenced_names: vec!["Color".to_string()],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }];
         let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -877,6 +990,7 @@ trait Greeter {
             referenced_names: vec!["String".to_string()],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }];
         let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -907,6 +1021,7 @@ trait Greeter {
             referenced_names: vec!["Greeter".to_string(), "String".to_string()],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }];
         let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -943,6 +1058,7 @@ const X: i32 = 1;
             referenced_names: vec![],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }],
     )]
     fn extract_changed_symbols_selective_cases(
@@ -1003,6 +1119,7 @@ fn foo(a: i32) -> i32 {
             referenced_names: vec![],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }];
         let actual = extract_changed_symbols(source, lang, &changed_file.changed_ranges);
 
@@ -1054,6 +1171,7 @@ func foo(a int) int {
                 referenced_names: vec!["int".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1082,6 +1200,7 @@ func foo(a int, c int) int {
                 referenced_names: vec!["int".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1117,6 +1236,7 @@ type Repo struct {
                 referenced_names: vec!["Repo".to_string(), "int".to_string(), "string".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1149,6 +1269,7 @@ type Fetcher interface {
                 ],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1211,6 +1332,7 @@ func (r *Repo) Save(id string) error {
                 ],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1244,6 +1366,7 @@ func (r Repo) Label() string {
                 referenced_names: vec!["Repo".to_string(), "string".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1318,6 +1441,7 @@ func (r *Repo) Save(id string) error {
                 ],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, lang, &changed_file.changed_ranges);
 
@@ -1351,6 +1475,7 @@ def foo(a):
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1376,6 +1501,7 @@ def foo(a, c):
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1409,6 +1535,7 @@ def top_level(a, b):
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1454,6 +1581,7 @@ def decorated(a):
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1488,6 +1616,7 @@ class Point:
                 referenced_names: vec!["int".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1515,6 +1644,7 @@ class Point:
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1542,6 +1672,7 @@ class Point:
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1577,6 +1708,7 @@ class Point:
                 referenced_names: vec!["str".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1640,6 +1772,7 @@ class Point:
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, lang, &changed_file.changed_ranges);
 
@@ -1673,6 +1806,7 @@ function foo(a: number): number {
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1699,6 +1833,7 @@ function foo(a: number, c: number): number {
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1726,6 +1861,7 @@ const arrow = (a: number): number => {
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1777,6 +1913,7 @@ interface Shape {
                 referenced_names: vec!["Shape".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1805,6 +1942,7 @@ type Point = {
                 referenced_names: vec!["Point".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1834,6 +1972,7 @@ enum Color {
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1866,6 +2005,7 @@ class Circle {
                 referenced_names: vec!["Circle".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1897,6 +2037,7 @@ class Circle {
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1928,6 +2069,7 @@ class Circle {
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -1961,6 +2103,7 @@ class Circle {
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -2024,6 +2167,7 @@ function foo(a: number): number {
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, lang, &changed_file.changed_ranges);
 
@@ -2057,6 +2201,7 @@ abstract class Shape {
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -2088,6 +2233,7 @@ abstract class Shape {
                 referenced_names: vec!["Shape".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -2129,6 +2275,7 @@ class Circle {
                 referenced_names: vec!["Circle".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
@@ -2158,6 +2305,7 @@ const Component = () => {
                 referenced_names: vec![],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
+                is_test: false,
             }];
             let actual = extract_changed_symbols(source, lang, &changed_ranges);
 

--- a/rinkaku-core/src/graph.rs
+++ b/rinkaku-core/src/graph.rs
@@ -465,6 +465,7 @@ mod tests {
             referenced_names: referenced_names.into_iter().map(str::to_string).collect(),
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }
     }
 

--- a/rinkaku-core/src/language.rs
+++ b/rinkaku-core/src/language.rs
@@ -36,6 +36,27 @@ pub trait LanguageSupport {
     /// definition index later, which has the same net effect without
     /// needing a per-language exclusion list.
     fn reference_query(&self) -> &str;
+
+    /// Whether `path` is, by convention, a test file in its entirety (ADR
+    /// 0009), e.g. Go's `*_test.go`, Python's `test_*.py`/`*_test.py`, or
+    /// any language's `tests/`-directory convention. When `true`, every
+    /// definition in the file is a test symbol regardless of
+    /// [`is_test_definition`](LanguageSupport::is_test_definition) — the
+    /// pipeline does not bother parsing the file to check node-level
+    /// context in that case.
+    fn is_test_path(&self, path: &str) -> bool;
+
+    /// Whether `node` (a captured `@definition` node, or an ancestor of
+    /// one) is a test symbol by its AST context rather than its file path
+    /// — needed only for languages where test code is colocated with
+    /// production code in the same file (Rust's `#[cfg(test)]` modules and
+    /// `#[test]`/`#[rstest]`/`#[tokio::test]`-attributed functions).
+    /// Defaults to `false`: most languages' test conventions are fully
+    /// captured by [`is_test_path`](LanguageSupport::is_test_path), so
+    /// there is nothing more to check at the node level.
+    fn is_test_definition(&self, _node: tree_sitter::Node, _source: &[u8]) -> bool {
+        false
+    }
 }
 
 /// Looks up the `LanguageSupport` registered for a file path, based on its

--- a/rinkaku-core/src/language/go.rs
+++ b/rinkaku-core/src/language/go.rs
@@ -68,11 +68,21 @@ impl LanguageSupport for GoSupport {
     fn reference_query(&self) -> &str {
         REFERENCE_QUERY
     }
+
+    /// Go's own toolchain convention: a `_test.go`-suffixed file is
+    /// excluded from normal builds and only compiled when running tests
+    /// (`go help test`), so it is unambiguously test-only regardless of
+    /// what package or directory it lives in.
+    fn is_test_path(&self, path: &str) -> bool {
+        path.ends_with("_test.go")
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
 
     #[test]
     fn should_report_go_as_name() {
@@ -110,5 +120,17 @@ mod tests {
 
         tree_sitter::Query::new(&support.grammar(), support.reference_query())
             .expect("REFERENCE_QUERY must be valid against the Go grammar");
+    }
+
+    #[rstest]
+    #[case::should_return_true_when_path_ends_with_test_go("repo_test.go", true)]
+    #[case::should_return_false_when_path_is_ordinary_go_file("repo.go", false)]
+    #[case::should_return_false_when_path_merely_contains_test_substring("contest.go", false)]
+    fn is_test_path_cases(#[case] path: &str, #[case] expected: bool) {
+        let support = GoSupport;
+
+        let actual = support.is_test_path(path);
+
+        assert_eq!(expected, actual);
     }
 }

--- a/rinkaku-core/src/language/python.rs
+++ b/rinkaku-core/src/language/python.rs
@@ -65,11 +65,36 @@ impl LanguageSupport for PythonSupport {
     fn reference_query(&self) -> &str {
         REFERENCE_QUERY
     }
+
+    /// pytest's own file-discovery convention (`test_*.py` / `*_test.py`,
+    /// see the pytest docs' "Conventions for Python test discovery") plus a
+    /// `tests/` directory anywhere in the path — the latter catches
+    /// fixture/helper modules inside a test suite that don't themselves
+    /// match the filename pattern (e.g. `tests/factories.py`).
+    fn is_test_path(&self, path: &str) -> bool {
+        is_in_tests_dir(path) || is_python_test_filename(path)
+    }
+}
+
+/// Whether `path` contains a `tests/` path segment anywhere (not just as
+/// the immediate parent), so `tests/unit/factories.py` is caught the same
+/// as `tests/factories.py`.
+fn is_in_tests_dir(path: &str) -> bool {
+    path.split('/').any(|segment| segment == "tests")
+}
+
+/// Whether the file name (last `/`-separated segment) matches pytest's
+/// `test_*.py` / `*_test.py` discovery convention.
+fn is_python_test_filename(path: &str) -> bool {
+    let file_name = path.rsplit('/').next().unwrap_or(path);
+    file_name.starts_with("test_") && file_name.ends_with(".py") || file_name.ends_with("_test.py")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
 
     #[test]
     fn should_report_python_as_name() {
@@ -107,5 +132,26 @@ mod tests {
 
         tree_sitter::Query::new(&support.grammar(), support.reference_query())
             .expect("REFERENCE_QUERY must be valid against the Python grammar");
+    }
+
+    #[rstest]
+    #[case::should_return_true_when_filename_starts_with_test_prefix("test_repo.py", true)]
+    #[case::should_return_true_when_filename_ends_with_test_suffix("repo_test.py", true)]
+    #[case::should_return_true_when_path_has_tests_directory_segment(
+        "src/tests/factories.py",
+        true
+    )]
+    #[case::should_return_true_when_tests_directory_is_nested("tests/unit/factories.py", true)]
+    #[case::should_return_false_when_path_is_ordinary_module("src/repo.py", false)]
+    #[case::should_return_false_when_filename_merely_contains_test_substring(
+        "src/contest.py",
+        false
+    )]
+    fn is_test_path_cases(#[case] path: &str, #[case] expected: bool) {
+        let support = PythonSupport;
+
+        let actual = support.is_test_path(path);
+
+        assert_eq!(expected, actual);
     }
 }

--- a/rinkaku-core/src/language/rust.rs
+++ b/rinkaku-core/src/language/rust.rs
@@ -58,11 +58,139 @@ impl LanguageSupport for RustSupport {
     fn reference_query(&self) -> &str {
         REFERENCE_QUERY
     }
+
+    /// Rust's `tests/` directory convention: integration test crates
+    /// (`tests/*.rs`, each compiled as its own binary by `cargo test`).
+    /// Unit tests (`#[cfg(test)] mod tests { ... }`) live colocated with
+    /// production code instead, so they are not caught by path alone — see
+    /// `is_test_definition`.
+    fn is_test_path(&self, path: &str) -> bool {
+        path.split('/').any(|segment| segment == "tests")
+    }
+
+    /// Whether `node` (a captured `@definition` node) is a Rust unit test:
+    /// nested inside a `#[cfg(test)]`-attributed `mod`, or itself
+    /// `#[test]`/`#[rstest]`/`#[tokio::test]`-attributed. Checked by
+    /// walking ancestors rather than only the immediate parent, since a
+    /// test helper function nested a few `impl`/`mod` levels inside a
+    /// `#[cfg(test)] mod tests { ... }` block is still test code.
+    fn is_test_definition(&self, node: tree_sitter::Node, source: &[u8]) -> bool {
+        if has_test_attribute(node, source) {
+            return true;
+        }
+        let mut current = node.parent();
+        while let Some(candidate) = current {
+            if candidate.kind() == "mod_item" && has_cfg_test_attribute(candidate, source) {
+                return true;
+            }
+            current = candidate.parent();
+        }
+        false
+    }
+}
+
+/// Whether `node` is immediately preceded by a `#[test]`, `#[rstest]`, or
+/// `#[tokio::test]` attribute — a test function marker. Tree-sitter's Rust
+/// grammar attaches an `attribute_item` as a preceding *sibling* of the
+/// node it annotates, not a child, so this walks backward through
+/// `prev_sibling` (skipping over other attributes/doc comments stacked on
+/// the same item) rather than inspecting `node`'s own children.
+///
+/// Matches any attribute whose name (the bare `identifier`, e.g. `test` in
+/// `#[test]`, or the `scoped_identifier`'s `name` field, e.g. `test` in
+/// `#[tokio::test]`) is `"test"`, plus the literal `rstest` attribute
+/// (which has no further `#[rstest::...]`-scoped form in common usage) —
+/// covers the attribute macros named in ADR 0009 without needing to
+/// enumerate every async test runner's exact macro path.
+fn has_test_attribute(node: tree_sitter::Node, source: &[u8]) -> bool {
+    let mut sibling = node.prev_sibling();
+    while let Some(candidate) = sibling {
+        if candidate.kind() == "attribute_item" && is_test_attribute_item(candidate, source) {
+            return true;
+        }
+        if candidate.kind() != "attribute_item" {
+            break;
+        }
+        sibling = candidate.prev_sibling();
+    }
+    false
+}
+
+/// Whether an `attribute_item` node's inner `attribute` name is `test` or
+/// `rstest` — see `has_test_attribute`'s doc comment for which forms this
+/// covers.
+///
+/// `attribute`'s grammar has no `name` field for its leading identifier
+/// (only `arguments`/`value` are named fields, per
+/// `tree-sitter-rust`'s `node-types.json`); the identifier or
+/// `scoped_identifier` is its first named child instead.
+fn is_test_attribute_item(attribute_item: tree_sitter::Node, source: &[u8]) -> bool {
+    let Some(attribute) = attribute_item
+        .named_child(0)
+        .filter(|n| n.kind() == "attribute")
+    else {
+        return false;
+    };
+    let Some(name_node) = attribute.named_child(0) else {
+        return false;
+    };
+    let name_text = match name_node.kind() {
+        "scoped_identifier" => name_node.child_by_field_name("name"),
+        _ => Some(name_node),
+    }
+    .and_then(|n| n.utf8_text(source).ok());
+    matches!(name_text, Some("test") | Some("rstest"))
+}
+
+/// Whether a `mod_item` node is immediately preceded by a `#[cfg(test)]`
+/// attribute — same preceding-sibling structure as `has_test_attribute`,
+/// but checking for the `cfg(test)` argument shape instead of a bare test
+/// marker name.
+fn has_cfg_test_attribute(mod_item: tree_sitter::Node, source: &[u8]) -> bool {
+    let mut sibling = mod_item.prev_sibling();
+    while let Some(candidate) = sibling {
+        if candidate.kind() == "attribute_item" && is_cfg_test_attribute_item(candidate, source) {
+            return true;
+        }
+        if candidate.kind() != "attribute_item" {
+            break;
+        }
+        sibling = candidate.prev_sibling();
+    }
+    false
+}
+
+/// Whether an `attribute_item` is `#[cfg(test)]` specifically (not just any
+/// `#[cfg(...)]`): its inner `attribute` must be named `cfg` with a
+/// `token_tree` argument whose text is exactly `(test)`. See
+/// `is_test_attribute_item`'s doc comment for why the name is read as a
+/// plain child rather than a `name` field.
+fn is_cfg_test_attribute_item(attribute_item: tree_sitter::Node, source: &[u8]) -> bool {
+    let Some(attribute) = attribute_item
+        .named_child(0)
+        .filter(|n| n.kind() == "attribute")
+    else {
+        return false;
+    };
+    let is_cfg = attribute
+        .named_child(0)
+        .and_then(|n| n.utf8_text(source).ok())
+        == Some("cfg");
+    if !is_cfg {
+        return false;
+    }
+    attribute
+        .child_by_field_name("arguments")
+        .and_then(|n| n.utf8_text(source).ok())
+        == Some("(test)")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+    use tree_sitter::StreamingIterator;
 
     #[test]
     fn should_report_rust_as_name() {
@@ -100,5 +228,185 @@ mod tests {
 
         tree_sitter::Query::new(&support.grammar(), support.reference_query())
             .expect("REFERENCE_QUERY must be valid against the Rust grammar");
+    }
+
+    #[rstest]
+    #[case::should_return_true_when_path_has_tests_directory_segment("tests/integration.rs", true)]
+    #[case::should_return_true_when_tests_directory_is_nested("crate/tests/it.rs", true)]
+    #[case::should_return_false_when_path_is_ordinary_module("src/lib.rs", false)]
+    #[case::should_return_false_when_filename_merely_contains_test_substring(
+        "src/contest.rs",
+        false
+    )]
+    fn is_test_path_cases(#[case] path: &str, #[case] expected: bool) {
+        let support = RustSupport;
+
+        let actual = support.is_test_path(path);
+
+        assert_eq!(expected, actual);
+    }
+
+    /// Parses `source` and returns the first node captured by
+    /// `DEFINITION_QUERY` whose own text contains `needle` — a small
+    /// end-to-end harness for `is_test_definition` tests, which need a real
+    /// tree-sitter node (attribute siblings, `mod_item` ancestors) rather
+    /// than the flat `ExtractedSymbol` shape `extract.rs` produces.
+    fn find_definition_node<'a>(
+        tree: &'a tree_sitter::Tree,
+        source: &'a str,
+        needle: &str,
+    ) -> tree_sitter::Node<'a> {
+        let support = RustSupport;
+        let query = tree_sitter::Query::new(&support.grammar(), support.definition_query())
+            .expect("DEFINITION_QUERY must be valid against the Rust grammar");
+        let definition_capture_index = query
+            .capture_index_for_name("definition")
+            .expect("definition query must have a @definition capture");
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
+        while let Some(m) = matches.next() {
+            for capture in m.captures {
+                if capture.index == definition_capture_index
+                    && capture
+                        .node
+                        .utf8_text(source.as_bytes())
+                        .is_ok_and(|text| text.contains(needle))
+                {
+                    return capture.node;
+                }
+            }
+        }
+        panic!("no definition node containing {needle:?} found in parsed source");
+    }
+
+    #[test]
+    fn should_return_true_when_function_is_nested_inside_cfg_test_mod() {
+        let source = "\
+#[cfg(test)]
+mod tests {
+    fn helper() {}
+}
+";
+        let support = RustSupport;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&support.grammar()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let node = find_definition_node(&tree, source, "fn helper");
+
+        let actual = support.is_test_definition(node, source.as_bytes());
+
+        assert!(actual);
+    }
+
+    #[test]
+    fn should_return_true_when_function_has_test_attribute() {
+        let source = "\
+#[test]
+fn should_add_two_numbers() {}
+";
+        let support = RustSupport;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&support.grammar()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let node = find_definition_node(&tree, source, "fn should_add_two_numbers");
+
+        let actual = support.is_test_definition(node, source.as_bytes());
+
+        assert!(actual);
+    }
+
+    #[test]
+    fn should_return_true_when_function_has_rstest_attribute() {
+        let source = "\
+#[rstest]
+fn should_do_something(#[case] input: i32) {}
+";
+        let support = RustSupport;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&support.grammar()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let node = find_definition_node(&tree, source, "fn should_do_something");
+
+        let actual = support.is_test_definition(node, source.as_bytes());
+
+        assert!(actual);
+    }
+
+    #[test]
+    fn should_return_true_when_function_has_tokio_test_attribute() {
+        let source = "\
+#[tokio::test]
+async fn should_fetch_data() {}
+";
+        let support = RustSupport;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&support.grammar()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let node = find_definition_node(&tree, source, "fn should_fetch_data");
+
+        let actual = support.is_test_definition(node, source.as_bytes());
+
+        assert!(actual);
+    }
+
+    #[test]
+    fn should_return_false_when_function_has_no_test_marker() {
+        let source = "\
+fn helper() -> i32 {
+    42
+}
+";
+        let support = RustSupport;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&support.grammar()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let node = find_definition_node(&tree, source, "fn helper");
+
+        let actual = support.is_test_definition(node, source.as_bytes());
+
+        assert!(!actual);
+    }
+
+    #[test]
+    fn should_return_false_when_mod_has_unrelated_cfg_attribute() {
+        let source = "\
+#[cfg(feature = \"extra\")]
+mod extra {
+    fn helper() {}
+}
+";
+        let support = RustSupport;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&support.grammar()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let node = find_definition_node(&tree, source, "fn helper");
+
+        let actual = support.is_test_definition(node, source.as_bytes());
+
+        assert!(!actual);
+    }
+
+    #[test]
+    fn should_return_true_when_function_is_deeply_nested_inside_cfg_test_mod() {
+        // A helper function nested inside an inner `mod` that is itself
+        // inside `#[cfg(test)] mod tests` is still test code — the walk
+        // must not stop at the immediate parent.
+        let source = "\
+#[cfg(test)]
+mod tests {
+    mod nested {
+        fn helper() {}
+    }
+}
+";
+        let support = RustSupport;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&support.grammar()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let node = find_definition_node(&tree, source, "fn helper");
+
+        let actual = support.is_test_definition(node, source.as_bytes());
+
+        assert!(actual);
     }
 }

--- a/rinkaku-core/src/language/rust.rs
+++ b/rinkaku-core/src/language/rust.rs
@@ -69,8 +69,8 @@ impl LanguageSupport for RustSupport {
     }
 
     /// Whether `node` (a captured `@definition` node) is a Rust unit test:
-    /// nested inside a `#[cfg(test)]`-attributed `mod`, or itself
-    /// `#[test]`/`#[rstest]`/`#[tokio::test]`-attributed. Checked by
+    /// nested inside a `#[cfg(test)]`/`#![cfg(test)]`-attributed `mod`, or
+    /// itself `#[test]`/`#[rstest]`/`#[tokio::test]`-attributed. Checked by
     /// walking ancestors rather than only the immediate parent, since a
     /// test helper function nested a few `impl`/`mod` levels inside a
     /// `#[cfg(test)] mod tests { ... }` block is still test code.
@@ -80,7 +80,7 @@ impl LanguageSupport for RustSupport {
         }
         let mut current = node.parent();
         while let Some(candidate) = current {
-            if candidate.kind() == "mod_item" && has_cfg_test_attribute(candidate, source) {
+            if candidate.kind() == "mod_item" && mod_has_cfg_test_attribute(candidate, source) {
                 return true;
             }
             current = candidate.parent();
@@ -89,12 +89,14 @@ impl LanguageSupport for RustSupport {
     }
 }
 
-/// Whether `node` is immediately preceded by a `#[test]`, `#[rstest]`, or
+/// Whether `node` is preceded by a `#[test]`, `#[rstest]`, or
 /// `#[tokio::test]` attribute — a test function marker. Tree-sitter's Rust
 /// grammar attaches an `attribute_item` as a preceding *sibling* of the
 /// node it annotates, not a child, so this walks backward through
-/// `prev_sibling` (skipping over other attributes/doc comments stacked on
-/// the same item) rather than inspecting `node`'s own children.
+/// `prev_sibling` (skipping over other attributes and doc comments stacked
+/// on the same item — see `is_skippable_between_attribute_and_item`'s doc
+/// comment for why doc comments must be skipped rather than treated as a
+/// search-stopping sibling) rather than inspecting `node`'s own children.
 ///
 /// Matches any attribute whose name (the bare `identifier`, e.g. `test` in
 /// `#[test]`, or the `scoped_identifier`'s `name` field, e.g. `test` in
@@ -108,12 +110,29 @@ fn has_test_attribute(node: tree_sitter::Node, source: &[u8]) -> bool {
         if candidate.kind() == "attribute_item" && is_test_attribute_item(candidate, source) {
             return true;
         }
-        if candidate.kind() != "attribute_item" {
+        if !is_skippable_between_attribute_and_item(candidate) {
             break;
         }
         sibling = candidate.prev_sibling();
     }
     false
+}
+
+/// Whether `node`, encountered while walking backward from an item toward
+/// its preceding attributes, should be skipped over rather than treated as
+/// "no more attributes to check": another `attribute_item` (multiple
+/// stacked attributes, e.g. `#[test]` above `#[should_panic]`), or a doc
+/// comment (`line_comment`/`block_comment` — tree-sitter's Rust grammar
+/// parses `///`/`/** */` as ordinary comment nodes, not as part of the
+/// attribute or the item they document). Without skipping comments, a
+/// `#[cfg(test)]` immediately followed by a `/// doc comment` line before
+/// `mod tests { ... }` would not be recognized as attached to that mod,
+/// since the doc comment sits between them as a non-attribute sibling.
+fn is_skippable_between_attribute_and_item(node: tree_sitter::Node) -> bool {
+    matches!(
+        node.kind(),
+        "attribute_item" | "line_comment" | "block_comment"
+    )
 }
 
 /// Whether an `attribute_item` node's inner `attribute` name is `test` or
@@ -142,29 +161,53 @@ fn is_test_attribute_item(attribute_item: tree_sitter::Node, source: &[u8]) -> b
     matches!(name_text, Some("test") | Some("rstest"))
 }
 
-/// Whether a `mod_item` node is immediately preceded by a `#[cfg(test)]`
-/// attribute — same preceding-sibling structure as `has_test_attribute`,
-/// but checking for the `cfg(test)` argument shape instead of a bare test
-/// marker name.
-fn has_cfg_test_attribute(mod_item: tree_sitter::Node, source: &[u8]) -> bool {
+/// Whether `mod_item` carries a `#[cfg(test)]` (outer, preceding-sibling
+/// form) or `#![cfg(test)]` (inner, first-child-of-`declaration_list` form)
+/// attribute. Both spellings apply the `cfg` to the module itself; only
+/// their tree position differs — tree-sitter's Rust grammar attaches an
+/// inner attribute (`#![...]`) as the first child of whatever block it
+/// appears inside, not as a sibling of the enclosing item the way an outer
+/// attribute (`#[...]`) is (`mod_item -> declaration_list -> [
+/// inner_attribute_item, ... ]`, vs. `[attribute_item, mod_item]` as
+/// siblings) — so the two forms need different tree-walks and cannot share
+/// `has_test_attribute`'s preceding-sibling walk.
+fn mod_has_cfg_test_attribute(mod_item: tree_sitter::Node, source: &[u8]) -> bool {
     let mut sibling = mod_item.prev_sibling();
     while let Some(candidate) = sibling {
         if candidate.kind() == "attribute_item" && is_cfg_test_attribute_item(candidate, source) {
             return true;
         }
-        if candidate.kind() != "attribute_item" {
+        if !is_skippable_between_attribute_and_item(candidate) {
             break;
         }
         sibling = candidate.prev_sibling();
     }
-    false
+
+    let Some(body) = mod_item.child_by_field_name("body") else {
+        return false;
+    };
+    let mut cursor = body.walk();
+    body.children(&mut cursor).any(|child| {
+        child.kind() == "inner_attribute_item" && is_cfg_test_attribute_item(child, source)
+    })
 }
 
-/// Whether an `attribute_item` is `#[cfg(test)]` specifically (not just any
-/// `#[cfg(...)]`): its inner `attribute` must be named `cfg` with a
-/// `token_tree` argument whose text is exactly `(test)`. See
-/// `is_test_attribute_item`'s doc comment for why the name is read as a
-/// plain child rather than a `name` field.
+/// Whether an `attribute_item`/`inner_attribute_item` is `#[cfg(test)]` /
+/// `#![cfg(test)]` in the sense `cfg(test)` would actually enable: its
+/// inner `attribute` must be named `cfg`, and a bare `test` identifier
+/// must appear somewhere in its argument `token_tree` *without* being
+/// negated by an enclosing `not(...)` and without being a string literal
+/// (`feature = "test"`).
+///
+/// A naive exact-text match against `"(test)"` (the v1 approach) only
+/// recognized the single spelling `#[cfg(test)]`; it missed
+/// `#[cfg(test,)]`, `#[cfg( test )]`, and `#[cfg(all(test, ...))]`/
+/// `#[cfg(any(test, ...))]` (all of which really do gate on `test`), and
+/// coincidentally rejected `#[cfg(not(test))]`/`#[cfg(feature = "test")]`
+/// (which must never match) only because their text happens to differ from
+/// the exact string, not because of any semantic check. This walks the
+/// argument's `token_tree` structurally instead, delegating to
+/// `token_tree_gates_on_test` for the `not(...)`-aware recursive search.
 fn is_cfg_test_attribute_item(attribute_item: tree_sitter::Node, source: &[u8]) -> bool {
     let Some(attribute) = attribute_item
         .named_child(0)
@@ -179,10 +222,55 @@ fn is_cfg_test_attribute_item(attribute_item: tree_sitter::Node, source: &[u8]) 
     if !is_cfg {
         return false;
     }
-    attribute
-        .child_by_field_name("arguments")
-        .and_then(|n| n.utf8_text(source).ok())
-        == Some("(test)")
+    let Some(arguments) = attribute.child_by_field_name("arguments") else {
+        return false;
+    };
+    token_tree_gates_on_test(arguments, source)
+}
+
+/// Recursively searches `token_tree` (a `cfg(...)`/`not(...)`/`all(...)`/
+/// `any(...)` argument list) for a bare `identifier` node with text
+/// `"test"`, treating any nested `token_tree` immediately preceded by a
+/// `not` identifier as negated and excluded from the search — `test`
+/// appearing only inside `not(...)` means "not test" (production-only),
+/// the opposite of what this function must report.
+///
+/// Walks `token_tree`'s direct children looking for the pattern
+/// `identifier("not")` followed by a nested `token_tree`, skipping that
+/// nested tree entirely when found (recursing into every *other* child
+/// normally, including nested `token_tree`s for `all(...)`/`any(...)`,
+/// which do gate on their contents). A bare `identifier` child with text
+/// `"test"` elsewhere in the tree (not consumed as the `not` marker itself)
+/// is a match. `string_literal` children (e.g. the `"test"` in
+/// `feature = "test"`) are a distinct node kind from `identifier` and so
+/// never match by construction — no separate exclusion needed.
+fn token_tree_gates_on_test(token_tree: tree_sitter::Node, source: &[u8]) -> bool {
+    let mut cursor = token_tree.walk();
+    let children: Vec<tree_sitter::Node> = token_tree.children(&mut cursor).collect();
+
+    let mut i = 0;
+    while i < children.len() {
+        let child = children[i];
+        if child.kind() == "identifier" && child.utf8_text(source) == Ok("not") {
+            // Skip the `not`'s own nested token_tree (typically the very
+            // next child): whatever `test` it contains is negated, not a
+            // match.
+            if let Some(next) = children.get(i + 1)
+                && next.kind() == "token_tree"
+            {
+                i += 2;
+                continue;
+            }
+        }
+        if child.kind() == "identifier" && child.utf8_text(source) == Ok("test") {
+            return true;
+        }
+        if child.kind() == "token_tree" && token_tree_gates_on_test(child, source) {
+            return true;
+        }
+        i += 1;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -404,6 +492,100 @@ mod tests {
         parser.set_language(&support.grammar()).unwrap();
         let tree = parser.parse(source, None).unwrap();
         let node = find_definition_node(&tree, source, "fn helper");
+
+        let actual = support.is_test_definition(node, source.as_bytes());
+
+        assert!(actual);
+    }
+
+    #[test]
+    fn should_return_true_when_function_is_inside_mod_with_inner_cfg_test_attribute() {
+        // `#![cfg(test)]` (inner attribute) applies to the enclosing `mod`
+        // itself, same as an outer `#[cfg(test)]` placed before it — but
+        // tree-sitter attaches it as the *first child of the mod's own
+        // `declaration_list`*, not as a preceding sibling of the `mod_item`
+        // the way an outer attribute is. A detector that only checks
+        // preceding siblings misses this form entirely.
+        let source = "\
+mod tests {
+    #![cfg(test)]
+
+    fn helper() {}
+}
+";
+        let support = RustSupport;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&support.grammar()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let node = find_definition_node(&tree, source, "fn helper");
+
+        let actual = support.is_test_definition(node, source.as_bytes());
+
+        assert!(actual);
+    }
+
+    #[rstest]
+    #[case::should_detect_plain_cfg_test("#[cfg(test)]", true)]
+    #[case::should_detect_cfg_test_with_inner_whitespace("#[cfg( test )]", true)]
+    #[case::should_detect_cfg_test_with_trailing_comma("#[cfg(test,)]", true)]
+    #[case::should_detect_test_nested_in_all("#[cfg(all(test, feature = \"x\"))]", true)]
+    #[case::should_detect_test_nested_in_any("#[cfg(any(test, doc))]", true)]
+    #[case::should_not_detect_test_negated_by_not("#[cfg(not(test))]", false)]
+    #[case::should_not_detect_test_as_feature_string_literal("#[cfg(feature = \"test\")]", false)]
+    fn is_cfg_test_attribute_item_cases(#[case] attribute_source: &str, #[case] expected: bool) {
+        let source = format!("{attribute_source}\nmod tests {{\n    fn helper() {{}}\n}}\n");
+        let support = RustSupport;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&support.grammar()).unwrap();
+        let tree = parser.parse(&source, None).unwrap();
+        let node = find_definition_node(&tree, &source, "fn helper");
+
+        let actual = support.is_test_definition(node, source.as_bytes());
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_true_when_doc_comment_sits_between_cfg_test_attribute_and_mod() {
+        // `attribute_item` and `mod_item` are not adjacent siblings when a
+        // doc comment (`line_comment` node) is written between them; the
+        // ancestor/sibling walk must skip over such comments rather than
+        // stopping the search the moment a non-`attribute_item` sibling is
+        // seen.
+        let source = "\
+#[cfg(test)]
+/// Doc comment on the test module.
+mod tests {
+    fn helper() {}
+}
+";
+        let support = RustSupport;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&support.grammar()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let node = find_definition_node(&tree, source, "fn helper");
+
+        let actual = support.is_test_definition(node, source.as_bytes());
+
+        assert!(actual);
+    }
+
+    #[test]
+    fn should_return_true_when_doc_comment_sits_between_test_attribute_and_function() {
+        // Same doc-comment-skipping requirement as the mod case above, but
+        // for a directly `#[test]`-attributed function.
+        let source = "\
+#[test]
+/// Doc comment on the test function.
+fn should_add_two_numbers() {
+    assert_eq!(2, 1 + 1);
+}
+";
+        let support = RustSupport;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&support.grammar()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let node = find_definition_node(&tree, source, "fn should_add_two_numbers");
 
         let actual = support.is_test_definition(node, source.as_bytes());
 

--- a/rinkaku-core/src/language/typescript.rs
+++ b/rinkaku-core/src/language/typescript.rs
@@ -90,6 +90,23 @@ impl LanguageSupport for TypeScriptSupport {
     fn reference_query(&self) -> &str {
         REFERENCE_QUERY
     }
+
+    fn is_test_path(&self, path: &str) -> bool {
+        is_test_path(path)
+    }
+}
+
+/// Common test-file convention checked by both grammars: `.test.ts(x)` /
+/// `.spec.ts(x)` (Jest/Vitest/Jasmine's shared discovery pattern) or a
+/// `__tests__/` directory anywhere in the path (Jest's other default
+/// convention, for files that don't themselves match the suffix pattern,
+/// e.g. `__tests__/factories.ts`).
+fn is_test_path(path: &str) -> bool {
+    let file_name = path.rsplit('/').next().unwrap_or(path);
+    let has_test_suffix = [".test.ts", ".test.tsx", ".spec.ts", ".spec.tsx"]
+        .iter()
+        .any(|suffix| file_name.ends_with(suffix));
+    has_test_suffix || path.split('/').any(|segment| segment == "__tests__")
 }
 
 /// TSX (`.tsx`): TypeScript with JSX syntax. Reports the same `"typescript"`
@@ -114,11 +131,17 @@ impl LanguageSupport for TsxSupport {
     fn reference_query(&self) -> &str {
         REFERENCE_QUERY
     }
+
+    fn is_test_path(&self, path: &str) -> bool {
+        is_test_path(path)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
 
     #[test]
     fn should_report_typescript_as_name() {
@@ -194,5 +217,27 @@ mod tests {
 
         tree_sitter::Query::new(&support.grammar(), support.reference_query())
             .expect("REFERENCE_QUERY must be valid against the TSX grammar");
+    }
+
+    #[rstest]
+    #[case::should_return_true_when_filename_has_test_ts_suffix("repo.test.ts", true)]
+    #[case::should_return_true_when_filename_has_test_tsx_suffix("Repo.test.tsx", true)]
+    #[case::should_return_true_when_filename_has_spec_ts_suffix("repo.spec.ts", true)]
+    #[case::should_return_true_when_filename_has_spec_tsx_suffix("Repo.spec.tsx", true)]
+    #[case::should_return_true_when_path_has_tests_directory_segment(
+        "src/__tests__/factories.ts",
+        true
+    )]
+    #[case::should_return_false_when_path_is_ordinary_module("src/repo.ts", false)]
+    #[case::should_return_false_when_filename_merely_contains_test_substring(
+        "src/contest.ts",
+        false
+    )]
+    fn is_test_path_cases(#[case] path: &str, #[case] expected: bool) {
+        let support = TypeScriptSupport;
+
+        let actual = support.is_test_path(path);
+
+        assert_eq!(expected, actual);
     }
 }

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -67,12 +67,14 @@ pub enum AnalyzeError {
 /// resolved as `-diff`/`linguist-generated` via `git check-attr` at the
 /// process boundary — this module stays pure and never runs `git` itself,
 /// so the set is computed by the caller and passed in as plain data, same
-/// as `read_file`. A path in this set is reported as
-/// `SkipReason::Generated` before any other check (deleted/binary/
-/// unsupported-language) runs for it, and `read_file` is never called for
-/// it. Empty when `--include-generated` is given or no local repository was
-/// available to resolve attributes against (`main.rs` degrades to an empty
-/// set rather than erroring in that case).
+/// as `read_file`. A path in this set is reported as `SkipReason::Generated`
+/// unless it was also deleted, in which case `SkipReason::Deleted` wins
+/// (checked first): the fact that a file was removed is more important
+/// information for a reviewer than an attribute the file no longer carries
+/// any content for, and `read_file` is never called either way. Empty when
+/// `--include-generated` is given or no local repository was available to
+/// resolve attributes against (`main.rs` degrades to an empty set rather
+/// than erroring in that case).
 ///
 /// Known inefficiency: a changed file is parsed here (via
 /// `extract_changed_symbols`) and, when `resolver` is `TagsResolver`,
@@ -96,17 +98,17 @@ pub fn analyze_diff(
     let mut skipped = Vec::new();
 
     for changed_file in changed_files {
-        if generated_paths.contains(&changed_file.path) {
-            skipped.push(SkippedFile {
-                path: changed_file.path,
-                reason: SkipReason::Generated,
-            });
-            continue;
-        }
         if changed_file.kind == ChangeKind::Deleted {
             skipped.push(SkippedFile {
                 path: changed_file.path,
                 reason: SkipReason::Deleted,
+            });
+            continue;
+        }
+        if generated_paths.contains(&changed_file.path) {
+            skipped.push(SkippedFile {
+                path: changed_file.path,
+                reason: SkipReason::Generated,
             });
             continue;
         }
@@ -900,6 +902,39 @@ index e69de29..4b825dc 100644
             let expected = vec![SkippedFile {
                 path: "Cargo.lock".to_string(),
                 reason: SkipReason::Generated,
+            }];
+            assert_eq!(expected, report.skipped);
+        }
+
+        // Regression test: a file that is both deleted and marked
+        // generated (e.g. a lockfile removed from a repo that also
+        // declares it `-diff`) must be reported as `Deleted`, not
+        // `Generated` — the fact that the file was removed is more
+        // important information for a reviewer than the (now moot)
+        // attribute it used to carry, and `Deleted` already carries no
+        // content to read either way.
+        #[test]
+        fn should_report_deleted_reason_when_a_deleted_path_is_also_marked_generated() {
+            let diff = "\
+diff --git a/Cargo.lock b/Cargo.lock
+deleted file mode 100644
+index 4b825dc..0000000
+--- a/Cargo.lock
++++ /dev/null
+@@ -1,1 +0,0 @@
+-version = 1
+";
+            // No entry in the map: if the pipeline tried to read a deleted
+            // file, this would return an Err and fail the test.
+            let read_file = fake_reader(HashMap::new());
+            let generated_paths: HashSet<String> = ["Cargo.lock".to_string()].into_iter().collect();
+
+            let report = analyze_diff(diff, read_file, None, true, &generated_paths)
+                .expect("analyze should succeed");
+
+            let expected = vec![SkippedFile {
+                path: "Cargo.lock".to_string(),
+                reason: SkipReason::Deleted,
             }];
             assert_eq!(expected, report.skipped);
         }

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -745,13 +745,38 @@ fn should_add_two_numbers() {
 ";
             let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
-            let report = analyze_diff(diff, read_file, None, true, &HashSet::new())
+            let expected = Report {
+                files: vec![FileReport {
+                    path: "src/lib.rs".to_string(),
+                    symbols: vec![ExtractedSymbol {
+                        id: "src/lib.rs::should_add_two_numbers".to_string(),
+                        name: "should_add_two_numbers".to_string(),
+                        kind: SymbolKind::Function,
+                        signature: "fn should_add_two_numbers()".to_string(),
+                        range: LineRange { start: 2, end: 4 },
+                        container: None,
+                        referenced_names: vec![],
+                        dependencies: vec![],
+                        omitted_dependency_matches: 0,
+                        is_test: true,
+                    }],
+                }],
+                skipped: vec![],
+                graph: crate::graph::SymbolGraph {
+                    nodes: vec![crate::graph::Node {
+                        id: "src/lib.rs::should_add_two_numbers".to_string(),
+                        path: "src/lib.rs".to_string(),
+                        name: "should_add_two_numbers".to_string(),
+                    }],
+                    edges: vec![],
+                    roots: vec!["src/lib.rs::should_add_two_numbers".to_string()],
+                },
+                tests: vec![],
+            };
+            let actual = analyze_diff(diff, read_file, None, true, &HashSet::new())
                 .expect("analyze should succeed");
 
-            let expected_tests: Vec<TestFileSummary> = Vec::new();
-            assert_eq!(1, report.files.len());
-            assert_eq!(1, report.files[0].symbols.len());
-            assert_eq!(expected_tests, report.tests);
+            assert_eq!(expected, actual);
         }
 
         #[test]
@@ -861,17 +886,41 @@ mod tests {
 ";
             let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
-            let report = analyze_diff(diff, read_file, None, false, &HashSet::new())
+            let expected = Report {
+                files: vec![FileReport {
+                    path: "src/lib.rs".to_string(),
+                    symbols: vec![ExtractedSymbol {
+                        id: "src/lib.rs::add".to_string(),
+                        name: "add".to_string(),
+                        kind: SymbolKind::Function,
+                        signature: "fn add(a: i32, b: i32) -> i32".to_string(),
+                        range: LineRange { start: 1, end: 3 },
+                        container: None,
+                        referenced_names: vec![],
+                        dependencies: vec![],
+                        omitted_dependency_matches: 0,
+                        is_test: false,
+                    }],
+                }],
+                skipped: vec![],
+                graph: crate::graph::SymbolGraph {
+                    nodes: vec![crate::graph::Node {
+                        id: "src/lib.rs::add".to_string(),
+                        path: "src/lib.rs".to_string(),
+                        name: "add".to_string(),
+                    }],
+                    edges: vec![],
+                    roots: vec!["src/lib.rs::add".to_string()],
+                },
+                tests: vec![TestFileSummary {
+                    path: "src/lib.rs".to_string(),
+                    symbol_count: 1,
+                }],
+            };
+            let actual = analyze_diff(diff, read_file, None, false, &HashSet::new())
                 .expect("analyze should succeed");
 
-            let expected_tests = vec![TestFileSummary {
-                path: "src/lib.rs".to_string(),
-                symbol_count: 1,
-            }];
-            assert_eq!(1, report.files.len());
-            assert_eq!(1, report.files[0].symbols.len());
-            assert_eq!("add", report.files[0].symbols[0].name);
-            assert_eq!(expected_tests, report.tests);
+            assert_eq!(expected, actual);
         }
     }
 

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -9,10 +9,10 @@
 
 use crate::deps::{Resolver, resolve_dependencies};
 use crate::diff::{ChangeKind, parse_unified_diff};
-use crate::extract::extract_changed_symbols;
+use crate::extract::{ExtractedSymbol, extract_changed_symbols};
 use crate::graph::{build_graph, stamp_ids};
-use crate::language::language_for_path;
-use crate::render::{FileReport, Report, SkipReason, SkippedFile};
+use crate::language::{LanguageSupport, language_for_path};
+use crate::render::{FileReport, Report, SkipReason, SkippedFile, TestFileSummary};
 use thiserror::Error;
 
 /// Errors that can occur while running the pipeline.
@@ -50,6 +50,30 @@ pub enum AnalyzeError {
 /// resolution entirely — no `Resolver::resolve` calls are made — which is
 /// how the CLI's `--deps 0` is wired (`main.rs`).
 ///
+/// `include_tests` controls ADR 0009's test-symbol exclusion: `false` (the
+/// CLI's default) drops every symbol a file's
+/// [`crate::language::LanguageSupport`] considers a test — by path
+/// ([`LanguageSupport::is_test_path`], the whole file) or by AST context
+/// ([`ExtractedSymbol::is_test`], set per-definition during extraction) —
+/// from `files` before dependency resolution and graph-building run, and
+/// summarizes the excluded counts per file in the returned `Report`'s
+/// `tests`. `true` (`--include-tests`) keeps every symbol in `files` as
+/// before and leaves `tests` empty. Filtering happens before
+/// `resolve_dependencies`/`build_graph` rather than at render time so test
+/// symbols are excluded from the dependency graph and 1-hop resolution too,
+/// not just hidden from the rendered "Change graph"/"Definitions" sections.
+///
+/// `generated_paths` (ADR 0010) is the set of changed paths `main.rs`
+/// resolved as `-diff`/`linguist-generated` via `git check-attr` at the
+/// process boundary — this module stays pure and never runs `git` itself,
+/// so the set is computed by the caller and passed in as plain data, same
+/// as `read_file`. A path in this set is reported as
+/// `SkipReason::Generated` before any other check (deleted/binary/
+/// unsupported-language) runs for it, and `read_file` is never called for
+/// it. Empty when `--include-generated` is given or no local repository was
+/// available to resolve attributes against (`main.rs` degrades to an empty
+/// set rather than erroring in that case).
+///
 /// Known inefficiency: a changed file is parsed here (via
 /// `extract_changed_symbols`) and, when `resolver` is `TagsResolver`,
 /// parsed *again* while building that resolver's index
@@ -63,6 +87,8 @@ pub fn analyze_diff(
     diff_text: &str,
     read_file: impl Fn(&str) -> std::io::Result<String>,
     resolver: Option<&dyn Resolver>,
+    include_tests: bool,
+    generated_paths: &std::collections::HashSet<String>,
 ) -> Result<Report, AnalyzeError> {
     let changed_files = parse_unified_diff(diff_text)?;
 
@@ -70,6 +96,13 @@ pub fn analyze_diff(
     let mut skipped = Vec::new();
 
     for changed_file in changed_files {
+        if generated_paths.contains(&changed_file.path) {
+            skipped.push(SkippedFile {
+                path: changed_file.path,
+                reason: SkipReason::Generated,
+            });
+            continue;
+        }
         if changed_file.kind == ChangeKind::Deleted {
             skipped.push(SkippedFile {
                 path: changed_file.path,
@@ -116,6 +149,11 @@ pub fn analyze_diff(
         });
     }
 
+    let mut tests = Vec::new();
+    if !include_tests {
+        (files, tests) = partition_test_symbols(files);
+    }
+
     let mut files = match resolver {
         Some(resolver) => resolve_dependencies(files, resolver),
         None => files,
@@ -133,7 +171,56 @@ pub fn analyze_diff(
         files,
         skipped,
         graph,
+        tests,
     })
+}
+
+/// Splits `files` into (non-test symbols, per-file test-symbol counts) for
+/// ADR 0009's default test-symbol exclusion. A symbol is a test if its
+/// file's [`LanguageSupport::is_test_path`] says the whole file is a test
+/// file, or if [`ExtractedSymbol::is_test`] says so by AST context (Rust's
+/// `#[cfg(test)]`/`#[test]`, set during extraction).
+///
+/// A file that had symbols before filtering but ends up with none after
+/// (every symbol it changed was a test) is dropped from the returned
+/// `files` entirely — it contributes only a [`TestFileSummary`], not an
+/// empty `FileReport` (which would otherwise render under "Other changed
+/// files" as if it were an uninteresting pure rename, which it is not). A
+/// file that already had no symbols *before* filtering (a genuine pure
+/// rename, see `analyze_diff`'s doc comment) is left alone and still kept,
+/// since filtering removed nothing from it.
+fn partition_test_symbols(files: Vec<FileReport>) -> (Vec<FileReport>, Vec<TestFileSummary>) {
+    let mut kept = Vec::new();
+    let mut tests = Vec::new();
+
+    for file in files {
+        let had_symbols = !file.symbols.is_empty();
+        let is_test_path = language_for_path(&file.path)
+            .is_some_and(|lang: &dyn LanguageSupport| lang.is_test_path(&file.path));
+
+        let (non_test, test): (Vec<ExtractedSymbol>, Vec<ExtractedSymbol>) = if is_test_path {
+            (Vec::new(), file.symbols)
+        } else {
+            file.symbols.into_iter().partition(|symbol| !symbol.is_test)
+        };
+
+        if !test.is_empty() {
+            tests.push(TestFileSummary {
+                path: file.path.clone(),
+                symbol_count: test.len(),
+            });
+        }
+        // Drop the file only if filtering actually emptied it — a file
+        // that had no symbols to begin with (pure rename) must stay.
+        if !had_symbols || !non_test.is_empty() {
+            kept.push(FileReport {
+                path: file.path,
+                symbols: non_test,
+            });
+        }
+    }
+
+    (kept, tests)
 }
 
 /// Parses `diff_text` and collects every name referenced by any changed
@@ -192,7 +279,7 @@ mod tests {
     use crate::diff::LineRange;
     use crate::extract::{ExtractedSymbol, SymbolKind};
     use pretty_assertions::assert_eq;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     /// Builds a `read_file` port backed by an in-memory map, so tests never
     /// touch the real filesystem.
@@ -224,8 +311,10 @@ mod tests {
             files: vec![],
             skipped: vec![],
             graph: empty_graph(),
+            tests: vec![],
         };
-        let actual = analyze_diff("", read_file, None).expect("analyze should succeed");
+        let actual = analyze_diff("", read_file, None, true, &HashSet::new())
+            .expect("analyze should succeed");
 
         assert_eq!(expected, actual);
     }
@@ -263,6 +352,7 @@ fn foo(a: i32) -> i32 {
                     referenced_names: vec![],
                     dependencies: vec![],
                     omitted_dependency_matches: 0,
+                    is_test: false,
                 }],
             }],
             skipped: vec![],
@@ -275,8 +365,10 @@ fn foo(a: i32) -> i32 {
                 edges: vec![],
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
+            tests: vec![],
         };
-        let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
+        let actual = analyze_diff(diff, read_file, None, true, &HashSet::new())
+            .expect("analyze should succeed");
 
         assert_eq!(expected, actual);
     }
@@ -304,8 +396,10 @@ index 4b825dc..0000000
                 reason: SkipReason::Deleted,
             }],
             graph: empty_graph(),
+            tests: vec![],
         };
-        let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
+        let actual = analyze_diff(diff, read_file, None, true, &HashSet::new())
+            .expect("analyze should succeed");
 
         assert_eq!(expected, actual);
     }
@@ -326,8 +420,10 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
                 reason: SkipReason::Binary,
             }],
             graph: empty_graph(),
+            tests: vec![],
         };
-        let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
+        let actual = analyze_diff(diff, read_file, None, true, &HashSet::new())
+            .expect("analyze should succeed");
 
         assert_eq!(expected, actual);
     }
@@ -356,8 +452,10 @@ index e69de29..4b825dc 100644
                 reason: SkipReason::UnsupportedLanguage,
             }],
             graph: empty_graph(),
+            tests: vec![],
         };
-        let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
+        let actual = analyze_diff(diff, read_file, None, true, &HashSet::new())
+            .expect("analyze should succeed");
 
         assert_eq!(expected, actual);
     }
@@ -390,8 +488,10 @@ rename to src/new_name.rs
             }],
             skipped: vec![],
             graph: empty_graph(),
+            tests: vec![],
         };
-        let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
+        let actual = analyze_diff(diff, read_file, None, true, &HashSet::new())
+            .expect("analyze should succeed");
 
         assert_eq!(expected, actual);
     }
@@ -408,7 +508,7 @@ index e69de29..4b825dc 100644
 ";
         let read_file = fake_reader(HashMap::new());
 
-        let actual = analyze_diff(diff, read_file, None);
+        let actual = analyze_diff(diff, read_file, None, true, &HashSet::new());
 
         assert!(matches!(actual, Err(AnalyzeError::Diff(_))));
     }
@@ -427,7 +527,7 @@ index e69de29..4b825dc 100644
         // Map has no entry for src/lib.rs, so the fake reader returns Err.
         let read_file = fake_reader(HashMap::new());
 
-        let actual = analyze_diff(diff, read_file, None);
+        let actual = analyze_diff(diff, read_file, None, true, &HashSet::new());
 
         assert!(matches!(
             actual,
@@ -471,6 +571,7 @@ index e69de29..4b825dc 100644
                     referenced_names: vec![],
                     dependencies: vec![],
                     omitted_dependency_matches: 0,
+                    is_test: false,
                 }],
             }],
             skipped: vec![SkippedFile {
@@ -486,8 +587,10 @@ index e69de29..4b825dc 100644
                 edges: vec![],
                 roots: vec!["src/lib.rs::a".to_string()],
             },
+            tests: vec![],
         };
-        let actual = analyze_diff(diff, read_file, None).expect("analyze should succeed");
+        let actual = analyze_diff(diff, read_file, None, true, &HashSet::new())
+            .expect("analyze should succeed");
 
         assert_eq!(expected, actual);
     }
@@ -535,7 +638,8 @@ fn foo(p: Point) -> i32 {
 ";
         let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
-        let report = analyze_diff(diff, read_file, None).expect("analyze should succeed");
+        let report = analyze_diff(diff, read_file, None, true, &HashSet::new())
+            .expect("analyze should succeed");
 
         // No resolver was passed, so every symbol's dependencies must stay
         // empty — this is `--deps 0`'s contract (main.rs), not merely "the
@@ -567,7 +671,8 @@ fn foo(p: Point) -> i32 {
         let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
         let resolver = CountingResolver::new();
 
-        analyze_diff(diff, read_file, Some(&resolver)).expect("analyze should succeed");
+        analyze_diff(diff, read_file, Some(&resolver), true, &HashSet::new())
+            .expect("analyze should succeed");
 
         let mut expected = vec!["Point".to_string(), "helper".to_string()];
         let mut actual = resolver.calls.borrow().clone();
@@ -575,6 +680,256 @@ fn foo(p: Point) -> i32 {
         actual.sort();
 
         assert_eq!(expected, actual);
+    }
+
+    mod test_symbol_exclusion_tests {
+        use super::*;
+        use crate::render::TestFileSummary;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn should_exclude_rust_symbol_from_files_and_summarize_it_when_include_tests_is_false() {
+            let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,4 +1,4 @@
+ #[test]
+ fn should_add_two_numbers() {
+-    assert_eq!(1, 1 + 0);
++    assert_eq!(2, 1 + 1);
+ }
+";
+            let source = "\
+#[test]
+fn should_add_two_numbers() {
+    assert_eq!(2, 1 + 1);
+}
+";
+            let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+
+            let report = analyze_diff(diff, read_file, None, false, &HashSet::new())
+                .expect("analyze should succeed");
+
+            let expected_files: Vec<FileReport> = Vec::new();
+            let expected_tests = vec![TestFileSummary {
+                path: "src/lib.rs".to_string(),
+                symbol_count: 1,
+            }];
+            assert_eq!(expected_files, report.files);
+            assert_eq!(expected_tests, report.tests);
+        }
+
+        #[test]
+        fn should_keep_test_symbol_in_files_and_leave_tests_empty_when_include_tests_is_true() {
+            let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,4 +1,4 @@
+ #[test]
+ fn should_add_two_numbers() {
+-    assert_eq!(1, 1 + 0);
++    assert_eq!(2, 1 + 1);
+ }
+";
+            let source = "\
+#[test]
+fn should_add_two_numbers() {
+    assert_eq!(2, 1 + 1);
+}
+";
+            let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+
+            let report = analyze_diff(diff, read_file, None, true, &HashSet::new())
+                .expect("analyze should succeed");
+
+            let expected_tests: Vec<TestFileSummary> = Vec::new();
+            assert_eq!(1, report.files.len());
+            assert_eq!(1, report.files[0].symbols.len());
+            assert_eq!(expected_tests, report.tests);
+        }
+
+        #[test]
+        fn should_drop_whole_file_from_files_when_go_test_file_has_only_test_symbols() {
+            let diff = "\
+diff --git a/repo_test.go b/repo_test.go
+index e69de29..4b825dc 100644
+--- a/repo_test.go
++++ b/repo_test.go
+@@ -1,5 +1,5 @@
+ package main
+
+ func TestFoo(t *testing.T) {
+-	old()
++	new_()
+ }
+";
+            let source = "\
+package main
+
+func TestFoo(t *testing.T) {
+	new_()
+}
+";
+            let read_file = fake_reader(HashMap::from([("repo_test.go", source)]));
+
+            let report = analyze_diff(diff, read_file, None, false, &HashSet::new())
+                .expect("analyze should succeed");
+
+            let expected_files: Vec<FileReport> = Vec::new();
+            let expected_tests = vec![TestFileSummary {
+                path: "repo_test.go".to_string(),
+                symbol_count: 1,
+            }];
+            assert_eq!(expected_files, report.files);
+            assert_eq!(expected_tests, report.tests);
+        }
+
+        // Regression test: a genuine pure rename produces a `FileReport`
+        // with an empty `symbols` list *before* test filtering ever runs
+        // (see `analyze_diff`'s doc comment) — that emptiness has nothing
+        // to do with tests, so `partition_test_symbols` must not drop it
+        // the same way it drops a file that became empty *because of*
+        // filtering (the Go all-test-file case above). Dropping it here
+        // would wrongly hide it from "Other changed files".
+        #[test]
+        fn should_keep_file_with_no_symbols_when_it_was_a_pure_rename_not_a_test_file() {
+            let diff = "\
+diff --git a/src/old_name.rs b/src/new_name.rs
+similarity index 100%
+rename from src/old_name.rs
+rename to src/new_name.rs
+";
+            let read_file = fake_reader(HashMap::new());
+
+            let report = analyze_diff(diff, read_file, None, false, &HashSet::new())
+                .expect("analyze should succeed");
+
+            let expected_files = vec![FileReport {
+                path: "src/new_name.rs".to_string(),
+                symbols: vec![],
+            }];
+            let expected_tests: Vec<TestFileSummary> = Vec::new();
+            assert_eq!(expected_files, report.files);
+            assert_eq!(expected_tests, report.tests);
+        }
+
+        #[test]
+        fn should_keep_non_test_symbols_and_summarize_test_symbols_when_file_mixes_both() {
+            // A Rust file with one production function and one
+            // `#[cfg(test)] mod tests` function both changed in the same
+            // diff — the production symbol stays in `files`, the test
+            // symbol is summarized in `tests`, and the file is not dropped
+            // entirely (unlike the all-test-file case above).
+            let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,9 +1,9 @@
+ fn add(a: i32, b: i32) -> i32 {
+-    a - b
++    a + b
+ }
+
+ #[cfg(test)]
+ mod tests {
+     #[test]
+     fn should_add_two_numbers() {
+-        assert_eq!(2, add(1, 1));
++        assert_eq!(3, add(1, 2));
+     }
+ }
+";
+            let source = "\
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn should_add_two_numbers() {
+        assert_eq!(3, add(1, 2));
+    }
+}
+";
+            let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+
+            let report = analyze_diff(diff, read_file, None, false, &HashSet::new())
+                .expect("analyze should succeed");
+
+            let expected_tests = vec![TestFileSummary {
+                path: "src/lib.rs".to_string(),
+                symbol_count: 1,
+            }];
+            assert_eq!(1, report.files.len());
+            assert_eq!(1, report.files[0].symbols.len());
+            assert_eq!("add", report.files[0].symbols[0].name);
+            assert_eq!(expected_tests, report.tests);
+        }
+    }
+
+    mod generated_path_exclusion_tests {
+        use super::*;
+        use crate::render::{SkipReason, SkippedFile};
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn should_skip_path_as_generated_when_in_generated_paths_set() {
+            let diff = "\
+diff --git a/Cargo.lock b/Cargo.lock
+index e69de29..4b825dc 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1,1 +1,1 @@
+-version = 1
++version = 2
+";
+            // No entry in the map: if the pipeline tried to read a
+            // generated file, this would return an Err and fail the test.
+            let read_file = fake_reader(HashMap::new());
+            let generated_paths: HashSet<String> = ["Cargo.lock".to_string()].into_iter().collect();
+
+            let report = analyze_diff(diff, read_file, None, true, &generated_paths)
+                .expect("analyze should succeed");
+
+            let expected = vec![SkippedFile {
+                path: "Cargo.lock".to_string(),
+                reason: SkipReason::Generated,
+            }];
+            assert_eq!(expected, report.skipped);
+        }
+
+        #[test]
+        fn should_not_skip_path_when_generated_paths_set_is_empty() {
+            let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,3 @@
+ fn foo(a: i32) -> i32 {
+-    a
++    a + 1
+ }
+";
+            let source = "\
+fn foo(a: i32) -> i32 {
+    a + 1
+}
+";
+            let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+
+            let report = analyze_diff(diff, read_file, None, true, &HashSet::new())
+                .expect("analyze should succeed");
+
+            let expected: Vec<SkippedFile> = Vec::new();
+            assert_eq!(expected, report.skipped);
+        }
     }
 
     mod collect_referenced_names_tests {

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -7,15 +7,21 @@
 //! This module turns a `Report` into either Markdown (the default, meant
 //! for humans and LLMs) or JSON (`serde`-derived, for machine consumption).
 //!
-//! Markdown renders as two sections: a "Change graph" tree (names only,
-//! rooted at the graph's auto-detected entry points) giving the reader a
-//! call-hierarchy reading order, followed by "Definitions" — the full
+//! Markdown renders as four sections, in this order: a "Change graph" tree
+//! (names only, rooted at the graph's auto-detected entry points) giving
+//! the reader a call-hierarchy reading order; "Definitions" — the full
 //! signature of every changed symbol, in the same tree order, each shown
 //! exactly once (ADR 0008's decision to avoid duplicating a symbol
-//! reachable from multiple roots).
+//! reachable from multiple roots); "Tests" — a per-file count of changed
+//! test symbols excluded from the graph/definitions above by default (ADR
+//! 0009); "Other changed files" — files with no changed-symbol-level
+//! content (e.g. pure renames); and "Skipped files".
 //!
 //! Skipped files are always listed, never silently dropped — a reviewer
 //! or LLM consuming the output needs to know what rinkaku didn't look at.
+//! Test symbols are summarized rather than dropped outright for the same
+//! reason: a reviewer still wants to know "did this change come with
+//! tests?" even though the individual test signatures are noise (ADR 0009).
 
 use crate::extract::{ExtractedSymbol, SymbolKind};
 use crate::graph::{NodeId, SymbolGraph};
@@ -33,6 +39,12 @@ pub struct Report {
     /// entry points used to render "Change graph" in Markdown, exposed here
     /// too so JSON consumers get the same structure without recomputing it.
     pub graph: SymbolGraph,
+    /// Per-file counts of changed test symbols excluded from `files` by
+    /// default (ADR 0009) — empty when `--include-tests` is given, since
+    /// test symbols then stay in `files` like any other symbol instead of
+    /// being summarized here. Source order (the order files were first
+    /// encountered in the diff), same as `files`.
+    pub tests: Vec<TestFileSummary>,
 }
 
 /// Extracted symbols for a single changed file.
@@ -40,6 +52,17 @@ pub struct Report {
 pub struct FileReport {
     pub path: String,
     pub symbols: Vec<ExtractedSymbol>,
+}
+
+/// How many changed test symbols were excluded from a given file's
+/// `FileReport` (ADR 0009). Kept separate from `FileReport` rather than as
+/// an extra field on it, since a file that is *entirely* tests (e.g. a Go
+/// `*_test.go` file) would otherwise need an empty `FileReport` just to
+/// carry this count — `tests` covers that file on its own instead.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TestFileSummary {
+    pub path: String,
+    pub symbol_count: usize,
 }
 
 /// A file the pipeline did not extract symbols from, and why.
@@ -60,6 +83,9 @@ pub enum SkipReason {
     Binary,
     /// The file was deleted; there is no new-side content to extract from.
     Deleted,
+    /// `.gitattributes` marks this file `-diff` or `linguist-generated`
+    /// (ADR 0010).
+    Generated,
 }
 
 /// Supported output formats for a [`Report`].
@@ -115,11 +141,13 @@ impl<'a> SymbolLookup<'a> {
     }
 }
 
-/// Renders a [`Report`] as Markdown: a "Change graph" tree of entry points
-/// (ADR 0008), a "Definitions" section with each changed symbol's signature
-/// in the same tree order, an "Other changed files" section for files that
-/// were analyzed but contributed no symbol (e.g. a pure rename — see
-/// `pipeline::analyze_diff`'s doc comment), and a list of skipped files.
+/// Renders a [`Report`] as Markdown, in this order: a "Change graph" tree
+/// of entry points (ADR 0008); a "Definitions" section with each changed
+/// symbol's signature in the same tree order; a "Tests" section
+/// summarizing excluded test symbols per file (ADR 0009); an "Other changed
+/// files" section for files that were analyzed but contributed no symbol
+/// (e.g. a pure rename — see `pipeline::analyze_diff`'s doc comment); and a
+/// list of skipped files.
 ///
 /// Path headings and tree labels (`{prefix} {name} ({path})`) do not escape
 /// Markdown special characters (`#`, `[`, `]`, `_`, ...). A path containing
@@ -136,6 +164,7 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
         .collect();
 
     if report.graph.nodes.is_empty()
+        && report.tests.is_empty()
         && files_with_no_symbols.is_empty()
         && report.skipped.is_empty()
     {
@@ -162,6 +191,24 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
             };
             render_definition(&mut out, path, symbol)?;
         }
+    }
+
+    if !report.tests.is_empty() {
+        writeln!(out, "## Tests")?;
+        writeln!(out)?;
+        for test_file in &report.tests {
+            let noun = if test_file.symbol_count == 1 {
+                "symbol"
+            } else {
+                "symbols"
+            };
+            writeln!(
+                out,
+                "- {}: {} changed test {noun}",
+                test_file.path, test_file.symbol_count
+            )?;
+        }
+        writeln!(out)?;
     }
 
     if !files_with_no_symbols.is_empty() {
@@ -464,6 +511,7 @@ fn skip_reason_label(reason: SkipReason) -> &'static str {
         SkipReason::UnsupportedLanguage => "unsupported language",
         SkipReason::Binary => "binary",
         SkipReason::Deleted => "deleted",
+        SkipReason::Generated => "generated",
     }
 }
 
@@ -490,6 +538,7 @@ mod tests {
             referenced_names: vec![],
             dependencies: vec![],
             omitted_dependency_matches: 0,
+            is_test: false,
         }
     }
 
@@ -511,6 +560,7 @@ mod tests {
                 edges: vec![],
                 roots: vec![],
             },
+            tests: vec![],
         };
 
         let expected = "".to_string();
@@ -541,6 +591,7 @@ mod tests {
                 edges: vec![],
                 roots: vec![],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -583,6 +634,7 @@ mod tests {
                 edges: vec![],
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -625,6 +677,7 @@ fn foo()
                 edges: vec![],
                 roots: vec![],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -635,6 +688,138 @@ fn foo()
 ## Skipped files
 
 - assets/logo.png (binary)
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_tests_section_with_singular_symbol_noun_when_count_is_one() {
+        let report = Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![crate::render::TestFileSummary {
+                path: "src/lib.rs".to_string(),
+                symbol_count: 1,
+            }],
+        };
+
+        let expected = "\
+## Tests
+
+- src/lib.rs: 1 changed test symbol
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_tests_section_with_plural_symbols_noun_when_count_is_greater_than_one() {
+        let report = Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![crate::render::TestFileSummary {
+                path: "src/lib.rs".to_string(),
+                symbol_count: 3,
+            }],
+        };
+
+        let expected = "\
+## Tests
+
+- src/lib.rs: 3 changed test symbols
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_tests_section_between_definitions_and_other_changed_files_when_report_has_all_sections()
+     {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    SymbolKind::Function,
+                    "fn foo()",
+                )],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
+            tests: vec![crate::render::TestFileSummary {
+                path: "src/lib.rs".to_string(),
+                symbol_count: 2,
+            }],
+        };
+
+        let expected = "\
+## Change graph
+
+- fn foo (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo()
+```
+
+## Tests
+
+- src/lib.rs: 2 changed test symbols
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_generated_skip_reason_label() {
+        let report = Report {
+            files: vec![],
+            skipped: vec![SkippedFile {
+                path: "Cargo.lock".to_string(),
+                reason: SkipReason::Generated,
+            }],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+        };
+
+        let expected = "\
+## Skipped files
+
+- Cargo.lock (generated)
 "
         .to_string();
         let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
@@ -660,6 +845,7 @@ fn foo()
                 edges: vec![],
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -726,6 +912,7 @@ fn foo(a: i32) -> i32
                     "src/lib.rs::foo@10".to_string(),
                 ],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -792,6 +979,7 @@ fn foo(a: i32, b: i32)
                 }],
                 roots: vec!["src/main.rs::handle_pr".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -869,6 +1057,7 @@ fn resolve_pr_base_sha() -> Result<String>
                 ],
                 roots: vec!["src/lib.rs::a".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -952,6 +1141,7 @@ fn c()
                 ],
                 roots: vec!["src/lib.rs::foo".to_string(), "src/lib.rs::bar".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1015,6 +1205,7 @@ fn bar()
                 }],
                 roots: vec!["src/git.rs::resolve_pr_base_sha".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1120,6 +1311,7 @@ fn resolve_pr_base_sha()
                     "src/config.rs::Config".to_string(),
                 ],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1185,6 +1377,7 @@ struct Config { path: String }
                 edges: vec![],
                 roots: vec!["src/lib.rs::bar".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1232,6 +1425,7 @@ fn bar(&self) -> i32
                 edges: vec![],
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1287,6 +1481,7 @@ Depends on:
                 edges: vec![],
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1338,6 +1533,7 @@ Depends on:
                 edges: vec![],
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1391,6 +1587,7 @@ Depends on:
                 edges: vec![],
                 roots: vec!["src/lib.rs::example_macro".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1437,6 +1634,7 @@ fn example_macro() { let s = \"```rust\\nfn f() {}\\n```\"; }
                 edges: vec![],
                 roots: vec!["src/lib.rs::bar".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1483,6 +1681,7 @@ fn bar(&self) -> i32
                 edges: vec![],
                 roots: vec![],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1519,6 +1718,7 @@ fn bar(&self) -> i32
                 edges: vec![],
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1567,6 +1767,7 @@ fn foo()
                 edges: vec![],
                 roots: vec!["src/lib.rs::ghost".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1596,6 +1797,7 @@ fn foo()
                 edges: vec![],
                 roots: vec!["src/lib.rs::ghost".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1643,6 +1845,7 @@ fn foo()
                 }],
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1686,6 +1889,7 @@ fn foo()
                 edges: vec![],
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
+            tests: vec![],
         };
 
         let expected = "\
@@ -1728,7 +1932,8 @@ fn foo()
     \"roots\": [
       \"src/lib.rs::foo\"
     ]
-  }
+  },
+  \"tests\": []
 }"
         .to_string();
         let actual = render(&report, OutputFormat::Json).expect("json render succeeds");

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -412,7 +412,11 @@ fn resolve_generated_paths(
 /// indication anything went wrong. `None` when `diff_text` is empty or
 /// whitespace-only (already covered by the separate "diff is empty" note
 /// at the call site — the two notes are mutually exclusive) or when the
-/// report has any file or skip entry at all.
+/// report has any file, skip, or test-summary entry at all — a diff that
+/// touched only test symbols (ADR 0009's default exclusion moves them out
+/// of `files` into `tests`) is a fully-recognized, legitimate result, not
+/// garbage input, even though `files`/`skipped` are both empty in that
+/// case.
 fn garbage_input_note(
     diff_text: &str,
     report: &rinkaku_core::render::Report,
@@ -420,7 +424,7 @@ fn garbage_input_note(
     if diff_text.trim().is_empty() {
         return None;
     }
-    if !report.files.is_empty() || !report.skipped.is_empty() {
+    if !report.files.is_empty() || !report.skipped.is_empty() || !report.tests.is_empty() {
         return None;
     }
     Some("note: no file changes recognized in input; expected a unified diff")
@@ -2684,6 +2688,69 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
         );
     }
 
+    // Regression test (companion to garbage_input_note_tests below): a real
+    // `--base` run whose diff touches only a test function must produce a
+    // Report with a non-empty `tests` summary and empty `files`/`skipped` —
+    // the exact shape garbage_input_note must treat as "a legitimate
+    // result", not "garbage input". This exercises the run_base_pipeline
+    // route end to end (a real git repo, real analyze_diff call), while the
+    // garbage_input_note_tests module below exercises the function in
+    // isolation with the same report shape; together they cover both the
+    // stdin and --base/--pr code paths that call garbage_input_note (both
+    // funnel through analyze_diff, so run_base_pipeline's coverage extends
+    // to the stdin route too).
+    #[test]
+    fn should_produce_test_only_report_without_garbage_input_shape_when_diff_touches_only_a_test() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        init_repo_with_committed_file(
+            dir.path(),
+            "\
+#[test]
+fn should_add_two_numbers() {
+    assert_eq!(1, 1 + 0);
+}
+",
+        );
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            "\
+#[test]
+fn should_add_two_numbers() {
+    assert_eq!(2, 1 + 1);
+}
+",
+        )
+        .expect("edit src/lib.rs");
+        run_git(dir.path(), &["add", "src/lib.rs"]);
+        run_git(dir.path(), &["commit", "-m", "fix test assertion"]);
+
+        let cli = Cli {
+            command: None,
+            base: None,
+            head: "HEAD".to_string(),
+            pr: None,
+            format: Format::Md,
+            deps: 0,
+            include_tests: false,
+            include_generated: false,
+        };
+        let actual = run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()))
+            .expect("run_base_pipeline should succeed for a test-only diff");
+
+        let expected_files: Vec<rinkaku_core::render::FileReport> = Vec::new();
+        let expected_skipped: Vec<rinkaku_core::render::SkippedFile> = Vec::new();
+        assert_eq!(expected_files, actual.files);
+        assert_eq!(expected_skipped, actual.skipped);
+        assert_eq!(1, actual.tests.len());
+        // The Report shape actually produced is the exact input
+        // garbage_input_note must not flag — pin that contract down
+        // directly here rather than only trusting the isolated unit test.
+        assert_eq!(
+            None,
+            garbage_input_note("dummy non-empty diff text", &actual)
+        );
+    }
+
     mod garbage_input_note_tests {
         use super::*;
         use pretty_assertions::assert_eq;
@@ -2759,6 +2826,29 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
                 }],
                 graph: empty_graph(),
                 tests: vec![],
+            };
+
+            let actual = garbage_input_note("some diff text", &report);
+
+            assert_eq!(None, actual);
+        }
+
+        // Regression test: a diff that touches only test symbols produces a
+        // Report with empty files/skipped but a non-empty tests summary
+        // (ADR 0009's default exclusion) — a legitimate, fully-recognized
+        // diff, not garbage input. Before this fix, garbage_input_note only
+        // checked files/skipped, so it wrongly printed "no file changes
+        // recognized" for every test-only diff.
+        #[test]
+        fn should_return_none_when_report_has_only_test_summary_entries() {
+            let report = Report {
+                files: vec![],
+                skipped: vec![],
+                graph: empty_graph(),
+                tests: vec![rinkaku_core::render::TestFileSummary {
+                    path: "src/lib.rs".to_string(),
+                    symbol_count: 1,
+                }],
             };
 
             let actual = garbage_input_note("some diff text", &report);

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -99,6 +99,17 @@ struct Cli {
     /// avoids the repo-wide indexing pass.
     #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u8).range(0..=1))]
     deps: u8,
+
+    /// Include test symbols in the "Change graph"/"Definitions" output
+    /// instead of excluding them by default and summarizing counts under
+    /// "Tests" (ADR 0009).
+    #[arg(long, default_value_t = false)]
+    include_tests: bool,
+
+    /// Include files `.gitattributes` marks `-diff` or `linguist-generated`
+    /// instead of skipping them by default (ADR 0010).
+    #[arg(long, default_value_t = false)]
+    include_generated: bool,
 }
 
 #[derive(Subcommand, Debug, PartialEq, Eq)]
@@ -195,6 +206,7 @@ fn main() -> anyhow::Result<()> {
             eprintln!("note: diff is empty, nothing to analyze");
         }
         let resolver = build_resolver(&cli, &diff_text, read_working_tree_file, None, None)?;
+        let generated_paths = resolve_generated_paths(&cli, &diff_text, None)?;
         log::info!("analyzing diff");
         let report = analyze_diff(
             &diff_text,
@@ -202,6 +214,8 @@ fn main() -> anyhow::Result<()> {
             resolver
                 .as_ref()
                 .map(|r| r as &dyn rinkaku_core::deps::Resolver),
+            cli.include_tests,
+            &generated_paths,
         )?;
         if let Some(note) = garbage_input_note(&diff_text, &report) {
             eprintln!("{note}");
@@ -337,6 +351,7 @@ fn run_base_pipeline(
                 edges: Vec::new(),
                 roots: Vec::new(),
             },
+            tests: Vec::new(),
         });
     }
 
@@ -345,6 +360,7 @@ fn run_base_pipeline(
         move |path: &str| read_git_show_file(cwd, &head, path)
     };
     let resolver = build_resolver(cli, &diff_text, &read_file, Some(head), cwd)?;
+    let generated_paths = resolve_generated_paths(cli, &diff_text, cwd)?;
     log::info!("analyzing diff");
     let report = analyze_diff(
         &diff_text,
@@ -352,11 +368,40 @@ fn run_base_pipeline(
         resolver
             .as_ref()
             .map(|r| r as &dyn rinkaku_core::deps::Resolver),
+        cli.include_tests,
+        &generated_paths,
     )?;
     if let Some(note) = garbage_input_note(&diff_text, &report) {
         eprintln!("{note}");
     }
     Ok(report)
+}
+
+/// Resolves ADR 0010's generated-path set for `diff_text`, or an empty set
+/// when `cli.include_generated` opts out. Parses `diff_text` once more
+/// (same accepted double-parse tradeoff as `build_resolver`'s
+/// `collect_referenced_names` call, see its doc comment) purely to collect
+/// the changed paths `git check-attr` needs to be asked about — this
+/// function does not otherwise touch symbol extraction.
+///
+/// `cwd` is passed straight through to `check_generated_paths`, so it
+/// inherits that function's best-effort behavior: no local repository (or
+/// `git check-attr` failing for any reason) yields an empty set rather than
+/// an error, since attribute filtering is a nice-to-have on top of the
+/// primary diff-condensation flow, not a hard requirement of it (ADR 0010).
+fn resolve_generated_paths(
+    cli: &Cli,
+    diff_text: &str,
+    cwd: Option<&std::path::Path>,
+) -> anyhow::Result<std::collections::HashSet<String>> {
+    if cli.include_generated {
+        return Ok(std::collections::HashSet::new());
+    }
+    let changed_paths: Vec<String> = rinkaku_core::diff::parse_unified_diff(diff_text)?
+        .into_iter()
+        .map(|changed_file| changed_file.path)
+        .collect();
+    Ok(check_generated_paths(cwd, &changed_paths))
 }
 
 /// Returns a warning note for stdin input that is garbage rather than a
@@ -485,6 +530,88 @@ fn list_git_files(cwd: Option<&std::path::Path>) -> anyhow::Result<Vec<String>> 
         .lines()
         .map(str::to_string)
         .collect())
+}
+
+/// Resolves which of `paths` are marked "not worth diffing" in
+/// `.gitattributes` (ADR 0010): the `diff` attribute is unset (`-diff`,
+/// git renders it as binary) or `linguist-generated` is set. Runs
+/// `git check-attr -z diff linguist-generated -- <paths...>` in `cwd` (or
+/// the process's current directory when `None`) and parses its output with
+/// the pure [`parse_generated_paths`].
+///
+/// Returns an empty set (rather than an error) whenever `git check-attr`
+/// itself cannot run or fails — e.g. `paths` is empty (nothing to check,
+/// `git check-attr` would otherwise still run happily but there is no
+/// point), or `cwd` is not inside a git repository at all. ADR 0010 treats
+/// attribute filtering as best-effort: a repository with no
+/// `.gitattributes`, or input that isn't backed by a local repository at
+/// all (see `resolve_generated_paths_for_stdin`), must not turn into a hard
+/// error for the primary diff-condensation flow.
+fn check_generated_paths(
+    cwd: Option<&std::path::Path>,
+    paths: &[String],
+) -> std::collections::HashSet<String> {
+    if paths.is_empty() {
+        return std::collections::HashSet::new();
+    }
+
+    let mut command = std::process::Command::new("git");
+    command
+        .args(["check-attr", "-z", "diff", "linguist-generated", "--"])
+        .args(paths);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let Ok(output) = command.output() else {
+        return std::collections::HashSet::new();
+    };
+    if !output.status.success() {
+        return std::collections::HashSet::new();
+    }
+    let Ok(stdout) = String::from_utf8(output.stdout) else {
+        return std::collections::HashSet::new();
+    };
+    parse_generated_paths(&stdout)
+}
+
+/// Parses `git check-attr -z diff linguist-generated -- <paths...>`'s
+/// NUL-separated stdout into the set of paths ADR 0010 considers
+/// "generated": the `diff` attribute is `unset` (a `.gitattributes` line
+/// with `-diff`) or `linguist-generated` is set to a truthy value.
+/// `git check-attr` reports two different value strings for
+/// `linguist-generated` depending on how `.gitattributes` spells the
+/// assignment (verified against a real `git check-attr -z` run): a bare
+/// `linguist-generated` (no `=...`) reports the boolean attribute value
+/// `set`, while `linguist-generated=true` — GitHub's own Linguist
+/// convention and the common real-world spelling — reports the literal
+/// string `true` instead. Both are treated as generated; any other value
+/// (`unspecified`, `unset`, or an explicit `linguist-generated=false`) is
+/// not.
+///
+/// Output shape (`git help check-attr`'s `-z` mode): a flat stream of
+/// `<path>\0<attribute>\0<value>\0` triples, one triple per
+/// `(path, attribute)` pair queried — so for two paths and two attributes,
+/// four triples in path-major order. Split out from `check_generated_paths`
+/// so the parsing logic is unit-testable without shelling out to `git`
+/// (CLAUDE.md's boundary-testing policy).
+fn parse_generated_paths(output: &str) -> std::collections::HashSet<String> {
+    let fields: Vec<&str> = output
+        .split('\0')
+        .filter(|field| !field.is_empty())
+        .collect();
+
+    let mut generated = std::collections::HashSet::new();
+    for triple in fields.chunks_exact(3) {
+        let [path, attribute, value] = triple else {
+            continue;
+        };
+        let is_generated = (*attribute == "diff" && *value == "unset")
+            || (*attribute == "linguist-generated" && matches!(*value, "set" | "true"));
+        if is_generated {
+            generated.insert((*path).to_string());
+        }
+    }
+    generated
 }
 
 /// Reads the diff from stdin. Errors with a clear message if stdin is a
@@ -1243,6 +1370,7 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
+    use std::collections::HashSet;
 
     #[test]
     fn should_default_to_markdown_head_and_no_base_when_no_args_given() {
@@ -1253,6 +1381,8 @@ mod tests {
             pr: None,
             format: Format::Md,
             deps: 1,
+            include_tests: false,
+            include_generated: false,
         };
         let actual = Cli::parse_from(["rinkaku"]);
 
@@ -1268,6 +1398,8 @@ mod tests {
             pr: None,
             format: Format::Md,
             deps: 1,
+            include_tests: false,
+            include_generated: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--base", "main"]);
 
@@ -1283,6 +1415,8 @@ mod tests {
             pr: None,
             format: Format::Md,
             deps: 1,
+            include_tests: false,
+            include_generated: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--base", "main", "--head", "feature-branch"]);
 
@@ -1298,6 +1432,8 @@ mod tests {
             pr: None,
             format: Format::Json,
             deps: 1,
+            include_tests: false,
+            include_generated: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--format", "json"]);
 
@@ -1320,6 +1456,8 @@ mod tests {
             pr: None,
             format: Format::Md,
             deps: 0,
+            include_tests: false,
+            include_generated: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--deps", "0"]);
 
@@ -1334,6 +1472,40 @@ mod tests {
     }
 
     #[test]
+    fn should_set_include_tests_when_include_tests_flag_given() {
+        let expected = Cli {
+            command: None,
+            base: None,
+            head: "HEAD".to_string(),
+            pr: None,
+            format: Format::Md,
+            deps: 1,
+            include_tests: true,
+            include_generated: false,
+        };
+        let actual = Cli::parse_from(["rinkaku", "--include-tests"]);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_set_include_generated_when_include_generated_flag_given() {
+        let expected = Cli {
+            command: None,
+            base: None,
+            head: "HEAD".to_string(),
+            pr: None,
+            format: Format::Md,
+            deps: 1,
+            include_tests: false,
+            include_generated: true,
+        };
+        let actual = Cli::parse_from(["rinkaku", "--include-generated"]);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn should_set_self_update_command_when_self_update_subcommand_given() {
         let expected = Cli {
             command: Some(Command::SelfUpdate { yes: false }),
@@ -1342,6 +1514,8 @@ mod tests {
             pr: None,
             format: Format::Md,
             deps: 1,
+            include_tests: false,
+            include_generated: false,
         };
         let actual = Cli::parse_from(["rinkaku", "self-update"]);
 
@@ -1357,6 +1531,8 @@ mod tests {
             pr: None,
             format: Format::Md,
             deps: 1,
+            include_tests: false,
+            include_generated: false,
         };
         let actual = Cli::parse_from(["rinkaku", "self-update", "--yes"]);
 
@@ -1372,6 +1548,8 @@ mod tests {
             pr: None,
             format: Format::Md,
             deps: 1,
+            include_tests: false,
+            include_generated: false,
         };
         let actual = Cli::parse_from(["rinkaku", "self-update", "-y"]);
 
@@ -1402,6 +1580,8 @@ mod tests {
             pr: Some("76".to_string()),
             format: Format::Md,
             deps: 1,
+            include_tests: false,
+            include_generated: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--pr", "76"]);
 
@@ -1627,6 +1807,75 @@ mod tests {
         #[case] expected: Vec<std::path::PathBuf>,
     ) {
         let actual = parse_ghq_list_output(stdout);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_mark_path_generated_when_diff_attribute_is_unset() {
+        let output = "Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0";
+
+        let expected: HashSet<String> = ["Cargo.lock".to_string()].into_iter().collect();
+        let actual = parse_generated_paths(output);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_mark_path_generated_when_linguist_generated_attribute_value_is_true() {
+        // `.gitattributes` line: `gen/*.go linguist-generated=true` — the
+        // common GitHub Linguist spelling. Verified against a real
+        // `git check-attr -z` run: this assignment reports the *literal*
+        // string `true`, not the boolean attribute value `set` (see
+        // `should_mark_path_generated_when_linguist_generated_attribute_is_bare_set`
+        // for the other spelling).
+        let output = "gen/foo.go\0diff\0unspecified\0gen/foo.go\0linguist-generated\0true\0";
+
+        let expected: HashSet<String> = ["gen/foo.go".to_string()].into_iter().collect();
+        let actual = parse_generated_paths(output);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_mark_path_generated_when_linguist_generated_attribute_is_bare_set() {
+        // `.gitattributes` line: `gen/*.go linguist-generated` (no
+        // `=value`) — reports the boolean attribute value `set`, distinct
+        // from the `=true` spelling's literal `true` value (verified
+        // against a real `git check-attr -z` run).
+        let output = "gen/foo.go\0diff\0unspecified\0gen/foo.go\0linguist-generated\0set\0";
+
+        let expected: HashSet<String> = ["gen/foo.go".to_string()].into_iter().collect();
+        let actual = parse_generated_paths(output);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_not_mark_path_generated_when_both_attributes_are_unspecified() {
+        let output = "normal.rs\0diff\0unspecified\0normal.rs\0linguist-generated\0unspecified\0";
+
+        let expected: HashSet<String> = HashSet::new();
+        let actual = parse_generated_paths(output);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_mark_only_matching_path_when_multiple_paths_are_queried() {
+        let output = "\
+Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\0diff\0unspecified\0normal.rs\0linguist-generated\0unspecified\0";
+
+        let expected: HashSet<String> = ["Cargo.lock".to_string()].into_iter().collect();
+        let actual = parse_generated_paths(output);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_empty_set_when_output_is_empty() {
+        let expected: HashSet<String> = HashSet::new();
+        let actual = parse_generated_paths("");
 
         assert_eq!(expected, actual);
     }
@@ -2000,6 +2249,62 @@ mod tests {
         );
     }
 
+    // Integration test for ADR 0010: `check_generated_paths` must shell out
+    // to a real `git check-attr` and report exactly the paths a
+    // `.gitattributes` file marks `-diff` or `linguist-generated`, leaving
+    // an ordinary tracked file out.
+    #[test]
+    fn should_report_paths_marked_generated_in_gitattributes() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        run_git(dir.path(), &["init", "--initial-branch=main"]);
+        std::fs::write(
+            dir.path().join(".gitattributes"),
+            "Cargo.lock -diff\ngen/*.go linguist-generated=true\n",
+        )
+        .expect("write .gitattributes");
+        std::fs::write(dir.path().join("Cargo.lock"), "").expect("write Cargo.lock");
+        std::fs::write(dir.path().join("normal.rs"), "").expect("write normal.rs");
+        std::fs::create_dir_all(dir.path().join("gen")).expect("create gen dir");
+        std::fs::write(dir.path().join("gen/foo.go"), "").expect("write gen/foo.go");
+
+        let paths = vec![
+            "Cargo.lock".to_string(),
+            "normal.rs".to_string(),
+            "gen/foo.go".to_string(),
+        ];
+        let actual = check_generated_paths(Some(dir.path()), &paths);
+
+        let expected: HashSet<String> = ["Cargo.lock".to_string(), "gen/foo.go".to_string()]
+            .into_iter()
+            .collect();
+        assert_eq!(expected, actual);
+    }
+
+    // Best-effort contract (ADR 0010): a directory that is not a git
+    // repository at all must not turn attribute resolution into a hard
+    // error — the caller degrades to "nothing is generated" instead.
+    #[test]
+    fn should_return_empty_set_when_cwd_is_not_a_git_repository() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        std::fs::write(dir.path().join("Cargo.lock"), "").expect("write Cargo.lock");
+
+        let actual = check_generated_paths(Some(dir.path()), &["Cargo.lock".to_string()]);
+
+        let expected: HashSet<String> = HashSet::new();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_empty_set_when_paths_is_empty() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        run_git(dir.path(), &["init", "--initial-branch=main"]);
+
+        let actual = check_generated_paths(Some(dir.path()), &[]);
+
+        let expected: HashSet<String> = HashSet::new();
+        assert_eq!(expected, actual);
+    }
+
     // Sibling case: a dirty working tree must not affect what the batch
     // read returns, same guarantee `read_git_show_file` already provides
     // per-file (`should_read_committed_content_when_working_tree_is_dirty`
@@ -2275,6 +2580,8 @@ mod tests {
             pr: None,
             format: Format::Md,
             deps: 0,
+            include_tests: false,
+            include_generated: false,
         };
         // Never called if `deps == 0` truly short-circuits before doing
         // any work at all — deliberately panics so a regression that
@@ -2305,6 +2612,8 @@ mod tests {
             pr: None,
             format: Format::Md,
             deps: 1,
+            include_tests: false,
+            include_generated: false,
         };
         let read_file = |_: &str| -> std::io::Result<String> { Ok(String::new()) };
 
@@ -2347,6 +2656,8 @@ mod tests {
             pr: None,
             format: Format::Md,
             deps: 1,
+            include_tests: false,
+            include_generated: false,
         };
         let actual = run_base_pipeline(&cli, "HEAD", "HEAD", Some(dir.path()));
 
@@ -2367,6 +2678,7 @@ mod tests {
                     edges: Vec::new(),
                     roots: Vec::new(),
                 },
+                tests: Vec::new(),
             },
             actual.expect("empty diff must not touch the repository-wide index scan")
         );
@@ -2390,6 +2702,7 @@ mod tests {
                 files: vec![],
                 skipped: vec![],
                 graph: empty_graph(),
+                tests: vec![],
             }
         }
 
@@ -2401,6 +2714,7 @@ mod tests {
                 }],
                 skipped: vec![],
                 graph: empty_graph(),
+                tests: vec![],
             }
         }
 
@@ -2444,6 +2758,7 @@ mod tests {
                     reason: rinkaku_core::render::SkipReason::Binary,
                 }],
                 graph: empty_graph(),
+                tests: vec![],
             };
 
             let actual = garbage_input_note("some diff text", &report);

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -465,6 +465,13 @@ fn garbage_input_note(
 /// `should_skip_git_ls_files_when_deps_is_zero` below (pointing `cwd` at
 /// a directory with no git repository would make `list_git_files` fail,
 /// so a passing `Ok(None)` there is proof the scan never ran).
+///
+/// `cli.include_tests` is threaded straight through to `TagsResolver::new`
+/// (ADR 0009), so the repo-wide index excludes test symbols by the same
+/// default `analyze_diff` uses for the diff's own symbols — without this, a
+/// changed production symbol's "Depends on:" could resolve to a same-named
+/// test helper/fixture elsewhere in the repo, which is almost always a
+/// false match rather than a real dependency.
 fn build_resolver(
     cli: &Cli,
     diff_text: &str,
@@ -512,6 +519,7 @@ fn build_resolver(
         files,
         language_for_path,
         &reference_names,
+        cli.include_tests,
     )))
 }
 

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -206,7 +206,8 @@ fn main() -> anyhow::Result<()> {
             eprintln!("note: diff is empty, nothing to analyze");
         }
         let resolver = build_resolver(&cli, &diff_text, read_working_tree_file, None, None)?;
-        let generated_paths = resolve_generated_paths(&cli, &diff_text, None)?;
+        let changed_paths = changed_paths(&diff_text)?;
+        let generated_paths = resolve_generated_paths(&cli, &changed_paths, None);
         log::info!("analyzing diff");
         let report = analyze_diff(
             &diff_text,
@@ -360,7 +361,8 @@ fn run_base_pipeline(
         move |path: &str| read_git_show_file(cwd, &head, path)
     };
     let resolver = build_resolver(cli, &diff_text, &read_file, Some(head), cwd)?;
-    let generated_paths = resolve_generated_paths(cli, &diff_text, cwd)?;
+    let changed_paths = changed_paths(&diff_text)?;
+    let generated_paths = resolve_generated_paths(cli, &changed_paths, cwd);
     log::info!("analyzing diff");
     let report = analyze_diff(
         &diff_text,
@@ -377,12 +379,33 @@ fn run_base_pipeline(
     Ok(report)
 }
 
-/// Resolves ADR 0010's generated-path set for `diff_text`, or an empty set
-/// when `cli.include_generated` opts out. Parses `diff_text` once more
-/// (same accepted double-parse tradeoff as `build_resolver`'s
-/// `collect_referenced_names` call, see its doc comment) purely to collect
-/// the changed paths `git check-attr` needs to be asked about — this
-/// function does not otherwise touch symbol extraction.
+/// Parses `diff_text` and extracts just the changed paths, for callers that
+/// only need path strings (currently only `resolve_generated_paths`) rather
+/// than the full `ChangedFile` data `analyze_diff` itself parses out.
+/// Sharing this single parse between `main`/`run_base_pipeline` and
+/// `resolve_generated_paths` is what lets `resolve_generated_paths` stay
+/// diff-text-free (see its own doc comment) — this function is the one
+/// place that still pays that specific parse's cost, once per run.
+fn changed_paths(diff_text: &str) -> anyhow::Result<Vec<String>> {
+    Ok(rinkaku_core::diff::parse_unified_diff(diff_text)?
+        .into_iter()
+        .map(|changed_file| changed_file.path)
+        .collect())
+}
+
+/// Resolves ADR 0010's generated-path set for `changed_paths`, or an empty
+/// set when `cli.include_generated` opts out.
+///
+/// Takes already-parsed changed paths rather than the raw diff text, so it
+/// never parses the diff itself: `main`/`run_base_pipeline` parse
+/// `diff_text` via `parse_unified_diff` exactly once per run and pass the
+/// resulting paths here, instead of this function re-parsing the same text
+/// a third time on top of `analyze_diff`'s own parse and
+/// `build_resolver`'s `collect_referenced_names` parse (both still
+/// separate, accepted the same way `collect_referenced_names`'s own doc
+/// comment already accepts that double-parse). Infallible now that there is
+/// no parse step of its own to fail — `check_generated_paths` never
+/// returns an `Err` either (see its own doc comment).
 ///
 /// `cwd` is passed straight through to `check_generated_paths`, so it
 /// inherits that function's best-effort behavior: no local repository (or
@@ -391,17 +414,13 @@ fn run_base_pipeline(
 /// primary diff-condensation flow, not a hard requirement of it (ADR 0010).
 fn resolve_generated_paths(
     cli: &Cli,
-    diff_text: &str,
+    changed_paths: &[String],
     cwd: Option<&std::path::Path>,
-) -> anyhow::Result<std::collections::HashSet<String>> {
+) -> std::collections::HashSet<String> {
     if cli.include_generated {
-        return Ok(std::collections::HashSet::new());
+        return std::collections::HashSet::new();
     }
-    let changed_paths: Vec<String> = rinkaku_core::diff::parse_unified_diff(diff_text)?
-        .into_iter()
-        .map(|changed_file| changed_file.path)
-        .collect();
-    Ok(check_generated_paths(cwd, &changed_paths))
+    check_generated_paths(cwd, changed_paths)
 }
 
 /// Returns a warning note for stdin input that is garbage rather than a
@@ -2312,6 +2331,62 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
         run_git(dir.path(), &["init", "--initial-branch=main"]);
 
         let actual = check_generated_paths(Some(dir.path()), &[]);
+
+        let expected: HashSet<String> = HashSet::new();
+        assert_eq!(expected, actual);
+    }
+
+    // resolve_generated_paths takes already-parsed changed paths (a
+    // Vec<String>) rather than the raw diff text, so it cannot re-parse the
+    // diff itself — parsing happens exactly once at the call site and the
+    // resulting paths are shared with analyze_diff's own parse (still
+    // unavoidable, since analyze_diff needs the full ChangedFile data, not
+    // just paths).
+    #[test]
+    fn should_resolve_generated_paths_from_already_parsed_changed_paths() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        run_git(dir.path(), &["init", "--initial-branch=main"]);
+        std::fs::write(dir.path().join(".gitattributes"), "Cargo.lock -diff\n")
+            .expect("write .gitattributes");
+        std::fs::write(dir.path().join("Cargo.lock"), "").expect("write Cargo.lock");
+
+        let cli = Cli {
+            command: None,
+            base: None,
+            head: "HEAD".to_string(),
+            pr: None,
+            format: Format::Md,
+            deps: 1,
+            include_tests: false,
+            include_generated: false,
+        };
+        let changed_paths = vec!["Cargo.lock".to_string()];
+        let actual = resolve_generated_paths(&cli, &changed_paths, Some(dir.path()));
+
+        let expected: HashSet<String> = ["Cargo.lock".to_string()].into_iter().collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_empty_set_when_include_generated_is_true() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        run_git(dir.path(), &["init", "--initial-branch=main"]);
+        std::fs::write(dir.path().join(".gitattributes"), "Cargo.lock -diff\n")
+            .expect("write .gitattributes");
+        std::fs::write(dir.path().join("Cargo.lock"), "").expect("write Cargo.lock");
+
+        let cli = Cli {
+            command: None,
+            base: None,
+            head: "HEAD".to_string(),
+            pr: None,
+            format: Format::Md,
+            deps: 1,
+            include_tests: false,
+            include_generated: true,
+        };
+        let changed_paths = vec!["Cargo.lock".to_string()];
+        let actual = resolve_generated_paths(&cli, &changed_paths, Some(dir.path()));
 
         let expected: HashSet<String> = HashSet::new();
         assert_eq!(expected, actual);


### PR DESCRIPTION
## Why

Dogfooding the entry-point tree rendering (#35) on a real branch produced 98 graph roots, most of them `should_...` test functions — the implementation symbols the output exists to surface were drowned out. Generated files (`-diff` / `linguist-generated` in `.gitattributes`) add the same kind of noise. Both exclusions are recorded in ADR 0009 and ADR 0010.

## What

- **Test symbols excluded by default** (ADR 0009): `LanguageSupport` gains `is_test_path` (all languages: `tests/` dirs, `_test.go`, `test_*.py`, `*.test.ts` / `*.spec.ts` / `__tests__/`, …) and `is_test_definition` (Rust only: `#[cfg(test)]` modules — including `#![cfg(test)]` inner attributes and `cfg(all(test, …))` compounds, but not `cfg(not(test))` — and `#[test]` / `#[rstest]` / `#[tokio::test]` functions). Excluded symbols are summarized per file in a new `## Tests` section; `--include-tests` restores them.
- **The exclusion also applies to the repo-wide dependency index**: a changed production symbol's `Depends on:` can no longer resolve to a coincidentally same-named test helper, removing a class of false positives from name-only resolution (ADR 0003).
- **Generated files skipped by default** (ADR 0010): when a git repository is available, `git check-attr` resolves `diff` / `linguist-generated`, and marked files appear under `Skipped files` with a new `generated` reason. Deleted files keep reporting `deleted`. `--include-generated` restores them; stdin outside a repo is unaffected (best effort).
- Output sections are now: Change graph → Definitions → Tests → Other changed files → Skipped files. JSON gains the `tests` summary and the `generated` skip reason (breaking for strict enum consumers, acceptable pre-1.0).

## QA

- `make test` (352 tests) and `make lint` (fmt + clippy `-D warnings`) pass.
- Dogfooded on this branch's own diff: Change graph shrank from 121 test-function entries to implementation symbols only, all 77 test symbols summarized under `## Tests`; `--include-tests` restores the old output.
- Verified in scratch repos: `#![cfg(test)]` / `cfg(not(test))` classification, test-only diffs no longer trigger the "no file changes recognized" note, `.gitattributes`-marked files skip as `(generated)` while deleted ones stay `(deleted)`, and a same-named test `helper()` no longer pollutes a production symbol's `Depends on:`.