### PR TITLE
docs: record output design decisions (ADR 0013-0015)

### DIFF
--- a/docs/adr/0013-hotspots-fan-in-section.md
+++ b/docs/adr/0013-hotspots-fan-in-section.md
@@ -1,0 +1,105 @@
+# 0013. Surface fan-in hotspots in rendered output
+
+- Status: accepted
+- Date: 2026-07-12
+
+## Context
+
+PR review answers two distinct questions, and this ADR names them
+because later ADRs will keep referring back to the split:
+
+- **Question A: "where do I start reading?"** Answered by the
+  entry-point tree (ADR 0008), since condensed for readability (ADR
+  0012).
+- **Question B: "what breaks if I touch this?"** Blast radius / fan-in.
+  Currently unanswered by any output.
+
+The tree structurally suppresses fan-in. A shared dependency is
+expanded in full the first time it is reached and every later
+occurrence collapses to `(see above)` (`render_tree_node`'s `printed:
+HashSet<String>` in render.rs); foldable leaf types are additionally
+inlined per-parent as `— uses:` annotations (ADR 0012). Both
+mechanisms exist to keep the tree short, but their side effect is that
+"this struct is referenced from three different call chains" never
+appears anywhere as a number — it is scattered across however many
+places the node happens to be reached from, most of them collapsed
+away.
+
+The data to answer question B already exists and needs no new model.
+`SymbolGraph` (graph.rs) carries the full edge list
+(`Edge { from, to, is_cycle }`), and render.rs already builds the
+forward grouping of those edges keyed by `edge.from`
+(`children_by_node`) for tree rendering. Fan-in is the symmetric
+reverse grouping, keyed by `edge.to`. `Report.graph` (render.rs)
+already serializes the full edge list to JSON, so no new data reaches
+the JSON boundary either — only a precomputed aggregation of what is
+already there.
+
+## Decision
+
+- Add a pure aggregation in `rinkaku-core` that groups `graph.edges` by
+  `to` and produces, per node, a referrer count and the sorted list of
+  referrer names. This is arithmetic over existing `Edge` values, not a
+  new graph concept — no new node or edge kind, no change to
+  `SymbolGraph`.
+- **Markdown**: a new `## Hotspots` section, placed between `##
+  Change graph` and `## Definitions`. It lists only symbols with
+  fan-in >= 2, sorted by fan-in descending, ties broken by path then
+  name for determinism. Line format:
+
+  ```
+  - struct FooRequest (api/types.go) — used by 3: HandleFoo, HandleBar, SyncFoo
+  ```
+
+  The section is omitted entirely when no symbol reaches fan-in >= 2,
+  matching the existing precedent of omitting empty sections rather
+  than printing them empty.
+- **JSON**: expose the same aggregation as a new `hotspots` field
+  alongside the existing `graph` field, so machine consumers get the
+  ranking precomputed instead of re-deriving it from raw edges. Raw
+  edges are unchanged — this is additive.
+- Cycle edges (`is_cycle: true`) still count toward fan-in. A cyclic
+  reference is still a reference; hiding it would understate blast
+  radius exactly where a design smell (ADR 0008's cycle warning) is
+  already flagged.
+
+## Alternatives
+
+- **Mermaid flowchart of the symbol graph**: renders fine for a
+  handful of nodes but becomes a hairball at 10-15, which is precisely
+  the size of PR where blast-radius help matters most. Rejected as
+  degrading on the cases it needs to serve.
+- **Per-line fan-in annotations on tree rows only**: keeps the signal
+  embedded in reading order instead of ranked, so the "widely used"
+  property stays buried the same way it is today — only annotated
+  instead of absent. Does not solve the actual problem (nothing ranks
+  importance).
+- **Leave aggregation to JSON consumers** (edges are already present
+  in `Report.graph`): Markdown is the primary LLM- and human-facing
+  surface; both benefit from a precomputed ranking, and a human reading
+  Markdown gets nothing under this alternative since they do not touch
+  the JSON output at all.
+- **TUI-only fan-in display**: an interactive surface is a separate
+  decision (ADR 0015). Static/machine-facing output (`gh pr diff |
+  rinkaku` piped into an LLM, JSON consumers) needs blast radius
+  regardless of whether an interactive mode ever ships.
+
+## Consequences
+
+- Question B gets a first-class, static answer. Combined with the
+  planned symbol-change classification (ADR 0014), fan-in count
+  becomes the basis for a risk ranking: "a widely used symbol whose
+  contract changed" is exactly the highest-risk case a reviewer wants
+  surfaced first.
+- Additive change to Markdown (new section only, existing sections
+  unchanged) and to JSON (new field, existing `graph.edges` unchanged)
+  — unlike ADR 0008/0012, this does not break existing output.
+- The fan-in >= 2 threshold is a judgment call, not derived from data.
+  Revisit if dogfooding on real diffs shows fan-in == 1 entries carry
+  useful signal (e.g. a single caller in a different file than the
+  callee, which the tree may still obscure).
+- `## Hotspots` reuses the word "hotspot" already used informally for
+  the busiest-file summary line (ADR 0012); the two are different
+  concepts (file-level symbol density vs. per-symbol fan-in) living in
+  the same output, so naming or wording may need a follow-up pass if
+  this reads as ambiguous in practice.

--- a/docs/adr/0014-classify-symbol-changes-by-contract.md
+++ b/docs/adr/0014-classify-symbol-changes-by-contract.md
@@ -1,0 +1,107 @@
+# 0014. Classify changed symbols by contract impact
+
+- Status: accepted
+- Date: 2026-07-12
+
+## Context
+
+Current output reports only *which* symbols were touched. A
+body-only edit to `HandleFoo` and a signature change that adds a
+parameter render identically. The review-risk signal reviewers
+actually want is fan-in x contract change — "a struct used from three
+places had a field added" — and reviewers have separately asked for
+the *location* of the change inside the signature to be visible, not
+just the fact that it changed.
+
+No symbol-level added/removed concept exists today. File-level
+`ChangeKind` (Added/Modified/Deleted/Renamed) exists in `diff.rs`, but
+`analyze_diff` (`pipeline.rs`) only special-cases `Deleted` files and
+merges the rest; base-side content of changed symbols is never read.
+
+The infrastructure to fix this is already in place. `main.rs` already
+batch-reads git blobs via `git cat-file --batch`
+(`read_git_show_files_batch`) to build the dependency index, and
+extraction (`extract_all_symbols` in `extract.rs`) is a pure function
+`(source, lang) -> symbols` that applies unchanged to base-side
+content. Language detection is extension-based and content-
+independent, so no new IO primitive is needed to parse a file's
+previous revision.
+
+Signature slicing today excludes function/method bodies, so a
+body-only edit already leaves the signature string unchanged; struct
+/ enum / trait / interface signatures deliberately include fields,
+variants, and method specs — that inclusion *is* the contract.
+Whitespace is normalized, but comment nodes inside a declaration are
+kept, so a comment-only edit inside e.g. `type FooRequest struct` would
+falsely register as a signature change unless comments are stripped
+first.
+
+## Decision
+
+Classify every changed symbol as one of: `added` (absent on the base
+side), `signature-changed`, `body-only`. Symbols present on base but
+absent on head are reported separately as `removed`.
+
+Detection: for each changed file, read the base-side content at the
+existing IO boundary (the batch blob reader already used for the
+dependency index; core stays pure — base content is passed in as
+plain data), run the same pure `extract_all_symbols` on it, and
+compare normalized signature strings of symbols matched by name (plus
+container, e.g. a method matched within its receiver type or class).
+Comment nodes are stripped during signature slicing so a comment-only
+edit does not register as a contract change — this also cleans up
+signatures shown today.
+
+Data model: the change classification and the previous signature (for
+`signature-changed`) live on the extracted symbol. `removed` symbols
+have no head-side symbol to attach the field to, so they get a new
+report-level list instead.
+
+Rendering (Markdown): tree rows carry a compact marker for `added` and
+`signature-changed` (`body-only` stays unmarked since it is the
+common case and adding a marker to most rows would defeat the point).
+`## Definitions` entries for `signature-changed` symbols show an
+old-to-new signature diff in a ` ```diff ` fenced block. A new
+`## Removed symbols` section lists the `removed` list. Hotspots
+entries (ADR 0013) carry the `signature-changed` marker so "widely
+used and contract changed" sorts to the top of that ranking.
+
+JSON: classification and previous signature serialize as new,
+additive fields on the symbol; `removed` is a new top-level array.
+
+## Alternatives
+
+- **Infer contract changes from diff hunk positions** (changed lines
+  overlapping the signature's line range) without parsing the base
+  side: cheap, but wrong for reformatted or reflowed declarations, and
+  cannot produce the old signature text needed for the diff display.
+- **Structured/AST-level signature comparison** (e.g. semantic
+  equivalence that ignores parameter reordering): more precise, but
+  far more per-language implementation work. Normalized-string
+  comparison on signatures that are already normalized for display is
+  proportionate for v1.
+- **LSP-based semantic diffing**: deferred by the resolution strategy
+  in ADR 0003 for the same reasons — too slow and fragile as a default
+  for arbitrary checkouts. The same tags-first, LSP-later posture
+  applies to change classification.
+- **Skip `removed` in v1**: a removed symbol is the sharpest possible
+  contract break for its callers, and base-side extraction produces
+  the `removed` list for free once base-side parsing exists for
+  `signature-changed` detection. Not worth deferring.
+
+## Consequences
+
+- Reviewers and LLMs can rank attention by contract impact; combined
+  with fan-in (ADR 0013) this produces the intended risk ordering
+  instead of a flat list of touched names.
+- Cost: one extra parse per changed file (base side only, not a full
+  repo re-index). Files with `ChangeKind::Deleted`, currently
+  special-cased and skipped, can now surface their symbols as
+  `removed` instead of being silently dropped — whether to fold that
+  in immediately or as a follow-up is an implementation-time decision.
+- Renames are not detected: a renamed symbol reports as `removed` +
+  `added` rather than a single rename event. Accepted for v1; revisit
+  if this proves noisy in practice.
+- Stripping comment nodes changes existing signature strings shown in
+  output — another pre-1.0 output-format change, consistent with prior
+  ADRs (0008, 0009, 0012).

--- a/docs/adr/0015-tui-for-humans-markdown-for-machines.md
+++ b/docs/adr/0015-tui-for-humans-markdown-for-machines.md
@@ -1,0 +1,114 @@
+# 0015. Split audiences: TUI for humans, Markdown/JSON for machines
+
+- Status: accepted
+- Date: 2026-07-12
+
+## Context
+
+ADR 0012 condensed the change-graph rendering and removed noise from
+Markdown output. Dogfooding since then shows the remaining human
+complaints are presentational, not noise:
+
+- Important rows — high fan-in symbols, contract changes — do not
+  visually stand out in a flat Markdown list. A reviewer must read
+  every line at equal weight to find the ones that matter.
+- Full file paths repeated on every row force the reader to
+  mentally re-parse the same prefixes over and over, when what they
+  actually want is the directory *shape* of the change: nesting depth
+  approximates architectural layering, and that shape is exactly what
+  a reviewer uses to judge blast radius.
+- Reviewers want to understand a change visually — scan, fold,
+  pivot — not read a sequence of path strings top to bottom.
+
+Static Markdown cannot express visual hierarchy, emphasis, folding, or
+on-demand pivoting between views. ADR 0012 already pushed static
+condensing about as far as string-level formatting goes; there is no
+further condensing move left that does not start encoding UI concerns
+(color, collapse state, navigation) into text. ADR 0012's Alternatives
+section deferred an interactive TUI specifically because it "does not
+fix the noise itself" — that objection targeted noise, which 0012 has
+since resolved. It does not apply to the presentational problems above,
+so that deferral is now resolved in favor of building the TUI; this
+does not reopen or supersede the rest of ADR 0012.
+
+The maintainer's workflow is terminal-centric; a web UI is explicitly
+out of scope regardless of its technical merits.
+
+Architecturally this fits without disruption: `rinkaku-core` is pure
+and the `Report`/graph model already serializes to JSON (ADR 0008,
+ADR 0010). An interactive front-end is simply another adapter reading
+the same `Report`, alongside the existing Markdown renderer — it adds
+a consumer, not a change to the domain model.
+
+## Decision
+
+Split the two audiences at the format level going forward:
+
+1. **Markdown and JSON are optimized for machine consumers** — LLMs
+   and CI tooling. They stay stable, parseable, and rich in
+   precomputed aggregates (fan-in counts, change classification; see
+   prerequisites below). No further Markdown work is aimed at human
+   visual comfort: no mermaid diagrams, no directory-grouping
+   sections, no color/emphasis markup in Markdown.
+2. **Human consumption moves to an interactive terminal UI**, shipped
+   as part of rinkaku, built on the same `Report` data. This ADR fixes
+   only the direction, at the concept level; framework and
+   implementation details are a separate track (see Consequences):
+   - The entry view is the **directory tree of changed files**, not
+     the call-graph tree. Nesting depth conveys architecture; each
+     directory/file row carries aggregate badges (changed-symbol
+     count, a contract-change marker, fan-in).
+   - Selecting a symbol opens a **detail pane**: its signature (an
+     old→new diff when the contract changed, per the change
+     classification prerequisite below), its fan-in as a "used by"
+     list, and a pivot to callers/callees for call-graph reading
+     order (ADR 0008's tree, reachable on demand rather than as the
+     spine).
+   - Drill-down bottoms out in **viewing the actual file source**
+     with the relevant lines highlighted — the reviewer never leaves
+     the terminal to open an editor.
+   - The call-graph tree (reading order) and the directory tree
+     (architecture) are orthogonal hierarchies. The TUI keeps the
+     directory tree as the spine and reaches call relations by
+     pivoting, rather than merging both into one combined tree.
+
+## Alternatives
+
+- **Keep improving Markdown for humans** (mermaid module diagrams,
+  directory-grouping sections, path-prefix trimming): string-level
+  tweaks cannot deliver real visual hierarchy or interaction, and each
+  addition bloats the same format that machine consumers depend on
+  staying stable and parseable.
+- **Web UI**: would satisfy the visual/interactive requirement, but
+  requires leaving the terminal and serving/opening a browser, which
+  is not the primary workflow. Rejected on that basis, not on
+  technical merit.
+- **One hybrid output serving both audiences**: this tension — humans
+  wanting hierarchy and folding, machines wanting stable flat
+  structure — is the root cause of the current complaints. Splitting
+  the audiences dissolves the tension instead of continuing to
+  compromise both sides.
+- **Separate standalone viewer tool consuming rinkaku's JSON**: keeps
+  rinkaku itself lean, but splits distribution and versioning across
+  two projects for no user benefit at this stage, since the TUI is
+  still small. Revisit if the TUI grows large enough to justify its
+  own release cycle.
+
+## Consequences
+
+- Markdown format can now freeze toward LLM/CI ergonomics; future
+  human-facing feature requests route to the TUI backlog rather than
+  new Markdown sections or flags.
+- The TUI is a significant new surface — framework choice (e.g.
+  ratatui), event handling, and testing strategy are deliberately out
+  of scope here. A follow-up ADR will fix the tech stack once
+  implementation starts.
+- Two data prerequisites must land before the TUI's badges and detail
+  pane are meaningful: fan-in aggregation (ADR 0013) and change
+  classification with old→new signature diffing (ADR 0014). Until
+  then, this ADR fixes direction only; implementation waits on that
+  data.
+- This resolves the TUI deferral recorded in ADR 0012's Alternatives
+  section (the "does not fix noise" objection no longer applies to
+  the presentational problems being solved here); it does not mark
+  ADR 0012 itself superseded.


### PR DESCRIPTION
## Summary

Records three agreed design decisions for the next iterations of rinkaku's output:

- **ADR 0013 — Surface fan-in hotspots in rendered output**: names the two review questions (A: reading order, answered by the entry-point tree; B: blast radius, currently unanswered) and adds a fan-in aggregation — a `## Hotspots` Markdown section (fan-in >= 2) and a `hotspots` JSON field — computed purely from existing graph edges.
- **ADR 0014 — Classify changed symbols by contract impact**: classifies changed symbols as added / signature-changed / body-only (plus a report-level removed list) by extracting base-side signatures with the existing pure extraction and comparing normalized signatures, with comment nodes stripped to avoid false positives. Rendering: tree markers, old→new signature diff blocks in Definitions, a `## Removed symbols` section, and signature-changed markers on Hotspots entries.
- **ADR 0015 — Split audiences: TUI for humans, Markdown/JSON for machines**: freezes Markdown/JSON toward LLM/CI ergonomics and moves human consumption to an interactive terminal UI (directory-tree entry view with badges, detail pane with signature diff and used-by list, drill-down to highlighted source). Resolves the TUI deferral noted in ADR 0012's Alternatives.

Implementation follows separately, in order: ADR 0013 → ADR 0014 → TUI (with its own tech-stack ADR).

## Notes

Docs-only change; no code affected.

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync