### PR TITLE
feat: surface fan-in hotspots in rendered output

### DIFF
--- a/rinkaku-core/src/graph.rs
+++ b/rinkaku-core/src/graph.rs
@@ -68,10 +68,12 @@ pub struct Hotspot {
     pub path: String,
     pub name: String,
     /// Names of every changed symbol referencing this node, sorted
-    /// ascending and deduplicated (see [`compute_hotspots`]'s doc comment).
-    /// Fan-in count is `used_by.len()` — no separate count field, since the
-    /// list already carries it and a reader who wants the number can just
-    /// count entries or check the (short) list itself.
+    /// ascending. Deduplication happens per referrer *node*, not per name,
+    /// so two distinct referrers sharing a name both appear (see
+    /// [`compute_hotspots`]'s doc comment). Fan-in count is
+    /// `used_by.len()` — no separate count field, since the list already
+    /// carries it and a reader who wants the number can just count entries
+    /// or check the (short) list itself.
     pub used_by: Vec<String>,
 }
 

--- a/rinkaku-core/src/graph.rs
+++ b/rinkaku-core/src/graph.rs
@@ -58,6 +58,86 @@ pub struct SymbolGraph {
     pub roots: Vec<NodeId>,
 }
 
+/// A changed symbol with two or more distinct referrers (ADR 0013): a
+/// "fan-in hotspot" a reviewer should pay extra attention to, since changing
+/// its signature has a wider blast radius than a symbol only one other
+/// changed symbol depends on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Hotspot {
+    pub id: NodeId,
+    pub path: String,
+    pub name: String,
+    /// Names of every changed symbol referencing this node, sorted
+    /// ascending and deduplicated (see [`compute_hotspots`]'s doc comment).
+    /// Fan-in count is `used_by.len()` — no separate count field, since the
+    /// list already carries it and a reader who wants the number can just
+    /// count entries or check the (short) list itself.
+    pub used_by: Vec<String>,
+}
+
+/// Aggregates `graph.edges` by target node into [`Hotspot`]s: nodes
+/// referenced by two or more distinct changed symbols (fan-in >= 2). A
+/// cycle edge (`Edge::is_cycle`) still counts as a real reference — the
+/// referrer really does depend on the target's signature, cycle or not — so
+/// cycle and non-cycle edges are aggregated together without distinction.
+///
+/// Multiple edges from the same referrer node to the same target
+/// (`collect_edges` cannot currently produce these, since a symbol's
+/// `referenced_names` come from a `HashSet` upstream in extraction, but nothing
+/// in this function's contract depends on that) are deduplicated by
+/// referrer *id*, not name, before names are collected — this matters when
+/// two distinct referrer nodes happen to share a name (e.g. two overloaded
+/// functions both named `helper` referencing the same target): both are
+/// kept as separate fan-in contributors (they are genuinely different
+/// symbols), so `used_by` can contain the same name twice in that case
+/// rather than silently under-counting fan-in.
+///
+/// Results are sorted by fan-in descending, ties broken by `(path, name)`
+/// ascending for determinism independent of edge/node iteration order.
+pub fn compute_hotspots(graph: &SymbolGraph) -> Vec<Hotspot> {
+    let node_by_id: HashMap<&str, &Node> = graph.nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+
+    // Dedup by (target, referrer id) first, so a target with multiple edges
+    // from the same referrer (however unlikely today) is not over-counted.
+    let mut referrers_by_target: HashMap<&str, Vec<&str>> = HashMap::new();
+    for edge in &graph.edges {
+        let referrers = referrers_by_target.entry(edge.to.as_str()).or_default();
+        if !referrers.contains(&edge.from.as_str()) {
+            referrers.push(edge.from.as_str());
+        }
+    }
+
+    let mut hotspots: Vec<Hotspot> = referrers_by_target
+        .into_iter()
+        .filter(|(_, referrers)| referrers.len() >= 2)
+        .filter_map(|(target_id, referrer_ids)| {
+            let node = node_by_id.get(target_id)?;
+            let mut used_by: Vec<String> = referrer_ids
+                .iter()
+                .filter_map(|id| node_by_id.get(id))
+                .map(|n| n.name.clone())
+                .collect();
+            used_by.sort();
+            Some(Hotspot {
+                id: node.id.clone(),
+                path: node.path.clone(),
+                name: node.name.clone(),
+                used_by,
+            })
+        })
+        .collect();
+
+    hotspots.sort_by(|a, b| {
+        b.used_by
+            .len()
+            .cmp(&a.used_by.len())
+            .then_with(|| a.path.cmp(&b.path))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+
+    hotspots
+}
+
 /// Builds a [`SymbolGraph`] over every symbol in `files`.
 ///
 /// Node order (and therefore `nodes`, tie-breaks in `roots`, and DFS
@@ -777,6 +857,319 @@ mod tests {
         }];
 
         assert_eq!(expected, files);
+    }
+
+    #[test]
+    fn should_return_no_hotspots_when_every_node_has_fan_in_below_two() {
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol("foo", vec!["bar"]), symbol("bar", vec![])],
+        }];
+        let graph = build_graph(&files);
+
+        let expected: Vec<Hotspot> = vec![];
+        let actual = compute_hotspots(&graph);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_count_fan_in_and_sort_referrer_names_when_two_symbols_reference_one_target() {
+        // "zoo" and "alpha" both reference "shared" — fan-in 2 qualifies as
+        // a hotspot, and `used_by` must come back name-sorted ("alpha"
+        // before "zoo") regardless of edge order.
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                symbol("zoo", vec!["shared"]),
+                symbol("alpha", vec!["shared"]),
+                symbol("shared", vec![]),
+            ],
+        }];
+        let graph = build_graph(&files);
+
+        let expected = vec![Hotspot {
+            id: "src/lib.rs::shared".to_string(),
+            path: "src/lib.rs".to_string(),
+            name: "shared".to_string(),
+            used_by: vec!["alpha".to_string(), "zoo".to_string()],
+        }];
+        let actual = compute_hotspots(&graph);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_count_cycle_edge_toward_fan_in_when_referrer_is_part_of_a_cycle() {
+        // "foo" and "bar" reference each other (mutual recursion, so one of
+        // the two edges gets marked `is_cycle: true` by `build_graph`) and
+        // "baz" independently references "bar" too — "bar" ends up with
+        // fan-in 2 (from "foo" and "baz"), and the cycle edge must count
+        // toward that just like a non-cycle edge would.
+        let files = vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                symbol("foo", vec!["bar"]),
+                symbol("bar", vec!["foo"]),
+                symbol("baz", vec!["bar"]),
+            ],
+        }];
+        let graph = build_graph(&files);
+        // Sanity check on the fixture: confirm build_graph actually marked
+        // one of foo<->bar's edges as a cycle, since this test's premise
+        // depends on that.
+        assert!(graph.edges.iter().any(|e| e.is_cycle));
+
+        let expected = vec![Hotspot {
+            id: "src/lib.rs::bar".to_string(),
+            path: "src/lib.rs".to_string(),
+            name: "bar".to_string(),
+            used_by: vec!["baz".to_string(), "foo".to_string()],
+        }];
+        let actual = compute_hotspots(&graph);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_dedup_referrer_when_same_node_references_target_more_than_once() {
+        // `collect_edges` cannot currently produce two edges from the same
+        // referrer to the same target (referenced_names de-dups upstream),
+        // but `compute_hotspots` must not over-count fan-in if it ever did
+        // — constructing the graph by hand here rather than through
+        // `build_graph` to exercise that defensively.
+        let graph = SymbolGraph {
+            nodes: vec![
+                Node {
+                    id: "src/lib.rs::foo".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "foo".to_string(),
+                },
+                Node {
+                    id: "src/lib.rs::bar".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "bar".to_string(),
+                },
+                Node {
+                    id: "src/lib.rs::shared".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "shared".to_string(),
+                },
+            ],
+            edges: vec![
+                Edge {
+                    from: "src/lib.rs::foo".to_string(),
+                    to: "src/lib.rs::shared".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "src/lib.rs::foo".to_string(),
+                    to: "src/lib.rs::shared".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "src/lib.rs::bar".to_string(),
+                    to: "src/lib.rs::shared".to_string(),
+                    is_cycle: false,
+                },
+            ],
+            roots: vec!["src/lib.rs::foo".to_string(), "src/lib.rs::bar".to_string()],
+        };
+
+        let expected = vec![Hotspot {
+            id: "src/lib.rs::shared".to_string(),
+            path: "src/lib.rs".to_string(),
+            name: "shared".to_string(),
+            used_by: vec!["bar".to_string(), "foo".to_string()],
+        }];
+        let actual = compute_hotspots(&graph);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_sort_hotspots_by_fan_in_descending_when_multiple_hotspots_exist() {
+        // "low" has fan-in 2 ("a", "b"); "high" has fan-in 3 ("c", "d",
+        // "e") — "high" must sort first despite "low" being discovered
+        // first in edge order.
+        let graph = SymbolGraph {
+            nodes: vec![
+                Node {
+                    id: "src/lib.rs::a".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "a".to_string(),
+                },
+                Node {
+                    id: "src/lib.rs::b".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "b".to_string(),
+                },
+                Node {
+                    id: "src/lib.rs::low".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "low".to_string(),
+                },
+                Node {
+                    id: "src/lib.rs::c".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "c".to_string(),
+                },
+                Node {
+                    id: "src/lib.rs::d".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "d".to_string(),
+                },
+                Node {
+                    id: "src/lib.rs::e".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "e".to_string(),
+                },
+                Node {
+                    id: "src/lib.rs::high".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "high".to_string(),
+                },
+            ],
+            edges: vec![
+                Edge {
+                    from: "src/lib.rs::a".to_string(),
+                    to: "src/lib.rs::low".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "src/lib.rs::b".to_string(),
+                    to: "src/lib.rs::low".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "src/lib.rs::c".to_string(),
+                    to: "src/lib.rs::high".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "src/lib.rs::d".to_string(),
+                    to: "src/lib.rs::high".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "src/lib.rs::e".to_string(),
+                    to: "src/lib.rs::high".to_string(),
+                    is_cycle: false,
+                },
+            ],
+            roots: vec![
+                "src/lib.rs::a".to_string(),
+                "src/lib.rs::b".to_string(),
+                "src/lib.rs::c".to_string(),
+                "src/lib.rs::d".to_string(),
+                "src/lib.rs::e".to_string(),
+            ],
+        };
+
+        let expected = vec![
+            Hotspot {
+                id: "src/lib.rs::high".to_string(),
+                path: "src/lib.rs".to_string(),
+                name: "high".to_string(),
+                used_by: vec!["c".to_string(), "d".to_string(), "e".to_string()],
+            },
+            Hotspot {
+                id: "src/lib.rs::low".to_string(),
+                path: "src/lib.rs".to_string(),
+                name: "low".to_string(),
+                used_by: vec!["a".to_string(), "b".to_string()],
+            },
+        ];
+        let actual = compute_hotspots(&graph);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_break_fan_in_tie_by_path_then_name_when_counts_are_equal() {
+        // Both "b_target" (path b.rs) and "a_target" (path a.rs) have
+        // fan-in 2 — must sort a.rs before b.rs by path, not by discovery
+        // order in the edges list.
+        let graph = SymbolGraph {
+            nodes: vec![
+                Node {
+                    id: "b.rs::b_target".to_string(),
+                    path: "b.rs".to_string(),
+                    name: "b_target".to_string(),
+                },
+                Node {
+                    id: "a.rs::a_target".to_string(),
+                    path: "a.rs".to_string(),
+                    name: "a_target".to_string(),
+                },
+                Node {
+                    id: "b.rs::x".to_string(),
+                    path: "b.rs".to_string(),
+                    name: "x".to_string(),
+                },
+                Node {
+                    id: "b.rs::y".to_string(),
+                    path: "b.rs".to_string(),
+                    name: "y".to_string(),
+                },
+                Node {
+                    id: "a.rs::m".to_string(),
+                    path: "a.rs".to_string(),
+                    name: "m".to_string(),
+                },
+                Node {
+                    id: "a.rs::n".to_string(),
+                    path: "a.rs".to_string(),
+                    name: "n".to_string(),
+                },
+            ],
+            edges: vec![
+                Edge {
+                    from: "b.rs::x".to_string(),
+                    to: "b.rs::b_target".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "b.rs::y".to_string(),
+                    to: "b.rs::b_target".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "a.rs::m".to_string(),
+                    to: "a.rs::a_target".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "a.rs::n".to_string(),
+                    to: "a.rs::a_target".to_string(),
+                    is_cycle: false,
+                },
+            ],
+            roots: vec![
+                "b.rs::x".to_string(),
+                "b.rs::y".to_string(),
+                "a.rs::m".to_string(),
+                "a.rs::n".to_string(),
+            ],
+        };
+
+        let expected = vec![
+            Hotspot {
+                id: "a.rs::a_target".to_string(),
+                path: "a.rs".to_string(),
+                name: "a_target".to_string(),
+                used_by: vec!["m".to_string(), "n".to_string()],
+            },
+            Hotspot {
+                id: "b.rs::b_target".to_string(),
+                path: "b.rs".to_string(),
+                name: "b_target".to_string(),
+                used_by: vec!["x".to_string(), "y".to_string()],
+            },
+        ];
+        let actual = compute_hotspots(&graph);
+
+        assert_eq!(expected, actual);
     }
 
     #[test]

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -10,7 +10,7 @@
 use crate::deps::{Resolver, is_generated_content, resolve_dependencies};
 use crate::diff::{ChangeKind, parse_unified_diff};
 use crate::extract::{ExtractedSymbol, extract_changed_symbols};
-use crate::graph::{build_graph, stamp_ids};
+use crate::graph::{build_graph, compute_hotspots, stamp_ids};
 use crate::language::{LanguageSupport, language_for_path};
 use crate::render::{FileReport, Report, SkipReason, SkippedFile, TestFileSummary};
 use thiserror::Error;
@@ -190,12 +190,17 @@ pub fn analyze_diff(
     // avoids relying on that invariant holding forever).
     let graph = build_graph(&files);
     stamp_ids(&mut files, &graph);
+    // Computed from the same final `graph` as everything else above, so a
+    // hotspot's `used_by` names always match the stamped ids/nodes
+    // (ADR 0013).
+    let hotspots = compute_hotspots(&graph);
 
     Ok(Report {
         files,
         skipped,
         graph,
         tests,
+        hotspots,
     })
 }
 
@@ -336,6 +341,7 @@ mod tests {
             skipped: vec![],
             graph: empty_graph(),
             tests: vec![],
+            hotspots: vec![],
         };
         let actual = analyze_diff("", read_file, None, true, &HashSet::new(), true)
             .expect("analyze should succeed");
@@ -390,6 +396,7 @@ fn foo(a: i32) -> i32 {
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, true, &HashSet::new(), true)
             .expect("analyze should succeed");
@@ -421,6 +428,7 @@ index 4b825dc..0000000
             }],
             graph: empty_graph(),
             tests: vec![],
+            hotspots: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, true, &HashSet::new(), true)
             .expect("analyze should succeed");
@@ -445,6 +453,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
             }],
             graph: empty_graph(),
             tests: vec![],
+            hotspots: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, true, &HashSet::new(), true)
             .expect("analyze should succeed");
@@ -477,6 +486,7 @@ index e69de29..4b825dc 100644
             }],
             graph: empty_graph(),
             tests: vec![],
+            hotspots: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, true, &HashSet::new(), true)
             .expect("analyze should succeed");
@@ -513,6 +523,7 @@ rename to src/new_name.rs
             skipped: vec![],
             graph: empty_graph(),
             tests: vec![],
+            hotspots: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, true, &HashSet::new(), true)
             .expect("analyze should succeed");
@@ -612,6 +623,7 @@ index e69de29..4b825dc 100644
                 roots: vec!["src/lib.rs::a".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, true, &HashSet::new(), true)
             .expect("analyze should succeed");
@@ -945,6 +957,7 @@ fn should_add_two_numbers() {
                     roots: vec!["src/lib.rs::should_add_two_numbers".to_string()],
                 },
                 tests: vec![],
+                hotspots: vec![],
             };
             let actual = analyze_diff(diff, read_file, None, true, &HashSet::new(), true)
                 .expect("analyze should succeed");
@@ -1089,6 +1102,7 @@ mod tests {
                     path: "src/lib.rs".to_string(),
                     symbol_count: 1,
                 }],
+                hotspots: vec![],
             };
             let actual = analyze_diff(diff, read_file, None, false, &HashSet::new(), true)
                 .expect("analyze should succeed");
@@ -1271,6 +1285,7 @@ func Foo() int { return 2 }
                     roots: vec!["models/user.go::Foo".to_string()],
                 },
                 tests: vec![],
+                hotspots: vec![],
             };
             let actual = analyze_diff(diff, read_file, None, true, &HashSet::new(), true)
                 .expect("analyze should succeed");
@@ -1325,6 +1340,7 @@ fn foo(a: i32) -> i32 {
                     roots: vec!["src/lib.rs::foo".to_string()],
                 },
                 tests: vec![],
+                hotspots: vec![],
             };
             let actual = analyze_diff(diff, read_file, None, true, &HashSet::new(), false)
                 .expect("analyze should succeed");
@@ -1389,6 +1405,7 @@ index e69de29..4b825dc 100644
                     roots: vec!["src/lib.rs::foo".to_string()],
                 },
                 tests: vec![],
+                hotspots: vec![],
             };
             let actual = analyze_diff(diff, read_file, None, true, &HashSet::new(), false)
                 .expect("analyze should succeed");
@@ -1426,6 +1443,94 @@ index e69de29..4b825dc 100644
                 reason: SkipReason::Generated,
             }];
             assert_eq!(expected, report.skipped);
+        }
+    }
+
+    mod hotspots_tests {
+        use super::*;
+        use crate::graph::Hotspot;
+        use pretty_assertions::assert_eq;
+
+        // ADR 0013 end-to-end: two changed functions ("caller_one",
+        // "caller_two") both call "shared_helper" in the same file — fan-in
+        // 2 qualifies "shared_helper" as a hotspot, and `analyze_diff` must
+        // populate `Report::hotspots` from the graph it builds, not leave
+        // it empty.
+        #[test]
+        fn should_populate_hotspots_when_diff_has_a_symbol_with_fan_in_of_two() {
+            let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,11 +1,11 @@
+ fn shared_helper() -> i32 {
+-    0
++    1
+ }
+
+ fn caller_one() -> i32 {
+-    0
++    shared_helper()
+ }
+
+ fn caller_two() -> i32 {
+-    0
++    shared_helper()
+ }
+";
+            let source = "\
+fn shared_helper() -> i32 {
+    1
+}
+
+fn caller_one() -> i32 {
+    shared_helper()
+}
+
+fn caller_two() -> i32 {
+    shared_helper()
+}
+";
+            let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+
+            let report = analyze_diff(diff, read_file, None, true, &HashSet::new(), true)
+                .expect("analyze should succeed");
+
+            let expected = vec![Hotspot {
+                id: "src/lib.rs::shared_helper".to_string(),
+                path: "src/lib.rs".to_string(),
+                name: "shared_helper".to_string(),
+                used_by: vec!["caller_one".to_string(), "caller_two".to_string()],
+            }];
+            assert_eq!(expected, report.hotspots);
+        }
+
+        #[test]
+        fn should_return_empty_hotspots_when_no_node_has_fan_in_of_two() {
+            let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,3 @@
+ fn foo(a: i32) -> i32 {
+-    a
++    a + 1
+ }
+";
+            let source = "\
+fn foo(a: i32) -> i32 {
+    a + 1
+}
+";
+            let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+
+            let report = analyze_diff(diff, read_file, None, true, &HashSet::new(), true)
+                .expect("analyze should succeed");
+
+            let expected: Vec<Hotspot> = Vec::new();
+            assert_eq!(expected, report.hotspots);
         }
     }
 

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -1456,6 +1456,11 @@ index e69de29..4b825dc 100644
         // 2 qualifies "shared_helper" as a hotspot, and `analyze_diff` must
         // populate `Report::hotspots` from the graph it builds, not leave
         // it empty.
+        //
+        // NOTE: asserts only `report.hotspots` instead of the whole
+        // `Report` — files/graph/tests wiring is already covered by the
+        // surrounding analyze_diff tests, and this module's concern is
+        // solely that the hotspot aggregation is hooked up.
         #[test]
         fn should_populate_hotspots_when_diff_has_a_symbol_with_fan_in_of_two() {
             let diff = "\
@@ -1506,6 +1511,8 @@ fn caller_two() -> i32 {
             assert_eq!(expected, report.hotspots);
         }
 
+        // NOTE: partial assert on `report.hotspots` only, same rationale
+        // as the test above.
         #[test]
         fn should_return_empty_hotspots_when_no_node_has_fan_in_of_two() {
             let diff = "\

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -30,7 +30,7 @@
 //! signatures are noise (ADR 0009).
 
 use crate::extract::{ExtractedSymbol, SymbolKind};
-use crate::graph::{Node, NodeId, SymbolGraph};
+use crate::graph::{Hotspot, Node, NodeId, SymbolGraph};
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
@@ -51,6 +51,13 @@ pub struct Report {
     /// being summarized here. Source order (the order files were first
     /// encountered in the diff), same as `files`.
     pub tests: Vec<TestFileSummary>,
+    /// Fan-in hotspots (ADR 0013): changed symbols referenced by two or more
+    /// other changed symbols, sorted by fan-in descending. Derived from
+    /// `graph` via [`crate::graph::compute_hotspots`] and kept as its own
+    /// `Report` field (rather than recomputed at render time) so JSON
+    /// consumers get it without recomputing the aggregation themselves,
+    /// matching how `graph` itself is already exposed alongside `files`.
+    pub hotspots: Vec<Hotspot>,
 }
 
 /// Extracted symbols for a single changed file.
@@ -209,6 +216,21 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
         writeln!(out)?;
         render_change_graph(&mut out, &report.graph, &children, &lookup)?;
         writeln!(out)?;
+
+        if !report.hotspots.is_empty() {
+            writeln!(out, "## Hotspots")?;
+            writeln!(out)?;
+            for hotspot in &report.hotspots {
+                writeln!(
+                    out,
+                    "- {} — used by {}: {}",
+                    hotspot_label(hotspot, &lookup),
+                    hotspot.used_by.len(),
+                    hotspot.used_by.join(", ")
+                )?;
+            }
+            writeln!(out)?;
+        }
 
         writeln!(out, "## Definitions")?;
         writeln!(out)?;
@@ -530,6 +552,25 @@ fn tree_label(path: &str, symbol: &ExtractedSymbol) -> String {
     )
 }
 
+/// Builds the "Hotspots" line label for a [`Hotspot`], reusing
+/// [`tree_label`] via `lookup` so a hotspot's label is identical to how the
+/// same symbol is labeled in "Change graph"/"Definitions" (ADR 0013's
+/// requirement that labels stay consistent across sections) — including
+/// the `:{start_line}` disambiguation suffix when applicable.
+///
+/// Falls back to a bare `{name} ({path})` (no kind prefix) when `lookup` has
+/// no matching `ExtractedSymbol` for `hotspot.id` — defensive, since
+/// `pipeline::analyze_diff` always builds `hotspots` from the same `graph`
+/// whose node ids match `files`' stamped symbol ids (same invariant
+/// `render_tree_node`'s own lookup-miss guards rely on), so this branch is
+/// not expected to trigger in practice.
+fn hotspot_label(hotspot: &Hotspot, lookup: &SymbolLookup) -> String {
+    match lookup.get(&hotspot.id) {
+        Some((path, symbol)) => tree_label(path, symbol),
+        None => format!("{} ({})", hotspot.name, hotspot.path),
+    }
+}
+
 /// The `(path)` or `(path:start_line)` portion shared by [`tree_label`] and
 /// folded `— uses: ...` annotations (see `render_tree_node`).
 ///
@@ -733,6 +774,7 @@ mod tests {
                 roots: vec![],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "".to_string();
@@ -764,6 +806,7 @@ mod tests {
                 roots: vec![],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -807,6 +850,7 @@ mod tests {
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -852,6 +896,7 @@ fn foo()
                 roots: vec![],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -883,6 +928,7 @@ fn foo()
                 path: "src/lib.rs".to_string(),
                 symbol_count: 1,
             }],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -911,6 +957,7 @@ fn foo()
                 path: "src/lib.rs".to_string(),
                 symbol_count: 3,
             }],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -948,6 +995,7 @@ fn foo()
                 path: "src/lib.rs".to_string(),
                 symbol_count: 2,
             }],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -998,6 +1046,7 @@ fn foo()
                 roots: vec![],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "".to_string();
@@ -1029,6 +1078,7 @@ fn foo()
                 roots: vec![],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1062,6 +1112,7 @@ fn foo()
                 roots: vec![],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1078,7 +1129,8 @@ fn foo()
     \"edges\": [],
     \"roots\": []
   },
-  \"tests\": []
+  \"tests\": [],
+  \"hotspots\": []
 }"
         .to_string();
         let actual = render(&report, OutputFormat::Json).expect("json render succeeds");
@@ -1105,6 +1157,7 @@ fn foo()
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1155,6 +1208,7 @@ fn foo(a: i32) -> i32
                 ],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1189,6 +1243,7 @@ fn foo(a: i32) -> i32
                 roots: vec!["src/lib.rs::a".to_string(), "src/lib.rs::b".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1231,6 +1286,7 @@ fn foo(a: i32) -> i32
                 ],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1293,6 +1349,7 @@ fn foo(a: i32) -> i32
                 ],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1362,6 +1419,7 @@ fn foo(a: i32, b: i32)
                 roots: vec!["src/main.rs::handle_pr".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1442,6 +1500,7 @@ fn resolve_pr_base_sha() -> Result<String>
                 roots: vec!["src/lib.rs::a".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1528,6 +1587,7 @@ fn c()
                 roots: vec!["src/lib.rs::foo".to_string(), "src/lib.rs::bar".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1594,6 +1654,7 @@ fn bar()
                 roots: vec!["src/git.rs::resolve_pr_base_sha".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1702,6 +1763,7 @@ fn resolve_pr_base_sha()
                 ],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1813,6 +1875,7 @@ struct Config { path: String }
                 roots: vec!["store/items.go::UpsertItems".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1906,6 +1969,7 @@ type UpsertItemsResponse struct { Count int }
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -1986,6 +2050,7 @@ struct Dup { b: i32 }
                 roots: vec!["src/lib.rs::foo".to_string(), "src/lib.rs::bar".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2047,6 +2112,7 @@ fn bar()
                 roots: vec!["src/config.rs::Config".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2121,6 +2187,7 @@ struct Config { path: String }
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2199,6 +2266,7 @@ struct Inner { x: i32 }
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2253,6 +2321,7 @@ struct Node { next: Option<Box<Node>> }
                 roots: vec!["src/lib.rs::bar".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2303,6 +2372,7 @@ fn bar(&self) -> i32
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2361,6 +2431,7 @@ Depends on:
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2415,6 +2486,7 @@ Depends on:
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2471,6 +2543,7 @@ Depends on:
                 roots: vec!["src/lib.rs::example_macro".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2520,6 +2593,7 @@ fn example_macro() { let s = \"```rust\\nfn f() {}\\n```\"; }
                 roots: vec!["src/lib.rs::bar".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2569,6 +2643,7 @@ fn bar(&self) -> i32
                 roots: vec![],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2606,6 +2681,7 @@ fn bar(&self) -> i32
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2626,6 +2702,209 @@ fn foo()
 ## Skipped files
 
 - assets/logo.png (binary)
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_omit_hotspots_section_when_hotspots_is_empty() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    SymbolKind::Function,
+                    "fn foo()",
+                )],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
+            tests: vec![],
+            hotspots: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+1 changed symbol in 1 file
+
+- fn foo (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo()
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_hotspots_section_between_change_graph_and_definitions_when_hotspots_is_non_empty()
+     {
+        // `UpsertItemsRequest` (a struct) is referenced by two changed
+        // functions — the label reuses tree_label's `{kind} {name}
+        // ({path})` form, so the line reads
+        // "struct UpsertItemsRequest (store/items.go) — used by 2: ..."
+        // exactly as the ADR spec requires, and used_by names are joined
+        // in the order `compute_hotspots` already sorted them in (not
+        // re-sorted here).
+        let report = Report {
+            files: vec![FileReport {
+                path: "store/items.go".to_string(),
+                symbols: vec![
+                    symbol(
+                        "store/items.go::HandleFoo",
+                        "HandleFoo",
+                        SymbolKind::Function,
+                        "func HandleFoo(req UpsertItemsRequest) error",
+                    ),
+                    symbol(
+                        "store/items.go::HandleBar",
+                        "HandleBar",
+                        SymbolKind::Function,
+                        "func HandleBar(req UpsertItemsRequest) error",
+                    ),
+                    symbol(
+                        "store/items.go::UpsertItemsRequest",
+                        "UpsertItemsRequest",
+                        SymbolKind::Struct,
+                        "type UpsertItemsRequest struct { Items []Item }",
+                    ),
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("store/items.go::HandleFoo", "store/items.go", "HandleFoo"),
+                    node("store/items.go::HandleBar", "store/items.go", "HandleBar"),
+                    node(
+                        "store/items.go::UpsertItemsRequest",
+                        "store/items.go",
+                        "UpsertItemsRequest",
+                    ),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "store/items.go::HandleFoo".to_string(),
+                        to: "store/items.go::UpsertItemsRequest".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "store/items.go::HandleBar".to_string(),
+                        to: "store/items.go::UpsertItemsRequest".to_string(),
+                        is_cycle: false,
+                    },
+                ],
+                roots: vec![
+                    "store/items.go::HandleFoo".to_string(),
+                    "store/items.go::HandleBar".to_string(),
+                ],
+            },
+            tests: vec![],
+            hotspots: vec![Hotspot {
+                id: "store/items.go::UpsertItemsRequest".to_string(),
+                path: "store/items.go".to_string(),
+                name: "UpsertItemsRequest".to_string(),
+                used_by: vec!["HandleBar".to_string(), "HandleFoo".to_string()],
+            }],
+        };
+
+        let expected = "\
+## Change graph
+
+3 changed symbols in 1 file
+
+- fn HandleFoo (store/items.go) — uses: UpsertItemsRequest
+- fn HandleBar (store/items.go) — uses: UpsertItemsRequest
+
+## Hotspots
+
+- struct UpsertItemsRequest (store/items.go) — used by 2: HandleBar, HandleFoo
+
+## Definitions
+
+### fn HandleFoo (store/items.go)
+
+```
+func HandleFoo(req UpsertItemsRequest) error
+```
+
+### struct UpsertItemsRequest (store/items.go)
+
+```
+type UpsertItemsRequest struct { Items []Item }
+```
+
+### fn HandleBar (store/items.go)
+
+```
+func HandleBar(req UpsertItemsRequest) error
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_hotspot_line_for_symbol_with_no_matching_definition() {
+        // Same defensive rationale as the "NOTE" block below: `hotspots`
+        // could in principle reference a node id with no corresponding
+        // `ExtractedSymbol` in `files` (the node is present in `graph`, so
+        // the empty-output guard does not short-circuit, but `files` itself
+        // has no matching symbol — mirroring the other lookup-miss tests'
+        // setup). Unlike "Change graph"/"Definitions" (which use
+        // `SymbolLookup`, keyed by symbol id, to find the container/
+        // signature and skip the line entirely on a miss), the "Hotspots"
+        // line still renders on a lookup miss, falling back to a bare
+        // `{name} ({path})` label with no kind prefix, rather than being
+        // dropped outright.
+        let report = Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::ghost", "src/lib.rs", "ghost")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::ghost".to_string()],
+            },
+            tests: vec![],
+            hotspots: vec![Hotspot {
+                id: "src/lib.rs::ghost".to_string(),
+                path: "src/lib.rs".to_string(),
+                name: "ghost".to_string(),
+                used_by: vec!["a".to_string(), "b".to_string()],
+            }],
+        };
+
+        let expected = "\
+## Change graph
+
+1 changed symbol in 1 file
+
+
+## Hotspots
+
+- ghost (src/lib.rs) — used by 2: a, b
+
+## Definitions
+
 "
         .to_string();
         let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
@@ -2657,6 +2936,7 @@ fn foo()
                 roots: vec!["src/lib.rs::ghost".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2689,6 +2969,7 @@ fn foo()
                 roots: vec!["src/lib.rs::ghost".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2739,6 +3020,7 @@ fn foo()
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2785,6 +3067,7 @@ fn foo()
                 roots: vec!["src/lib.rs::foo".to_string()],
             },
             tests: vec![],
+            hotspots: vec![],
         };
 
         let expected = "\
@@ -2828,7 +3111,8 @@ fn foo()
       \"src/lib.rs::foo\"
     ]
   },
-  \"tests\": []
+  \"tests\": [],
+  \"hotspots\": []
 }"
         .to_string();
         let actual = render(&report, OutputFormat::Json).expect("json render succeeds");

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -354,6 +354,7 @@ fn run_base_pipeline(
                 roots: Vec::new(),
             },
             tests: Vec::new(),
+            hotspots: Vec::new(),
         });
     }
 
@@ -3131,6 +3132,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
                     roots: Vec::new(),
                 },
                 tests: Vec::new(),
+                hotspots: Vec::new(),
             },
             actual.expect("empty diff must not touch the repository-wide index scan")
         );
@@ -3218,6 +3220,7 @@ fn should_add_two_numbers() {
                 skipped: vec![],
                 graph: empty_graph(),
                 tests: vec![],
+                hotspots: vec![],
             }
         }
 
@@ -3230,6 +3233,7 @@ fn should_add_two_numbers() {
                 skipped: vec![],
                 graph: empty_graph(),
                 tests: vec![],
+                hotspots: vec![],
             }
         }
 
@@ -3274,6 +3278,7 @@ fn should_add_two_numbers() {
                 }],
                 graph: empty_graph(),
                 tests: vec![],
+                hotspots: vec![],
             };
 
             let actual = garbage_input_note("some diff text", &report);
@@ -3297,6 +3302,7 @@ fn should_add_two_numbers() {
                     path: "src/lib.rs".to_string(),
                     symbol_count: 1,
                 }],
+                hotspots: vec![],
             };
 
             let actual = garbage_input_note("some diff text", &report);
@@ -3332,6 +3338,7 @@ fn should_add_two_numbers() {
                 ],
                 graph: empty_graph(),
                 tests: vec![],
+                hotspots: vec![],
             };
 
             let actual = garbage_input_note("some diff text", &report);


### PR DESCRIPTION
## Summary

Implements ADR 0013 (#42): answers review question B — "what breaks if I
touch this?" — which the entry-point tree structurally suppresses
(shared dependencies collapse to `(see above)` / `— uses:` notes).

- `compute_hotspots` in `rinkaku-core::graph`: pure aggregation of
  `graph.edges` grouped by target, keeping nodes with fan-in >= 2.
  Referrers are deduplicated per referrer *node* (not name), cycle edges
  count as real references, and results sort by fan-in descending with
  `(path, name)` tie-breaks for determinism.
- `Report.hotspots`: populated in `analyze_diff` from the same graph as
  everything else; serializes to JSON as an additive `hotspots` field.
- Markdown: new `## Hotspots` section between `## Change graph` and
  `## Definitions`, omitted when empty:

  ```markdown
  ## Hotspots

  - struct FooRequest (api/types.go) — used by 3: HandleBar, HandleFoo, SyncFoo
  ```

  Labels reuse `tree_label` so a symbol is labeled identically across
  sections.

## Test plan

- `make test` (270 tests) and `make lint` pass.
- New unit tests: aggregation (fan-in counting, name sorting, cycle
  edges, referrer dedup, ordering and tie-breaks), pipeline wiring
  (populated / empty), Markdown section placement and exact formatting,
  JSON round-trip including empty `hotspots`.

Depends on ADR 0013 in #42 (docs only; no code dependency).

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync