### PR TITLE
feat: condense change-graph rendering for human readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ rinkaku --base main --deps 0
 ### What it looks like
 
 All examples below are captured from the `cargo build --release` binary
-against `main` post-[ADR 0008](docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md)
-(entry-point tree rendering), not fabricated. The example diff below
+post-[ADR 0008](docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md)
+(entry-point tree rendering) and
+[ADR 0012](docs/adr/0012-condense-change-graph-rendering.md)
+(condensed rendering), not fabricated. The example diff below
 touches no test symbols and no generated files, so it renders the same
 with or without the defaults introduced in
 [ADR 0009](docs/adr/0009-exclude-test-symbols-from-output-by-default.md),
@@ -166,6 +168,8 @@ $ git show aa7ca34 --format="" | rinkaku --deps 0
 
 ````markdown
 ## Change graph
+
+4 changed symbols in 1 file
 
 - fn main (rinkaku/src/main.rs)
   - fn build_resolver (rinkaku/src/main.rs)
@@ -201,6 +205,12 @@ fn run_base_pipeline( cli: &Cli, base: &str, head: &str, cwd: Option<&std::path:
 
 ````
 
+The line under the heading summarizes the shape of the change — how many
+symbols changed, across how many files, and (for multi-file diffs) which
+file concentrates most of them, e.g.
+`16 changed symbols in 3 files — most in store/items.go (11)` — so a
+reviewer sees the epicenter before reading a single tree line.
+
 "Change graph" reads top-down in call-hierarchy order: `main` is the only
 entry point (nothing else changed in this diff calls it), and every
 function it reaches is nested beneath it. `build_resolver` is reachable
@@ -212,6 +222,32 @@ mutual-recursion cycle), the edge that closes the loop is marked
 `⚠️ ... — dependency cycle, see above` instead of being walked into again;
 see [ADR 0008](docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md)
 for the full rationale.
+
+Two more condensations
+([ADR 0012](docs/adr/0012-condense-change-graph-rendering.md)) keep
+request/response-style diffs readable. Changed **data-carrier types**
+(structs/enums/type aliases with no outgoing edges of their own) don't get
+tree lines; they're folded into the line of each symbol that references
+them as a `— uses:` annotation, with their full signatures still listed
+under "Definitions". And an **interface/trait declaration is linked to its
+changed methods** by method-spec name, so the methods nest under the
+interface instead of duplicating it at top level. A Go diff adding an
+`ItemStore` interface, two receiver-method implementations, and four
+request/response structs — 8 changed symbols — renders as just three tree
+lines:
+
+```markdown
+## Change graph
+
+8 changed symbols in 1 file
+
+- interface ItemStore (store.go) — uses: ListItemsRequest, ListItemsResponse, SaveItemRequest, SaveItemResponse
+  - fn ListItems (store.go) — uses: ListItemsRequest, ListItemsResponse, itemStore
+  - fn SaveItem (store.go) — uses: SaveItemRequest, SaveItemResponse, itemStore
+```
+
+(The "Definitions" section, omitted here, still carries all 8 full
+signatures.)
 
 Unchanged 1-hop dependencies (ADR 0003) — functions/types the diff touches
 but did not itself change — still show up as a `Depends on:` list under

--- a/docs/adr/0012-condense-change-graph-rendering.md
+++ b/docs/adr/0012-condense-change-graph-rendering.md
@@ -1,0 +1,99 @@
+# 0012. Condense change-graph rendering for human readability
+
+- Status: accepted
+- Date: 2026-07-12
+
+## Context
+
+Dogfooding the entry-point tree (ADR 0008, after the test/generated
+exclusions of ADR 0009–0011) on a real-world Go diff that touched a
+repository interface and its callers still produced output that humans
+found hard to read. Three structural problems were observed:
+
+1. **Leaf data-carrier types dominate the tree.** In request/response
+   style APIs, every changed method drags in one or two changed structs
+   (`FooRequest` / `FooResponse`). These render as their own nested
+   lines — most of them `(see above)` repeats — so the majority of tree
+   lines carry near-zero information. Over half of a 35-line graph was
+   such lines in the observed diff.
+2. **An interface and its methods are listed twice.** The data model has
+   no link between an interface declaration and the (receiver) methods
+   that implement or mirror its specs. When both change, each becomes an
+   independent root: the interface appears at top level, and every
+   method appears again at top level with the same struct children
+   repeated as `(see above)`.
+3. **The shape of the change is invisible.** A typical diff has an
+   epicenter (one file where changed symbols concentrate) and a blast
+   radius (callers spread across a few files), but a flat list of roots
+   with a full path on every line does not convey that fan shape.
+
+## Decision
+
+Three rendering-layer changes, Markdown output only (JSON continues to
+expose the raw graph unchanged, per the ADR 0010 precedent):
+
+1. **Inline leaf type dependencies.** A child node that (a) is a
+   non-function symbol (struct / enum / type / interface / trait /
+   class) and (b) has no children of its own in the graph is not
+   rendered as a nested line. Instead its name is appended to the parent
+   line as an inline annotation: `- fn UpsertItems (store/items.go) —
+   uses: UpsertItemsRequest, UpsertItemsResponse`. The criterion is
+   structural, not name-based (`*Request` / `*DTO` conventions vary),
+   so it is language-agnostic and needs no per-language tuning. No flag
+   is added: unlike ADR 0009/0010 exclusions, no information is removed
+   — every folded name is still visible inline and its full signature
+   still appears under `## Definitions`.
+2. **Link interfaces to their methods.** Each `LanguageSupport` whose
+   grammar has interface-like declarations with named method specs (Go
+   `interface`, TypeScript `interface`, Rust `trait`, Python `Protocol`
+   left to its existing class handling) adds those spec names to the
+   interface symbol's `referenced_names`. The existing name-based edge
+   builder (ADR 0008) then links the interface node to same-named
+   changed function nodes, which removes those methods from the root
+   set and nests them under the interface. This stays inside the
+   established name-based model — no new edge kind, no new symbol
+   relation in the data model.
+3. **Summary line under `## Change graph`.** One line stating the
+   total changed-symbol count, file count, and the file with the most
+   changed symbols, e.g. `16 changed symbols in 3 files — most in
+   store/items.go (11)`. Computed from `graph.nodes` alone; no new data
+   structures.
+
+## Alternatives
+
+- **Name-based DTO folding (`*Request` / `*Response` suffixes)**:
+  precise for one Go idiom, useless elsewhere; a structural "childless
+  type" criterion covers the same cases without encoding a naming
+  convention.
+- **Hiding leaf types entirely** (ADR 0009-style exclusion + flag):
+  loses the "this method's contract changed" signal at the tree level
+  and forces a flag; inlining keeps the information at lower cost.
+- **Render-side grouping of methods under their interface** (post-pass
+  matching `container` names): the receiver type name usually differs
+  from the interface name in Go, so container matching is unreliable;
+  method-spec references are exact and reuse the existing edge builder.
+- **A dedicated `implements` edge kind in the graph model**: more
+  faithful semantics, but ADR 0008 deliberately chose a name-based
+  model; introducing typed edges for one rendering concern is not yet
+  justified.
+- **Interactive TUI instead of better static output**: does not fix the
+  noise itself and forks the product into pipe and interactive modes;
+  deferred until static output is as good as it can be.
+
+## Consequences
+
+- Markdown output shrinks and reads as "epicenter → callers": the
+  summary line states the fan shape, interfaces group their methods,
+  and data-carrier types no longer occupy tree lines.
+- Another breaking change to default Markdown output on top of ADR
+  0008/0009; acceptable pre-1.0.
+- Interface→method linking is name-based and repo-global like every
+  other edge, so an unrelated changed function that happens to share a
+  method-spec name can be captured under an interface. Accepted as
+  consistent with the ADR 0008 model's known trade-off.
+- Adding method-spec names to `referenced_names` also feeds ADR 0003
+  dependency resolution, so an interface's `Depends on:` may now list
+  implementing methods — a desirable side effect for review.
+- The inline `uses:` annotation is a new micro-format LLM consumers
+  must parse; it is stable prose (`— uses: A, B`) and documented by the
+  render tests.

--- a/rinkaku-core/src/extract.rs
+++ b/rinkaku-core/src/extract.rs
@@ -1016,9 +1016,62 @@ trait Greeter {
             signature: "trait Greeter { fn greet(&self) -> String; }".to_string(),
             range: LineRange { start: 1, end: 3 },
             container: None,
-            // The trait's own name plus the referenced `String` return
-            // type of its method signature.
-            referenced_names: vec!["Greeter".to_string(), "String".to_string()],
+            // The trait's own name, its "greet" method name (ADR 0012
+            // decision 2), and the referenced `String` return type of its
+            // method signature.
+            referenced_names: vec![
+                "Greeter".to_string(),
+                "String".to_string(),
+                "greet".to_string(),
+            ],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+        }];
+        let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_include_both_bodiless_and_default_body_method_names_in_trait_referenced_names() {
+        let source = "\
+trait Repo {
+    fn save(&self, id: &str);
+
+    fn label(&self) -> String {
+        String::new()
+    }
+}
+";
+        let lang = RustSupport;
+        // Line 1 (`trait Repo {`) belongs to the trait node but not to
+        // either method signature inside it, so the trait itself (not a
+        // narrower method) is the reported symbol — same rule as
+        // `should_extract_trait_signature_when_no_method_line_specifically_changed`.
+        let changed_ranges = vec![LineRange { start: 1, end: 1 }];
+
+        let expected = vec![ExtractedSymbol {
+            id: String::new(),
+            name: "Repo".to_string(),
+            kind: SymbolKind::Trait,
+            signature:
+                "trait Repo { fn save(&self, id: &str); fn label(&self) -> String { String::new() } }"
+                    .to_string(),
+            range: LineRange { start: 1, end: 7 },
+            container: None,
+            // Both the bodiless `save` signature and the default-body
+            // `label` method contribute their names (ADR 0012 decision 2),
+            // alongside the trait's own name and referenced types. `str`
+            // is a `primitive_type` node in this grammar, not
+            // `type_identifier`, so it is not captured as a reference (see
+            // REFERENCE_QUERY's doc comment).
+            referenced_names: vec![
+                "Repo".to_string(),
+                "String".to_string(),
+                "label".to_string(),
+                "save".to_string(),
+            ],
             dependencies: vec![],
             omitted_dependency_matches: 0,
             is_test: false,
@@ -1262,8 +1315,50 @@ type Fetcher interface {
                 signature: "Fetcher interface { Fetch(id string) (string, error) }".to_string(),
                 range: LineRange { start: 3, end: 5 },
                 container: None,
+                // "Fetch" is the interface's own method spec name (ADR
+                // 0012 decision 2), alongside the interface's own name and
+                // its referenced parameter/return types.
                 referenced_names: vec![
+                    "Fetch".to_string(),
                     "Fetcher".to_string(),
+                    "error".to_string(),
+                    "string".to_string(),
+                ],
+                dependencies: vec![],
+                omitted_dependency_matches: 0,
+                is_test: false,
+            }];
+            let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn should_include_every_method_spec_name_in_referenced_names_when_interface_has_multiple_methods()
+         {
+            let source = "\
+package main
+
+type Repo interface {
+	Save(id string) error
+	Delete(id string) error
+}
+";
+            let lang = GoSupport;
+            let changed_ranges = vec![LineRange { start: 3, end: 6 }];
+
+            let expected = vec![ExtractedSymbol {
+                id: String::new(),
+                name: "Repo".to_string(),
+                kind: SymbolKind::Interface,
+                signature: "Repo interface { Save(id string) error Delete(id string) error }"
+                    .to_string(),
+                range: LineRange { start: 3, end: 6 },
+                container: None,
+                referenced_names: vec![
+                    "Delete".to_string(),
+                    "Repo".to_string(),
+                    "Save".to_string(),
                     "error".to_string(),
                     "string".to_string(),
                 ],
@@ -1907,10 +2002,52 @@ interface Shape {
                 range: LineRange { start: 1, end: 4 },
                 container: None,
                 // The interface's own name is a `type_identifier` (self-
-                // reference, filtered later by deps.rs); `number` is
-                // TypeScript's built-in `predefined_type`, a distinct
-                // node kind the reference query does not capture.
-                referenced_names: vec!["Shape".to_string()],
+                // reference, filtered later by deps.rs); `area`/`perimeter`
+                // are its method signature names (ADR 0012 decision 2);
+                // `number` is TypeScript's built-in `predefined_type`, a
+                // distinct node kind the reference query does not capture.
+                referenced_names: vec![
+                    "Shape".to_string(),
+                    "area".to_string(),
+                    "perimeter".to_string(),
+                ],
+                dependencies: vec![],
+                omitted_dependency_matches: 0,
+                is_test: false,
+            }];
+            let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn should_not_include_property_signature_names_in_interface_referenced_names() {
+            let source = "\
+interface Repo {
+    id: string;
+    save(item: string): void;
+}
+";
+            let lang = TypeScriptSupport;
+            // Line 2 (`id: string;`) is a plain data field, not a method
+            // signature; touching it (rather than the `save` line) still
+            // reports the whole interface since neither member line is
+            // itself the interface's own declaration line, but keeps this
+            // test focused on the `referenced_names` distinction between a
+            // property and a method signature.
+            let changed_ranges = vec![LineRange { start: 1, end: 1 }];
+
+            let expected = vec![ExtractedSymbol {
+                id: String::new(),
+                name: "Repo".to_string(),
+                kind: SymbolKind::Interface,
+                signature: "interface Repo { id: string; save(item: string): void; }".to_string(),
+                range: LineRange { start: 1, end: 4 },
+                container: None,
+                // "id" (a `property_signature` name) is deliberately
+                // excluded; only "save" (a `method_signature` name) is
+                // included alongside the interface's own name.
+                referenced_names: vec!["Repo".to_string(), "save".to_string()],
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
                 is_test: false,

--- a/rinkaku-core/src/language/go.rs
+++ b/rinkaku-core/src/language/go.rs
@@ -28,7 +28,8 @@ const DEFINITION_QUERY: &str = "\
 ] @definition";
 
 /// Tree-sitter query capturing identifiers referenced from inside a
-/// definition: called function names and referenced type names.
+/// definition: called function names, referenced type names, and (when
+/// the definition is an interface) its method spec names.
 ///
 /// - `call_expression function: (identifier)` captures free function calls
 ///   (`Helper(x)`). Method/selector calls
@@ -44,10 +45,25 @@ const DEFINITION_QUERY: &str = "\
 ///   `type_identifier` — so they are captured the same way and simply
 ///   fail to resolve later since the repo has no definition for them
 ///   (see the trait doc comment on `reference_query`).
+/// - `interface_type (method_elem name: (field_identifier))` captures each
+///   method spec's name inside an interface body (ADR 0012 decision 2):
+///   feeding these into the interface symbol's `referenced_names` makes
+///   `graph::collect_edges`'s existing name-based matching link the
+///   interface to a same-named changed receiver method, so the two stop
+///   appearing as independent roots in the change graph. Scoped to
+///   `interface_type`'s own `method_elem` children (rather than a bare
+///   `(method_elem name: (field_identifier) @reference.call)` pattern) so
+///   this cannot match anything else — `method_elem` only ever occurs
+///   inside an `interface_type` in this grammar, but the explicit parent
+///   keeps the intent legible. Captured under `reference.call` (not a new
+///   capture prefix) since a method spec name plays the same role here as
+///   a called function name: both are "a name this definition expects to
+///   find elsewhere."
 const REFERENCE_QUERY: &str = "\
 [
   (call_expression function: (identifier) @reference.call)
   (type_identifier) @reference.type
+  (interface_type (method_elem name: (field_identifier) @reference.call))
 ]";
 
 pub struct GoSupport;

--- a/rinkaku-core/src/language/rust.rs
+++ b/rinkaku-core/src/language/rust.rs
@@ -17,7 +17,8 @@ const DEFINITION_QUERY: &str = "\
 ] @definition";
 
 /// Tree-sitter query capturing identifiers referenced from inside a
-/// definition: called function names and referenced type names.
+/// definition: called function names, referenced type names, and (when the
+/// definition is a trait) its method names.
 ///
 /// - `call_expression function: (identifier)` captures free function calls
 ///   (`helper(x)`) and tuple-struct/enum-variant constructors used as
@@ -34,10 +35,25 @@ const DEFINITION_QUERY: &str = "\
 ///   pattern. Rust's primitive types (`i32`, `str`, `bool`, ...) parse as
 ///   the distinct `primitive_type` node kind, so they are already excluded
 ///   by construction rather than needing an explicit exclusion list.
+/// - `trait_item body: (declaration_list (function_signature_item name:
+///   (identifier)))` and the same shape for `function_item` capture a
+///   trait's method names — both the common bodiless `fn name(...);` form
+///   and a default-body `fn name(...) { ... }` form (ADR 0012 decision 2):
+///   feeding these into the trait symbol's `referenced_names` makes
+///   `graph::collect_edges`'s existing name-based matching link the trait
+///   to a same-named changed impl method, so the two stop appearing as
+///   independent roots in the change graph. Scoped to a `trait_item`'s own
+///   `body` field (rather than matching `function_signature_item`/
+///   `function_item` anywhere) so an `impl_item`'s or free function's name
+///   is never captured this way — those are already covered by
+///   `definition_query` capturing the function/method itself, not via this
+///   path.
 const REFERENCE_QUERY: &str = "\
 [
   (call_expression function: (identifier) @reference.call)
   (type_identifier) @reference.type
+  (trait_item body: (declaration_list (function_signature_item name: (identifier) @reference.call)))
+  (trait_item body: (declaration_list (function_item name: (identifier) @reference.call)))
 ]";
 
 pub struct RustSupport;

--- a/rinkaku-core/src/language/typescript.rs
+++ b/rinkaku-core/src/language/typescript.rs
@@ -45,8 +45,9 @@ const DEFINITION_QUERY: &str = "\
 ] @definition";
 
 /// Tree-sitter query capturing identifiers referenced from inside a
-/// definition: called function names, constructed class names, and
-/// referenced type names.
+/// definition: called function names, constructed class names, referenced
+/// type names, and (when the definition is an interface) its method
+/// signature names.
 ///
 /// - `call_expression function: (identifier)` captures free function
 ///   calls (`helper(x)`). Method calls
@@ -65,11 +66,23 @@ const DEFINITION_QUERY: &str = "\
 ///   ...) parse as the distinct `predefined_type` node kind, so they are
 ///   already excluded by construction rather than needing an explicit
 ///   exclusion list.
+/// - `interface_declaration body: (interface_body (method_signature name:
+///   (property_identifier)))` captures an interface's method signature
+///   names (ADR 0012 decision 2): feeding these into the interface
+///   symbol's `referenced_names` makes `graph::collect_edges`'s existing
+///   name-based matching link the interface to a same-named changed class
+///   method, so the two stop appearing as independent roots in the change
+///   graph. Deliberately `method_signature` only, not `property_signature`
+///   — a plain data field is not a method spec, and including it would
+///   pull unrelated same-named symbols into the interface's edges without
+///   the "this is a method the interface declares" justification method
+///   specs have.
 const REFERENCE_QUERY: &str = "\
 [
   (call_expression function: (identifier) @reference.call)
   (new_expression constructor: (identifier) @reference.call)
   (type_identifier) @reference.type
+  (interface_declaration body: (interface_body (method_signature name: (property_identifier) @reference.call)))
 ]";
 
 pub struct TypeScriptSupport;

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -619,6 +619,87 @@ index e69de29..4b825dc 100644
         assert_eq!(expected, actual);
     }
 
+    /// End-to-end regression test for ADR 0012 decision 2: a Go interface
+    /// and a same-named receiver method that both change in one diff must
+    /// render as a single tree (the method nested under the interface) in
+    /// the "Change graph" section, not as two duplicate top-level roots —
+    /// see the ADR's "listed twice" problem statement. Runs through the
+    /// whole pipeline (`analyze_diff` then `render::render`) rather than
+    /// building a `Report`/`SymbolGraph` by hand, since the point is to
+    /// prove the real `Repo` interface's `referenced_names` (populated by
+    /// `GoSupport::reference_query`) actually produces the edge, not to
+    /// exercise `render.rs`'s formatting in isolation.
+    #[test]
+    fn should_nest_go_receiver_method_under_its_interface_when_both_change_in_one_diff() {
+        let diff = "\
+diff --git a/repo.go b/repo.go
+index e69de29..4b825dc 100644
+--- a/repo.go
++++ b/repo.go
+@@ -1,10 +1,10 @@
+ package main
+
+ type Repo interface {
+-	Save(id string) error
++	Save(id string) (err error)
+ }
+
+ type repoImpl struct{}
+
+ func (r *repoImpl) Save(id string) error {
+-	return errors.New(\"not implemented\")
++	return nil
+ }
+";
+        let source = "\
+package main
+
+type Repo interface {
+	Save(id string) (err error)
+}
+
+type repoImpl struct{}
+
+func (r *repoImpl) Save(id string) error {
+	return nil
+}
+";
+        let read_file = fake_reader(HashMap::from([("repo.go", source)]));
+
+        let report = analyze_diff(diff, read_file, None, true, &HashSet::new(), true)
+            .expect("analyze should succeed");
+        let markdown = crate::render::render(&report, crate::render::OutputFormat::Markdown)
+            .expect("markdown render should succeed");
+
+        let expected = "\
+## Change graph
+
+2 changed symbols in 1 file
+
+- interface Repo (repo.go)
+  - fn Save (repo.go)
+
+## Definitions
+
+### interface Repo (repo.go)
+
+```
+Repo interface { Save(id string) (err error) }
+```
+
+### fn Save (repo.go)
+
+```
+// repoImpl
+func (r *repoImpl) Save(id string) error
+```
+
+"
+        .to_string();
+
+        assert_eq!(expected, markdown);
+    }
+
     /// A [`Resolver`] test double that records every name it was asked to
     /// resolve, so `--deps 0`'s "resolver is never called" contract can be
     /// verified directly rather than inferred from empty `dependencies`

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -327,6 +327,14 @@ fn change_graph_summary(nodes: &[Node]) -> String {
 /// warning line instead of being walked into (walking into one would loop
 /// forever, since a cycle edge points back to an ancestor already on the
 /// current path).
+///
+/// A child that is both a non-function symbol and childless in the graph
+/// (see [`is_foldable`]) is not rendered as its own nested line — its name
+/// is folded into its parent's line instead, as an inline `— uses: ...`
+/// annotation (ADR 0012 decision 1). `roots` is passed alongside `children`
+/// so `render_tree_node` can exempt root nodes from folding even when they
+/// would otherwise qualify: a root is always its own top-level DFS, never
+/// "just a dependency" of something else.
 fn render_change_graph(
     out: &mut String,
     graph: &SymbolGraph,
@@ -334,11 +342,36 @@ fn render_change_graph(
     lookup: &SymbolLookup,
 ) -> Result<(), RenderError> {
     let mut printed: HashSet<String> = HashSet::new();
+    let roots: HashSet<&str> = graph.roots.iter().map(String::as_str).collect();
 
     for root in &graph.roots {
-        render_tree_node(out, root, children, lookup, &mut printed, 0)?;
+        render_tree_node(out, root, children, lookup, &roots, &mut printed, 0)?;
     }
     Ok(())
+}
+
+/// A node is foldable — eligible to be inlined into its parent's line
+/// rather than rendered as its own nested line (ADR 0012 decision 1) —
+/// when both hold:
+/// - its symbol's kind is not [`SymbolKind::Function`] (i.e. it is a data
+///   shape: struct/enum/trait/interface/class/type-alias), and
+/// - it has no outgoing edges at all in the graph, including cycle edges —
+///   a node whose only children are cycle edges is *not* foldable, so the
+///   cycle warning stays visible rather than being silently swallowed.
+///
+/// Root nodes are exempt from folding regardless of this check — see
+/// `render_change_graph`'s doc comment — so this function only answers "is
+/// this node structurally childless and non-function", leaving the root
+/// exemption to the caller.
+fn is_foldable(
+    id: &str,
+    lookup: &SymbolLookup,
+    children: &HashMap<&str, Vec<(&str, bool)>>,
+) -> bool {
+    let Some((_, symbol)) = lookup.get(id) else {
+        return false;
+    };
+    symbol.kind != SymbolKind::Function && !children.contains_key(id)
 }
 
 /// Groups `graph.edges` by their `from` node, each target annotated with
@@ -358,13 +391,25 @@ fn children_by_node(graph: &SymbolGraph) -> HashMap<&str, Vec<(&str, bool)>> {
 }
 
 /// Writes one tree line for `id` at `depth`, then recurses into its
-/// children (unless `id` was already printed earlier in the tree, in which
-/// case it is shown as a `(see above)` reference and not expanded).
+/// non-foldable children (unless `id` was already printed earlier in the
+/// tree, in which case it is shown as a `(see above)` reference and not
+/// expanded).
+///
+/// Foldable children (see [`is_foldable`]; roots are always exempt, per
+/// `render_change_graph`'s doc comment) are not visited recursively at
+/// all — they never enter `printed` and never get a `(see above)` line
+/// anywhere. Instead their names are collected and appended to *this*
+/// line as `— uses: A, B`, in the same order they appear in the edge
+/// list. Because folding is a per-call decision (not a global one), the
+/// same folded name legitimately repeats verbatim on every parent that
+/// references it — that repetition is intentional, not a duplicate-
+/// rendering bug.
 fn render_tree_node(
     out: &mut String,
     id: &str,
     children: &HashMap<&str, Vec<(&str, bool)>>,
     lookup: &SymbolLookup,
+    roots: &HashSet<&str>,
     printed: &mut HashSet<String>,
     depth: usize,
 ) -> Result<(), RenderError> {
@@ -378,24 +423,39 @@ fn render_tree_node(
         writeln!(out, "{indent}- {label} (see above)")?;
         return Ok(());
     }
-    writeln!(out, "{indent}- {label}")?;
 
-    if let Some(kids) = children.get(id) {
-        for &(child_id, is_cycle) in kids {
-            if is_cycle {
-                let Some((child_path, child_symbol)) = lookup.get(child_id) else {
-                    continue;
-                };
-                let child_label = tree_label(child_path, child_symbol);
-                writeln!(
-                    out,
-                    "{}  - ⚠️ {child_label} — dependency cycle, see above",
-                    indent
-                )?;
+    let kids = children.get(id).map(Vec::as_slice).unwrap_or(&[]);
+    let folded_names: Vec<&str> = kids
+        .iter()
+        .filter(|&&(child_id, is_cycle)| {
+            !is_cycle && !roots.contains(child_id) && is_foldable(child_id, lookup, children)
+        })
+        .filter_map(|&(child_id, _)| lookup.get(child_id).map(|(_, sym)| sym.name.as_str()))
+        .collect();
+
+    if folded_names.is_empty() {
+        writeln!(out, "{indent}- {label}")?;
+    } else {
+        writeln!(out, "{indent}- {label} — uses: {}", folded_names.join(", "))?;
+    }
+
+    for &(child_id, is_cycle) in kids {
+        if is_cycle {
+            let Some((child_path, child_symbol)) = lookup.get(child_id) else {
                 continue;
-            }
-            render_tree_node(out, child_id, children, lookup, printed, depth + 1)?;
+            };
+            let child_label = tree_label(child_path, child_symbol);
+            writeln!(
+                out,
+                "{}  - ⚠️ {child_label} — dependency cycle, see above",
+                indent
+            )?;
+            continue;
         }
+        if !roots.contains(child_id) && is_foldable(child_id, lookup, children) {
+            continue;
+        }
+        render_tree_node(out, child_id, children, lookup, roots, printed, depth + 1)?;
     }
     Ok(())
 }
@@ -1649,6 +1709,396 @@ fn fetch_base_branch() -> Result<()>
 
 ```
 struct Config { path: String }
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_inline_two_leaf_struct_children_as_uses_annotation_on_method_line() {
+        // A method referencing two childless, non-function structs (the
+        // request/response shape the ADR calls out): both fold into the
+        // parent's own line as `— uses: ...` instead of rendering as their
+        // own nested lines, but both still get full "### ..." entries
+        // under "Definitions" (ADR 0012 decision 1).
+        let report = Report {
+            files: vec![FileReport {
+                path: "store/items.go".to_string(),
+                symbols: vec![
+                    symbol(
+                        "store/items.go::UpsertItems",
+                        "UpsertItems",
+                        SymbolKind::Function,
+                        "func UpsertItems(req UpsertItemsRequest) (UpsertItemsResponse, error)",
+                    ),
+                    symbol(
+                        "store/items.go::UpsertItemsRequest",
+                        "UpsertItemsRequest",
+                        SymbolKind::Struct,
+                        "type UpsertItemsRequest struct { Items []Item }",
+                    ),
+                    symbol(
+                        "store/items.go::UpsertItemsResponse",
+                        "UpsertItemsResponse",
+                        SymbolKind::Struct,
+                        "type UpsertItemsResponse struct { Count int }",
+                    ),
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node(
+                        "store/items.go::UpsertItems",
+                        "store/items.go",
+                        "UpsertItems",
+                    ),
+                    node(
+                        "store/items.go::UpsertItemsRequest",
+                        "store/items.go",
+                        "UpsertItemsRequest",
+                    ),
+                    node(
+                        "store/items.go::UpsertItemsResponse",
+                        "store/items.go",
+                        "UpsertItemsResponse",
+                    ),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "store/items.go::UpsertItems".to_string(),
+                        to: "store/items.go::UpsertItemsRequest".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "store/items.go::UpsertItems".to_string(),
+                        to: "store/items.go::UpsertItemsResponse".to_string(),
+                        is_cycle: false,
+                    },
+                ],
+                roots: vec!["store/items.go::UpsertItems".to_string()],
+            },
+            tests: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+3 changed symbols in 1 file
+
+- fn UpsertItems (store/items.go) — uses: UpsertItemsRequest, UpsertItemsResponse
+
+## Definitions
+
+### fn UpsertItems (store/items.go)
+
+```
+func UpsertItems(req UpsertItemsRequest) (UpsertItemsResponse, error)
+```
+
+### struct UpsertItemsRequest (store/items.go)
+
+```
+type UpsertItemsRequest struct { Items []Item }
+```
+
+### struct UpsertItemsResponse (store/items.go)
+
+```
+type UpsertItemsResponse struct { Count int }
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_repeat_folded_struct_annotation_on_every_referencing_parent() {
+        // Both `foo` and `bar` reference the same childless struct `Shared`
+        // — unlike function children (which get a single full render plus
+        // `(see above)` elsewhere, ADR 0008), a folded name has no
+        // "see above" tracking: it legitimately repeats verbatim in the
+        // `— uses: ...` annotation on every parent that references it, and
+        // it must never itself get a `(see above)` line.
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![
+                    symbol("src/lib.rs::foo", "foo", SymbolKind::Function, "fn foo()"),
+                    symbol("src/lib.rs::bar", "bar", SymbolKind::Function, "fn bar()"),
+                    symbol(
+                        "src/lib.rs::Shared",
+                        "Shared",
+                        SymbolKind::Struct,
+                        "struct Shared { x: i32 }",
+                    ),
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                    node("src/lib.rs::bar", "src/lib.rs", "bar"),
+                    node("src/lib.rs::Shared", "src/lib.rs", "Shared"),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "src/lib.rs::foo".to_string(),
+                        to: "src/lib.rs::Shared".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "src/lib.rs::bar".to_string(),
+                        to: "src/lib.rs::Shared".to_string(),
+                        is_cycle: false,
+                    },
+                ],
+                roots: vec!["src/lib.rs::foo".to_string(), "src/lib.rs::bar".to_string()],
+            },
+            tests: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+3 changed symbols in 1 file
+
+- fn foo (src/lib.rs) — uses: Shared
+- fn bar (src/lib.rs) — uses: Shared
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo()
+```
+
+### struct Shared (src/lib.rs)
+
+```
+struct Shared { x: i32 }
+```
+
+### fn bar (src/lib.rs)
+
+```
+fn bar()
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_childless_non_function_root_as_top_level_line_when_it_would_otherwise_be_foldable()
+     {
+        // `Config` is a childless struct — foldable by the structural
+        // criterion — but it is also a root, so it must still render as
+        // its own top-level tree line rather than being folded away
+        // entirely (roots are always their own top-level DFS start).
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/config.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/config.rs::Config",
+                    "Config",
+                    SymbolKind::Struct,
+                    "struct Config { path: String }",
+                )],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/config.rs::Config", "src/config.rs", "Config")],
+                edges: vec![],
+                roots: vec!["src/config.rs::Config".to_string()],
+            },
+            tests: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+1 changed symbol in 1 file
+
+- struct Config (src/config.rs)
+
+## Definitions
+
+### struct Config (src/config.rs)
+
+```
+struct Config { path: String }
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_nested_line_when_non_function_child_has_its_own_children() {
+        // `Wrapper` is a non-function child of `foo`, but it is not
+        // foldable because it has an outgoing edge of its own (to `Inner`)
+        // — the structural criterion is "childless", not "non-function",
+        // so `Wrapper` itself still renders as a nested line exactly as
+        // before this feature. `Inner`, in turn, *is* childless and
+        // non-function, so it folds into `Wrapper`'s own line instead of
+        // getting a third nesting level.
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![
+                    symbol("src/lib.rs::foo", "foo", SymbolKind::Function, "fn foo()"),
+                    symbol(
+                        "src/lib.rs::Wrapper",
+                        "Wrapper",
+                        SymbolKind::Struct,
+                        "struct Wrapper { inner: Inner }",
+                    ),
+                    symbol(
+                        "src/lib.rs::Inner",
+                        "Inner",
+                        SymbolKind::Struct,
+                        "struct Inner { x: i32 }",
+                    ),
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                    node("src/lib.rs::Wrapper", "src/lib.rs", "Wrapper"),
+                    node("src/lib.rs::Inner", "src/lib.rs", "Inner"),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "src/lib.rs::foo".to_string(),
+                        to: "src/lib.rs::Wrapper".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "src/lib.rs::Wrapper".to_string(),
+                        to: "src/lib.rs::Inner".to_string(),
+                        is_cycle: false,
+                    },
+                ],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
+            tests: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+3 changed symbols in 1 file
+
+- fn foo (src/lib.rs)
+  - struct Wrapper (src/lib.rs) — uses: Inner
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo()
+```
+
+### struct Wrapper (src/lib.rs)
+
+```
+struct Wrapper { inner: Inner }
+```
+
+### struct Inner (src/lib.rs)
+
+```
+struct Inner { x: i32 }
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_not_fold_non_function_child_when_its_only_children_are_cycle_edges() {
+        // `Node` is a non-function type whose only outgoing edge is a
+        // cycle edge back to itself — `children_by_node` still records an
+        // entry for it, so it is *not* foldable (folding requires no
+        // outgoing edges at all) and must render as its own nested line
+        // with the cycle warning still visible beneath it.
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![
+                    symbol("src/lib.rs::foo", "foo", SymbolKind::Function, "fn foo()"),
+                    symbol(
+                        "src/lib.rs::Node",
+                        "Node",
+                        SymbolKind::Struct,
+                        "struct Node { next: Option<Box<Node>> }",
+                    ),
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                    node("src/lib.rs::Node", "src/lib.rs", "Node"),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "src/lib.rs::foo".to_string(),
+                        to: "src/lib.rs::Node".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "src/lib.rs::Node".to_string(),
+                        to: "src/lib.rs::Node".to_string(),
+                        is_cycle: true,
+                    },
+                ],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
+            tests: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+2 changed symbols in 1 file
+
+- fn foo (src/lib.rs)
+  - struct Node (src/lib.rs)
+    - ⚠️ struct Node (src/lib.rs) — dependency cycle, see above
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo()
+```
+
+### struct Node (src/lib.rs)
+
+```
+struct Node { next: Option<Box<Node>> }
 ```
 
 "

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -425,12 +425,16 @@ fn render_tree_node(
     }
 
     let kids = children.get(id).map(Vec::as_slice).unwrap_or(&[]);
-    let folded_names: Vec<&str> = kids
+    let folded_names: Vec<String> = kids
         .iter()
         .filter(|&&(child_id, is_cycle)| {
             !is_cycle && !roots.contains(child_id) && is_foldable(child_id, lookup, children)
         })
-        .filter_map(|&(child_id, _)| lookup.get(child_id).map(|(_, sym)| sym.name.as_str()))
+        .filter_map(|&(child_id, _)| {
+            lookup
+                .get(child_id)
+                .map(|(child_path, sym)| folded_name(child_path, sym))
+        })
         .collect();
 
     if folded_names.is_empty() {
@@ -513,28 +517,54 @@ fn render_definition(
 /// [`symbol_kind_prefix`], fixed per [`SymbolKind`] rather than derived
 /// from the signature text, so it stays stable across languages.
 ///
-/// When `symbol.id` was disambiguated by line number (`graph::collect_nodes`
-/// appends `@{start_line}` whenever a report contains more than one symbol
-/// sharing the same `(path, name)` pair, e.g. two overloaded free
-/// functions), the label includes that line number too —
+/// When `symbol.id` was disambiguated by line number (see
+/// [`symbol_location`]), the label includes that line number too —
 /// `{prefix} {name} ({path}:{start_line})` — so the otherwise-identical
-/// entries stay distinguishable in "Change graph"/"Definitions". Detected
-/// by comparing `symbol.id` against the plain (non-disambiguated) form
-/// rather than parsing the id string, since `symbol.range.start` is the
-/// exact same line number `collect_nodes` used to build it.
+/// entries stay distinguishable in "Change graph"/"Definitions".
 fn tree_label(path: &str, symbol: &ExtractedSymbol) -> String {
-    let plain_id = format!("{path}::{}", symbol.name);
-    let location = if symbol.id == plain_id {
-        path.to_string()
-    } else {
-        format!("{path}:{}", symbol.range.start)
-    };
     format!(
         "{} {} ({})",
         symbol_kind_prefix(symbol.kind),
         symbol.name,
-        location
+        symbol_location(path, symbol)
     )
+}
+
+/// The `(path)` or `(path:start_line)` portion shared by [`tree_label`] and
+/// folded `— uses: ...` annotations (see `render_tree_node`).
+///
+/// `graph::collect_nodes` appends `@{start_line}` to `symbol.id` whenever a
+/// report contains more than one symbol sharing the same `(path, name)`
+/// pair (e.g. two overloaded free functions, or two structs named the same
+/// in different scopes of one file) — comparing `symbol.id` against the
+/// plain (non-disambiguated) form detects that case without parsing the id
+/// string, since `symbol.range.start` is the exact same line number
+/// `collect_nodes` used to build it. Plain (non-disambiguated) symbols get
+/// just `path`.
+fn symbol_location(path: &str, symbol: &ExtractedSymbol) -> String {
+    let plain_id = format!("{path}::{}", symbol.name);
+    if symbol.id == plain_id {
+        path.to_string()
+    } else {
+        format!("{path}:{}", symbol.range.start)
+    }
+}
+
+/// The name shown for a folded child in a `— uses: ...` annotation (see
+/// `render_tree_node`): bare `symbol.name` normally, or `{name}
+/// ({path}:{start_line})` — the same disambiguation [`tree_label`] applies
+/// to tree lines and "Definitions" headers — when `collect_nodes` had to
+/// disambiguate this symbol's id. Without this, two distinct same-named
+/// symbols folded under the same parent would both render as the bare
+/// name (`— uses: Dup, Dup`), indistinguishable from each other even
+/// though "Definitions" shows two different headers for them.
+fn folded_name(path: &str, symbol: &ExtractedSymbol) -> String {
+    let plain_id = format!("{path}::{}", symbol.name);
+    if symbol.id == plain_id {
+        symbol.name.clone()
+    } else {
+        format!("{} ({})", symbol.name, symbol_location(path, symbol))
+    }
 }
 
 /// Maps a [`SymbolKind`] to the short, lowercase word used as a tree/heading
@@ -1810,6 +1840,99 @@ type UpsertItemsRequest struct { Items []Item }
 
 ```
 type UpsertItemsResponse struct { Count int }
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_disambiguate_folded_names_when_duplicate_symbols_fold_under_same_parent() {
+        // Two distinct `Dup` structs in the same file (mirroring an
+        // overloaded/shadowed-name scenario `graph::collect_nodes`
+        // disambiguates by appending `@{start_line}` to the node id) both
+        // fold under `foo`. Bare `Dup, Dup` would be ambiguous — Definitions
+        // shows two distinct `### struct Dup (src/lib.rs:5)` /
+        // `(src/lib.rs:10)` headers, so the folded annotation must use the
+        // same `Name (path:line)` form `tree_label` already uses for
+        // disambiguated symbols, not the bare name.
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![
+                    symbol("src/lib.rs::foo", "foo", SymbolKind::Function, "fn foo()"),
+                    ExtractedSymbol {
+                        range: LineRange { start: 5, end: 6 },
+                        ..symbol(
+                            "src/lib.rs::Dup@5",
+                            "Dup",
+                            SymbolKind::Struct,
+                            "struct Dup { a: i32 }",
+                        )
+                    },
+                    ExtractedSymbol {
+                        range: LineRange { start: 10, end: 11 },
+                        ..symbol(
+                            "src/lib.rs::Dup@10",
+                            "Dup",
+                            SymbolKind::Struct,
+                            "struct Dup { b: i32 }",
+                        )
+                    },
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                    node("src/lib.rs::Dup@5", "src/lib.rs", "Dup"),
+                    node("src/lib.rs::Dup@10", "src/lib.rs", "Dup"),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "src/lib.rs::foo".to_string(),
+                        to: "src/lib.rs::Dup@5".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "src/lib.rs::foo".to_string(),
+                        to: "src/lib.rs::Dup@10".to_string(),
+                        is_cycle: false,
+                    },
+                ],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
+            tests: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+3 changed symbols in 1 file
+
+- fn foo (src/lib.rs) — uses: Dup (src/lib.rs:5), Dup (src/lib.rs:10)
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo()
+```
+
+### struct Dup (src/lib.rs:5)
+
+```
+struct Dup { a: i32 }
+```
+
+### struct Dup (src/lib.rs:10)
+
+```
+struct Dup { b: i32 }
 ```
 
 "

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -30,7 +30,7 @@
 //! signatures are noise (ADR 0009).
 
 use crate::extract::{ExtractedSymbol, SymbolKind};
-use crate::graph::{NodeId, SymbolGraph};
+use crate::graph::{Node, NodeId, SymbolGraph};
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
@@ -205,6 +205,8 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
     if !report.graph.nodes.is_empty() {
         writeln!(out, "## Change graph")?;
         writeln!(out)?;
+        writeln!(out, "{}", change_graph_summary(&report.graph.nodes))?;
+        writeln!(out)?;
         render_change_graph(&mut out, &report.graph, &children, &lookup)?;
         writeln!(out)?;
 
@@ -259,6 +261,61 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
     }
 
     Ok(out)
+}
+
+/// Builds the one-line summary shown under the "## Change graph" heading,
+/// e.g. `16 changed symbols in 3 files — most in store/items.go (11)`
+/// (ADR 0012 decision 3). Computed from `nodes` alone (not `edges`/`roots`),
+/// so it stays meaningful even if graph-building changes independently.
+///
+/// The `— most in ...` suffix is dropped when every node lives in the same
+/// file: naming "the file with the most nodes" is redundant when there is
+/// only one file to begin with. Ties for "most" go to whichever path's node
+/// appears first in `nodes` (stable, diff-derived order), matching the
+/// tie-break `render_markdown` already relies on elsewhere (e.g. root
+/// order) rather than an arbitrary path-string sort.
+///
+/// Callers must not call this with an empty `nodes` — `render_markdown`
+/// only emits the "Change graph" section (and this summary) when
+/// `graph.nodes` is non-empty, matching pre-ADR-0012 behavior for an empty
+/// graph.
+fn change_graph_summary(nodes: &[Node]) -> String {
+    let total = nodes.len();
+    let symbol_noun = if total == 1 { "symbol" } else { "symbols" };
+
+    // First-seen order for paths, with per-path counts, so both the file
+    // count and the "most changed" tie-break can be read off in one pass.
+    let mut path_order: Vec<&str> = Vec::new();
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for node in nodes {
+        let path = node.path.as_str();
+        if !counts.contains_key(path) {
+            path_order.push(path);
+        }
+        *counts.entry(path).or_insert(0) += 1;
+    }
+
+    let file_count = path_order.len();
+    let file_noun = if file_count == 1 { "file" } else { "files" };
+
+    if file_count <= 1 {
+        return format!("{total} changed {symbol_noun} in {file_count} {file_noun}");
+    }
+
+    // `max_by_key` keeps the *last* maximal element on ties, but the
+    // tie-break we want is "first in `nodes` order" — negate the position
+    // so an earlier path outranks a later one with the same count.
+    let (hotspot_path, hotspot_count) = path_order
+        .iter()
+        .enumerate()
+        .map(|(i, &path)| (path, counts[path], i))
+        .max_by_key(|&(_, count, i)| (count, std::cmp::Reverse(i)))
+        .map(|(path, count, _)| (path, count))
+        .expect("file_count > 1 implies path_order is non-empty");
+
+    format!(
+        "{total} changed {symbol_noun} in {file_count} {file_noun} — most in {hotspot_path} ({hotspot_count})"
+    )
 }
 
 /// Renders the "Change graph" section: an indented, names-only tree rooted
@@ -665,6 +722,8 @@ mod tests {
         let expected = "\
 ## Change graph
 
+1 changed symbol in 1 file
+
 - fn foo (src/lib.rs)
 
 ## Definitions
@@ -803,6 +862,8 @@ fn foo()
 
         let expected = "\
 ## Change graph
+
+1 changed symbol in 1 file
 
 - fn foo (src/lib.rs)
 
@@ -959,6 +1020,8 @@ fn foo()
         let expected = "\
 ## Change graph
 
+1 changed symbol in 1 file
+
 - fn foo (src/lib.rs)
 
 ## Definitions
@@ -968,6 +1031,125 @@ fn foo()
 ```
 fn foo(a: i32) -> i32
 ```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_summary_with_hotspot_when_report_has_multiple_symbols_and_files() {
+        // 5 nodes across store/items.go (3, the hotspot) and store/db.go (2)
+        // — pins the plural "changed symbols"/"files" wording together with
+        // the "— most in ..." suffix and its count.
+        let report = Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("store/items.go::A", "store/items.go", "A"),
+                    node("store/items.go::B", "store/items.go", "B"),
+                    node("store/items.go::C", "store/items.go", "C"),
+                    node("store/db.go::D", "store/db.go", "D"),
+                    node("store/db.go::E", "store/db.go", "E"),
+                ],
+                edges: vec![],
+                roots: vec![
+                    "store/items.go::A".to_string(),
+                    "store/items.go::B".to_string(),
+                    "store/items.go::C".to_string(),
+                    "store/db.go::D".to_string(),
+                    "store/db.go::E".to_string(),
+                ],
+            },
+            tests: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+5 changed symbols in 2 files — most in store/items.go (3)
+
+
+## Definitions
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_omit_hotspot_suffix_when_all_symbols_are_in_one_file() {
+        // Every node lives in the same file, so naming "the file with the
+        // most nodes" would be redundant — the suffix must be dropped
+        // entirely, not degenerate into e.g. "(2)".
+        let report = Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("src/lib.rs::a", "src/lib.rs", "a"),
+                    node("src/lib.rs::b", "src/lib.rs", "b"),
+                ],
+                edges: vec![],
+                roots: vec!["src/lib.rs::a".to_string(), "src/lib.rs::b".to_string()],
+            },
+            tests: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+2 changed symbols in 1 file
+
+
+## Definitions
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_break_hotspot_tie_by_first_seen_path_order_when_counts_are_equal() {
+        // b.rs and a.rs both have 2 nodes each; b.rs's node appears first in
+        // `graph.nodes`, so it must win the tie over a.rs despite sorting
+        // after it alphabetically — the tie-break is source order, not a
+        // path-string comparison.
+        let report = Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("b.rs::x", "b.rs", "x"),
+                    node("a.rs::y", "a.rs", "y"),
+                    node("b.rs::z", "b.rs", "z"),
+                    node("a.rs::w", "a.rs", "w"),
+                ],
+                edges: vec![],
+                roots: vec![
+                    "b.rs::x".to_string(),
+                    "a.rs::y".to_string(),
+                    "b.rs::z".to_string(),
+                    "a.rs::w".to_string(),
+                ],
+            },
+            tests: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+4 changed symbols in 2 files — most in b.rs (2)
+
+
+## Definitions
 
 "
         .to_string();
@@ -1025,6 +1207,8 @@ fn foo(a: i32) -> i32
 
         let expected = "\
 ## Change graph
+
+2 changed symbols in 1 file
 
 - fn foo (src/lib.rs:1)
 - fn foo (src/lib.rs:10)
@@ -1092,6 +1276,8 @@ fn foo(a: i32, b: i32)
 
         let expected = "\
 ## Change graph
+
+2 changed symbols in 1 file
 
 - fn handle_pr (src/main.rs)
   - fn resolve_pr_base_sha (src/main.rs)
@@ -1170,6 +1356,8 @@ fn resolve_pr_base_sha() -> Result<String>
 
         let expected = "\
 ## Change graph
+
+4 changed symbols in 1 file
 
 - fn a (src/lib.rs)
   - fn b (src/lib.rs)
@@ -1255,6 +1443,8 @@ fn c()
         let expected = "\
 ## Change graph
 
+3 changed symbols in 1 file
+
 - fn foo (src/lib.rs)
   - fn shared (src/lib.rs)
 - fn bar (src/lib.rs)
@@ -1318,6 +1508,8 @@ fn bar()
 
         let expected = "\
 ## Change graph
+
+1 changed symbol in 1 file
 
 - fn resolve_pr_base_sha (src/git.rs)
   - ⚠️ fn resolve_pr_base_sha (src/git.rs) — dependency cycle, see above
@@ -1425,6 +1617,8 @@ fn resolve_pr_base_sha()
         let expected = "\
 ## Change graph
 
+4 changed symbols in 3 files — most in src/git.rs (2)
+
 - fn handle_pr (src/main.rs)
   - fn resolve_pr_base_sha (src/git.rs)
     - fn fetch_base_branch (src/git.rs)
@@ -1491,6 +1685,8 @@ struct Config { path: String }
         let expected = "\
 ## Change graph
 
+1 changed symbol in 1 file
+
 - fn bar (src/lib.rs)
 
 ## Definitions
@@ -1538,6 +1734,8 @@ fn bar(&self) -> i32
 
         let expected = "\
 ## Change graph
+
+1 changed symbol in 1 file
 
 - fn foo (src/lib.rs)
 
@@ -1595,6 +1793,8 @@ Depends on:
         let expected = "\
 ## Change graph
 
+1 changed symbol in 1 file
+
 - fn foo (src/lib.rs)
 
 ## Definitions
@@ -1646,6 +1846,8 @@ Depends on:
 
         let expected = "\
 ## Change graph
+
+1 changed symbol in 1 file
 
 - fn foo (src/lib.rs)
 
@@ -1701,6 +1903,8 @@ Depends on:
         let expected = "\
 ## Change graph
 
+1 changed symbol in 1 file
+
 - fn example_macro (src/lib.rs)
 
 ## Definitions
@@ -1747,6 +1951,8 @@ fn example_macro() { let s = \"```rust\\nfn f() {}\\n```\"; }
 
         let expected = "\
 ## Change graph
+
+1 changed symbol in 1 file
 
 - fn bar (src/lib.rs)
 
@@ -1832,6 +2038,8 @@ fn bar(&self) -> i32
         let expected = "\
 ## Change graph
 
+1 changed symbol in 1 file
+
 - fn foo (src/lib.rs)
 
 ## Definitions
@@ -1881,6 +2089,8 @@ fn foo()
         let expected = "\
 ## Change graph
 
+1 changed symbol in 1 file
+
 
 ## Definitions
 
@@ -1910,6 +2120,8 @@ fn foo()
 
         let expected = "\
 ## Change graph
+
+1 changed symbol in 1 file
 
 
 ## Definitions
@@ -1958,6 +2170,8 @@ fn foo()
 
         let expected = "\
 ## Change graph
+
+1 changed symbol in 1 file
 
 - fn foo (src/lib.rs)
 


### PR DESCRIPTION
## Why

Dogfooding the entry-point tree (ADR 0008–0011) on a real-world Go diff that touched a repository interface and its callers still produced hard-to-read output: over half the tree lines were request/response struct leaves (mostly `(see above)` repeats), the interface and its methods were each listed twice as separate roots, and the fan shape of the change (one epicenter file, a few caller files) was invisible.

Design rationale is recorded in [ADR 0012](docs/adr/0012-condense-change-graph-rendering.md). Markdown output only — JSON is unchanged.

## What

- **Summary line** under `## Change graph`: `16 changed symbols in 3 files — most in store/items.go (11)` (hotspot suffix omitted for single-file diffs).
- **Inline leaf type folding**: changed non-function symbols with no outgoing edges no longer get tree lines; they appear as a `— uses: A, B` annotation on each referencing parent's line. Structural criterion (not `*Request` name matching), so it is language-agnostic. Full signatures still appear under `## Definitions`. Duplicate names are disambiguated as `Name (path:line)`, matching Definitions headers.
- **Interface→method linking**: Go `interface` / TS `interface` / Rust `trait` declarations now include their method-spec names in `referenced_names`, so the existing name-based edge builder nests changed same-named methods under the interface instead of duplicating them at top level.
- README examples re-captured from the new binary; a condensed-rendering example added.

Example — a Go diff adding an interface, two receiver-method implementations, and four request/response structs (8 changed symbols) now renders as:

```markdown
## Change graph

8 changed symbols in 1 file

- interface ItemStore (store.go) — uses: ListItemsRequest, ListItemsResponse, SaveItemRequest, SaveItemResponse
  - fn ListItems (store.go) — uses: ListItemsRequest, ListItemsResponse, itemStore
  - fn SaveItem (store.go) — uses: SaveItemRequest, SaveItemResponse, itemStore
```

## QA

- `make test` (390 tests) and `make lint` clean.
- Dogfooded the release binary on this branch's own diff, on a historical commit (README example re-captured at that commit's tree), and on synthetic Go/Rust repos exercising interface nesting, folding, and duplicate-name disambiguation.
- Known pre-existing behavior (not a regression, verified identical on `main`): a call expression inside a Rust trait's default method body already contributes a reference edge from the trait to a same-named changed function; out of scope here.

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync