### PR TITLE
feat: add interactive TUI with directory-tree entry view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,6 +2061,7 @@ dependencies = [
  "log",
  "pretty_assertions",
  "rinkaku-core",
+ "rinkaku-tui",
  "rstest",
  "self_update",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,6 +1320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rinkaku-tui"
+version = "0.1.0"
+dependencies = [
+ "pretty_assertions",
+ "rinkaku-core",
+ "rstest",
+]
+
+[[package]]
 name = "rstest"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,10 +80,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -90,6 +120,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -119,10 +164,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -188,7 +254,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -202,6 +268,20 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "console"
@@ -221,6 +301,15 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -250,6 +339,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +379,16 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -283,7 +415,41 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -305,7 +471,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -314,8 +480,14 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der"
@@ -325,6 +497,34 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -351,7 +551,16 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -431,6 +640,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +675,17 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
 
 [[package]]
 name = "filetime"
@@ -459,6 +704,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +730,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -539,7 +802,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -602,6 +865,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -609,7 +884,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -641,15 +916,37 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -833,6 +1130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,7 +1163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -877,6 +1180,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +1212,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -916,7 +1250,7 @@ checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -931,10 +1265,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -949,10 +1321,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -961,10 +1357,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -983,8 +1410,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1006,10 +1492,160 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1050,6 +1686,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pretty_assertions"
@@ -1102,7 +1744,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1117,14 +1759,14 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1155,9 +1797,24 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "rand"
@@ -1192,6 +1849,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
+ "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1311,7 +2078,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tree-sitter",
  "tree-sitter-go",
  "tree-sitter-python",
@@ -1323,7 +2090,9 @@ dependencies = [
 name = "rinkaku-tui"
 version = "0.1.0"
 dependencies = [
+ "crossterm",
  "pretty_assertions",
+ "ratatui",
  "rinkaku-core",
  "rstest",
 ]
@@ -1354,7 +2123,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.118",
  "unicode-ident",
 ]
 
@@ -1434,6 +2203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "self-replace"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,7 +2275,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1547,6 +2322,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +2367,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1601,6 +2413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,10 +2431,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1646,7 +2496,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1674,12 +2524,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1690,8 +2636,29 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
@@ -1922,10 +2889,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "unicode-width"
@@ -1970,10 +2960,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "want"
@@ -1989,6 +3000,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2032,7 +3052,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -2073,6 +3093,100 @@ checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2181,6 +3295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,7 +3341,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2242,7 +3362,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2282,7 +3402,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2293,7 +3413,7 @@ checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
 dependencies = [
  "base64",
  "ed25519-dalek",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,7 +2091,6 @@ dependencies = [
 name = "rinkaku-tui"
 version = "0.1.0"
 dependencies = [
- "crossterm",
  "pretty_assertions",
  "ratatui",
  "rinkaku-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["rinkaku-core", "rinkaku"]
+members = ["rinkaku-core", "rinkaku-tui", "rinkaku"]
 
 [workspace.package]
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ tempfile = "3.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 self_update = { version = "0.42", default-features = false, features = ["archive-tar", "compression-flate2", "rustls"] }
-# Only rinkaku-tui depends on these (ADR 0016 decision 2): rinkaku-core's
-# dependency set stays untouched.
+# Only rinkaku-tui depends on this (ADR 0016 decision 2): rinkaku-core's
+# dependency set stays untouched. crossterm is not declared separately —
+# rinkaku-tui uses ratatui's own `ratatui::crossterm` re-export instead of
+# depending on crossterm directly (see rinkaku-tui/Cargo.toml).
 ratatui = "0.30"
-crossterm = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ tempfile = "3.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 self_update = { version = "0.42", default-features = false, features = ["archive-tar", "compression-flate2", "rustls"] }
+# Only rinkaku-tui depends on these (ADR 0016 decision 2): rinkaku-core's
+# dependency set stays untouched.
+ratatui = "0.30"
+crossterm = "0.29"

--- a/README.md
+++ b/README.md
@@ -449,7 +449,10 @@ rather than combining with it.
   highlighting the symbol's line range; `esc`/`q` returns to the entry
   view. Reads the working tree directly (not the historical commit a
   `--base`/`--pr` diff was computed against), so it always shows the
-  file's current content.
+  file's current content — note that the highlighted line range itself is
+  from analysis time, so it can drift (or, if the file has since shrunk,
+  get clamped to the end of the file) if you edit the file after opening
+  the TUI.
 
 ### Key bindings
 

--- a/README.md
+++ b/README.md
@@ -460,10 +460,10 @@ rather than combining with it.
 | --- | --- |
 | `j` / `k` / `↓` / `↑` | Move the cursor |
 | `enter` / `space` | Expand or collapse a directory/file row |
-| `e` | Expand every row |
-| `c` | Collapse every row |
-| `o` | Toggle topological / alphabetical ordering |
-| `s` | Open the source view for the symbol under the cursor |
+| `e` / `E` | Expand every row |
+| `c` / `C` | Collapse every row |
+| `o` / `O` | Toggle topological / alphabetical ordering |
+| `s` / `S` | Open the source view for the symbol under the cursor |
 | `esc` / `q` | Return to the entry view (from the source view) |
 | `q` / `ctrl-c` | Quit (from the entry view) |
 

--- a/README.md
+++ b/README.md
@@ -413,14 +413,71 @@ Pass `--include-generated` to restore the previous behavior (generated
 files — by either detection method — are analyzed like any other file, in
 both output formats).
 
+## Interactive TUI
+
+Markdown/JSON stay optimized for LLMs and CI ([ADR 0015](docs/adr/0015-tui-for-humans-markdown-for-machines.md));
+for a human reviewing a change in a terminal, pass `--tui` instead of
+`--format` to open an interactive terminal UI ([ADR 0016](docs/adr/0016-tui-crate-and-stack.md)),
+built with [ratatui](https://ratatui.rs):
+
+```sh
+rinkaku --base main --tui
+```
+
+`--tui` takes the same input flow as every other mode (stdin / `--base` /
+`--pr`) and only changes the output stage, so it conflicts with `--format`
+rather than combining with it.
+
+### What it shows
+
+- **Entry pane (left):** the directory tree of changed files, not the
+  call-graph tree — nesting depth mirrors your repository's layout.
+  Directories and files carry badges: `~N` changed symbols, `!N` contract
+  changes (added/removed/signature-changed), `^N` fan-in (hotspot
+  aggregate). A directory that participates in a dependency cycle is
+  marked `(cycle)`. By default, sibling directories are ordered
+  topologically — entry points (least depended-on) first, foundations
+  (most depended-on) last — the same shape the "Change graph" root-finding
+  uses in Markdown, condensed to the directory level; `o` toggles to plain
+  alphabetical order. Symbol rows show a kind abbreviation (`fn`, `struct`,
+  ...) and a classification marker: `+` added, `~` signature-changed, `x`
+  removed (dimmed and crossed out).
+- **Detail pane (right):** the symbol under the cursor — its
+  classification, signature (an old/new diff when the contract changed),
+  who depends on it ("used by"), and its callees.
+- **Source view:** `s` on a symbol row opens that file, scrolled to and
+  highlighting the symbol's line range; `esc`/`q` returns to the entry
+  view. Reads the working tree directly (not the historical commit a
+  `--base`/`--pr` diff was computed against), so it always shows the
+  file's current content.
+
+### Key bindings
+
+| Key(s) | Action |
+| --- | --- |
+| `j` / `k` / `↓` / `↑` | Move the cursor |
+| `enter` / `space` | Expand or collapse a directory/file row |
+| `e` | Expand every row |
+| `c` | Collapse every row |
+| `o` | Toggle topological / alphabetical ordering |
+| `s` | Open the source view for the symbol under the cursor |
+| `esc` / `q` | Return to the entry view (from the source view) |
+| `q` / `ctrl-c` | Quit (from the entry view) |
+
+Glyphs are plain ASCII (`~`/`!`/`^`/`+`/`x`, `v`/`>` for expand state)
+rather than Unicode/emoji, for compatibility with plainer terminal
+configurations.
+
 ## Development
 
 Requires a Rust toolchain (pinned in [`rust-toolchain.toml`](rust-toolchain.toml);
 `rustup` will install it automatically).
 
-The workspace has two crates: `rinkaku-core` (the pure diff-condensation
-library, published standalone so it can be embedded in other tools) and
-`rinkaku` (the thin CLI binary, depending on `rinkaku-core`).
+The workspace has three crates: `rinkaku-core` (the pure diff-condensation
+library, published standalone so it can be embedded in other tools),
+`rinkaku-tui` (the interactive terminal UI's view-models and `ratatui`
+rendering, depending on `rinkaku-core`; see [ADR 0016](docs/adr/0016-tui-crate-and-stack.md)),
+and `rinkaku` (the thin CLI binary, depending on both).
 
 ```sh
 make test    # cargo test --all-features

--- a/rinkaku-tui/Cargo.toml
+++ b/rinkaku-tui/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "rinkaku-tui"
+# See rinkaku-core/Cargo.toml for why this is a literal version instead
+# of `version.workspace = true`.
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Interactive terminal UI view-models for rinkaku (ADR 0015/0016): directory tree, navigation, and detail views over a Report"
+readme = "../README.md"
+keywords = ["diff", "tui", "code-review"]
+categories = ["development-tools"]
+
+[lib]
+name = "rinkaku_tui"
+path = "src/lib.rs"
+
+[dependencies]
+rinkaku-core = { path = "../rinkaku-core", version = "0.1.0" }
+
+[dev-dependencies]
+rstest = { workspace = true }
+pretty_assertions = { workspace = true }

--- a/rinkaku-tui/Cargo.toml
+++ b/rinkaku-tui/Cargo.toml
@@ -18,8 +18,11 @@ path = "src/lib.rs"
 
 [dependencies]
 rinkaku-core = { path = "../rinkaku-core", version = "0.1.0" }
+# crossterm itself is not a direct dependency: every use goes through
+# ratatui's own `ratatui::crossterm` re-export, which pins the matching
+# version internally (see ratatui-crossterm) — declaring it here too would
+# just be a second, redundant version to keep in sync.
 ratatui = { workspace = true }
-crossterm = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/rinkaku-tui/Cargo.toml
+++ b/rinkaku-tui/Cargo.toml
@@ -18,6 +18,8 @@ path = "src/lib.rs"
 
 [dependencies]
 rinkaku-core = { path = "../rinkaku-core", version = "0.1.0" }
+ratatui = { workspace = true }
+crossterm = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -1,0 +1,427 @@
+//! Interactive application state (stage B, ADR 0015/0016): composes the
+//! stage-A view-models (`crate::tree`, `crate::nav`, `crate::order`,
+//! `crate::detail`) into one state machine driven by user key input.
+//!
+//! [`App::handle_key`] is a pure transition — no `ratatui`/`crossterm`
+//! types in this module's public signatures, mirroring the discipline
+//! `crate::nav`'s doc comment already establishes. The event loop
+//! (`crate::run`) is the only place that translates a real
+//! `crossterm::event::KeyEvent` into this module's [`InputKey`] and calls
+//! into `ratatui` to draw.
+
+use crate::detail::{DetailView, build_detail};
+use crate::nav::{Action, Nav};
+use crate::order::{DirRank, OrderMode, rank_directories};
+use crate::tree::{NodeKind, Tree, build_tree};
+use rinkaku_core::render::Report;
+use std::collections::HashMap;
+
+/// A user key press, already stripped of `crossterm`-specific detail
+/// (repeat/release events, modifier bitflags irrelevant to this app) down
+/// to exactly the variants the app reacts to. Built by `crate::run`'s
+/// event loop from a real `crossterm::event::KeyEvent`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputKey {
+    Up,
+    Down,
+    /// Enter or Space: expand/collapse a directory row, or open the
+    /// source view on a symbol row (`App::handle_key`'s doc comment).
+    Select,
+    /// `e`/`E`: expand every row.
+    ExpandAll,
+    /// `c`/`C`: collapse every row.
+    CollapseAll,
+    /// `o`: toggle topological/alphabetical ordering.
+    ToggleOrder,
+    /// `s`: open the source view on the row under the cursor (a symbol
+    /// row only — see `App::handle_key`).
+    Source,
+    /// Esc or `q` while in the source view: return to the entry view.
+    /// A no-op on the entry view itself (`q`'s quit behavior on the entry
+    /// view is `InputKey::Quit`, a separate variant, since Esc has no
+    /// "back" target to return to there).
+    Back,
+    /// `q` or Ctrl-C on the entry view: exit the application.
+    Quit,
+}
+
+/// Which pane is currently on screen. The directory tree (`Entry`) is
+/// always the spine; `Source` is a drill-down reached from a symbol row
+/// and returns to `Entry` on `InputKey::Back` (ADR 0015: "the reviewer
+/// never leaves the terminal to open an editor", reached on demand rather
+/// than replacing the entry view permanently).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Screen {
+    Entry,
+    /// `symbol_id` is the symbol whose source is shown, kept as an id
+    /// (not owned source text) so `App` stays cheap to clone/compare in
+    /// tests — `crate::run`'s event loop resolves the actual file content
+    /// via `crate::source` only when it redraws.
+    Source {
+        symbol_id: String,
+    },
+}
+
+/// The whole interactive application's state: the stage-A view-models
+/// composed together, plus which screen is active and a status-line
+/// message for the caller to render. Rebuilt once per `Report` (in
+/// [`App::new`]) and then evolved purely via [`App::handle_key`] — no
+/// field here is re-derived from IO after construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct App {
+    tree: Tree,
+    nav: Nav,
+    ranks: HashMap<String, DirRank>,
+    order_mode: OrderMode,
+    screen: Screen,
+    /// A transient message for the status line (e.g. a source-read
+    /// failure) — cleared on the next action that doesn't re-set it, so a
+    /// stale error doesn't linger forever once the user has moved on.
+    status: Option<String>,
+    should_quit: bool,
+}
+
+impl App {
+    /// Builds the initial application state from `report`: the directory
+    /// tree, its topological ranks, and a fresh [`Nav`] with everything
+    /// expanded and the cursor on the first row (`Nav::new`'s own doc
+    /// comment). Starts on [`Screen::Entry`] in [`OrderMode::Topological`]
+    /// (ADR 0016 decision 4's default), ordered immediately so the first
+    /// frame already reflects it rather than showing source order for one
+    /// tick.
+    pub fn new(report: &Report) -> Self {
+        let mut tree = build_tree(report);
+        let ranks = rank_directories(report);
+        let order_mode = OrderMode::default();
+        crate::order::order_tree(&mut tree, &ranks, order_mode);
+
+        Self {
+            tree,
+            nav: Nav::new(),
+            ranks,
+            order_mode,
+            screen: Screen::Entry,
+            status: None,
+            should_quit: false,
+        }
+    }
+
+    pub fn tree(&self) -> &Tree {
+        &self.tree
+    }
+
+    pub fn nav(&self) -> &Nav {
+        &self.nav
+    }
+
+    pub fn order_mode(&self) -> OrderMode {
+        self.order_mode
+    }
+
+    /// Every directory's computed [`DirRank`], keyed by path — exposed so
+    /// `crate::ui`/`crate::row_view` can show the cycle-warning marker on
+    /// a directory row without recomputing `rank_directories` (which would
+    /// also require re-threading a `Report` reference into rendering just
+    /// for this) or duplicating the map onto every row.
+    pub fn ranks(&self) -> &HashMap<String, DirRank> {
+        &self.ranks
+    }
+
+    pub fn screen(&self) -> &Screen {
+        &self.screen
+    }
+
+    pub fn status(&self) -> Option<&str> {
+        self.status.as_deref()
+    }
+
+    pub fn should_quit(&self) -> bool {
+        self.should_quit
+    }
+
+    /// The detail view for the row currently under the cursor, or `None`
+    /// when the cursor is not on a present (non-removed) symbol row, there
+    /// are no rows at all, or `report` no longer contains that symbol
+    /// (defensive — `report` should be the same one `App::new` was built
+    /// from). `report` is threaded in per call rather than stored on `App`
+    /// itself, since `build_detail` is already a cheap pure lookup and
+    /// storing a whole `Report` on every `App` would duplicate data the
+    /// caller (`crate::run`) already owns for the process's lifetime.
+    pub fn selected_detail(&self, report: &Report) -> Option<DetailView> {
+        let rows = self.nav.rows(&self.tree);
+        let row = rows.get(self.nav.cursor())?;
+        match &row.node.kind {
+            NodeKind::Symbol(symbol_ref) if !symbol_ref.removed => {
+                build_detail(report, &symbol_ref.id)
+            }
+            _ => None,
+        }
+    }
+
+    /// Applies one [`InputKey`] and returns the next `App`. `report` is
+    /// needed only for [`InputKey::Source`] (to confirm the row under the
+    /// cursor is a present symbol before switching screens — the actual
+    /// file read happens later, in `crate::run`, once `Screen::Source` is
+    /// active) and is otherwise unused.
+    pub fn handle_key(mut self, key: InputKey) -> Self {
+        self.status = None;
+
+        match (&self.screen, key) {
+            (Screen::Source { .. }, InputKey::Back) => {
+                self.screen = Screen::Entry;
+            }
+            // Every other key is a no-op while the source view is open —
+            // navigation/reordering only make sense against the entry
+            // view's tree, and re-dispatching them would silently move
+            // the cursor underneath a screen the user can't see moving.
+            (Screen::Source { .. }, _) => {}
+
+            (Screen::Entry, InputKey::Quit) => {
+                self.should_quit = true;
+            }
+            (Screen::Entry, InputKey::Up) => {
+                self.nav = self.nav.handle(Action::CursorUp, &self.tree);
+            }
+            (Screen::Entry, InputKey::Down) => {
+                self.nav = self.nav.handle(Action::CursorDown, &self.tree);
+            }
+            (Screen::Entry, InputKey::Select) => {
+                self.nav = self.nav.handle(Action::ToggleExpand, &self.tree);
+            }
+            (Screen::Entry, InputKey::ExpandAll) => {
+                self.nav = self.nav.handle(Action::ExpandAll, &self.tree);
+            }
+            (Screen::Entry, InputKey::CollapseAll) => {
+                self.nav = self.nav.handle(Action::CollapseAll, &self.tree);
+            }
+            (Screen::Entry, InputKey::ToggleOrder) => {
+                self.order_mode = match self.order_mode {
+                    OrderMode::Topological => OrderMode::AlphaNumeric,
+                    OrderMode::AlphaNumeric => OrderMode::Topological,
+                };
+                crate::order::order_tree(&mut self.tree, &self.ranks, self.order_mode);
+            }
+            (Screen::Entry, InputKey::Source) => {
+                let rows = self.nav.rows(&self.tree);
+                if let Some(row) = rows.get(self.nav.cursor())
+                    && let NodeKind::Symbol(symbol_ref) = &row.node.kind
+                    && !symbol_ref.removed
+                {
+                    self.screen = Screen::Source {
+                        symbol_id: symbol_ref.id.clone(),
+                    };
+                }
+            }
+            (Screen::Entry, InputKey::Back) => {
+                // No-op: Esc/q-as-back on the entry view has nowhere to
+                // return to. Quitting from the entry view is the
+                // dedicated `InputKey::Quit` variant instead.
+            }
+        }
+
+        self
+    }
+
+    /// Sets the status-line message directly — used by `crate::run` to
+    /// surface a source-read failure (`ADR 0016`: file reads are
+    /// adapter-side IO, so a failure there is reported back into this
+    /// pure state rather than handled inside this module).
+    pub fn set_status(&mut self, message: impl Into<String>) {
+        self.status = Some(message.into());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+    use rinkaku_core::graph::SymbolGraph;
+    use rinkaku_core::render::FileReport;
+
+    fn symbol(id: &str, name: &str) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature: format!("fn {name}()"),
+            range: LineRange { start: 1, end: 1 },
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        }
+    }
+
+    fn empty_report() -> Report {
+        Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    fn report_with_one_symbol() -> Report {
+        Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo")],
+            }],
+            ..empty_report()
+        }
+    }
+
+    #[test]
+    fn should_start_on_entry_screen_with_topological_order_and_no_status() {
+        let report = report_with_one_symbol();
+
+        let app = App::new(&report);
+
+        assert_eq!(Screen::Entry, *app.screen());
+        assert_eq!(OrderMode::Topological, app.order_mode());
+        assert_eq!(None, app.status());
+        assert_eq!(false, app.should_quit());
+    }
+
+    #[test]
+    fn should_set_should_quit_when_quit_is_pressed_on_entry_screen() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let app = app.handle_key(InputKey::Quit);
+
+        assert_eq!(true, app.should_quit());
+    }
+
+    #[test]
+    fn should_move_cursor_down_when_down_is_pressed() {
+        // lib.rs has one file row and one symbol row; Down should move off
+        // the initial cursor position (0) onto the symbol row (1).
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+
+        let app = app.handle_key(InputKey::Down);
+
+        assert_eq!(1, app.nav().cursor());
+    }
+
+    #[test]
+    fn should_toggle_order_mode_between_topological_and_alpha_numeric() {
+        let report = empty_report();
+        let app = App::new(&report);
+        assert_eq!(OrderMode::Topological, app.order_mode());
+
+        let app = app.handle_key(InputKey::ToggleOrder);
+        assert_eq!(OrderMode::AlphaNumeric, app.order_mode());
+
+        let app = app.handle_key(InputKey::ToggleOrder);
+        assert_eq!(OrderMode::Topological, app.order_mode());
+    }
+
+    #[test]
+    fn should_open_source_screen_when_source_key_is_pressed_on_a_symbol_row() {
+        let report = report_with_one_symbol();
+        // Row 0 is the "lib.rs" file, row 1 is the "foo" symbol.
+        let app = App::new(&report).handle_key(InputKey::Down);
+
+        let app = app.handle_key(InputKey::Source);
+
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string()
+            },
+            *app.screen()
+        );
+    }
+
+    #[test]
+    fn should_stay_on_entry_screen_when_source_key_is_pressed_on_a_file_row() {
+        let report = report_with_one_symbol();
+        // Row 0 is the "lib.rs" file row itself, not a symbol.
+        let app = App::new(&report);
+
+        let app = app.handle_key(InputKey::Source);
+
+        assert_eq!(Screen::Entry, *app.screen());
+    }
+
+    #[test]
+    fn should_return_to_entry_screen_when_back_is_pressed_on_source_screen() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Source);
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string()
+            },
+            *app.screen()
+        );
+
+        let app = app.handle_key(InputKey::Back);
+
+        assert_eq!(Screen::Entry, *app.screen());
+    }
+
+    #[test]
+    fn should_ignore_navigation_keys_while_source_screen_is_open() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Source);
+        let cursor_before = app.nav().cursor();
+
+        let app = app.handle_key(InputKey::Down);
+
+        assert_eq!(cursor_before, app.nav().cursor());
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string()
+            },
+            *app.screen()
+        );
+    }
+
+    #[test]
+    fn should_clear_status_message_on_the_next_handled_key() {
+        let report = empty_report();
+        let mut app = App::new(&report);
+        app.set_status("a source read failed");
+        assert_eq!(Some("a source read failed"), app.status());
+
+        let app = app.handle_key(InputKey::Down);
+
+        assert_eq!(None, app.status());
+    }
+
+    #[test]
+    fn should_return_none_detail_when_cursor_is_on_a_directory_row() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+
+        let actual = app.selected_detail(&report);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_return_detail_view_when_cursor_is_on_a_symbol_row() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(InputKey::Down);
+
+        let actual = app.selected_detail(&report);
+
+        assert_eq!("foo", actual.expect("detail for selected symbol").name);
+    }
+}

--- a/rinkaku-tui/src/detail.rs
+++ b/rinkaku-tui/src/detail.rs
@@ -119,12 +119,21 @@ pub fn build_detail(report: &Report, id: &str) -> Option<DetailView> {
     // endpoint's id before collecting mentions keeps a duplicate edge from
     // making the same caller/callee show up twice in the detail pane's
     // pivots, mirroring `compute_hotspots`'s own dedup-by-referrer-id.
+    //
+    // Self-edges (`from == to == id`) are filtered the same defensive way:
+    // `collect_edges` in `rinkaku-core::graph` explicitly excludes them
+    // (`if target.id != from.id`), so they cannot occur through the normal
+    // pipeline today, but — same reasoning as the dedup above — this
+    // function's own contract does not want to depend on that staying true
+    // forever. Without this filter, a hypothetical self-edge would make a
+    // symbol list itself as its own caller/callee/used-by, which is never
+    // a meaningful pivot to show a reviewer.
     let mut seen_callees = HashSet::new();
     let callees: Vec<SymbolMention> = report
         .graph
         .edges
         .iter()
-        .filter(|edge| edge.from == id)
+        .filter(|edge| edge.from == id && edge.to != id)
         .filter(|edge| seen_callees.insert(edge.to.as_str()))
         .filter_map(|edge| mentions_by_id(&edge.to))
         .collect();
@@ -134,7 +143,7 @@ pub fn build_detail(report: &Report, id: &str) -> Option<DetailView> {
         .graph
         .edges
         .iter()
-        .filter(|edge| edge.to == id)
+        .filter(|edge| edge.to == id && edge.from != id)
         .filter(|edge| seen_callers.insert(edge.from.as_str()))
         .filter_map(|edge| mentions_by_id(&edge.from))
         .collect();
@@ -502,5 +511,38 @@ mod tests {
         assert_eq!(expected_caller_mention, callee_detail.callers);
         assert_eq!(expected_caller_mention, callee_detail.used_by);
         assert_eq!(expected_callee_mention, caller_detail.callees);
+    }
+
+    // SHOULD-FIX 5: `rinkaku-core::graph::collect_edges` explicitly excludes
+    // self-edges (`if target.id != from.id`), so a self-edge cannot occur
+    // through the normal pipeline today — but `build_detail`'s own contract
+    // should not rely on that staying true forever, same reasoning as the
+    // duplicate-edge dedup above. This pins the defensive filter with a
+    // hand-built graph containing a self-edge no real `build_graph` call
+    // would currently produce.
+    #[test]
+    fn should_exclude_self_edge_from_callers_callees_and_used_by() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::recursive", "recursive")],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![node("lib.rs::recursive", "lib.rs", "recursive")],
+                edges: vec![Edge {
+                    from: "lib.rs::recursive".to_string(),
+                    to: "lib.rs::recursive".to_string(),
+                    is_cycle: false,
+                }],
+                roots: vec!["lib.rs::recursive".to_string()],
+            },
+            ..empty_report()
+        };
+
+        let actual = build_detail(&report, "lib.rs::recursive").expect("symbol found");
+
+        assert_eq!(Vec::<SymbolMention>::new(), actual.callees);
+        assert_eq!(Vec::<SymbolMention>::new(), actual.callers);
+        assert_eq!(Vec::<SymbolMention>::new(), actual.used_by);
     }
 }

--- a/rinkaku-tui/src/detail.rs
+++ b/rinkaku-tui/src/detail.rs
@@ -9,6 +9,7 @@
 
 use rinkaku_core::extract::{Classification, SymbolKind};
 use rinkaku_core::render::Report;
+use std::collections::HashSet;
 
 /// One symbol referenced from a [`DetailView`] (a caller or callee), named
 /// and located but not carrying its full signature — a caller/callee
@@ -110,19 +111,31 @@ pub fn build_detail(report: &Report, id: &str) -> Option<DetailView> {
         })
     };
 
+    // Edge uniqueness within `graph.edges` is not a contractual guarantee —
+    // `compute_hotspots`'s own doc comment in `rinkaku-core::graph` notes
+    // that a repeated edge between the same pair of nodes is not something
+    // `build_graph` can currently produce, but nothing in this function's
+    // contract depends on that staying true either. Deduping by the other
+    // endpoint's id before collecting mentions keeps a duplicate edge from
+    // making the same caller/callee show up twice in the detail pane's
+    // pivots, mirroring `compute_hotspots`'s own dedup-by-referrer-id.
+    let mut seen_callees = HashSet::new();
     let callees: Vec<SymbolMention> = report
         .graph
         .edges
         .iter()
         .filter(|edge| edge.from == id)
+        .filter(|edge| seen_callees.insert(edge.to.as_str()))
         .filter_map(|edge| mentions_by_id(&edge.to))
         .collect();
 
+    let mut seen_callers = HashSet::new();
     let callers: Vec<SymbolMention> = report
         .graph
         .edges
         .iter()
         .filter(|edge| edge.to == id)
+        .filter(|edge| seen_callers.insert(edge.from.as_str()))
         .filter_map(|edge| mentions_by_id(&edge.from))
         .collect();
 
@@ -427,5 +440,67 @@ mod tests {
         assert_eq!(Vec::<SymbolMention>::new(), actual.callers);
         assert_eq!(Vec::<SymbolMention>::new(), actual.callees);
         assert_eq!(Vec::<SymbolMention>::new(), actual.used_by);
+    }
+
+    // SHOULD-FIX 5: `graph.edges` uniqueness is not a contractual guarantee
+    // (`compute_hotspots`'s own doc comment in rinkaku-core::graph notes
+    // this, and defends against it by deduping referrers per target) —
+    // `build_detail` must apply the same defensive dedup to `callees`,
+    // `callers`, and `used_by` rather than assume `graph.edges` never
+    // repeats an edge, or a duplicate edge would silently double-count a
+    // caller/callee in the detail pane's pivots.
+    #[test]
+    fn should_dedup_duplicate_edges_between_the_same_pair_of_symbols() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![
+                    symbol("lib.rs::caller", "caller"),
+                    symbol("lib.rs::callee", "callee"),
+                ],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("lib.rs::caller", "lib.rs", "caller"),
+                    node("lib.rs::callee", "lib.rs", "callee"),
+                ],
+                // Same caller -> callee edge listed twice — a hand-built
+                // graph standing in for whatever upstream circumstance
+                // (not currently reachable through `build_graph`, per
+                // `compute_hotspots`'s own doc comment) might one day
+                // produce a repeated edge.
+                edges: vec![
+                    Edge {
+                        from: "lib.rs::caller".to_string(),
+                        to: "lib.rs::callee".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "lib.rs::caller".to_string(),
+                        to: "lib.rs::callee".to_string(),
+                        is_cycle: false,
+                    },
+                ],
+                roots: vec!["lib.rs::caller".to_string()],
+            },
+            ..empty_report()
+        };
+
+        let callee_detail = build_detail(&report, "lib.rs::callee").expect("symbol found");
+        let caller_detail = build_detail(&report, "lib.rs::caller").expect("symbol found");
+
+        let expected_caller_mention = vec![SymbolMention {
+            id: "lib.rs::caller".to_string(),
+            name: "caller".to_string(),
+            path: "lib.rs".to_string(),
+        }];
+        let expected_callee_mention = vec![SymbolMention {
+            id: "lib.rs::callee".to_string(),
+            name: "callee".to_string(),
+            path: "lib.rs".to_string(),
+        }];
+        assert_eq!(expected_caller_mention, callee_detail.callers);
+        assert_eq!(expected_caller_mention, callee_detail.used_by);
+        assert_eq!(expected_callee_mention, caller_detail.callees);
     }
 }

--- a/rinkaku-tui/src/detail.rs
+++ b/rinkaku-tui/src/detail.rs
@@ -1,0 +1,431 @@
+//! Detail-pane view-model (ADR 0015): given a selected symbol, produces
+//! the plain data a detail pane shows — signature (old/new when the
+//! contract changed), classification, who depends on it ("used by"), and
+//! a pivot to callers/callees for call-graph reading order (ADR 0008's
+//! tree, reached on demand rather than as the entry view's spine).
+//!
+//! [`build_detail`] is a pure function of a symbol id plus [`Report`]: no
+//! IO, no `ratatui` types.
+
+use rinkaku_core::extract::{Classification, SymbolKind};
+use rinkaku_core::render::Report;
+
+/// One symbol referenced from a [`DetailView`] (a caller or callee), named
+/// and located but not carrying its full signature — a caller/callee
+/// pivot is meant to answer "what else is involved", not duplicate the
+/// full detail a reviewer would get by selecting that symbol in turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolMention {
+    pub id: String,
+    pub name: String,
+    pub path: String,
+}
+
+/// A symbol's signature, either unchanged/newly-added (`Current`) or shown
+/// as an old/new pair (`Changed`) when [`Classification::SignatureChanged`]
+/// applies — mirrors `render.rs`'s Markdown ` ```diff ` block decision
+/// (`render_definition`), just as plain data instead of formatted text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignatureView {
+    Current(String),
+    Changed { previous: String, current: String },
+}
+
+/// The full detail-pane view-model for one selected, *present* symbol
+/// (see [`build_detail`]'s doc comment for why removed symbols are out of
+/// scope).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetailView {
+    pub id: String,
+    pub name: String,
+    pub kind: SymbolKind,
+    pub path: String,
+    pub container: Option<String>,
+    pub signature: SignatureView,
+    pub classification: Option<Classification>,
+    /// Every changed symbol that references this one, i.e. this symbol's
+    /// fan-in (ADR 0013). Computed directly from `report.graph.edges`
+    /// (every incoming edge), not from `report.hotspots` — `Hotspot` only
+    /// aggregates fan-in >= 2 (see `compute_hotspots`'s doc comment in
+    /// `rinkaku-core::graph`) and would under-report a fan-in of 0 or 1,
+    /// so a symbol with exactly one referrer still shows it here instead
+    /// of reading as "nobody depends on this".
+    pub used_by: Vec<SymbolMention>,
+    /// Every symbol this one references, i.e. outgoing edges
+    /// (`report.graph.edges` where `from == id`) — the callees pivot ADR
+    /// 0015 asks for.
+    pub callees: Vec<SymbolMention>,
+    /// Every symbol referencing this one, i.e. incoming edges
+    /// (`report.graph.edges` where `to == id`) — the callers pivot ADR 0015
+    /// asks for. Deliberately kept as its own field even though its
+    /// *content* always matches `used_by` (both derive from the same
+    /// incoming-edge set): `used_by` is fan-in framing ("who depends on my
+    /// signature"), `callers` is call-graph framing ("where do I get
+    /// reached from") — ADR 0015 asks for both framings as distinct pivots
+    /// even though v1's data happens to make them redundant. A future
+    /// resolver-based dependency model (ADR 0015's context on pluggable
+    /// `Resolver`s) could pull these apart (e.g. a caller found via a
+    /// different mechanism than a fan-in-relevant reference), so keeping
+    /// two fields now avoids a breaking rename later.
+    pub callers: Vec<SymbolMention>,
+}
+
+/// Builds a [`DetailView`] for the *present* (non-removed) symbol
+/// identified by `id` in `report`, or `None` when no such symbol exists.
+///
+/// Removed symbols are out of scope for this function: a
+/// [`rinkaku_core::extract::RemovedSymbol`] carries no stable id
+/// (`crate::tree::SymbolRef`'s doc comment already notes this), no
+/// `graph` presence to pivot callers/callees from, and no dependencies —
+/// there is no call-graph detail to show beyond what `Report.removed`
+/// already carries directly (name, kind, path, prior signature), which a
+/// caller can render straight from that struct without going through this
+/// pure function.
+pub fn build_detail(report: &Report, id: &str) -> Option<DetailView> {
+    let (path, symbol) = report.files.iter().find_map(|file| {
+        file.symbols
+            .iter()
+            .find(|symbol| symbol.id == id)
+            .map(|symbol| (file.path.as_str(), symbol))
+    })?;
+
+    let signature = match (symbol.classification, &symbol.previous_signature) {
+        (Some(Classification::SignatureChanged), Some(previous)) => SignatureView::Changed {
+            previous: previous.clone(),
+            current: symbol.signature.clone(),
+        },
+        _ => SignatureView::Current(symbol.signature.clone()),
+    };
+
+    let mentions_by_id = |target_id: &str| -> Option<SymbolMention> {
+        report.files.iter().find_map(|file| {
+            file.symbols
+                .iter()
+                .find(|s| s.id == target_id)
+                .map(|s| SymbolMention {
+                    id: s.id.clone(),
+                    name: s.name.clone(),
+                    path: file.path.clone(),
+                })
+        })
+    };
+
+    let callees: Vec<SymbolMention> = report
+        .graph
+        .edges
+        .iter()
+        .filter(|edge| edge.from == id)
+        .filter_map(|edge| mentions_by_id(&edge.to))
+        .collect();
+
+    let callers: Vec<SymbolMention> = report
+        .graph
+        .edges
+        .iter()
+        .filter(|edge| edge.to == id)
+        .filter_map(|edge| mentions_by_id(&edge.from))
+        .collect();
+
+    // `used_by` is every incoming edge, same set `callers` already
+    // computed above — `report.hotspots` is not consulted here because it
+    // only aggregates fan-in >= 2 (see `compute_hotspots`'s doc comment in
+    // `rinkaku-core::graph`) and would under-report a fan-in of 0 or 1;
+    // reading `graph.edges` directly covers every fan-in count uniformly,
+    // `Hotspot` included (a hotspot's referrers are exactly its incoming
+    // edges). `used_by` is kept as its own field distinct from `callers`
+    // for the same forward-compatibility reason documented on
+    // `DetailView::callers`.
+    let used_by = callers.clone();
+
+    Some(DetailView {
+        id: symbol.id.clone(),
+        name: symbol.name.clone(),
+        kind: symbol.kind,
+        path: path.to_string(),
+        container: symbol.container.clone(),
+        signature,
+        classification: symbol.classification,
+        used_by,
+        callees,
+        callers,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::ExtractedSymbol;
+    use rinkaku_core::graph::{Edge, Hotspot, Node, SymbolGraph};
+    use rinkaku_core::render::FileReport;
+
+    fn symbol(id: &str, name: &str) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature: format!("fn {name}()"),
+            range: LineRange { start: 1, end: 1 },
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        }
+    }
+
+    fn node(id: &str, path: &str, name: &str) -> Node {
+        Node {
+            id: id.to_string(),
+            path: path.to_string(),
+            name: name.to_string(),
+        }
+    }
+
+    fn empty_report() -> Report {
+        Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    #[test]
+    fn should_return_none_when_symbol_id_is_not_found() {
+        let report = empty_report();
+
+        let actual = build_detail(&report, "missing::id");
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_build_current_signature_when_classification_is_not_signature_changed() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    classification: Some(Classification::BodyOnly),
+                    ..symbol("lib.rs::foo", "foo")
+                }],
+            }],
+            ..empty_report()
+        };
+
+        let expected = DetailView {
+            id: "lib.rs::foo".to_string(),
+            name: "foo".to_string(),
+            kind: SymbolKind::Function,
+            path: "lib.rs".to_string(),
+            container: None,
+            signature: SignatureView::Current("fn foo()".to_string()),
+            classification: Some(Classification::BodyOnly),
+            used_by: vec![],
+            callees: vec![],
+            callers: vec![],
+        };
+        let actual = build_detail(&report, "lib.rs::foo");
+
+        assert_eq!(Some(expected), actual);
+    }
+
+    #[test]
+    fn should_build_changed_signature_when_classification_is_signature_changed() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    classification: Some(Classification::SignatureChanged),
+                    previous_signature: Some("fn foo(a: i32)".to_string()),
+                    signature: "fn foo(a: i32, b: i32)".to_string(),
+                    ..symbol("lib.rs::foo", "foo")
+                }],
+            }],
+            ..empty_report()
+        };
+
+        let actual = build_detail(&report, "lib.rs::foo").expect("symbol found");
+
+        let expected_signature = SignatureView::Changed {
+            previous: "fn foo(a: i32)".to_string(),
+            current: "fn foo(a: i32, b: i32)".to_string(),
+        };
+        assert_eq!(expected_signature, actual.signature);
+    }
+
+    #[test]
+    fn should_fall_back_to_current_signature_when_previous_signature_is_missing() {
+        // Defensive: SignatureChanged without a previous_signature (should
+        // not happen per `classify_symbols`'s contract) still renders
+        // something sane rather than panicking.
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    classification: Some(Classification::SignatureChanged),
+                    previous_signature: None,
+                    ..symbol("lib.rs::foo", "foo")
+                }],
+            }],
+            ..empty_report()
+        };
+
+        let actual = build_detail(&report, "lib.rs::foo").expect("symbol found");
+
+        assert_eq!(
+            SignatureView::Current("fn foo()".to_string()),
+            actual.signature
+        );
+    }
+
+    #[test]
+    fn should_list_single_caller_as_used_by_when_fan_in_is_one() {
+        // fan-in of exactly 1 is below Hotspot's >= 2 threshold, so
+        // `report.hotspots` has nothing for "callee" — used_by must still
+        // show the one caller by reading `graph.edges` directly.
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![
+                    symbol("lib.rs::caller", "caller"),
+                    symbol("lib.rs::callee", "callee"),
+                ],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("lib.rs::caller", "lib.rs", "caller"),
+                    node("lib.rs::callee", "lib.rs", "callee"),
+                ],
+                edges: vec![Edge {
+                    from: "lib.rs::caller".to_string(),
+                    to: "lib.rs::callee".to_string(),
+                    is_cycle: false,
+                }],
+                roots: vec!["lib.rs::caller".to_string()],
+            },
+            hotspots: vec![],
+            ..empty_report()
+        };
+
+        let actual = build_detail(&report, "lib.rs::callee").expect("symbol found");
+
+        let expected_used_by = vec![SymbolMention {
+            id: "lib.rs::caller".to_string(),
+            name: "caller".to_string(),
+            path: "lib.rs".to_string(),
+        }];
+        assert_eq!(expected_used_by, actual.used_by);
+    }
+
+    #[test]
+    fn should_list_every_referrer_as_used_by_when_symbol_is_a_hotspot() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![
+                    symbol("lib.rs::a", "a"),
+                    symbol("lib.rs::b", "b"),
+                    symbol("lib.rs::shared", "shared"),
+                ],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("lib.rs::a", "lib.rs", "a"),
+                    node("lib.rs::b", "lib.rs", "b"),
+                    node("lib.rs::shared", "lib.rs", "shared"),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "lib.rs::a".to_string(),
+                        to: "lib.rs::shared".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "lib.rs::b".to_string(),
+                        to: "lib.rs::shared".to_string(),
+                        is_cycle: false,
+                    },
+                ],
+                roots: vec!["lib.rs::a".to_string(), "lib.rs::b".to_string()],
+            },
+            hotspots: vec![Hotspot {
+                id: "lib.rs::shared".to_string(),
+                path: "lib.rs".to_string(),
+                name: "shared".to_string(),
+                used_by: vec!["a".to_string(), "b".to_string()],
+            }],
+            ..empty_report()
+        };
+
+        let actual = build_detail(&report, "lib.rs::shared").expect("symbol found");
+
+        let mut used_by_names: Vec<&str> = actual.used_by.iter().map(|m| m.name.as_str()).collect();
+        used_by_names.sort();
+        assert_eq!(vec!["a", "b"], used_by_names);
+    }
+
+    #[test]
+    fn should_list_outgoing_edges_as_callees() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::a", "a"), symbol("lib.rs::b", "b")],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("lib.rs::a", "lib.rs", "a"),
+                    node("lib.rs::b", "lib.rs", "b"),
+                ],
+                edges: vec![Edge {
+                    from: "lib.rs::a".to_string(),
+                    to: "lib.rs::b".to_string(),
+                    is_cycle: false,
+                }],
+                roots: vec!["lib.rs::a".to_string()],
+            },
+            ..empty_report()
+        };
+
+        let actual = build_detail(&report, "lib.rs::a").expect("symbol found");
+
+        let expected_callees = vec![SymbolMention {
+            id: "lib.rs::b".to_string(),
+            name: "b".to_string(),
+            path: "lib.rs".to_string(),
+        }];
+        assert_eq!(expected_callees, actual.callees);
+        assert_eq!(Vec::<SymbolMention>::new(), actual.callers);
+    }
+
+    #[test]
+    fn should_have_empty_callers_and_callees_when_symbol_has_no_edges() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::solo", "solo")],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![node("lib.rs::solo", "lib.rs", "solo")],
+                edges: vec![],
+                roots: vec!["lib.rs::solo".to_string()],
+            },
+            ..empty_report()
+        };
+
+        let actual = build_detail(&report, "lib.rs::solo").expect("symbol found");
+
+        assert_eq!(Vec::<SymbolMention>::new(), actual.callers);
+        assert_eq!(Vec::<SymbolMention>::new(), actual.callees);
+        assert_eq!(Vec::<SymbolMention>::new(), actual.used_by);
+    }
+}

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -1,0 +1,8 @@
+//! View-models for rinkaku's terminal UI (ADR 0015/0016).
+//!
+//! This crate holds only plain data and pure functions/state machines
+//! derived from [`rinkaku_core::render::Report`] — directory-tree
+//! building, topological ordering, navigation state, and the detail-pane
+//! view-model. No `ratatui`/`crossterm` types appear in any public
+//! signature here (ADR 0016 decision 3): rendering those view-models to
+//! the terminal is a later stage's job, layered on top of this crate.

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -7,6 +7,7 @@
 //! signature here (ADR 0016 decision 3): rendering those view-models to
 //! the terminal is a later stage's job, layered on top of this crate.
 
+pub mod detail;
 pub mod nav;
 pub mod order;
 pub mod tree;

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -39,16 +39,23 @@ use std::time::Duration;
 
 /// Runs the interactive TUI over `report` until the user quits, taking
 /// over the terminal for the duration of the call (raw mode + alternate
-/// screen via [`ratatui::init`], restored on return **and** on panic —
-/// `ratatui::init`'s own panic hook covers the latter, so a bug in this
+/// screen via [`ratatui::try_init`], restored on return **and** on panic —
+/// `ratatui::try_init`'s own panic hook covers the latter, so a bug in this
 /// crate cannot leave the caller's terminal in raw mode).
+///
+/// Uses `try_init` rather than [`ratatui::init`] specifically so terminal
+/// setup failure (e.g. stdin/stdout is not a TTY at all — piped input,
+/// `< /dev/null`, a CI runner) surfaces as an `Err` for `main.rs`'s
+/// `anyhow` path to print cleanly and exit 1, instead of `ratatui::init`'s
+/// own `.expect(...)` panicking with a raw Rust panic message and exit
+/// code 101.
 ///
 /// This is the only function in the crate that touches a real terminal or
 /// blocks on input; everything it calls into (`App`, `row_view`, `ui`,
 /// `source`) is either pure or an isolated, narrowly-scoped IO call (a
 /// single source-file read).
 pub fn run(report: &Report) -> std::io::Result<()> {
-    let mut terminal = ratatui::init();
+    let mut terminal = ratatui::try_init()?;
     let result = run_app(&mut terminal, report);
     ratatui::restore();
     result
@@ -80,6 +87,14 @@ fn run_app(terminal: &mut ratatui::DefaultTerminal, report: &Report) -> std::io:
                 app = app.handle_key(input_key);
                 if let Screen::Source { symbol_id } = app.screen().clone() {
                     match source::load_symbol_source(report, &symbol_id) {
+                        // The `SourceView` itself is discarded here — only
+                        // used to detect a failure early so it can be
+                        // surfaced on the status line right away, rather
+                        // than silently on the next redraw. `ui::draw`'s
+                        // `draw_source_screen` re-reads the file itself
+                        // when it renders the screen (see that function's
+                        // doc comment for why it re-reads instead of
+                        // caching this result).
                         Ok(_) => {}
                         Err(message) => app.set_status(message),
                     }

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -6,3 +6,5 @@
 //! view-model. No `ratatui`/`crossterm` types appear in any public
 //! signature here (ADR 0016 decision 3): rendering those view-models to
 //! the terminal is a later stage's job, layered on top of this crate.
+
+pub mod tree;

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -7,4 +7,5 @@
 //! signature here (ADR 0016 decision 3): rendering those view-models to
 //! the terminal is a later stage's job, layered on top of this crate.
 
+pub mod order;
 pub mod tree;

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -7,5 +7,6 @@
 //! signature here (ADR 0016 decision 3): rendering those view-models to
 //! the terminal is a later stage's job, layered on top of this crate.
 
+pub mod nav;
 pub mod order;
 pub mod tree;

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -1,13 +1,170 @@
-//! View-models for rinkaku's terminal UI (ADR 0015/0016).
+//! rinkaku's interactive terminal UI (ADR 0015/0016).
 //!
-//! This crate holds only plain data and pure functions/state machines
-//! derived from [`rinkaku_core::render::Report`] — directory-tree
-//! building, topological ordering, navigation state, and the detail-pane
-//! view-model. No `ratatui`/`crossterm` types appear in any public
-//! signature here (ADR 0016 decision 3): rendering those view-models to
-//! the terminal is a later stage's job, layered on top of this crate.
+//! Two layers, kept deliberately separate:
+//!
+//! - **View-models** (`tree`, `nav`, `order`, `detail`, `app`, `row_view`):
+//!   plain data and pure functions/state machines derived from
+//!   [`rinkaku_core::render::Report`]. `tree`/`nav`/`order`/`detail` carry
+//!   no `ratatui`/`crossterm` types at all (ADR 0016 decision 3). `app`
+//!   and `row_view` are the stage B additions that compose those
+//!   view-models into one navigable state machine and format its rows —
+//!   `row_view` uses `ratatui::text`/`style` types (`Line`/`Span`/`Style`),
+//!   which are plain, comparable data rather than a live `Frame`/
+//!   `Terminal`, so building one from a row stays a pure, unit-testable
+//!   transformation. `app` stays entirely free of `ratatui`/`crossterm`
+//!   types, translating real key events at the boundary instead (see
+//!   `run`'s event loop).
+//! - **Terminal adapter** (`ui`, `source`, [`run`]): draws `App`'s state
+//!   with `ratatui`, reads source files for the drill-down view, and owns
+//!   the terminal lifecycle (raw mode, alternate screen, the event loop).
+//!   This is the only layer that performs IO or holds a live `Terminal`.
+//!
+//! [`run`] is the crate's single public entry point for the CLI binary:
+//! `rinkaku`'s `main.rs` hands it a [`rinkaku_core::render::Report`] once
+//! `--tui` is passed, in place of rendering Markdown/JSON.
 
+pub mod app;
 pub mod detail;
 pub mod nav;
 pub mod order;
+pub mod row_view;
+pub mod source;
 pub mod tree;
+pub mod ui;
+
+use app::{App, InputKey, Screen};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use rinkaku_core::render::Report;
+use std::time::Duration;
+
+/// Runs the interactive TUI over `report` until the user quits, taking
+/// over the terminal for the duration of the call (raw mode + alternate
+/// screen via [`ratatui::init`], restored on return **and** on panic —
+/// `ratatui::init`'s own panic hook covers the latter, so a bug in this
+/// crate cannot leave the caller's terminal in raw mode).
+///
+/// This is the only function in the crate that touches a real terminal or
+/// blocks on input; everything it calls into (`App`, `row_view`, `ui`,
+/// `source`) is either pure or an isolated, narrowly-scoped IO call (a
+/// single source-file read).
+pub fn run(report: &Report) -> std::io::Result<()> {
+    let mut terminal = ratatui::init();
+    let result = run_app(&mut terminal, report);
+    ratatui::restore();
+    result
+}
+
+fn run_app(terminal: &mut ratatui::DefaultTerminal, report: &Report) -> std::io::Result<()> {
+    let mut app = App::new(report);
+
+    loop {
+        terminal.draw(|frame| ui::draw(frame, &app, report))?;
+
+        if app.should_quit() {
+            return Ok(());
+        }
+
+        // A 100ms poll timeout keeps the loop responsive to terminal
+        // resize events without busy-spinning — `event::read()` alone
+        // would block indefinitely on a genuinely idle terminal, which is
+        // fine for input but would also delay reacting to anything else
+        // this loop might grow to check in the future (kept short as a
+        // resize/redraw responsiveness margin, not a correctness
+        // requirement of the key-handling itself).
+        if event::poll(Duration::from_millis(100))?
+            && let Event::Key(key_event) = event::read()?
+            && key_event.kind == KeyEventKind::Press
+            && let Some(input_key) = translate_key(key_event.code, key_event.modifiers, &app)
+        {
+            if let InputKey::Source = input_key {
+                app = app.handle_key(input_key);
+                if let Screen::Source { symbol_id } = app.screen().clone() {
+                    match source::load_symbol_source(report, &symbol_id) {
+                        Ok(_) => {}
+                        Err(message) => app.set_status(message),
+                    }
+                }
+            } else {
+                app = app.handle_key(input_key);
+            }
+        }
+    }
+}
+
+/// Translates a raw `crossterm` key press into this crate's
+/// terminal-agnostic [`InputKey`], or `None` for a key the app does not
+/// react to. Depends on `app.screen()` only to disambiguate `q`/Esc
+/// (`Quit` on the entry view, `Back` on the source view) — every other
+/// mapping is context-free.
+fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<InputKey> {
+    let on_source_screen = matches!(app.screen(), Screen::Source { .. });
+
+    match code {
+        KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
+        KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
+        KeyCode::Enter | KeyCode::Char(' ') => Some(InputKey::Select),
+        KeyCode::Char('e') | KeyCode::Char('E') => Some(InputKey::ExpandAll),
+        KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::Quit),
+        KeyCode::Char('c') | KeyCode::Char('C') => Some(InputKey::CollapseAll),
+        KeyCode::Char('o') | KeyCode::Char('O') => Some(InputKey::ToggleOrder),
+        KeyCode::Char('s') | KeyCode::Char('S') => Some(InputKey::Source),
+        KeyCode::Esc if on_source_screen => Some(InputKey::Back),
+        KeyCode::Char('q') if on_source_screen => Some(InputKey::Back),
+        KeyCode::Char('q') => Some(InputKey::Quit),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rinkaku_core::graph::SymbolGraph;
+
+    fn empty_report() -> Report {
+        Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    #[test]
+    fn should_translate_ctrl_c_to_quit_regardless_of_screen() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('c'), KeyModifiers::CONTROL, &app);
+
+        assert_eq!(Some(InputKey::Quit), actual);
+    }
+
+    #[test]
+    fn should_translate_q_to_quit_on_entry_screen() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('q'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::Quit), actual);
+    }
+
+    #[test]
+    fn should_translate_esc_to_none_on_entry_screen() {
+        // Esc has no "back" target on the entry screen (App::handle_key's
+        // own doc comment) and is not bound to quit there either — quit is
+        // 'q'/Ctrl-C only, so Esc is simply not handled at this screen.
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+        assert_eq!(None, actual);
+    }
+}

--- a/rinkaku-tui/src/nav.rs
+++ b/rinkaku-tui/src/nav.rs
@@ -106,16 +106,31 @@ impl Nav {
     /// `rows(tree)` internally is how cursor bounds and "what is under the
     /// cursor" are determined, consistent with `rows` never being cached
     /// (see its own doc comment).
+    ///
+    /// A collapse action (`ToggleExpand` collapsing a node, or
+    /// `CollapseAll`) can make the row the cursor was on disappear from the
+    /// flattened list entirely — the row list shrinks, but `self.cursor` is
+    /// just an index, so it would otherwise keep pointing at whatever row
+    /// happens to now occupy that slot (or past the end of the list). To
+    /// keep the cursor meaningfully attached to "the thing the user was
+    /// looking at", every action re-targets the cursor afterward via
+    /// [`Self::retarget_cursor`] rather than only the actions that are
+    /// obviously collapse-shaped — this also future-proofs against a new
+    /// `Action` variant that shrinks the row list in some other way.
     pub fn handle(mut self, action: Action, tree: &Tree) -> Self {
+        let cursor_path_chain = self.cursor_path_chain(tree);
+
         match action {
             Action::CursorUp => {
                 self.cursor = self.cursor.saturating_sub(1);
+                return self;
             }
             Action::CursorDown => {
                 let row_count = self.rows(tree).len();
                 if row_count > 0 {
                     self.cursor = (self.cursor + 1).min(row_count - 1);
                 }
+                return self;
             }
             Action::ToggleExpand => {
                 let rows = self.rows(tree);
@@ -136,7 +151,76 @@ impl Nav {
                 self.collapsed = collapsible_paths(tree);
             }
         }
+
+        self.retarget_cursor(tree, &cursor_path_chain);
         self
+    }
+
+    /// The path of the row currently under the cursor, followed by every
+    /// ancestor's path out to the root (nearest ancestor first) — the
+    /// candidates [`Self::retarget_cursor`] walks through, nearest first, to
+    /// find where the cursor should land after the row list changes shape.
+    /// Empty when there are no rows at all (nothing to chain from).
+    fn cursor_path_chain(&self, tree: &Tree) -> Vec<String> {
+        let mut chain = Vec::new();
+        for root in &tree.roots {
+            if self.collect_path_chain(root, self.cursor, &mut 0, &mut chain) {
+                break;
+            }
+        }
+        chain
+    }
+
+    /// Pre-order walk mirroring [`Self::push_rows`], tracking `visited` as a
+    /// running row index. When the node at `target_cursor` is found, records
+    /// its own path followed by the path of every open call frame (i.e.
+    /// every ancestor directory/file currently on the path from the root),
+    /// and returns `true` to unwind the recursion immediately.
+    fn collect_path_chain(
+        &self,
+        node: &TreeNode,
+        target_cursor: usize,
+        visited: &mut usize,
+        chain: &mut Vec<String>,
+    ) -> bool {
+        if *visited == target_cursor {
+            chain.push(node.path.clone());
+            return true;
+        }
+        *visited += 1;
+
+        let has_children = !node.children.is_empty();
+        let expanded = has_children && !self.collapsed.contains(&node.path);
+        if expanded {
+            for child in &node.children {
+                if self.collect_path_chain(child, target_cursor, visited, chain) {
+                    chain.push(node.path.clone());
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Moves the cursor to the nearest row in `chain` (the pre-action
+    /// cursor's own path, then its ancestors nearest-first) that is still
+    /// present in `tree`'s current rows, or clamps to the last row (0 for an
+    /// empty tree) when nothing in `chain` survived — e.g. `CollapseAll`,
+    /// where every ancestor above the top-level root row also collapses, so
+    /// there is no "nearest still-expanded ancestor" to land on, only "the
+    /// nearest still-*visible*" one, which the chain walk already finds
+    /// (collapsing hides a node's children, never the node's own row).
+    fn retarget_cursor(&mut self, tree: &Tree, chain: &[String]) {
+        let rows = self.rows(tree);
+
+        for path in chain {
+            if let Some(index) = rows.iter().position(|row| &row.node.path == path) {
+                self.cursor = index;
+                return;
+            }
+        }
+
+        self.cursor = rows.len().saturating_sub(1);
     }
 }
 
@@ -349,5 +433,157 @@ mod tests {
 
         let paths: Vec<&str> = rows.iter().map(|r| r.node.path.as_str()).collect();
         assert_eq!(vec!["src"], paths);
+    }
+
+    /// A deeper tree than `sample_tree` — src/pkg/lib.rs with two symbol
+    /// leaves — so the cursor can sit on a row nested under two ancestor
+    /// directories, matching the depth the CRITICAL 2 regression needs
+    /// (collapsing an ancestor several levels above the cursor).
+    /// Expanded row order: src(0), src/pkg(1), src/pkg/lib.rs(2), foo(3),
+    /// bar(4).
+    fn deep_tree() -> Tree {
+        Tree {
+            roots: vec![dir_node(
+                "src",
+                vec![dir_node(
+                    "src/pkg",
+                    vec![file_node(
+                        "src/pkg/lib.rs",
+                        vec![
+                            symbol_node("src/pkg/lib.rs", "foo"),
+                            symbol_node("src/pkg/lib.rs", "bar"),
+                        ],
+                    )],
+                )],
+            )],
+        }
+    }
+
+    fn row_paths<'a>(rows: &'a [Row<'a>]) -> Vec<&'a str> {
+        rows.iter().map(|r| r.node.path.as_str()).collect()
+    }
+
+    // CRITICAL 2 regression: `cursor()`'s doc comment invites
+    // `rows(tree)[cursor()]`, but collapsing an ancestor of the cursor's
+    // row used to leave the cursor index pointing past the now-shrunk row
+    // list — the documented lookup would then panic (index out of
+    // bounds). The cursor genuinely sits on the deep leaf "foo" (row 3, a
+    // descendant of "src/pkg" that is about to be hidden) for this whole
+    // test — `ToggleExpand` always acts on the row *under the cursor*, so
+    // the only way to collapse "src/pkg" without first moving the cursor
+    // onto "src/pkg" itself (which would trivially avoid ever exercising
+    // the "cursor's own row disappeared" path) is to collapse it via a
+    // second, independent `Nav` positioned at "src/pkg", then transplant
+    // that `Nav`'s resulting `collapsed` state onto the first — the same
+    // state-transplant pattern
+    // `should_not_move_cursor_when_collapse_happens_elsewhere_in_the_tree`
+    // uses below, just applied to a collapse that *does* hide the cursor's
+    // row instead of one that doesn't. The cursor must land on "src/pkg"
+    // itself (the nearest still-visible ancestor of the row it used to be
+    // on), not stay at index 3 (now out of bounds) and not blindly clamp
+    // to "new last row" (which would coincidentally also be 1 here, but
+    // that is not the semantics being tested — see the CollapseAll variant
+    // below for a case where a naive last-row clamp gives a different,
+    // wrong answer).
+    #[test]
+    fn should_move_cursor_to_nearest_visible_ancestor_when_toggle_expand_hides_its_row() {
+        let tree = deep_tree();
+        let mut nav = Nav::new();
+        for _ in 0..3 {
+            nav = nav.handle(Action::CursorDown, &tree);
+        }
+        assert_eq!(3, nav.cursor()); // cursor on "foo", never moved off it
+
+        // Collapse "src/pkg" (row 1) via a second, independent Nav, then
+        // bring that collapse state back onto `nav` without touching its
+        // cursor — simulates "src/pkg" collapsing while the cursor of
+        // interest stays on the hidden descendant "foo".
+        let mut collapse_pkg = Nav::new();
+        collapse_pkg = collapse_pkg.handle(Action::CursorDown, &tree);
+        assert_eq!(1, collapse_pkg.cursor()); // "src/pkg"
+        collapse_pkg = collapse_pkg.handle(Action::ToggleExpand, &tree);
+
+        // `nav`'s own path chain ("foo" then its ancestors) must be
+        // captured *before* the collapsed set is transplanted in, exactly
+        // as `handle` does internally — capturing it after would just
+        // observe the already-shrunk row list and defeat the test.
+        let chain = nav.cursor_path_chain(&tree);
+        nav.collapsed = collapse_pkg.collapsed;
+        nav.retarget_cursor(&tree, &chain);
+
+        let rows = nav.rows(&tree);
+        assert_eq!(vec!["src", "src/pkg"], row_paths(&rows));
+        assert_eq!(1, nav.cursor());
+    }
+
+    #[test]
+    fn should_clamp_cursor_to_last_row_when_collapse_all_shrinks_the_row_list() {
+        let tree = deep_tree();
+        // Cursor on "bar" (row 4, the last row).
+        let mut nav = Nav::new();
+        for _ in 0..4 {
+            nav = nav.handle(Action::CursorDown, &tree);
+        }
+        assert_eq!(4, nav.cursor());
+
+        let nav = nav.handle(Action::CollapseAll, &tree);
+
+        let rows = nav.rows(&tree);
+        assert_eq!(vec!["src"], row_paths(&rows));
+        assert_eq!(0, nav.cursor());
+    }
+
+    #[test]
+    fn should_clamp_cursor_to_last_row_when_collapse_all_hides_a_deep_cursor_row() {
+        let tree = deep_tree();
+        // Cursor on "src/pkg/lib.rs" (row 2, neither the first nor the
+        // last row) — CollapseAll has no single "nearest visible ancestor"
+        // notion the way a single ToggleExpand does (every directory
+        // collapses at once), so this falls back to the simple "clamp to
+        // last row" rule.
+        let mut nav = Nav::new();
+        for _ in 0..2 {
+            nav = nav.handle(Action::CursorDown, &tree);
+        }
+        assert_eq!(2, nav.cursor());
+
+        let nav = nav.handle(Action::CollapseAll, &tree);
+
+        let rows = nav.rows(&tree);
+        assert_eq!(vec!["src"], row_paths(&rows));
+        assert_eq!(0, nav.cursor());
+    }
+
+    #[test]
+    fn should_not_move_cursor_when_collapse_happens_elsewhere_in_the_tree() {
+        // Two independent top-level directories: collapsing "b" (which
+        // the cursor is not on, and is not an ancestor of the cursor's
+        // row) must leave the cursor exactly where it was.
+        let tree = Tree {
+            roots: vec![
+                dir_node("a", vec![file_node("a/one.rs", vec![])]),
+                dir_node("b", vec![file_node("b/two.rs", vec![])]),
+            ],
+        };
+        // Rows expanded: a(0), a/one.rs(1), b(2), b/two.rs(3).
+        let mut nav = Nav::new().handle(Action::CursorDown, &tree); // cursor -> "a/one.rs" (1)
+        assert_eq!(1, nav.cursor());
+
+        // Move a *second*, independent Nav to "b" (row 2) and collapse it
+        // there, then bring that collapse state back without disturbing
+        // `nav`'s own cursor — simulates two collapse actions happening
+        // in the tree while the cursor of interest stays on "a/one.rs".
+        let mut collapse_b = Nav::new();
+        collapse_b = collapse_b.handle(Action::CursorDown, &tree);
+        collapse_b = collapse_b.handle(Action::CursorDown, &tree); // cursor -> "b" (2)
+        assert_eq!(2, collapse_b.cursor());
+        collapse_b = collapse_b.handle(Action::ToggleExpand, &tree); // collapse "b"
+
+        nav.collapsed = collapse_b.collapsed;
+
+        let rows = nav.rows(&tree);
+        assert_eq!(vec!["a", "a/one.rs", "b"], row_paths(&rows));
+        assert_eq!(1, nav.cursor());
+        assert_eq!("a/one.rs", rows[nav.cursor()].node.path);
     }
 }

--- a/rinkaku-tui/src/nav.rs
+++ b/rinkaku-tui/src/nav.rs
@@ -1,0 +1,353 @@
+//! Navigation state machine over a flattened, visible view of a
+//! [`crate::tree::Tree`] (ADR 0015/0016): cursor movement, expand/collapse,
+//! and a stable mapping from the cursor back to the underlying node so a
+//! future detail pane knows what is selected.
+//!
+//! Every transition here is pure — `Nav::handle` takes an [`Action`] and
+//! returns the next `Nav`, no IO, no `ratatui`/`crossterm` types in any
+//! signature (ADR 0016 decision 3).
+
+use crate::tree::{NodeKind, Tree, TreeNode};
+use std::collections::HashSet;
+
+/// A user-driven navigation action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    CursorUp,
+    CursorDown,
+    /// Toggles the node under the cursor between expanded and collapsed.
+    /// A no-op on a [`NodeKind::Symbol`] row (symbols are leaves — see
+    /// this module's doc comment) or when there are no visible rows at
+    /// all.
+    ToggleExpand,
+    ExpandAll,
+    CollapseAll,
+}
+
+/// One visible row in the flattened tree: a reference into the [`Tree`]
+/// this [`Nav`] was built from (by path, not by owned data — the view-
+/// model stays cheap to rebuild every frame, matching `ratatui`'s
+/// immediate-mode redraw-from-state model per ADR 0016 decision 1) plus
+/// its depth for indentation and whether it is currently expanded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Row<'a> {
+    pub node: &'a TreeNode,
+    pub depth: usize,
+    /// `true` when this row has children *and* they are currently shown
+    /// beneath it. Always `false` for a childless node (a file with no
+    /// symbols, or a symbol leaf) — there is nothing to expand, regardless
+    /// of collapse-state bookkeeping.
+    pub expanded: bool,
+}
+
+/// Navigation state: which nodes are collapsed (keyed by [`TreeNode::path`]
+/// — stable across tree rebuilds from a re-run `Report`, per
+/// `crate::tree::TreeNode::path`'s own doc comment) and where the cursor
+/// sits, as a position in the *current* flattened visible-row list rather
+/// than a node reference — the row list is recomputed from `collapsed` on
+/// every call to [`Nav::rows`], so the cursor position is the only stable
+/// coordinate to keep between calls.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Nav {
+    collapsed: HashSet<String>,
+    cursor: usize,
+}
+
+impl Nav {
+    /// Starts with every directory/file expanded (`collapsed` empty) and
+    /// the cursor on the first visible row — the most useful default for
+    /// a reviewer opening the TUI fresh: everything is already visible,
+    /// nothing needs an initial expand pass.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The current cursor position, as an index into [`Nav::rows`]'s
+    /// result for the same `tree`. Exposed so a caller building a detail
+    /// pane can look up `rows(tree)[cursor()]` without this module
+    /// duplicating that indexing itself.
+    pub fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    /// Flattens `tree` into visible [`Row`]s given this `Nav`'s collapse
+    /// state: a pre-order walk that skips a node's children whenever that
+    /// node's path is in `collapsed`. Recomputed from `tree` + `collapsed`
+    /// on every call rather than cached, matching the immediate-mode
+    /// philosophy the rest of the TUI stack follows (ADR 0016 decision 1)
+    /// — the tree itself is already cheap to rebuild from a `Report`, and
+    /// this flattening is cheaper still.
+    pub fn rows<'a>(&self, tree: &'a Tree) -> Vec<Row<'a>> {
+        let mut rows = Vec::new();
+        for root in &tree.roots {
+            self.push_rows(root, 0, &mut rows);
+        }
+        rows
+    }
+
+    fn push_rows<'a>(&self, node: &'a TreeNode, depth: usize, rows: &mut Vec<Row<'a>>) {
+        let has_children = !node.children.is_empty();
+        let expanded = has_children && !self.collapsed.contains(&node.path);
+        rows.push(Row {
+            node,
+            depth,
+            expanded,
+        });
+        if expanded {
+            for child in &node.children {
+                self.push_rows(child, depth + 1, rows);
+            }
+        }
+    }
+
+    /// Applies one [`Action`] against the current `tree`, returning the
+    /// resulting `Nav`. `tree` must be the same tree (or a tree with the
+    /// same shape/paths) the caller is rendering rows from — recomputing
+    /// `rows(tree)` internally is how cursor bounds and "what is under the
+    /// cursor" are determined, consistent with `rows` never being cached
+    /// (see its own doc comment).
+    pub fn handle(mut self, action: Action, tree: &Tree) -> Self {
+        match action {
+            Action::CursorUp => {
+                self.cursor = self.cursor.saturating_sub(1);
+            }
+            Action::CursorDown => {
+                let row_count = self.rows(tree).len();
+                if row_count > 0 {
+                    self.cursor = (self.cursor + 1).min(row_count - 1);
+                }
+            }
+            Action::ToggleExpand => {
+                let rows = self.rows(tree);
+                if let Some(row) = rows.get(self.cursor)
+                    && !matches!(row.node.kind, NodeKind::Symbol(_))
+                    && !row.node.children.is_empty()
+                {
+                    let path = row.node.path.clone();
+                    if !self.collapsed.remove(&path) {
+                        self.collapsed.insert(path);
+                    }
+                }
+            }
+            Action::ExpandAll => {
+                self.collapsed.clear();
+            }
+            Action::CollapseAll => {
+                self.collapsed = collapsible_paths(tree);
+            }
+        }
+        self
+    }
+}
+
+/// Every path in `tree` that has at least one child — i.e. every
+/// directory/file node eligible to collapse (symbols never are, see this
+/// module's doc comment) — used by [`Action::CollapseAll`] to mark every
+/// such node collapsed in one step.
+fn collapsible_paths(tree: &Tree) -> HashSet<String> {
+    let mut paths = HashSet::new();
+    for root in &tree.roots {
+        collect_collapsible(root, &mut paths);
+    }
+    paths
+}
+
+fn collect_collapsible(node: &TreeNode, paths: &mut HashSet<String>) {
+    if !node.children.is_empty() {
+        paths.insert(node.path.clone());
+        for child in &node.children {
+            collect_collapsible(child, paths);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::Badges;
+    use pretty_assertions::assert_eq;
+
+    fn symbol_node(path: &str, name: &str) -> TreeNode {
+        TreeNode {
+            kind: NodeKind::Symbol(crate::tree::SymbolRef {
+                id: format!("{path}::{name}"),
+                name: name.to_string(),
+                kind: rinkaku_core::extract::SymbolKind::Function,
+                classification: None,
+                removed: false,
+            }),
+            path: path.to_string(),
+            badges: Badges::default(),
+            children: vec![],
+        }
+    }
+
+    fn file_node(path: &str, children: Vec<TreeNode>) -> TreeNode {
+        TreeNode {
+            kind: NodeKind::File,
+            path: path.to_string(),
+            badges: Badges::default(),
+            children,
+        }
+    }
+
+    fn dir_node(path: &str, children: Vec<TreeNode>) -> TreeNode {
+        TreeNode {
+            kind: NodeKind::Dir,
+            path: path.to_string(),
+            badges: Badges::default(),
+            children,
+        }
+    }
+
+    fn sample_tree() -> Tree {
+        // src/
+        //   lib.rs
+        //     fn foo
+        //     fn bar
+        Tree {
+            roots: vec![dir_node(
+                "src",
+                vec![file_node(
+                    "src/lib.rs",
+                    vec![
+                        symbol_node("src/lib.rs", "foo"),
+                        symbol_node("src/lib.rs", "bar"),
+                    ],
+                )],
+            )],
+        }
+    }
+
+    #[test]
+    fn should_show_every_row_expanded_when_nav_is_new() {
+        let tree = sample_tree();
+        let nav = Nav::new();
+
+        let rows = nav.rows(&tree);
+
+        let paths: Vec<&str> = rows.iter().map(|r| r.node.path.as_str()).collect();
+        assert_eq!(vec!["src", "src/lib.rs", "src/lib.rs", "src/lib.rs"], paths);
+    }
+
+    #[test]
+    fn should_hide_children_when_toggle_expand_collapses_the_dir_under_cursor() {
+        let tree = sample_tree();
+        let nav = Nav::new(); // cursor at 0 ("src")
+
+        let nav = nav.handle(Action::ToggleExpand, &tree);
+        let rows = nav.rows(&tree);
+
+        let paths: Vec<&str> = rows.iter().map(|r| r.node.path.as_str()).collect();
+        assert_eq!(vec!["src"], paths);
+        assert_eq!(false, rows[0].expanded);
+    }
+
+    #[test]
+    fn should_show_children_again_when_toggle_expand_is_applied_twice() {
+        let tree = sample_tree();
+        let nav = Nav::new()
+            .handle(Action::ToggleExpand, &tree)
+            .handle(Action::ToggleExpand, &tree);
+
+        let rows = nav.rows(&tree);
+
+        assert_eq!(4, rows.len());
+        assert_eq!(true, rows[0].expanded);
+    }
+
+    #[test]
+    fn should_not_toggle_when_cursor_is_on_a_symbol_leaf() {
+        let tree = sample_tree();
+        // Move cursor down twice: src (0) -> src/lib.rs (1) -> foo (2).
+        let nav = Nav::new()
+            .handle(Action::CursorDown, &tree)
+            .handle(Action::CursorDown, &tree);
+        assert_eq!(2, nav.cursor());
+
+        let nav = nav.handle(Action::ToggleExpand, &tree);
+        let rows = nav.rows(&tree);
+
+        // Nothing collapsed: still every row visible.
+        assert_eq!(4, rows.len());
+    }
+
+    #[test]
+    fn should_clamp_cursor_at_zero_when_cursor_up_past_the_top() {
+        let tree = sample_tree();
+        let nav = Nav::new().handle(Action::CursorUp, &tree);
+
+        assert_eq!(0, nav.cursor());
+    }
+
+    #[test]
+    fn should_clamp_cursor_at_last_row_when_cursor_down_past_the_bottom() {
+        let tree = sample_tree();
+        let mut nav = Nav::new();
+        for _ in 0..10 {
+            nav = nav.handle(Action::CursorDown, &tree);
+        }
+
+        assert_eq!(3, nav.cursor());
+    }
+
+    #[test]
+    fn should_move_cursor_down_one_row_at_a_time() {
+        let tree = sample_tree();
+        let nav = Nav::new().handle(Action::CursorDown, &tree);
+
+        assert_eq!(1, nav.cursor());
+    }
+
+    #[test]
+    fn should_collapse_every_dir_and_file_when_collapse_all_is_applied() {
+        let tree = sample_tree();
+        let nav = Nav::new().handle(Action::CollapseAll, &tree);
+
+        let rows = nav.rows(&tree);
+
+        let paths: Vec<&str> = rows.iter().map(|r| r.node.path.as_str()).collect();
+        assert_eq!(vec!["src"], paths);
+    }
+
+    #[test]
+    fn should_expand_every_node_when_expand_all_is_applied_after_collapse_all() {
+        let tree = sample_tree();
+        let nav = Nav::new()
+            .handle(Action::CollapseAll, &tree)
+            .handle(Action::ExpandAll, &tree);
+
+        let rows = nav.rows(&tree);
+
+        assert_eq!(4, rows.len());
+    }
+
+    #[test]
+    fn should_report_row_as_not_expanded_when_node_has_no_children() {
+        // A childless file (e.g. a pure rename with no symbols) can never
+        // be "expanded" — nothing to show — regardless of collapse state.
+        let tree = Tree {
+            roots: vec![file_node("renamed.rs", vec![])],
+        };
+        let nav = Nav::new();
+
+        let rows = nav.rows(&tree);
+
+        assert_eq!(1, rows.len());
+        assert_eq!(false, rows[0].expanded);
+    }
+
+    #[test]
+    fn should_keep_collapse_state_stable_across_a_tree_rebuild_with_same_paths() {
+        // Simulates a Report re-run producing a structurally identical
+        // tree (same paths) — collapse state, keyed by path, must survive.
+        let tree_v1 = sample_tree();
+        let nav = Nav::new().handle(Action::ToggleExpand, &tree_v1);
+
+        let tree_v2 = sample_tree(); // fresh tree, same paths/shape
+        let rows = nav.rows(&tree_v2);
+
+        let paths: Vec<&str> = rows.iter().map(|r| r.node.path.as_str()).collect();
+        assert_eq!(vec!["src"], paths);
+    }
+}

--- a/rinkaku-tui/src/nav.rs
+++ b/rinkaku-tui/src/nav.rs
@@ -29,6 +29,19 @@ pub enum Action {
 /// model stays cheap to rebuild every frame, matching `ratatui`'s
 /// immediate-mode redraw-from-state model per ADR 0016 decision 1) plus
 /// its depth for indentation and whether it is currently expanded.
+///
+/// A `Symbol` row's `node.path` is its containing file's path, not a path
+/// unique to that symbol (`crate::tree::TreeNode::path`'s own doc comment
+/// notes this) — so several symbol rows can share the same `path` with
+/// each other and with their file's own row. This is safe for the
+/// `collapsed` set this module keys by path (`Nav`'s own doc comment)
+/// specifically because `push_rows`/`retarget_cursor` only ever treat a
+/// path as a collapse/lookup key together with `has_children`: a `Symbol`
+/// row always has `has_children == false`, so it is never itself a
+/// candidate to collapse or a distinct target to re-target the cursor onto
+/// — code relying on `path` to identify a *specific* row must additionally
+/// check `has_children`/`expanded` (or the node's `kind`) rather than
+/// assume `path` alone disambiguates.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Row<'a> {
     pub node: &'a TreeNode,

--- a/rinkaku-tui/src/nav.rs
+++ b/rinkaku-tui/src/nav.rs
@@ -126,10 +126,20 @@ impl Nav {
     /// just an index, so it would otherwise keep pointing at whatever row
     /// happens to now occupy that slot (or past the end of the list). To
     /// keep the cursor meaningfully attached to "the thing the user was
-    /// looking at", every action re-targets the cursor afterward via
-    /// [`Self::retarget_cursor`] rather than only the actions that are
-    /// obviously collapse-shaped — this also future-proofs against a new
-    /// `Action` variant that shrinks the row list in some other way.
+    /// looking at", every action that can shrink or reshuffle the row list
+    /// re-targets the cursor afterward via [`Self::retarget_cursor`] — that
+    /// covers `ToggleExpand`, `ExpandAll`, and `CollapseAll` below, falling
+    /// through to the shared `retarget_cursor` call after the `match`
+    /// rather than only the branches that are obviously collapse-shaped, so
+    /// this also future-proofs against a new `Action` variant added there
+    /// later that shrinks the row list in some other way.
+    ///
+    /// `CursorUp`/`CursorDown` are the two exceptions: they `return self`
+    /// directly from inside the `match`, bypassing `retarget_cursor`
+    /// entirely. This is safe rather than an oversight — moving the cursor
+    /// is the action that *sets* the cursor's new target, so there is
+    /// nothing to re-target it against; both arms already do their own
+    /// bounds clamping against the current `rows(tree).len()` inline.
     pub fn handle(mut self, action: Action, tree: &Tree) -> Self {
         let cursor_path_chain = self.cursor_path_chain(tree);
 

--- a/rinkaku-tui/src/order.rs
+++ b/rinkaku-tui/src/order.rs
@@ -1,0 +1,737 @@
+//! Topological directory ordering for the entry view (ADR 0016 decision
+//! 4): by default, sibling directories are ordered so that outermost
+//! (least-depended-on) directories show first and foundational
+//! (most-depended-on) directories show last — the same shape
+//! `rinkaku-core`'s `graph::find_roots` already computes at the symbol
+//! level, condensed here to directories instead.
+//!
+//! This module reimplements the SCC-condensation approach locally rather
+//! than reusing `rinkaku-core::graph`'s private helpers (CLAUDE.md: no
+//! shared abstraction without a concrete second use case argued in an
+//! ADR) — the algorithm is the same shape, but it operates over
+//! directories, a concept `rinkaku-core`'s graph module has no notion of.
+
+use rinkaku_core::render::Report;
+use std::collections::{HashMap, HashSet};
+
+/// How sibling directories/files are ordered in the entry view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OrderMode {
+    /// Topological: least-depended-on directories first, foundations last
+    /// (ADR 0016 decision 4, this module's default per that ADR).
+    #[default]
+    Topological,
+    /// Plain alphabetical ordering, the toggle ADR 0016 keeps available.
+    AlphaNumeric,
+}
+
+/// One directory's computed rank: its position in topological order, plus
+/// whether it participates in a dependency cycle with at least one other
+/// directory (a design-warning signal, ADR 0016 decision 4 / ADR 0008's
+/// existing symbol-level cycle warning).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DirRank {
+    /// Ascending sort key: directories sharing an SCC share the same rank.
+    /// Directories absent from the change graph entirely (e.g. a directory
+    /// whose only content is removed symbols, which never enter
+    /// `graph.edges`/`graph.nodes`) get no `DirRank` at all — see
+    /// `rank_directories`'s doc comment — rather than an arbitrary rank
+    /// value, so callers cannot accidentally compare "no data" against a
+    /// real rank.
+    pub rank: usize,
+    pub in_cycle: bool,
+}
+
+/// Computes each directory's [`DirRank`] from `report.graph`'s edges,
+/// condensed from symbol-level to directory-level.
+///
+/// Condensation: every [`rinkaku_core::graph::Edge`] is remapped from its
+/// endpoints' node ids to the parent directory of each endpoint's file path
+/// (the empty string for a root-level file, e.g. `"lib.rs"` condenses to
+/// `""`). An edge whose two endpoints condense to the *same* directory is
+/// dropped — it says nothing about inter-directory dependency, only
+/// intra-directory structure, which is not this module's concern (a
+/// directory doesn't depend on itself).
+///
+/// Ranking: Tarjan SCCs the condensed directory graph, then orders SCCs by
+/// a Kahn topological sort starting from in-degree-0 SCCs — the same
+/// direction `graph::find_roots` uses (an edge's `from` depends on/
+/// references its `to`, so a 0-indegree SCC is reached by nobody, i.e. an
+/// entry point) — so entry-point directories rank lowest (shown first) and
+/// directories heavily depended upon by others rank highest (shown last,
+/// as foundations). Every directory inside one SCC shares that SCC's rank
+/// and is marked `in_cycle` when the SCC has more than one member.
+///
+/// Returns only directories that appear in the condensed graph (i.e. own at
+/// least one node in `report.graph.nodes`, directly or via a descendant
+/// directory once nesting is accounted for by the caller). A directory
+/// whose only content is symbols absent from the graph (removed symbols,
+/// or files with no changed-symbol nodes at all) is not present in the
+/// returned map — `crate::tree`'s ordering step is expected to sort those
+/// after every ranked directory, A-Z (ADR 0016 decision 4), since this
+/// module has no graph data to rank them by.
+pub fn rank_directories(report: &Report) -> HashMap<String, DirRank> {
+    let dir_of_node: HashMap<&str, &str> = report
+        .graph
+        .nodes
+        .iter()
+        .map(|node| (node.id.as_str(), parent_dir(&node.path)))
+        .collect();
+
+    let mut dirs: Vec<&str> = dir_of_node
+        .values()
+        .copied()
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    dirs.sort_unstable();
+    let dir_index: HashMap<&str, usize> = dirs.iter().enumerate().map(|(i, &d)| (d, i)).collect();
+
+    let mut adjacency: Vec<HashSet<usize>> = vec![HashSet::new(); dirs.len()];
+    for edge in &report.graph.edges {
+        let (Some(&from_dir), Some(&to_dir)) = (
+            dir_of_node.get(edge.from.as_str()),
+            dir_of_node.get(edge.to.as_str()),
+        ) else {
+            continue;
+        };
+        if from_dir == to_dir {
+            continue;
+        }
+        let (from_i, to_i) = (dir_index[from_dir], dir_index[to_dir]);
+        adjacency[from_i].insert(to_i);
+    }
+    let adjacency: Vec<Vec<usize>> = adjacency
+        .into_iter()
+        .map(|targets| targets.into_iter().collect())
+        .collect();
+
+    let sccs = tarjan_sccs(&adjacency);
+    let mut scc_of = vec![0usize; dirs.len()];
+    for (scc_index, scc) in sccs.iter().enumerate() {
+        for &node_index in scc {
+            scc_of[node_index] = scc_index;
+        }
+    }
+
+    let scc_order = topological_scc_order(&sccs, &scc_of, &adjacency);
+
+    let mut rank_of_scc = vec![0usize; sccs.len()];
+    for (rank, &scc_index) in scc_order.iter().enumerate() {
+        rank_of_scc[scc_index] = rank;
+    }
+
+    let mut result = HashMap::new();
+    for (scc_index, scc) in sccs.iter().enumerate() {
+        let in_cycle = scc.len() > 1;
+        for &node_index in scc {
+            result.insert(
+                dirs[node_index].to_string(),
+                DirRank {
+                    rank: rank_of_scc[scc_index],
+                    in_cycle,
+                },
+            );
+        }
+    }
+    result
+}
+
+/// The parent directory of a slash-separated `path` — everything before
+/// the last `/`, or the empty string when `path` has no `/` at all (a
+/// root-level file).
+fn parent_dir(path: &str) -> &str {
+    path.rsplit_once('/').map(|(dir, _)| dir).unwrap_or("")
+}
+
+/// Orders SCC indices via Kahn's algorithm on the condensation DAG, ties
+/// broken by each SCC's smallest member index (stable, deterministic
+/// regardless of `tarjan_sccs`' own discovery order) — mirrors
+/// `graph::find_roots`'s own tie-break ("earliest in source order").
+/// Starting the frontier at in-degree-0 SCCs and always picking the
+/// lowest-index-available candidate next produces entry points first,
+/// foundations last, same direction `find_roots` establishes for roots.
+fn topological_scc_order(
+    sccs: &[Vec<usize>],
+    scc_of: &[usize],
+    adjacency: &[Vec<usize>],
+) -> Vec<usize> {
+    let scc_count = sccs.len();
+    let mut scc_adjacency: Vec<HashSet<usize>> = vec![HashSet::new(); scc_count];
+    let mut in_degree = vec![0usize; scc_count];
+
+    for (from_node, targets) in adjacency.iter().enumerate() {
+        let from_scc = scc_of[from_node];
+        for &to_node in targets {
+            let to_scc = scc_of[to_node];
+            if from_scc != to_scc && scc_adjacency[from_scc].insert(to_scc) {
+                in_degree[to_scc] += 1;
+            }
+        }
+    }
+
+    let scc_min_member: Vec<usize> = sccs
+        .iter()
+        .map(|scc| {
+            *scc.iter()
+                .min()
+                .expect("tarjan_sccs never emits an empty component")
+        })
+        .collect();
+
+    let mut frontier: Vec<usize> = (0..scc_count).filter(|&i| in_degree[i] == 0).collect();
+    let mut order = Vec::with_capacity(scc_count);
+    let mut visited = vec![false; scc_count];
+
+    while !frontier.is_empty() {
+        // Deterministic regardless of HashSet/discovery order: always
+        // advance whichever ready SCC has the earliest source-order
+        // member.
+        frontier.sort_by_key(|&i| scc_min_member[i]);
+        let scc_index = frontier.remove(0);
+        if visited[scc_index] {
+            continue;
+        }
+        visited[scc_index] = true;
+        order.push(scc_index);
+
+        for &neighbor in &scc_adjacency[scc_index] {
+            in_degree[neighbor] -= 1;
+            if in_degree[neighbor] == 0 {
+                frontier.push(neighbor);
+            }
+        }
+    }
+
+    // Defensive: a bug in in-degree bookkeeping could in principle leave an
+    // SCC unvisited (Kahn's algorithm always terminates on a DAG, and the
+    // SCC condensation is always a DAG by construction). Append any
+    // stragglers in source order rather than silently dropping them.
+    for (scc_index, &was_visited) in visited.iter().enumerate() {
+        if !was_visited {
+            order.push(scc_index);
+        }
+    }
+
+    order
+}
+
+/// Tarjan's strongly-connected-components algorithm, iterative to avoid
+/// stack overflow on a large directory graph — same shape as
+/// `rinkaku-core::graph`'s private `tarjan_sccs` (reimplemented here per
+/// this module's own doc comment on not sharing an abstraction across the
+/// crate boundary for one use case).
+fn tarjan_sccs(adjacency: &[Vec<usize>]) -> Vec<Vec<usize>> {
+    let n = adjacency.len();
+    let mut index_counter = 0usize;
+    let mut indices: Vec<Option<usize>> = vec![None; n];
+    let mut lowlink: Vec<usize> = vec![0; n];
+    let mut on_stack: Vec<bool> = vec![false; n];
+    let mut stack: Vec<usize> = Vec::new();
+    let mut sccs: Vec<Vec<usize>> = Vec::new();
+
+    for start in 0..n {
+        if indices[start].is_some() {
+            continue;
+        }
+        let mut work: Vec<(usize, usize)> = vec![(start, 0)];
+
+        while let Some(&(v, child_i)) = work.last() {
+            if child_i == 0 {
+                indices[v] = Some(index_counter);
+                lowlink[v] = index_counter;
+                index_counter += 1;
+                stack.push(v);
+                on_stack[v] = true;
+            }
+
+            let Some(frame) = work.last_mut() else {
+                break;
+            };
+
+            if child_i < adjacency[v].len() {
+                let w = adjacency[v][child_i];
+                frame.1 += 1;
+
+                match indices[w] {
+                    None => work.push((w, 0)),
+                    Some(w_index) if on_stack[w] => {
+                        lowlink[v] = lowlink[v].min(w_index);
+                    }
+                    Some(_) => {}
+                }
+            } else {
+                work.pop();
+                if let Some(&(parent, _)) = work.last() {
+                    lowlink[parent] = lowlink[parent].min(lowlink[v]);
+                }
+
+                if let Some(v_index) = indices[v]
+                    && lowlink[v] == v_index
+                {
+                    let mut component = Vec::new();
+                    while let Some(w) = stack.pop() {
+                        on_stack[w] = false;
+                        let is_v = w == v;
+                        component.push(w);
+                        if is_v {
+                            break;
+                        }
+                    }
+                    sccs.push(component);
+                }
+            }
+        }
+    }
+
+    sccs
+}
+
+/// Reorders every level of `tree` in place according to `mode`, using
+/// `ranks` (from [`rank_directories`]) when `mode` is
+/// [`OrderMode::Topological`].
+///
+/// Ordering rule at each level (ADR 0016 decision 4): directory children
+/// sort first, file children after — files never carry a rank of their
+/// own (only directories do), so keeping the two groups separate avoids
+/// interleaving "ranked" and "unrankable" siblings in a way that would be
+/// hard to read. Symbol children (leaves under a `File`) are never
+/// reordered; they stay in the extraction/graph order `crate::tree`
+/// already gave them, since ADR 0016 only asks for directory ordering.
+///
+/// Within the directory group: [`OrderMode::Topological`] sorts by
+/// `ranks[dir.path]` ascending, with directories absent from `ranks` (no
+/// graph presence at all — e.g. a directory containing only removed
+/// symbols) sorted after every ranked directory, then A-Z among
+/// themselves and among ties on the same rank (a stable, readable
+/// tie-break absent from `rank_directories`' own contract, which only
+/// promises *a* deterministic rank, not a name-based tie-break).
+/// [`OrderMode::AlphaNumeric`] ignores `ranks` entirely and sorts every
+/// directory A-Z. Either way, the file group is always A-Z regardless of
+/// `mode` — files have no rank concept to toggle between.
+pub fn order_tree(tree: &mut crate::tree::Tree, ranks: &HashMap<String, DirRank>, mode: OrderMode) {
+    order_siblings(&mut tree.roots, ranks, mode);
+}
+
+fn order_siblings(
+    nodes: &mut [crate::tree::TreeNode],
+    ranks: &HashMap<String, DirRank>,
+    mode: OrderMode,
+) {
+    for node in nodes.iter_mut() {
+        if matches!(node.kind, crate::tree::NodeKind::Dir) {
+            order_siblings(&mut node.children, ranks, mode);
+        }
+    }
+
+    nodes.sort_by(|a, b| {
+        let a_is_dir = matches!(a.kind, crate::tree::NodeKind::Dir);
+        let b_is_dir = matches!(b.kind, crate::tree::NodeKind::Dir);
+        // Directories before files, regardless of mode.
+        b_is_dir.cmp(&a_is_dir).then_with(|| match mode {
+            OrderMode::Topological if a_is_dir && b_is_dir => {
+                // `None` (unranked: no graph presence at all) must sort
+                // after every `Some` rank — the opposite of
+                // `Option<usize>`'s derived `Ord`, which puts `None`
+                // first — so rank is compared via an explicit "unranked
+                // last" key (`usize::MAX` standing in for "no rank") rather
+                // than relying on `Option`'s own ordering. Ties (same
+                // rank, or both unranked) break A-Z on path.
+                let rank_key = |path: &str| ranks.get(path).map_or(usize::MAX, |r| r.rank);
+                rank_key(&a.path)
+                    .cmp(&rank_key(&b.path))
+                    .then_with(|| a.path.cmp(&b.path))
+            }
+            _ => a.path.cmp(&b.path),
+        })
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+    use rinkaku_core::graph::{Edge, Node, SymbolGraph};
+    use rinkaku_core::render::FileReport;
+
+    fn symbol(id: &str, name: &str) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature: format!("fn {name}()"),
+            range: rinkaku_core::diff::LineRange { start: 1, end: 1 },
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        }
+    }
+
+    fn node(id: &str, path: &str, name: &str) -> Node {
+        Node {
+            id: id.to_string(),
+            path: path.to_string(),
+            name: name.to_string(),
+        }
+    }
+
+    fn report_with_graph(nodes: Vec<Node>, edges: Vec<Edge>) -> Report {
+        Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes,
+                edges,
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    #[test]
+    fn should_return_empty_ranking_when_graph_has_no_nodes() {
+        let report = report_with_graph(vec![], vec![]);
+
+        let expected: HashMap<String, DirRank> = HashMap::new();
+        let actual = rank_directories(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_rank_directory_with_no_edges_at_rank_zero_and_not_in_cycle() {
+        let report = report_with_graph(vec![node("api/lib.rs::foo", "api/lib.rs", "foo")], vec![]);
+
+        let mut expected = HashMap::new();
+        expected.insert(
+            "api".to_string(),
+            DirRank {
+                rank: 0,
+                in_cycle: false,
+            },
+        );
+        let actual = rank_directories(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_rank_caller_directory_before_callee_directory() {
+        // api/ calls store/: api is the entry point (0 incoming
+        // inter-directory edges), store is the foundation.
+        let report = report_with_graph(
+            vec![
+                node("api/handler.rs::handle", "api/handler.rs", "handle"),
+                node("store/db.rs::save", "store/db.rs", "save"),
+            ],
+            vec![Edge {
+                from: "api/handler.rs::handle".to_string(),
+                to: "store/db.rs::save".to_string(),
+                is_cycle: false,
+            }],
+        );
+
+        let ranks = rank_directories(&report);
+
+        let api_rank = ranks["api"].rank;
+        let store_rank = ranks["store"].rank;
+        assert!(
+            api_rank < store_rank,
+            "expected api ({api_rank}) to rank before store ({store_rank})"
+        );
+        assert_eq!(false, ranks["api"].in_cycle);
+        assert_eq!(false, ranks["store"].in_cycle);
+    }
+
+    #[test]
+    fn should_drop_edge_and_still_rank_zero_when_both_endpoints_share_a_directory() {
+        // Both symbols live in the same directory ("api"), so the edge
+        // between them condenses to a self-loop and must be dropped —
+        // otherwise "api" would wrongly show up as depending on itself.
+        let report = report_with_graph(
+            vec![
+                node("api/a.rs::a", "api/a.rs", "a"),
+                node("api/b.rs::b", "api/b.rs", "b"),
+            ],
+            vec![Edge {
+                from: "api/a.rs::a".to_string(),
+                to: "api/b.rs::b".to_string(),
+                is_cycle: false,
+            }],
+        );
+
+        let expected = {
+            let mut m = HashMap::new();
+            m.insert(
+                "api".to_string(),
+                DirRank {
+                    rank: 0,
+                    in_cycle: false,
+                },
+            );
+            m
+        };
+        let actual = rank_directories(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_mark_directories_in_cycle_and_give_them_the_same_rank() {
+        // api/ and store/ depend on each other — a directory-level cycle.
+        let report = report_with_graph(
+            vec![
+                node("api/handler.rs::handle", "api/handler.rs", "handle"),
+                node("store/db.rs::save", "store/db.rs", "save"),
+            ],
+            vec![
+                Edge {
+                    from: "api/handler.rs::handle".to_string(),
+                    to: "store/db.rs::save".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "store/db.rs::save".to_string(),
+                    to: "api/handler.rs::handle".to_string(),
+                    is_cycle: false,
+                },
+            ],
+        );
+
+        let ranks = rank_directories(&report);
+
+        assert_eq!(ranks["api"].rank, ranks["store"].rank);
+        assert_eq!(true, ranks["api"].in_cycle);
+        assert_eq!(true, ranks["store"].in_cycle);
+    }
+
+    #[test]
+    fn should_rank_root_level_file_directory_as_empty_string() {
+        let report = report_with_graph(vec![node("lib.rs::foo", "lib.rs", "foo")], vec![]);
+
+        let expected = {
+            let mut m = HashMap::new();
+            m.insert(
+                String::new(),
+                DirRank {
+                    rank: 0,
+                    in_cycle: false,
+                },
+            );
+            m
+        };
+        let actual = rank_directories(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_chain_three_directories_in_dependency_order() {
+        // api -> service -> store: three distinct ranks, strictly
+        // increasing in that dependency order.
+        let report = report_with_graph(
+            vec![
+                node("api/a.rs::a", "api/a.rs", "a"),
+                node("service/s.rs::s", "service/s.rs", "s"),
+                node("store/db.rs::save", "store/db.rs", "save"),
+            ],
+            vec![
+                Edge {
+                    from: "api/a.rs::a".to_string(),
+                    to: "service/s.rs::s".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "service/s.rs::s".to_string(),
+                    to: "store/db.rs::save".to_string(),
+                    is_cycle: false,
+                },
+            ],
+        );
+
+        let ranks = rank_directories(&report);
+
+        assert_eq!(0, ranks["api"].rank);
+        assert_eq!(1, ranks["service"].rank);
+        assert_eq!(2, ranks["store"].rank);
+    }
+
+    // Uses `symbol` to document that `rank_directories` only reads
+    // `report.graph`, not `report.files`, even though a realistic `Report`
+    // always carries matching `files` alongside its `graph` — this pins
+    // that `rank_directories`' contract is graph-only, matching its own doc
+    // comment.
+    #[test]
+    fn should_ignore_files_field_and_rank_from_graph_alone() {
+        let mut report = report_with_graph(vec![node("api/a.rs::a", "api/a.rs", "a")], vec![]);
+        report.files = vec![FileReport {
+            path: "api/a.rs".to_string(),
+            symbols: vec![symbol("api/a.rs::a", "a")],
+        }];
+
+        let ranks = rank_directories(&report);
+
+        assert_eq!(1, ranks.len());
+        assert_eq!(0, ranks["api"].rank);
+    }
+
+    fn dir_node(path: &str, children: Vec<crate::tree::TreeNode>) -> crate::tree::TreeNode {
+        crate::tree::TreeNode {
+            kind: crate::tree::NodeKind::Dir,
+            path: path.to_string(),
+            badges: crate::tree::Badges::default(),
+            children,
+        }
+    }
+
+    fn file_node(path: &str) -> crate::tree::TreeNode {
+        crate::tree::TreeNode {
+            kind: crate::tree::NodeKind::File,
+            path: path.to_string(),
+            badges: crate::tree::Badges::default(),
+            children: vec![],
+        }
+    }
+
+    #[test]
+    fn should_order_directories_before_files_at_the_same_level() {
+        let mut tree = crate::tree::Tree {
+            roots: vec![file_node("z.rs"), dir_node("a", vec![])],
+        };
+
+        order_tree(&mut tree, &HashMap::new(), OrderMode::AlphaNumeric);
+
+        let paths: Vec<&str> = tree.roots.iter().map(|n| n.path.as_str()).collect();
+        assert_eq!(vec!["a", "z.rs"], paths);
+    }
+
+    #[test]
+    fn should_order_files_alphabetically_regardless_of_mode() {
+        let mut tree = crate::tree::Tree {
+            roots: vec![file_node("z.rs"), file_node("a.rs")],
+        };
+
+        order_tree(&mut tree, &HashMap::new(), OrderMode::Topological);
+
+        let paths: Vec<&str> = tree.roots.iter().map(|n| n.path.as_str()).collect();
+        assert_eq!(vec!["a.rs", "z.rs"], paths);
+    }
+
+    #[test]
+    fn should_order_directories_by_rank_ascending_when_mode_is_topological() {
+        let mut tree = crate::tree::Tree {
+            roots: vec![dir_node("store", vec![]), dir_node("api", vec![])],
+        };
+        let mut ranks = HashMap::new();
+        ranks.insert(
+            "api".to_string(),
+            DirRank {
+                rank: 0,
+                in_cycle: false,
+            },
+        );
+        ranks.insert(
+            "store".to_string(),
+            DirRank {
+                rank: 1,
+                in_cycle: false,
+            },
+        );
+
+        order_tree(&mut tree, &ranks, OrderMode::Topological);
+
+        let paths: Vec<&str> = tree.roots.iter().map(|n| n.path.as_str()).collect();
+        assert_eq!(vec!["api", "store"], paths);
+    }
+
+    #[test]
+    fn should_order_directories_alphabetically_when_mode_is_alpha_numeric_even_with_ranks_present()
+    {
+        let mut tree = crate::tree::Tree {
+            roots: vec![dir_node("store", vec![]), dir_node("api", vec![])],
+        };
+        let mut ranks = HashMap::new();
+        // Ranks say "store first" but AlphaNumeric mode must ignore them.
+        ranks.insert(
+            "store".to_string(),
+            DirRank {
+                rank: 0,
+                in_cycle: false,
+            },
+        );
+        ranks.insert(
+            "api".to_string(),
+            DirRank {
+                rank: 1,
+                in_cycle: false,
+            },
+        );
+
+        order_tree(&mut tree, &ranks, OrderMode::AlphaNumeric);
+
+        let paths: Vec<&str> = tree.roots.iter().map(|n| n.path.as_str()).collect();
+        assert_eq!(vec!["api", "store"], paths);
+    }
+
+    #[test]
+    fn should_sort_unranked_directory_after_ranked_ones() {
+        let mut tree = crate::tree::Tree {
+            roots: vec![dir_node("unranked", vec![]), dir_node("api", vec![])],
+        };
+        let mut ranks = HashMap::new();
+        ranks.insert(
+            "api".to_string(),
+            DirRank {
+                rank: 0,
+                in_cycle: false,
+            },
+        );
+        // "unranked" has no entry in `ranks` at all.
+
+        order_tree(&mut tree, &ranks, OrderMode::Topological);
+
+        let paths: Vec<&str> = tree.roots.iter().map(|n| n.path.as_str()).collect();
+        assert_eq!(vec!["api", "unranked"], paths);
+    }
+
+    #[test]
+    fn should_order_nested_directory_children_recursively() {
+        let mut tree = crate::tree::Tree {
+            roots: vec![dir_node(
+                "src",
+                vec![dir_node("src/store", vec![]), dir_node("src/api", vec![])],
+            )],
+        };
+        let mut ranks = HashMap::new();
+        ranks.insert(
+            "src/api".to_string(),
+            DirRank {
+                rank: 0,
+                in_cycle: false,
+            },
+        );
+        ranks.insert(
+            "src/store".to_string(),
+            DirRank {
+                rank: 1,
+                in_cycle: false,
+            },
+        );
+
+        order_tree(&mut tree, &ranks, OrderMode::Topological);
+
+        let paths: Vec<&str> = tree.roots[0]
+            .children
+            .iter()
+            .map(|n| n.path.as_str())
+            .collect();
+        assert_eq!(vec!["src/api", "src/store"], paths);
+    }
+}

--- a/rinkaku-tui/src/order.rs
+++ b/rinkaku-tui/src/order.rs
@@ -179,13 +179,17 @@ fn topological_scc_order(
         }
     }
 
+    // `tarjan_sccs` never produces an empty component (each `component` it
+    // pushes starts from a freshly-visited node and is only pushed after
+    // collecting at least that node), so `min()` always finds a value in
+    // practice; `if let` avoids asserting that invariant via `.expect()` in
+    // library code (mirrors `rinkaku-core::graph::find_roots`'s identical
+    // defensive handling of the same invariant) and falls back to
+    // `usize::MAX` for a component that somehow turned out empty, which
+    // sorts it last in the frontier rather than panicking.
     let scc_min_member: Vec<usize> = sccs
         .iter()
-        .map(|scc| {
-            *scc.iter()
-                .min()
-                .expect("tarjan_sccs never emits an empty component")
-        })
+        .map(|scc| scc.iter().min().copied().unwrap_or(usize::MAX))
         .collect();
 
     let mut frontier: Vec<usize> = (0..scc_count).filter(|&i| in_degree[i] == 0).collect();
@@ -230,6 +234,12 @@ fn topological_scc_order(
 /// `rinkaku-core::graph`'s private `tarjan_sccs` (reimplemented here per
 /// this module's own doc comment on not sharing an abstraction across the
 /// crate boundary for one use case).
+///
+/// Because this is a deliberate duplication rather than a shared
+/// dependency, the two copies do not stay in sync automatically: a bugfix
+/// or algorithmic change made to one (e.g. the empty-component handling in
+/// `find_roots`/`topological_scc_order`) should be checked against the
+/// other and mirrored by hand if it applies there too.
 fn tarjan_sccs(adjacency: &[Vec<usize>]) -> Vec<Vec<usize>> {
     let n = adjacency.len();
     let mut index_counter = 0usize;
@@ -938,5 +948,119 @@ mod tests {
             badges: crate::tree::Badges::default(),
             children,
         }
+    }
+
+    // The `rank_directories`-level tests above exercise `tarjan_sccs` and
+    // `topological_scc_order` only indirectly, through a full directory
+    // condensation built from a `Report`. These tests instead drive the two
+    // private helpers directly with hand-built adjacency lists, so a future
+    // change to either algorithm gets pinned down at the shape it actually
+    // operates on (plain `usize` adjacency), not just observed through the
+    // directory-name-shaped output several layers up.
+
+    #[test]
+    fn should_split_into_singleton_sccs_when_graph_is_a_diamond() {
+        // 0 -> 1, 0 -> 2, 1 -> 3, 2 -> 3: acyclic diamond, so every node is
+        // its own SCC (no back edges to merge any of them together).
+        let adjacency = vec![vec![1, 2], vec![3], vec![3], vec![]];
+
+        let mut sccs = tarjan_sccs(&adjacency);
+        for scc in &mut sccs {
+            scc.sort_unstable();
+        }
+        sccs.sort_by_key(|scc| scc[0]);
+
+        assert_eq!(vec![vec![0], vec![1], vec![2], vec![3]], sccs);
+    }
+
+    #[test]
+    fn should_group_mutually_reachable_nodes_into_one_scc_when_graph_has_two_independent_cycles() {
+        // 0 <-> 1 and 2 <-> 3, with no edges between the two pairs: two
+        // independent 2-node SCCs, neither depending on the other.
+        let adjacency = vec![vec![1], vec![0], vec![3], vec![2]];
+
+        let mut sccs = tarjan_sccs(&adjacency);
+        for scc in &mut sccs {
+            scc.sort_unstable();
+        }
+        sccs.sort_by_key(|scc| scc[0]);
+
+        assert_eq!(vec![vec![0, 1], vec![2, 3]], sccs);
+    }
+
+    #[test]
+    fn should_isolate_cycle_from_surrounding_acyclic_nodes_when_graph_mixes_both() {
+        // 0 -> 1 -> 2 -> 1 -> 3: nodes 1 and 2 form a cycle (1 -> 2 -> 1),
+        // while 0 (entry) and 3 (reached only from the cycle) stay acyclic
+        // singletons on either side of it.
+        let adjacency = vec![vec![1], vec![2], vec![1, 3], vec![]];
+
+        let mut sccs = tarjan_sccs(&adjacency);
+        for scc in &mut sccs {
+            scc.sort_unstable();
+        }
+        sccs.sort_by_key(|scc| scc[0]);
+
+        assert_eq!(vec![vec![0], vec![1, 2], vec![3]], sccs);
+    }
+
+    #[test]
+    fn should_order_diamond_sccs_with_entry_first_and_join_last() {
+        // Same diamond as the tarjan_sccs test above: 0 -> {1, 2} -> 3.
+        // Every node is its own singleton SCC; topological order must place
+        // 0 first (the only in-degree-0 SCC) and 3 last (depended on by
+        // both 1 and 2), with 1 before 2 as the deterministic tie-break
+        // (smaller member index first) since neither depends on the other.
+        let adjacency = vec![vec![1, 2], vec![3], vec![3], vec![]];
+        let sccs: Vec<Vec<usize>> = vec![vec![0], vec![1], vec![2], vec![3]];
+        let mut scc_of = vec![0usize; 4];
+        for (scc_index, scc) in sccs.iter().enumerate() {
+            for &node_index in scc {
+                scc_of[node_index] = scc_index;
+            }
+        }
+
+        let order = topological_scc_order(&sccs, &scc_of, &adjacency);
+
+        assert_eq!(vec![0, 1, 2, 3], order);
+    }
+
+    #[test]
+    fn should_order_two_independent_sccs_by_smallest_member_when_neither_depends_on_the_other() {
+        // {0, 1} and {2, 3} are independent SCCs (no edges between them) —
+        // both have in-degree 0 in the condensation, so the tie-break
+        // (smallest member index) alone decides that {0, 1} orders first.
+        let adjacency = vec![vec![1], vec![0], vec![3], vec![2]];
+        let sccs: Vec<Vec<usize>> = vec![vec![0, 1], vec![2, 3]];
+        let mut scc_of = vec![0usize; 4];
+        for (scc_index, scc) in sccs.iter().enumerate() {
+            for &node_index in scc {
+                scc_of[node_index] = scc_index;
+            }
+        }
+
+        let order = topological_scc_order(&sccs, &scc_of, &adjacency);
+
+        assert_eq!(vec![0, 1], order);
+    }
+
+    #[test]
+    fn should_order_cycle_between_its_acyclic_neighbors_when_graph_mixes_both() {
+        // Same mixed graph as the tarjan_sccs test above: 0 -> {1, 2} (a
+        // cycle) -> 3. The condensation is 0 -> scc{1,2} -> 3, so the
+        // topological order must be exactly [0, scc{1,2}, 3] regardless of
+        // which of 1/2 tarjan_sccs happened to list first inside the SCC.
+        let adjacency = vec![vec![1], vec![2], vec![1, 3], vec![]];
+        let sccs: Vec<Vec<usize>> = vec![vec![0], vec![1, 2], vec![3]];
+        let mut scc_of = vec![0usize; 4];
+        for (scc_index, scc) in sccs.iter().enumerate() {
+            for &node_index in scc {
+                scc_of[node_index] = scc_index;
+            }
+        }
+
+        let order = topological_scc_order(&sccs, &scc_of, &adjacency);
+
+        assert_eq!(vec![0, 1, 2], order);
     }
 }

--- a/rinkaku-tui/src/order.rs
+++ b/rinkaku-tui/src/order.rs
@@ -62,14 +62,23 @@ pub struct DirRank {
 /// as foundations). Every directory inside one SCC shares that SCC's rank
 /// and is marked `in_cycle` when the SCC has more than one member.
 ///
-/// Returns only directories that appear in the condensed graph (i.e. own at
-/// least one node in `report.graph.nodes`, directly or via a descendant
-/// directory once nesting is accounted for by the caller). A directory
-/// whose only content is symbols absent from the graph (removed symbols,
-/// or files with no changed-symbol nodes at all) is not present in the
-/// returned map — `crate::tree`'s ordering step is expected to sort those
-/// after every ranked directory, A-Z (ADR 0016 decision 4), since this
-/// module has no graph data to rank them by.
+/// Returns an entry only for a *leaf* directory: one that is the direct
+/// parent of at least one `report.graph.nodes` path (e.g. `"src/api"` for
+/// a node at `"src/api/handler.rs"`). A branching/intermediate directory
+/// that owns no node directly — e.g. `"src"` itself, when only its
+/// subdirectories do — is deliberately **not** given an entry here; that
+/// would require walking the whole subtree per directory, which this
+/// function has no tree structure to do (it only sees `report.graph`, not
+/// `crate::tree::Tree`). [`effective_ranks`] is "the caller accounting for
+/// nesting" this comment used to gesture at without naming: it walks the
+/// built `Tree` bottom-up and gives every ancestor directory the minimum
+/// rank of its descendants, so `order_tree` (which calls it internally)
+/// still ranks intermediate directories correctly despite this function's
+/// leaf-only contract. A directory whose entire subtree has no graph
+/// presence at all (removed symbols only, or files with no changed-symbol
+/// nodes) still ends up with no effective rank either, and
+/// `order_tree`/`order_siblings` sort those after every ranked directory,
+/// A-Z (ADR 0016 decision 4).
 pub fn rank_directories(report: &Report) -> HashMap<String, DirRank> {
     let dir_of_node: HashMap<&str, &str> = report
         .graph
@@ -299,28 +308,105 @@ fn tarjan_sccs(adjacency: &[Vec<usize>]) -> Vec<Vec<usize>> {
 /// reordered; they stay in the extraction/graph order `crate::tree`
 /// already gave them, since ADR 0016 only asks for directory ordering.
 ///
-/// Within the directory group: [`OrderMode::Topological`] sorts by
-/// `ranks[dir.path]` ascending, with directories absent from `ranks` (no
-/// graph presence at all — e.g. a directory containing only removed
-/// symbols) sorted after every ranked directory, then A-Z among
-/// themselves and among ties on the same rank (a stable, readable
-/// tie-break absent from `rank_directories`' own contract, which only
-/// promises *a* deterministic rank, not a name-based tie-break).
+/// Within the directory group: [`OrderMode::Topological`] sorts by each
+/// directory's *effective* rank ascending (see [`effective_ranks`] — a
+/// branching/intermediate directory that owns no graph node directly,
+/// e.g. "src" when only "src/api"/"src/store" have nodes, inherits the
+/// minimum rank of its descendant directories rather than being treated
+/// as unranked), with directories that have no effective rank at all (no
+/// ranked directory anywhere in their subtree — e.g. a directory
+/// containing only removed symbols) sorted after every ranked directory,
+/// then A-Z among themselves and among ties on the same rank (a stable,
+/// readable tie-break absent from `rank_directories`' own contract, which
+/// only promises *a* deterministic rank, not a name-based tie-break).
 /// [`OrderMode::AlphaNumeric`] ignores `ranks` entirely and sorts every
 /// directory A-Z. Either way, the file group is always A-Z regardless of
 /// `mode` — files have no rank concept to toggle between.
 pub fn order_tree(tree: &mut crate::tree::Tree, ranks: &HashMap<String, DirRank>, mode: OrderMode) {
-    order_siblings(&mut tree.roots, ranks, mode);
+    // Computed once up front (rather than re-derived per sort comparison)
+    // since it requires a full bottom-up subtree walk per directory node —
+    // doing that inside the `Ord::cmp` closure `order_siblings` uses would
+    // recompute the same descendants' minimum rank on every comparison.
+    let effective = effective_ranks(tree, ranks);
+    order_siblings(&mut tree.roots, &effective, mode);
+}
+
+/// For every directory node in `tree`, its effective rank: the minimum
+/// (outermost/least-depended-on-first) [`DirRank::rank`] across the
+/// directory itself and every directory nested under it, or `None` when
+/// neither the directory nor any descendant directory has a `ranks` entry
+/// at all.
+///
+/// This is what makes `rank_directories`' contract true in practice: that
+/// function only promises ranks for *leaf* directories (the direct parent
+/// of a graph node's path, see its own doc comment), and this function is
+/// "the caller accounting for nesting" its doc comment refers to. Without
+/// this propagation, a branching intermediate directory that owns no node
+/// of its own (e.g. "src" when only its subdirectories do) would have no
+/// `ranks` entry and silently sort as unranked, degrading topological
+/// order back to alphabetical among top-level entries — exactly the bug
+/// this function exists to close.
+///
+/// Taking the *minimum* (rather than e.g. an average) is what preserves
+/// "entry points first": if any descendant is an entry point (rank 0),
+/// the ancestor directory containing it should show early too, since a
+/// reviewer scanning top-to-bottom expects to reach that entry point
+/// promptly rather than have it buried under unrelated higher-ranked
+/// siblings.
+fn effective_ranks(
+    tree: &crate::tree::Tree,
+    ranks: &HashMap<String, DirRank>,
+) -> HashMap<String, usize> {
+    let mut effective = HashMap::new();
+    for root in &tree.roots {
+        compute_effective_rank(root, ranks, &mut effective);
+    }
+    effective
+}
+
+/// Post-order walk: computes every descendant directory's effective rank
+/// first, then this node's own as `min(own direct rank, min of children's
+/// effective ranks)`. Returns this node's effective rank (`None` when
+/// nothing in its own subtree is ranked) so the caller (a parent
+/// directory) can fold it into its own minimum without re-reading the map.
+fn compute_effective_rank(
+    node: &crate::tree::TreeNode,
+    ranks: &HashMap<String, DirRank>,
+    effective: &mut HashMap<String, usize>,
+) -> Option<usize> {
+    if !matches!(node.kind, crate::tree::NodeKind::Dir) {
+        // Files/symbols never carry a rank; nothing to fold into a parent.
+        return None;
+    }
+
+    let own_rank = ranks.get(&node.path).map(|r| r.rank);
+    let min_child_rank = node
+        .children
+        .iter()
+        .filter_map(|child| compute_effective_rank(child, ranks, effective))
+        .min();
+
+    let resolved = match (own_rank, min_child_rank) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    };
+
+    if let Some(rank) = resolved {
+        effective.insert(node.path.clone(), rank);
+    }
+    resolved
 }
 
 fn order_siblings(
     nodes: &mut [crate::tree::TreeNode],
-    ranks: &HashMap<String, DirRank>,
+    effective_ranks: &HashMap<String, usize>,
     mode: OrderMode,
 ) {
     for node in nodes.iter_mut() {
         if matches!(node.kind, crate::tree::NodeKind::Dir) {
-            order_siblings(&mut node.children, ranks, mode);
+            order_siblings(&mut node.children, effective_ranks, mode);
         }
     }
 
@@ -330,14 +416,15 @@ fn order_siblings(
         // Directories before files, regardless of mode.
         b_is_dir.cmp(&a_is_dir).then_with(|| match mode {
             OrderMode::Topological if a_is_dir && b_is_dir => {
-                // `None` (unranked: no graph presence at all) must sort
-                // after every `Some` rank — the opposite of
-                // `Option<usize>`'s derived `Ord`, which puts `None`
-                // first — so rank is compared via an explicit "unranked
-                // last" key (`usize::MAX` standing in for "no rank") rather
-                // than relying on `Option`'s own ordering. Ties (same
-                // rank, or both unranked) break A-Z on path.
-                let rank_key = |path: &str| ranks.get(path).map_or(usize::MAX, |r| r.rank);
+                // `None` (unranked: no ranked directory anywhere in this
+                // subtree) must sort after every `Some` rank — the
+                // opposite of `Option<usize>`'s derived `Ord`, which puts
+                // `None` first — so rank is compared via an explicit
+                // "unranked last" key (`usize::MAX` standing in for "no
+                // rank") rather than relying on `Option`'s own ordering.
+                // Ties (same rank, or both unranked) break A-Z on path.
+                let rank_key =
+                    |path: &str| effective_ranks.get(path).copied().unwrap_or(usize::MAX);
                 rank_key(&a.path)
                     .cmp(&rank_key(&b.path))
                     .then_with(|| a.path.cmp(&b.path))
@@ -733,5 +820,123 @@ mod tests {
             .map(|n| n.path.as_str())
             .collect();
         assert_eq!(vec!["src/api", "src/store"], paths);
+    }
+
+    // INTEGRATION test: rank_directories -> order_tree end to end, on a
+    // real 3-level branching tree — the shape the unit test above (which
+    // hand-builds the `ranks` map) cannot catch. `rank_directories` only
+    // emits an entry for a *leaf* directory (the direct parent of a graph
+    // node's path); an intermediate/branching directory like "zzz" here
+    // owns no node directly (only its descendants "zzz/api"/"zzz/service"
+    // do). Without effective-rank propagation up through ancestors, "zzz"
+    // would have no rank at all and sort A-Z against "aaa" (i.e. after
+    // it, since "aaa" < "zzz") regardless of dependency direction.
+    //
+    // The whole graph here is a single connected chain (zzz/api ->
+    // zzz/service -> aaa/store) precisely to avoid any ambiguity from
+    // independent/unrelated SCCs sharing in-degree 0 — this test's only
+    // job is to pin down propagation through a branching intermediate
+    // directory, not `topological_scc_order`'s tie-break among unrelated
+    // components (covered separately, see the `tarjan_sccs`/
+    // `topological_scc_order` unit tests below). Package names are chosen
+    // so the correct topological order ("zzz" first, "aaa" last) disagrees
+    // with alphabetical order, making a regression to A-Z observable.
+    #[test]
+    fn should_order_full_tree_by_effective_rank_through_branching_intermediate_directories() {
+        // zzz/api/handler.rs -> zzz/service/logic.rs -> aaa/store/db.rs:
+        // "zzz" contains both the entry point (api, rank 0) and a middle
+        // link (service, rank 1) — its effective rank must become 0 (the
+        // minimum of its descendants) so it still sorts first despite
+        // "aaa" < "zzz" alphabetically.
+        let report = report_with_graph(
+            vec![
+                node("zzz/api/handler.rs::handle", "zzz/api/handler.rs", "handle"),
+                node("zzz/service/logic.rs::run", "zzz/service/logic.rs", "run"),
+                node("aaa/store/db.rs::save", "aaa/store/db.rs", "save"),
+            ],
+            vec![
+                Edge {
+                    from: "zzz/api/handler.rs::handle".to_string(),
+                    to: "zzz/service/logic.rs::run".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "zzz/service/logic.rs::run".to_string(),
+                    to: "aaa/store/db.rs::save".to_string(),
+                    is_cycle: false,
+                },
+            ],
+        );
+        let ranks = rank_directories(&report);
+
+        // Build the corresponding tree by hand (mirrors what
+        // `tree::build_tree` would produce for this Report's files, minus
+        // badges which this test doesn't care about): two top-level
+        // packages, "zzz" branching into two subdirectories, "aaa" with
+        // one.
+        let mut tree = crate::tree::Tree {
+            roots: vec![
+                dir_node(
+                    "aaa",
+                    vec![dir_node(
+                        "aaa/store",
+                        vec![file_node_with_children("aaa/store/db.rs", vec![])],
+                    )],
+                ),
+                dir_node(
+                    "zzz",
+                    vec![
+                        dir_node(
+                            "zzz/service",
+                            vec![file_node_with_children("zzz/service/logic.rs", vec![])],
+                        ),
+                        dir_node(
+                            "zzz/api",
+                            vec![file_node_with_children("zzz/api/handler.rs", vec![])],
+                        ),
+                    ],
+                ),
+            ],
+        };
+
+        order_tree(&mut tree, &ranks, OrderMode::Topological);
+
+        let expected = crate::tree::Tree {
+            roots: vec![
+                dir_node(
+                    "zzz",
+                    vec![
+                        dir_node(
+                            "zzz/api",
+                            vec![file_node_with_children("zzz/api/handler.rs", vec![])],
+                        ),
+                        dir_node(
+                            "zzz/service",
+                            vec![file_node_with_children("zzz/service/logic.rs", vec![])],
+                        ),
+                    ],
+                ),
+                dir_node(
+                    "aaa",
+                    vec![dir_node(
+                        "aaa/store",
+                        vec![file_node_with_children("aaa/store/db.rs", vec![])],
+                    )],
+                ),
+            ],
+        };
+        assert_eq!(expected, tree);
+    }
+
+    fn file_node_with_children(
+        path: &str,
+        children: Vec<crate::tree::TreeNode>,
+    ) -> crate::tree::TreeNode {
+        crate::tree::TreeNode {
+            kind: crate::tree::NodeKind::File,
+            path: path.to_string(),
+            badges: crate::tree::Badges::default(),
+            children,
+        }
     }
 }

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -531,6 +531,36 @@ mod tests {
     }
 
     #[test]
+    fn should_not_strip_partial_string_overlap_between_sibling_directory_names() {
+        // "src" and "src2" are two independent top-level roots (both
+        // depth 0, i.e. siblings, not ancestor/descendant) that happen to
+        // share "src" as a string prefix. `relative_labels` only ever
+        // compares a row against its own ancestor chain (via
+        // `ancestor_path_at[row.depth - 1]`), never against a sibling at
+        // the same depth, so "src2" must keep its full label rather than
+        // having "src" spuriously stripped off it as if "src" were its
+        // parent.
+        let src = dir_node("src", Badges::default(), vec![]);
+        let src2 = dir_node("src2", Badges::default(), vec![]);
+        let rows = vec![
+            Row {
+                node: &src,
+                depth: 0,
+                expanded: false,
+            },
+            Row {
+                node: &src2,
+                depth: 0,
+                expanded: false,
+            },
+        ];
+
+        let labels = relative_labels(&rows);
+
+        assert_eq!(vec!["src".to_string(), "src2".to_string()], labels);
+    }
+
+    #[test]
     fn should_return_empty_label_for_symbol_rows() {
         let node = symbol_node("lib.rs", plain_symbol("foo"), Badges::default());
         let rows = vec![Row {

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -1,0 +1,592 @@
+//! Pure formatting of one entry-view row into styled `ratatui` text
+//! (stage B, ADR 0015/0016): given a `crate::nav::Row` (already resolved
+//! against the tree/collapse state) plus its display label, produces the
+//! [`ratatui::text::Line`] that `crate::ui` draws for it.
+//!
+//! `Line`/`Span`/`Style` are plain, `PartialEq`-comparable data — not
+//! `Frame`/`Terminal` — so building one from a `Row` is a pure
+//! transformation, unit-tested here the same way `crate::tree`/`crate::nav`
+//! test their own plain-data outputs. Layout (which rows are visible at
+//! all, where the split between panes falls, and computing each row's
+//! `label` from ancestor context — see [`relative_label`]) is `crate::ui`'s
+//! job; this module only decides one row's content and styling given that
+//! label.
+
+use crate::nav::Row;
+use crate::order::DirRank;
+use crate::tree::{Badges, NodeKind, SymbolRef};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use rinkaku_core::extract::{Classification, SymbolKind};
+use std::collections::HashMap;
+
+/// Indent width per tree depth level, in columns.
+const INDENT_WIDTH: usize = 2;
+
+/// Builds the styled [`Line`] for one visible row.
+///
+/// `label` is this row's display name: for a `Dir`/`File` row, the
+/// segment(s) of `crate::tree::TreeNode::path` not already implied by an
+/// ancestor row on screen (see [`relative_label`], which `crate::ui` uses
+/// to compute it while walking the tree — a pure per-row function like
+/// this one has no ancestor context of its own, since `crate::nav::Row`
+/// only exposes one node). Unused for a `Symbol` row, which always
+/// displays `SymbolRef::name` regardless of `label`.
+///
+/// `ranks` is consulted only for a [`NodeKind::Dir`] row, to show the
+/// `(cycle)` warning marker (ADR 0016 decision 4 / ADR 0008's existing
+/// symbol-level cycle warning) — a directory's own `crate::order::DirRank`
+/// is looked up by its `path`, matching `crate::order`'s own map key.
+/// `selected` styles the row for the cursor (reverse video), independent
+/// of the node's own kind-based styling.
+pub fn entry_row_line(
+    row: &Row<'_>,
+    label: &str,
+    ranks: &HashMap<String, DirRank>,
+    selected: bool,
+) -> Line<'static> {
+    let indent = " ".repeat(row.depth * INDENT_WIDTH);
+    let mut spans = vec![Span::raw(indent)];
+
+    match &row.node.kind {
+        NodeKind::Dir => {
+            let in_cycle = ranks.get(&row.node.path).is_some_and(|rank| rank.in_cycle);
+            spans.push(Span::raw(format!("{} ", expand_marker(row))));
+            spans.push(Span::styled(
+                label.to_string(),
+                Style::default().add_modifier(Modifier::BOLD),
+            ));
+            spans.push(Span::raw(" "));
+            spans.push(badges_span(&row.node.badges));
+            if in_cycle {
+                spans.push(Span::raw(" "));
+                spans.push(Span::styled(
+                    "(cycle)",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            }
+        }
+        NodeKind::File => {
+            spans.push(Span::raw(format!("{} ", expand_marker(row))));
+            spans.push(Span::raw(label.to_string()));
+            spans.push(Span::raw(" "));
+            spans.push(badges_span(&row.node.badges));
+        }
+        NodeKind::Symbol(symbol_ref) => {
+            spans.push(Span::raw("  "));
+            spans.push(symbol_marker_span(symbol_ref));
+            spans.push(Span::raw(" "));
+            spans.push(Span::raw(format!("{} ", kind_abbrev(symbol_ref.kind))));
+            spans.push(Span::styled(
+                symbol_ref.name.clone(),
+                symbol_name_style(symbol_ref),
+            ));
+        }
+    }
+
+    let mut line = Line::from(spans);
+    if selected {
+        line = line.style(Style::default().add_modifier(Modifier::REVERSED));
+    }
+    line
+}
+
+/// The expand/collapse indicator for a `Dir`/`File` row: `" "` (blank) for
+/// a childless node (nothing to expand), `"v"` when its children are
+/// currently shown, `">"` when collapsed.
+fn expand_marker(row: &Row<'_>) -> &'static str {
+    if row.node.children.is_empty() {
+        " "
+    } else if row.expanded {
+        "v"
+    } else {
+        ">"
+    }
+}
+
+/// Computes the display label for every row in `rows` (as returned by
+/// `crate::nav::Nav::rows`), stripping each `Dir`/`File` node's ancestor
+/// directory path already shown by a preceding row on screen — e.g. a
+/// `"src/foo"` directory nested under a `"src"` row displays as `"foo"`,
+/// not the repeated `"src/foo"` its `TreeNode::path` carries in full (per
+/// `crate::tree::TreeNode::path`'s own doc comment).
+///
+/// This only works correctly because `rows` is a pre-order flattening
+/// (`Nav::rows`'s own doc comment): a directory's ancestor rows always
+/// appear earlier in the slice, at a strictly smaller `depth`, so tracking
+/// "the most recent path seen at each depth" while scanning forward once
+/// is enough to compute every row's relative label in a single pass — no
+/// need to reconstruct the tree's own recursive shape here. A `Symbol`
+/// row's label is never consulted by `entry_row_line` (it always shows
+/// `SymbolRef::name` instead), so this function returns an empty string
+/// for those rows rather than computing a meaningless one.
+pub fn relative_labels(rows: &[Row<'_>]) -> Vec<String> {
+    // `ancestor_path_at[d]` is the full `TreeNode::path` of the most
+    // recent `Dir`/`File` row seen at depth `d` — the nearest enclosing
+    // ancestor for any later row at depth `d + 1`.
+    let mut ancestor_path_at: Vec<Option<String>> = Vec::new();
+
+    rows.iter()
+        .map(|row| {
+            if matches!(row.node.kind, NodeKind::Symbol(_)) {
+                return String::new();
+            }
+
+            let parent_path = row.depth.checked_sub(1).and_then(|parent_depth| {
+                ancestor_path_at
+                    .get(parent_depth)
+                    .and_then(|p| p.as_deref())
+            });
+            let label = match parent_path {
+                Some(parent) => row
+                    .node
+                    .path
+                    .strip_prefix(parent)
+                    .and_then(|rest| rest.strip_prefix('/'))
+                    .unwrap_or(&row.node.path)
+                    .to_string(),
+                None => row.node.path.clone(),
+            };
+
+            if ancestor_path_at.len() <= row.depth {
+                ancestor_path_at.resize(row.depth + 1, None);
+            }
+            ancestor_path_at[row.depth] = Some(row.node.path.clone());
+            // Truncate any deeper stale entries from a sibling subtree
+            // this row's own depth just returned to (a pre-order walk can
+            // go from a deep leaf back up to a shallower sibling), so a
+            // later row never mistakes a previous, now-unrelated branch's
+            // path for its actual parent.
+            ancestor_path_at.truncate(row.depth + 1);
+
+            label
+        })
+        .collect()
+}
+
+/// The compact badge summary shared by `Dir`/`File` rows: changed-symbol
+/// count, contract-change count, and fan-in, each only shown when nonzero
+/// (an all-zero badge set renders as an empty span, keeping quiet rows
+/// quiet) — ASCII-only glyphs (`~`/`!`/`^`) chosen over Unicode/emoji for
+/// terminal-compatibility (this implementation's own decision, see the
+/// README's Interactive TUI section for the legend).
+fn badges_span(badges: &Badges) -> Span<'static> {
+    let mut parts = Vec::new();
+    if badges.changed_symbols > 0 {
+        parts.push(format!("~{}", badges.changed_symbols));
+    }
+    if badges.contract_changes > 0 {
+        parts.push(format!("!{}", badges.contract_changes));
+    }
+    if badges.fan_in > 0 {
+        parts.push(format!("^{}", badges.fan_in));
+    }
+    Span::styled(parts.join(" "), Style::default().fg(Color::Cyan))
+}
+
+/// A symbol row's leading classification marker: `+` added, `~`
+/// signature-changed, ` ` (blank, one column) body-only or unclassified,
+/// `x` removed. Kept as its own single-character span (rather than folded
+/// into `symbol_name_style`) so it reads as a consistent left-aligned
+/// column across rows regardless of name length.
+fn symbol_marker_span(symbol_ref: &SymbolRef) -> Span<'static> {
+    if symbol_ref.removed {
+        return Span::styled("x", Style::default().fg(Color::Red));
+    }
+    match symbol_ref.classification {
+        Some(Classification::Added) => Span::styled("+", Style::default().fg(Color::Green)),
+        Some(Classification::SignatureChanged) => {
+            Span::styled("~", Style::default().fg(Color::Yellow))
+        }
+        Some(Classification::BodyOnly) | None => Span::raw(" "),
+    }
+}
+
+/// The symbol name's own style: a removed symbol renders dimmed +
+/// crossed-out (`Modifier::CROSSED_OUT`, widely supported by modern
+/// terminals) to read as "gone" at a glance, distinct from the marker span
+/// above which only flags *why*.
+fn symbol_name_style(symbol_ref: &SymbolRef) -> Style {
+    if symbol_ref.removed {
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::CROSSED_OUT)
+    } else {
+        Style::default()
+    }
+}
+
+/// A short, fixed-width kind abbreviation for a symbol row (mirrors
+/// `render.rs`'s Markdown rendering's own `fn`/`struct`/... prefixes, just
+/// abbreviated further since the entry view is column-constrained).
+fn kind_abbrev(kind: SymbolKind) -> &'static str {
+    match kind {
+        SymbolKind::Function => "fn",
+        SymbolKind::Struct => "struct",
+        SymbolKind::Enum => "enum",
+        SymbolKind::Trait => "trait",
+        SymbolKind::Class => "class",
+        SymbolKind::Interface => "iface",
+        SymbolKind::TypeAlias => "type",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::{NodeKind, TreeNode};
+
+    fn dir_node(path: &str, badges: Badges, children: Vec<TreeNode>) -> TreeNode {
+        TreeNode {
+            kind: NodeKind::Dir,
+            path: path.to_string(),
+            badges,
+            children,
+        }
+    }
+
+    fn file_node(path: &str, badges: Badges) -> TreeNode {
+        TreeNode {
+            kind: NodeKind::File,
+            path: path.to_string(),
+            badges,
+            children: vec![],
+        }
+    }
+
+    fn symbol_node(path: &str, symbol_ref: SymbolRef, badges: Badges) -> TreeNode {
+        TreeNode {
+            kind: NodeKind::Symbol(symbol_ref),
+            path: path.to_string(),
+            badges,
+            children: vec![],
+        }
+    }
+
+    fn plain_symbol(name: &str) -> SymbolRef {
+        SymbolRef {
+            id: format!("lib.rs::{name}"),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            classification: None,
+            removed: false,
+        }
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
+    }
+
+    #[test]
+    fn should_render_plain_text_for_zero_badges_and_no_classification() {
+        let node = symbol_node("lib.rs", plain_symbol("foo"), Badges::default());
+        let row = Row {
+            node: &node,
+            depth: 2,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "", &HashMap::new(), false);
+
+        assert_eq!("        fn foo", line_text(&line));
+    }
+
+    #[test]
+    fn should_include_badge_glyphs_for_nonzero_badges_on_a_dir_row() {
+        let node = dir_node(
+            "src",
+            Badges {
+                changed_symbols: 2,
+                contract_changes: 1,
+                fan_in: 3,
+            },
+            vec![file_node("src/a.rs", Badges::default())],
+        );
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: true,
+        };
+
+        let line = entry_row_line(&row, "src", &HashMap::new(), false);
+
+        assert_eq!("v src ~2 !1 ^3", line_text(&line));
+    }
+
+    #[test]
+    fn should_omit_zero_badges_entirely() {
+        let node = file_node("lib.rs", Badges::default());
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
+
+        assert_eq!("  lib.rs ", line_text(&line));
+    }
+
+    #[test]
+    fn should_show_collapse_marker_when_dir_is_not_expanded() {
+        let node = dir_node(
+            "src",
+            Badges::default(),
+            vec![file_node("src/a.rs", Badges::default())],
+        );
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "src", &HashMap::new(), false);
+
+        assert_eq!("> src ", line_text(&line));
+    }
+
+    #[test]
+    fn should_append_cycle_marker_when_dir_path_is_in_cycle() {
+        let node = dir_node("src", Badges::default(), vec![]);
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+        let mut ranks = HashMap::new();
+        ranks.insert(
+            "src".to_string(),
+            DirRank {
+                rank: 0,
+                in_cycle: true,
+            },
+        );
+
+        let line = entry_row_line(&row, "src", &ranks, false);
+
+        assert_eq!("  src  (cycle)", line_text(&line));
+    }
+
+    #[test]
+    fn should_not_append_cycle_marker_when_dir_path_is_not_in_cycle() {
+        let node = dir_node("src", Badges::default(), vec![]);
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+        let mut ranks = HashMap::new();
+        ranks.insert(
+            "src".to_string(),
+            DirRank {
+                rank: 0,
+                in_cycle: false,
+            },
+        );
+
+        let line = entry_row_line(&row, "src", &ranks, false);
+
+        assert_eq!("  src ", line_text(&line));
+    }
+
+    #[test]
+    fn should_mark_added_symbol_with_plus() {
+        let symbol_ref = SymbolRef {
+            classification: Some(Classification::Added),
+            ..plain_symbol("new_fn")
+        };
+        let node = symbol_node("lib.rs", symbol_ref, Badges::default());
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "", &HashMap::new(), false);
+
+        assert_eq!("  + fn new_fn", line_text(&line));
+    }
+
+    #[test]
+    fn should_mark_signature_changed_symbol_with_tilde() {
+        let symbol_ref = SymbolRef {
+            classification: Some(Classification::SignatureChanged),
+            ..plain_symbol("changed_fn")
+        };
+        let node = symbol_node("lib.rs", symbol_ref, Badges::default());
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "", &HashMap::new(), false);
+
+        assert_eq!("  ~ fn changed_fn", line_text(&line));
+    }
+
+    #[test]
+    fn should_mark_removed_symbol_with_x() {
+        let symbol_ref = SymbolRef {
+            removed: true,
+            ..plain_symbol("gone_fn")
+        };
+        let node = symbol_node("lib.rs", symbol_ref, Badges::default());
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "", &HashMap::new(), false);
+
+        assert_eq!("  x fn gone_fn", line_text(&line));
+    }
+
+    #[test]
+    fn should_apply_reversed_modifier_when_row_is_selected() {
+        let node = file_node("lib.rs", Badges::default());
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "lib.rs", &HashMap::new(), true);
+
+        assert!(line.style.add_modifier.contains(Modifier::REVERSED));
+    }
+
+    #[test]
+    fn should_not_apply_reversed_modifier_when_row_is_not_selected() {
+        let node = file_node("lib.rs", Badges::default());
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
+
+        assert!(!line.style.add_modifier.contains(Modifier::REVERSED));
+    }
+
+    #[test]
+    fn should_indent_by_depth_times_indent_width() {
+        let node = file_node("lib.rs", Badges::default());
+        let row = Row {
+            node: &node,
+            depth: 3,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
+
+        assert_eq!("        lib.rs ", line_text(&line));
+    }
+
+    #[test]
+    fn should_strip_ancestor_prefix_from_nested_dir_label() {
+        // "src" (depth 0) then "src/foo" (depth 1): the second row's label
+        // must be just "foo", not the full "src/foo" its `path` carries.
+        let root = dir_node("src", Badges::default(), vec![]);
+        let child = dir_node("src/foo", Badges::default(), vec![]);
+        let rows = vec![
+            Row {
+                node: &root,
+                depth: 0,
+                expanded: true,
+            },
+            Row {
+                node: &child,
+                depth: 1,
+                expanded: false,
+            },
+        ];
+
+        let labels = relative_labels(&rows);
+
+        assert_eq!(vec!["src".to_string(), "foo".to_string()], labels);
+    }
+
+    #[test]
+    fn should_keep_full_collapsed_label_when_no_ancestor_row_precedes_it() {
+        // A root-level collapsed chain "src/foo/bar" has no ancestor row
+        // above it at all, so its label stays the full collapsed path.
+        let root = dir_node("src/foo/bar", Badges::default(), vec![]);
+        let rows = vec![Row {
+            node: &root,
+            depth: 0,
+            expanded: true,
+        }];
+
+        let labels = relative_labels(&rows);
+
+        assert_eq!(vec!["src/foo/bar".to_string()], labels);
+    }
+
+    #[test]
+    fn should_return_empty_label_for_symbol_rows() {
+        let node = symbol_node("lib.rs", plain_symbol("foo"), Badges::default());
+        let rows = vec![Row {
+            node: &node,
+            depth: 1,
+            expanded: false,
+        }];
+
+        let labels = relative_labels(&rows);
+
+        assert_eq!(vec![String::new()], labels);
+    }
+
+    #[test]
+    fn should_recompute_label_correctly_after_returning_to_a_shallower_sibling() {
+        // "a" (depth 0) -> "a/one.rs" (depth 1) -> "b" (depth 0, a sibling
+        // of "a", not a descendant) -> "b/two.rs" (depth 1). The second
+        // "depth 1" row must strip "b"'s prefix, not stale ancestor state
+        // left over from "a"'s subtree.
+        let a = dir_node("a", Badges::default(), vec![]);
+        let a_file = file_node("a/one.rs", Badges::default());
+        let b = dir_node("b", Badges::default(), vec![]);
+        let b_file = file_node("b/two.rs", Badges::default());
+        let rows = vec![
+            Row {
+                node: &a,
+                depth: 0,
+                expanded: true,
+            },
+            Row {
+                node: &a_file,
+                depth: 1,
+                expanded: false,
+            },
+            Row {
+                node: &b,
+                depth: 0,
+                expanded: true,
+            },
+            Row {
+                node: &b_file,
+                depth: 1,
+                expanded: false,
+            },
+        ];
+
+        let labels = relative_labels(&rows);
+
+        assert_eq!(
+            vec![
+                "a".to_string(),
+                "one.rs".to_string(),
+                "b".to_string(),
+                "two.rs".to_string(),
+            ],
+            labels
+        );
+    }
+}

--- a/rinkaku-tui/src/source.rs
+++ b/rinkaku-tui/src/source.rs
@@ -1,0 +1,266 @@
+//! Source drill-down (ADR 0015): given a selected symbol, reads its file
+//! from disk and computes which lines to show, scrolled to and
+//! highlighting the symbol's own range.
+//!
+//! ADR 0016 explicitly allows adapter-side file reads in `rinkaku-tui` for
+//! this feature ("All IO the TUI needs beyond `Report` itself... is
+//! adapter-side file reads in `rinkaku-tui`"), on the condition that it
+//! stays isolated to one small function rather than spreading IO through
+//! the rest of the crate. [`load_symbol_source`] is that one function;
+//! everything else here (locating the symbol, computing the visible
+//! window) is pure and takes the file content as a plain `&str`.
+
+/// A symbol's location in `Report`, resolved from its id — enough for
+/// [`load_symbol_source`] to know which file to read and
+/// [`visible_window`] to know which lines to highlight.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SymbolLocation {
+    path: String,
+    /// 1-based inclusive, matching `ExtractedSymbol::range`'s own
+    /// convention (see that field's doc comment in `rinkaku-core`).
+    start_line: usize,
+    end_line: usize,
+}
+
+/// The result of opening a symbol's source: its full file content, split
+/// into lines, plus the 1-based inclusive line range to highlight.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceView {
+    pub path: String,
+    pub lines: Vec<String>,
+    pub highlight_start: usize,
+    pub highlight_end: usize,
+}
+
+/// Reads `id`'s file off the working tree and builds a [`SourceView`] for
+/// it, or an error message suitable for the status line on failure (no
+/// such symbol in `report`, or the file read itself failing — a moved/
+/// deleted file since the diff was analyzed, a permissions error, etc.).
+///
+/// Always reads from the working tree, regardless of which input mode
+/// (`--base`, `--pr`, stdin) produced `report` — unlike `main.rs`'s
+/// `--base`/`--pr` pipelines, which read historical content via
+/// `git show <rev>:<path>` to stay pinned to the exact diffed commit, the
+/// TUI's source view is a live "look at the file now" drill-down, so
+/// reading the working tree is the right behavior even when `report` was
+/// built from a historical diff (the alternative — plumbing the resolved
+/// head SHA all the way from `main.rs` into `rinkaku_tui::run` just for
+/// this one view — is deferred until a real user need for it shows up).
+pub fn load_symbol_source(
+    report: &rinkaku_core::render::Report,
+    id: &str,
+) -> Result<SourceView, String> {
+    let location = find_symbol_location(report, id)
+        .ok_or_else(|| format!("symbol not found in report: {id}"))?;
+
+    let content = std::fs::read_to_string(&location.path)
+        .map_err(|source| format!("failed to read {}: {source}", location.path))?;
+
+    Ok(SourceView {
+        path: location.path,
+        lines: content.lines().map(str::to_string).collect(),
+        highlight_start: location.start_line,
+        highlight_end: location.end_line,
+    })
+}
+
+/// Finds `id`'s file path and line range in `report.files`. `None` when no
+/// symbol with that id is present — e.g. `id` refers to a removed symbol
+/// (out of scope, same as `crate::detail::build_detail`'s contract: a
+/// `RemovedSymbol` has no stable id or line range to highlight, only the
+/// prior signature `Report.removed` already carries).
+fn find_symbol_location(report: &rinkaku_core::render::Report, id: &str) -> Option<SymbolLocation> {
+    report.files.iter().find_map(|file| {
+        file.symbols
+            .iter()
+            .find(|symbol| symbol.id == id)
+            .map(|symbol| SymbolLocation {
+                path: file.path.clone(),
+                start_line: symbol.range.start,
+                end_line: symbol.range.end,
+            })
+    })
+}
+
+/// Computes the 0-based `[start, end)` slice of `total_lines` to display
+/// in a viewport `viewport_height` rows tall, centering `highlight_start`/
+/// `highlight_end` (1-based inclusive, matching `SourceView`'s own fields)
+/// when the symbol's range is smaller than the viewport, and clamping to
+/// `[0, total_lines)` so a symbol near the top/bottom of a short file never
+/// asks for an out-of-bounds slice.
+///
+/// Centering (rather than e.g. always putting the highlight at the top)
+/// keeps a few lines of leading context visible for a mid-function
+/// selection, matching how an editor's "jump to definition" typically
+/// scrolls.
+pub fn visible_window(
+    total_lines: usize,
+    highlight_start: usize,
+    highlight_end: usize,
+    viewport_height: usize,
+) -> (usize, usize) {
+    if total_lines == 0 || viewport_height == 0 {
+        return (0, 0);
+    }
+
+    // Convert to 0-based for arithmetic; a `highlight_start` of 0 (out of
+    // range for the 1-based convention, defensive only) is clamped to 1
+    // first so the subtraction below cannot underflow.
+    let highlight_start = highlight_start.max(1) - 1;
+    let highlight_end = highlight_end.max(1) - 1;
+    let highlight_center = highlight_start + (highlight_end.saturating_sub(highlight_start)) / 2;
+
+    let half = viewport_height / 2;
+    let ideal_start = highlight_center.saturating_sub(half);
+
+    // Clamp so the window never runs past the end of the file, then
+    // clamp again at zero so a short file (fewer lines than
+    // `viewport_height`) still yields a valid, in-bounds window rather
+    // than a negative start.
+    let max_start = total_lines.saturating_sub(viewport_height);
+    let start = ideal_start.min(max_start);
+    let end = (start + viewport_height).min(total_lines);
+
+    (start, end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_center_window_around_highlight_when_file_is_larger_than_viewport() {
+        let (start, end) = visible_window(100, 50, 50, 10);
+
+        // Highlight at 0-based line 49, viewport 10 rows -> half=5,
+        // ideal_start = 49 - 5 = 44.
+        assert_eq!((44, 54), (start, end));
+    }
+
+    #[test]
+    fn should_clamp_window_to_start_of_file_when_highlight_is_near_the_top() {
+        let (start, end) = visible_window(100, 1, 1, 10);
+
+        assert_eq!((0, 10), (start, end));
+    }
+
+    #[test]
+    fn should_clamp_window_to_end_of_file_when_highlight_is_near_the_bottom() {
+        let (start, end) = visible_window(100, 100, 100, 10);
+
+        assert_eq!((90, 100), (start, end));
+    }
+
+    #[test]
+    fn should_show_whole_file_when_file_is_shorter_than_viewport() {
+        let (start, end) = visible_window(5, 3, 3, 10);
+
+        assert_eq!((0, 5), (start, end));
+    }
+
+    #[test]
+    fn should_return_empty_window_when_file_has_no_lines() {
+        let (start, end) = visible_window(0, 1, 1, 10);
+
+        assert_eq!((0, 0), (start, end));
+    }
+
+    #[test]
+    fn should_return_empty_window_when_viewport_height_is_zero() {
+        let (start, end) = visible_window(100, 1, 1, 0);
+
+        assert_eq!((0, 0), (start, end));
+    }
+
+    #[test]
+    fn should_span_multi_line_highlight_range_at_its_midpoint() {
+        // Highlight spans lines 10-20 (1-based inclusive); midpoint
+        // (0-based) is 9 + (19-9)/2 = 14.
+        let (start, _end) = visible_window(1000, 10, 20, 10);
+
+        assert_eq!(9, start);
+    }
+
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+    use rinkaku_core::graph::SymbolGraph;
+    use rinkaku_core::render::{FileReport, Report};
+
+    fn symbol(id: &str, name: &str, range: LineRange) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature: format!("fn {name}()"),
+            range,
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        }
+    }
+
+    fn empty_report() -> Report {
+        Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    #[test]
+    fn should_find_symbol_location_from_matching_file() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    LineRange { start: 10, end: 20 },
+                )],
+            }],
+            ..empty_report()
+        };
+
+        let expected = Some(SymbolLocation {
+            path: "src/lib.rs".to_string(),
+            start_line: 10,
+            end_line: 20,
+        });
+        let actual = find_symbol_location(&report, "src/lib.rs::foo");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_none_when_symbol_id_is_not_found() {
+        let report = empty_report();
+
+        let actual = find_symbol_location(&report, "missing::id");
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_return_error_message_when_load_symbol_source_finds_no_such_symbol() {
+        let report = empty_report();
+
+        let actual = load_symbol_source(&report, "missing::id");
+
+        assert_eq!(
+            Err("symbol not found in report: missing::id".to_string()),
+            actual
+        );
+    }
+}

--- a/rinkaku-tui/src/source.rs
+++ b/rinkaku-tui/src/source.rs
@@ -46,6 +46,15 @@ pub struct SourceView {
 /// built from a historical diff (the alternative — plumbing the resolved
 /// head SHA all the way from `main.rs` into `rinkaku_tui::run` just for
 /// this one view — is deferred until a real user need for it shows up).
+///
+/// A consequence of reading live: a symbol's `range` in `report` reflects
+/// the file's content *at analysis time*. If the file is edited on disk
+/// afterward (including between opening the TUI and pressing `s` on a
+/// given row), the highlighted lines can drift from the symbol's actual
+/// current location, or — if the file shrank — extend past its current
+/// end entirely. [`visible_window`] clamps to the file's current length
+/// either way rather than producing an out-of-bounds window, but it makes
+/// no attempt to re-locate the symbol in the changed content.
 pub fn load_symbol_source(
     report: &rinkaku_core::render::Report,
     id: &str,
@@ -180,6 +189,21 @@ mod tests {
         let (start, _end) = visible_window(1000, 10, 20, 10);
 
         assert_eq!(9, start);
+    }
+
+    #[test]
+    fn should_clamp_to_end_of_file_when_highlight_range_exceeds_current_line_count() {
+        // The symbol's range (50-60) came from analysis time; the file has
+        // since shrunk to 10 lines (e.g. edited in the working tree after
+        // the diff was analyzed — `load_symbol_source`'s own doc comment
+        // notes the source view always reads the *current* working tree,
+        // not the analyzed commit). Neither endpoint of the highlight is a
+        // valid line any more, so this must degrade to "clamp to the end
+        // of the file" rather than producing an out-of-bounds or empty
+        // window.
+        let (start, end) = visible_window(10, 50, 60, 10);
+
+        assert_eq!((0, 10), (start, end));
     }
 
     use rinkaku_core::diff::LineRange;

--- a/rinkaku-tui/src/tree.rs
+++ b/rinkaku-tui/src/tree.rs
@@ -72,6 +72,17 @@ pub enum NodeKind {
 ///   because a directory containing several independently risky hotspots
 ///   should read as riskier than one containing a single hotspot with the
 ///   same peak fan-in — max would hide that difference.
+///
+///   This badge's `fan_in` is deliberately **not** the same computation
+///   `crate::detail::build_detail` uses for a single symbol's `used_by`:
+///   this badge only counts a symbol at all once it clears `Hotspot`'s own
+///   fan-in >= 2 threshold (see `symbol_badges`'s doc comment), while the
+///   detail pane's `used_by` reads `report.graph.edges` directly and so
+///   also surfaces a fan-in of 0 or 1. A symbol with exactly one referrer
+///   therefore shows up in its own detail view's `used_by` but contributes
+///   nothing to any ancestor directory's `fan_in` badge here — expected,
+///   not a bug, since the badge's whole purpose is to flag hotspots
+///   specifically, not fan-in in general.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Badges {
     pub changed_symbols: usize,
@@ -584,13 +595,35 @@ mod tests {
             ..empty_report()
         };
 
-        let tree = build_tree(&report);
+        let expected = Tree {
+            roots: vec![TreeNode {
+                kind: NodeKind::Dir,
+                path: "src".to_string(),
+                badges: Badges::default(),
+                children: vec![
+                    TreeNode {
+                        kind: NodeKind::File,
+                        path: "src/mod.rs".to_string(),
+                        badges: Badges::default(),
+                        children: vec![],
+                    },
+                    TreeNode {
+                        kind: NodeKind::Dir,
+                        path: "src/foo".to_string(),
+                        badges: Badges::default(),
+                        children: vec![TreeNode {
+                            kind: NodeKind::File,
+                            path: "src/foo/bar.rs".to_string(),
+                            badges: Badges::default(),
+                            children: vec![],
+                        }],
+                    },
+                ],
+            }],
+        };
+        let actual = build_tree(&report);
 
-        assert_eq!(1, tree.roots.len());
-        let src = &tree.roots[0];
-        assert_eq!(NodeKind::Dir, src.kind);
-        assert_eq!("src", src.path);
-        assert_eq!(2, src.children.len());
+        assert_eq!(expected, actual);
     }
 
     #[test]
@@ -707,20 +740,64 @@ mod tests {
             ..empty_report()
         };
 
-        let tree = build_tree(&report);
-
-        assert_eq!(1, tree.roots.len());
-        let file_node = &tree.roots[0];
-        assert_eq!(NodeKind::File, file_node.kind);
-        assert_eq!(2, file_node.children.len());
-        let expected_badges = Badges {
-            changed_symbols: 1,
-            contract_changes: 1,
-            fan_in: 0,
+        let expected = Tree {
+            roots: vec![TreeNode {
+                kind: NodeKind::File,
+                path: "lib.rs".to_string(),
+                badges: Badges {
+                    changed_symbols: 1,
+                    contract_changes: 1,
+                    fan_in: 0,
+                },
+                children: vec![
+                    TreeNode {
+                        kind: NodeKind::Symbol(SymbolRef {
+                            id: "lib.rs::foo".to_string(),
+                            name: "foo".to_string(),
+                            kind: SymbolKind::Function,
+                            classification: None,
+                            removed: false,
+                        }),
+                        path: "lib.rs".to_string(),
+                        badges: Badges {
+                            changed_symbols: 1,
+                            contract_changes: 0,
+                            fan_in: 0,
+                        },
+                        children: vec![],
+                    },
+                    TreeNode {
+                        kind: NodeKind::Symbol(SymbolRef {
+                            id: "lib.rs::gone".to_string(),
+                            name: "gone".to_string(),
+                            kind: SymbolKind::Function,
+                            classification: None,
+                            removed: true,
+                        }),
+                        path: "lib.rs".to_string(),
+                        badges: Badges {
+                            changed_symbols: 0,
+                            contract_changes: 1,
+                            fan_in: 0,
+                        },
+                        children: vec![],
+                    },
+                ],
+            }],
         };
-        assert_eq!(expected_badges, file_node.badges);
+        let actual = build_tree(&report);
+
+        assert_eq!(expected, actual);
     }
 
+    // NOTE: partial assert (root count, path, then only the aggregated
+    // `Badges`) rather than a whole-`Tree` comparison — this test's only
+    // concern is that bottom-up aggregation reaches the top of a
+    // multi-level, multi-file subtree correctly; restating the full
+    // "src/a/one.rs" and "src/b/two.rs" node structure (already pinned down
+    // by other tests in this module, e.g.
+    // `should_build_flat_file_node_when_path_has_no_directory`) would just
+    // add noise without strengthening what this test is checking.
     #[test]
     fn should_aggregate_badges_bottom_up_across_nested_directories() {
         let report = Report {

--- a/rinkaku-tui/src/tree.rs
+++ b/rinkaku-tui/src/tree.rs
@@ -1,0 +1,855 @@
+//! Directory tree view-model (ADR 0015): the TUI's entry view is the
+//! directory tree of changed files, not the call-graph tree — nesting
+//! depth conveys architecture, and each row carries aggregate badges.
+//!
+//! [`build_tree`] is a pure function from [`Report`] alone: same `Report`
+//! in, same [`Tree`] out, no IO, no ordering decisions (ordering is a
+//! separate concern, see `crate::order`).
+
+use rinkaku_core::extract::{Classification, SymbolKind};
+use rinkaku_core::render::Report;
+use std::collections::{BTreeMap, HashMap};
+
+/// A symbol's identity, as carried by a [`NodeKind::Symbol`] leaf — enough
+/// for the entry view to render a badge-worthy row and for the detail view
+/// (`crate::detail`) to look the full symbol back up in the `Report` it was
+/// built from, without this crate duplicating `ExtractedSymbol`'s full
+/// shape (signature, dependencies, ...) into the view-model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolRef {
+    /// Matches [`rinkaku_core::graph::Node::id`] for a present symbol, or is
+    /// synthesized as `{path}::{name}` for a [`RemovedSymbol`] (which has no
+    /// stable id of its own — see `RemovedSymbol`'s doc comment in
+    /// `rinkaku-core`). Not guaranteed unique for two removed symbols
+    /// sharing `(path, name)`, same limitation `render.rs`'s Markdown
+    /// rendering already accepts for removed symbols.
+    pub id: String,
+    pub name: String,
+    pub kind: SymbolKind,
+    /// `None` when this symbol is a [`RemovedSymbol`] — a removed symbol
+    /// was never classified against itself (there is no head-side symbol to
+    /// classify), only reported as `Report.removed` because a base-side
+    /// match went missing entirely.
+    pub classification: Option<Classification>,
+    pub removed: bool,
+}
+
+/// What kind of thing a [`TreeNode`] represents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeKind {
+    /// A directory. May be a collapsed chain of several path segments (see
+    /// `build_tree`'s doc comment on collapsing) — `name` is the full
+    /// collapsed label (e.g. `"a/b/c"`), not just the last segment.
+    Dir,
+    /// A changed file. `name` is the file's base name; the file's full path
+    /// is reconstructed by joining ancestor `Dir`/`File` labels, which the
+    /// tree itself does not do — callers needing the full path should track
+    /// it during traversal (kept simple here since this stage has no
+    /// renderer yet to demand it).
+    File,
+    /// A leaf: one changed or removed symbol.
+    Symbol(SymbolRef),
+}
+
+/// Badges aggregated bottom-up for a [`TreeNode`] (ADR 0015/0016): every
+/// count also includes this node's descendants, so a directory's badge
+/// summarizes everything nested under it without a reader needing to
+/// expand it first.
+///
+/// Field semantics, decided here since ADR 0015/0016 left them open:
+/// - `changed_symbols`: count of present (non-removed) symbols, i.e. every
+///   [`SymbolRef`] with `removed == false`. Removed symbols are *not*
+///   counted here — a removed symbol has no signature/graph presence of
+///   its own, so folding it into "changed" would blur "this many symbols
+///   still exist and changed" with "this many disappeared".
+/// - `contract_changes`: count of symbols whose classification is
+///   [`Classification::SignatureChanged`], **plus** every removed symbol.
+///   Removal is unambiguously a contract change — the API surface the
+///   removed symbol represented is gone — so it counts here even though it
+///   is excluded from `changed_symbols` above.
+/// - `fan_in`: **sum** (not max) of `used_by.len()` for every hotspot
+///   symbol contained in this node's subtree. Sum was chosen over max
+///   because a directory containing several independently risky hotspots
+///   should read as riskier than one containing a single hotspot with the
+///   same peak fan-in — max would hide that difference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Badges {
+    pub changed_symbols: usize,
+    pub contract_changes: usize,
+    pub fan_in: usize,
+}
+
+impl Badges {
+    fn merge(&mut self, other: Badges) {
+        self.changed_symbols += other.changed_symbols;
+        self.contract_changes += other.contract_changes;
+        self.fan_in += other.fan_in;
+    }
+}
+
+/// One node in the [`Tree`]: a directory, file, or symbol, with its
+/// bottom-up aggregated [`Badges`] and its children in source order (before
+/// any topological/A-Z reordering — see `crate::order`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeNode {
+    pub kind: NodeKind,
+    /// Full slash-joined path from the tree root to this node, used as a
+    /// stable key by `crate::nav`'s collapse-state map. For a `Dir` this is
+    /// the collapsed chain (e.g. `"a/b/c"`); for a `File`/`Symbol` it is the
+    /// file's path (a `Symbol`'s path is its containing file's path, not a
+    /// path-plus-symbol-name compound, since a symbol's [`SymbolRef::id`]
+    /// already disambiguates it within that file).
+    pub path: String,
+    pub badges: Badges,
+    pub children: Vec<TreeNode>,
+}
+
+/// The whole directory tree built from one [`Report`]. `roots` holds the
+/// top-level entries (in source order); there is no single synthetic root
+/// node, mirroring how a file explorer shows multiple top-level
+/// directories/files rather than one root labeled `"."`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Tree {
+    pub roots: Vec<TreeNode>,
+}
+
+/// Builds the directory tree over every file with content in `report`
+/// (`report.files`, including files with an empty `symbols` list — e.g. a
+/// pure rename, still shown as a `File` node with zero badges — and
+/// `report.removed`'s files, which may not otherwise appear in `files` at
+/// all if every symbol in that file was removed).
+///
+/// Construction is a pure function of `report` alone and deterministic:
+/// files are visited in `report.files` order (already source order per
+/// `pipeline::analyze_diff`), then `report.removed` for any additional
+/// files/symbols not already covered, and directory chains are inserted in
+/// that same discovery order.
+///
+/// **Single-child directory collapsing**: a directory whose only content is
+/// exactly one child directory (and nothing else — no files or symbols of
+/// its own) collapses with that child into one `Dir` node labeled with the
+/// full joined path (e.g. `"src/foo/bar"` instead of three nested `"src"` /
+/// `"foo"` / `"bar"` nodes). This is what reviewers expect from familiar
+/// file-tree UIs (VS Code's explorer, `git log --stat` style tools): a
+/// three-deep chain that exists only to reach one file underneath carries
+/// no architectural signal on its own, so collapsing it removes a click/
+/// scroll without losing information — the full path is still shown, just
+/// on one row. Collapsing stops as soon as a directory has more than one
+/// child, or has files/symbols of its own alongside a subdirectory.
+pub fn build_tree(report: &Report) -> Tree {
+    let fan_in_by_id: HashMap<&str, usize> = report
+        .hotspots
+        .iter()
+        .map(|hotspot| (hotspot.id.as_str(), hotspot.used_by.len()))
+        .collect();
+
+    let mut builder = TreeBuilder::new(fan_in_by_id);
+
+    for file in &report.files {
+        builder.insert_file(&file.path, &file.symbols);
+    }
+    for removed in &report.removed {
+        builder.insert_removed(&removed.path, removed);
+    }
+
+    builder.finish()
+}
+
+/// Intermediate mutable tree used only during construction — a
+/// [`BTreeMap`]-backed trie keyed by path segment, so repeated
+/// `insert_file`/`insert_removed` calls sharing a path prefix merge into
+/// the same directory node instead of creating duplicates. Converted into
+/// the immutable [`Tree`] (with badges aggregated and collapsing applied)
+/// by [`TreeBuilder::finish`].
+struct TreeBuilder<'a> {
+    root: DirBuilder,
+    /// `report.hotspots`, keyed by [`rinkaku_core::graph::NodeId`], so a
+    /// symbol's fan-in badge can be looked up by id while walking
+    /// `report.files` — built once in `build_tree` rather than per-symbol,
+    /// since `report.hotspots` doesn't change during one `build_tree` call.
+    fan_in_by_id: HashMap<&'a str, usize>,
+}
+
+#[derive(Default)]
+struct DirBuilder {
+    // BTreeMap only to get a deterministic iteration order out of the
+    // builder itself as a safety net; `finish` overrides visit order with
+    // each node's recorded `insertion_order` so actual output order still
+    // matches source order, not alphabetical.
+    dirs: BTreeMap<String, DirBuilder>,
+    files: BTreeMap<String, FileBuilder>,
+    insertion_order: Vec<String>,
+}
+
+#[derive(Default)]
+struct FileBuilder {
+    symbols: Vec<SymbolRef>,
+}
+
+impl<'a> TreeBuilder<'a> {
+    fn new(fan_in_by_id: HashMap<&'a str, usize>) -> Self {
+        Self {
+            root: DirBuilder::default(),
+            fan_in_by_id,
+        }
+    }
+
+    fn insert_file(&mut self, path: &str, symbols: &[rinkaku_core::extract::ExtractedSymbol]) {
+        let segments: Vec<&str> = path.split('/').collect();
+        let file_builder = self.root.file_at(&segments);
+        for symbol in symbols {
+            file_builder.symbols.push(SymbolRef {
+                id: symbol.id.clone(),
+                name: symbol.name.clone(),
+                kind: symbol.kind,
+                classification: symbol.classification,
+                removed: false,
+            });
+        }
+    }
+
+    fn insert_removed(&mut self, path: &str, removed: &rinkaku_core::extract::RemovedSymbol) {
+        let segments: Vec<&str> = path.split('/').collect();
+        let file_builder = self.root.file_at(&segments);
+        file_builder.symbols.push(SymbolRef {
+            id: format!("{path}::{}", removed.name),
+            name: removed.name.clone(),
+            kind: removed.kind,
+            classification: None,
+            removed: true,
+        });
+    }
+
+    fn finish(self) -> Tree {
+        Tree {
+            roots: self.root.into_nodes(String::new(), &self.fan_in_by_id),
+        }
+    }
+}
+
+impl DirBuilder {
+    /// Descends (creating as needed) to the directory containing the last
+    /// path segment, returning the [`FileBuilder`] for that segment —
+    /// shared by both `insert_file` and `insert_removed` so a file touched
+    /// by both a present symbol and a removed one lands in the same node.
+    fn file_at(&mut self, segments: &[&str]) -> &mut FileBuilder {
+        match segments {
+            [] => unreachable!("split('/') on a non-empty path always yields at least one segment"),
+            [file_name] => {
+                if !self.files.contains_key(*file_name) {
+                    self.insertion_order.push(format!("f:{file_name}"));
+                    self.files
+                        .insert(file_name.to_string(), FileBuilder::default());
+                }
+                self.files.get_mut(*file_name).expect("just inserted")
+            }
+            [dir_name, rest @ ..] => {
+                if !self.dirs.contains_key(*dir_name) {
+                    self.insertion_order.push(format!("d:{dir_name}"));
+                    self.dirs
+                        .insert(dir_name.to_string(), DirBuilder::default());
+                }
+                self.dirs
+                    .get_mut(*dir_name)
+                    .expect("just inserted")
+                    .file_at(rest)
+            }
+        }
+    }
+
+    /// Converts this builder into `TreeNode`s in discovery (`insertion_order`)
+    /// order, applying single-child directory collapsing (see
+    /// `build_tree`'s doc comment) and computing bottom-up [`Badges`] as it
+    /// goes. `fan_in_by_id` is threaded through to leaf symbols unchanged —
+    /// see `symbol_badges`.
+    fn into_nodes(self, prefix: String, fan_in_by_id: &HashMap<&str, usize>) -> Vec<TreeNode> {
+        let DirBuilder {
+            mut dirs,
+            mut files,
+            insertion_order,
+        } = self;
+
+        let mut nodes = Vec::with_capacity(insertion_order.len());
+        for key in insertion_order {
+            if let Some(dir_name) = key.strip_prefix("d:") {
+                let child = dirs.remove(dir_name).expect("recorded in insertion_order");
+                nodes.push(build_dir_node(
+                    dir_name.to_string(),
+                    &prefix,
+                    child,
+                    fan_in_by_id,
+                ));
+            } else if let Some(file_name) = key.strip_prefix("f:") {
+                let file = files
+                    .remove(file_name)
+                    .expect("recorded in insertion_order");
+                nodes.push(build_file_node(
+                    file_name.to_string(),
+                    &prefix,
+                    file,
+                    fan_in_by_id,
+                ));
+            }
+        }
+        nodes
+    }
+}
+
+/// Builds one directory's [`TreeNode`], collapsing single-child directory
+/// chains into this node rather than nesting them (see `build_tree`'s doc
+/// comment). Collapsing is applied repeatedly: after folding in one child
+/// directory, the result might itself now be foldable again if that
+/// child's own single child was also a lone directory — the `loop` below
+/// keeps folding until the node has more than one child or a non-directory
+/// child of its own.
+fn build_dir_node(
+    name: String,
+    prefix: &str,
+    mut dir: DirBuilder,
+    fan_in_by_id: &HashMap<&str, usize>,
+) -> TreeNode {
+    let mut label = name;
+    loop {
+        let only_child_is_lone_dir =
+            dir.files.is_empty() && dir.dirs.len() == 1 && dir.insertion_order.len() == 1;
+        if !only_child_is_lone_dir {
+            break;
+        }
+        let (child_name, child_dir) = dir
+            .dirs
+            .into_iter()
+            .next()
+            .expect("dirs.len() == 1 just checked");
+        label = format!("{label}/{child_name}");
+        dir = child_dir;
+    }
+
+    let path = join_path(prefix, &label);
+    let children = dir.into_nodes(path.clone(), fan_in_by_id);
+    let mut badges = Badges::default();
+    for child in &children {
+        badges.merge(child.badges);
+    }
+
+    TreeNode {
+        kind: NodeKind::Dir,
+        path,
+        badges,
+        children,
+    }
+}
+
+fn build_file_node(
+    name: String,
+    prefix: &str,
+    file: FileBuilder,
+    fan_in_by_id: &HashMap<&str, usize>,
+) -> TreeNode {
+    let path = join_path(prefix, &name);
+    let mut badges = Badges::default();
+    let children: Vec<TreeNode> = file
+        .symbols
+        .into_iter()
+        .map(|symbol_ref| {
+            let symbol_badges = symbol_badges(&symbol_ref, fan_in_by_id);
+            badges.merge(symbol_badges);
+            TreeNode {
+                kind: NodeKind::Symbol(symbol_ref),
+                path: path.clone(),
+                badges: symbol_badges,
+                children: Vec::new(),
+            }
+        })
+        .collect();
+
+    TreeNode {
+        kind: NodeKind::File,
+        path,
+        badges,
+        children,
+    }
+}
+
+/// A single symbol's own (non-aggregated) badge contribution.
+/// `fan_in_by_id` is `report.hotspots` keyed by id (see `build_tree`): a
+/// symbol not present there (fan-in < 2, or a removed symbol — never a
+/// graph node) contributes zero fan-in, same as `Hotspot`'s own >= 2
+/// threshold.
+fn symbol_badges(symbol_ref: &SymbolRef, fan_in_by_id: &HashMap<&str, usize>) -> Badges {
+    Badges {
+        changed_symbols: if symbol_ref.removed { 0 } else { 1 },
+        contract_changes: if symbol_ref.removed
+            || symbol_ref.classification == Some(Classification::SignatureChanged)
+        {
+            1
+        } else {
+            0
+        },
+        fan_in: fan_in_by_id
+            .get(symbol_ref.id.as_str())
+            .copied()
+            .unwrap_or(0),
+    }
+}
+
+fn join_path(prefix: &str, segment: &str) -> String {
+    if prefix.is_empty() {
+        segment.to_string()
+    } else {
+        format!("{prefix}/{segment}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::{ExtractedSymbol, RemovedSymbol};
+    use rinkaku_core::graph::{Hotspot, SymbolGraph};
+    use rinkaku_core::render::FileReport;
+
+    fn symbol(id: &str, name: &str, kind: SymbolKind) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind,
+            signature: format!("fn {name}()"),
+            range: LineRange { start: 1, end: 1 },
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        }
+    }
+
+    fn empty_report() -> Report {
+        Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    #[test]
+    fn should_build_empty_tree_when_report_has_no_files_and_no_removed() {
+        let report = empty_report();
+
+        let expected = Tree { roots: vec![] };
+        let actual = build_tree(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_build_flat_file_node_when_path_has_no_directory() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo", SymbolKind::Function)],
+            }],
+            ..empty_report()
+        };
+
+        let expected = Tree {
+            roots: vec![TreeNode {
+                kind: NodeKind::File,
+                path: "lib.rs".to_string(),
+                badges: Badges {
+                    changed_symbols: 1,
+                    contract_changes: 0,
+                    fan_in: 0,
+                },
+                children: vec![TreeNode {
+                    kind: NodeKind::Symbol(SymbolRef {
+                        id: "lib.rs::foo".to_string(),
+                        name: "foo".to_string(),
+                        kind: SymbolKind::Function,
+                        classification: None,
+                        removed: false,
+                    }),
+                    path: "lib.rs".to_string(),
+                    badges: Badges {
+                        changed_symbols: 1,
+                        contract_changes: 0,
+                        fan_in: 0,
+                    },
+                    children: vec![],
+                }],
+            }],
+        };
+        let actual = build_tree(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_collapse_single_child_directory_chain_into_one_node() {
+        // src/foo/bar/lib.rs — src, foo, bar each have exactly one child,
+        // so all three collapse into one Dir node labeled "src/foo/bar".
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/foo/bar/lib.rs".to_string(),
+                symbols: vec![],
+            }],
+            ..empty_report()
+        };
+
+        let expected = Tree {
+            roots: vec![TreeNode {
+                kind: NodeKind::Dir,
+                path: "src/foo/bar".to_string(),
+                badges: Badges::default(),
+                children: vec![TreeNode {
+                    kind: NodeKind::File,
+                    path: "src/foo/bar/lib.rs".to_string(),
+                    badges: Badges::default(),
+                    children: vec![],
+                }],
+            }],
+        };
+        let actual = build_tree(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_not_collapse_directory_with_two_children() {
+        let report = Report {
+            files: vec![
+                FileReport {
+                    path: "src/a.rs".to_string(),
+                    symbols: vec![],
+                },
+                FileReport {
+                    path: "src/b.rs".to_string(),
+                    symbols: vec![],
+                },
+            ],
+            ..empty_report()
+        };
+
+        let expected = Tree {
+            roots: vec![TreeNode {
+                kind: NodeKind::Dir,
+                path: "src".to_string(),
+                badges: Badges::default(),
+                children: vec![
+                    TreeNode {
+                        kind: NodeKind::File,
+                        path: "src/a.rs".to_string(),
+                        badges: Badges::default(),
+                        children: vec![],
+                    },
+                    TreeNode {
+                        kind: NodeKind::File,
+                        path: "src/b.rs".to_string(),
+                        badges: Badges::default(),
+                        children: vec![],
+                    },
+                ],
+            }],
+        };
+        let actual = build_tree(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_not_collapse_directory_that_has_own_file_alongside_subdirectory() {
+        // src/ has both a direct file (mod.rs) and a subdirectory (foo/) —
+        // src is not "just a chain" to reach foo, so it must stay a
+        // separate node rather than collapsing with foo.
+        let report = Report {
+            files: vec![
+                FileReport {
+                    path: "src/mod.rs".to_string(),
+                    symbols: vec![],
+                },
+                FileReport {
+                    path: "src/foo/bar.rs".to_string(),
+                    symbols: vec![],
+                },
+            ],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        assert_eq!(1, tree.roots.len());
+        let src = &tree.roots[0];
+        assert_eq!(NodeKind::Dir, src.kind);
+        assert_eq!("src", src.path);
+        assert_eq!(2, src.children.len());
+    }
+
+    #[test]
+    fn should_count_contract_change_for_signature_changed_symbol() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    classification: Some(Classification::SignatureChanged),
+                    ..symbol("lib.rs::foo", "foo", SymbolKind::Function)
+                }],
+            }],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        let expected = Badges {
+            changed_symbols: 1,
+            contract_changes: 1,
+            fan_in: 0,
+        };
+        let actual = tree.roots[0].badges;
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_not_count_contract_change_for_body_only_symbol() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    classification: Some(Classification::BodyOnly),
+                    ..symbol("lib.rs::foo", "foo", SymbolKind::Function)
+                }],
+            }],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        let expected = Badges {
+            changed_symbols: 1,
+            contract_changes: 0,
+            fan_in: 0,
+        };
+        let actual = tree.roots[0].badges;
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_add_removed_symbol_as_marked_leaf_under_its_file_without_counting_as_changed() {
+        let report = Report {
+            files: vec![],
+            removed: vec![RemovedSymbol {
+                name: "gone".to_string(),
+                kind: SymbolKind::Function,
+                path: "lib.rs".to_string(),
+                signature: "fn gone()".to_string(),
+            }],
+            ..empty_report()
+        };
+
+        let expected = Tree {
+            roots: vec![TreeNode {
+                kind: NodeKind::File,
+                path: "lib.rs".to_string(),
+                badges: Badges {
+                    changed_symbols: 0,
+                    contract_changes: 1,
+                    fan_in: 0,
+                },
+                children: vec![TreeNode {
+                    kind: NodeKind::Symbol(SymbolRef {
+                        id: "lib.rs::gone".to_string(),
+                        name: "gone".to_string(),
+                        kind: SymbolKind::Function,
+                        classification: None,
+                        removed: true,
+                    }),
+                    path: "lib.rs".to_string(),
+                    badges: Badges {
+                        changed_symbols: 0,
+                        contract_changes: 1,
+                        fan_in: 0,
+                    },
+                    children: vec![],
+                }],
+            }],
+        };
+        let actual = build_tree(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_merge_removed_symbol_into_existing_file_with_present_symbols() {
+        // A file with one present (unchanged classification-wise) symbol
+        // and one removed symbol must land under the same File node, not
+        // create two separate entries for "lib.rs".
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo", SymbolKind::Function)],
+            }],
+            removed: vec![RemovedSymbol {
+                name: "gone".to_string(),
+                kind: SymbolKind::Function,
+                path: "lib.rs".to_string(),
+                signature: "fn gone()".to_string(),
+            }],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        assert_eq!(1, tree.roots.len());
+        let file_node = &tree.roots[0];
+        assert_eq!(NodeKind::File, file_node.kind);
+        assert_eq!(2, file_node.children.len());
+        let expected_badges = Badges {
+            changed_symbols: 1,
+            contract_changes: 1,
+            fan_in: 0,
+        };
+        assert_eq!(expected_badges, file_node.badges);
+    }
+
+    #[test]
+    fn should_aggregate_badges_bottom_up_across_nested_directories() {
+        let report = Report {
+            files: vec![
+                FileReport {
+                    path: "src/a/one.rs".to_string(),
+                    symbols: vec![ExtractedSymbol {
+                        classification: Some(Classification::SignatureChanged),
+                        ..symbol("src/a/one.rs::x", "x", SymbolKind::Function)
+                    }],
+                },
+                FileReport {
+                    path: "src/b/two.rs".to_string(),
+                    symbols: vec![symbol("src/b/two.rs::y", "y", SymbolKind::Function)],
+                },
+            ],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        assert_eq!(1, tree.roots.len());
+        let src = &tree.roots[0];
+        assert_eq!("src", src.path);
+        let expected = Badges {
+            changed_symbols: 2,
+            contract_changes: 1,
+            fan_in: 0,
+        };
+        assert_eq!(expected, src.badges);
+    }
+
+    #[test]
+    fn should_keep_file_with_no_symbols_as_childless_file_node() {
+        // A pure rename (FileReport with empty symbols) must still show up
+        // as a File node with zero badges, not be dropped from the tree.
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/renamed.rs".to_string(),
+                symbols: vec![],
+            }],
+            ..empty_report()
+        };
+
+        let expected = Tree {
+            roots: vec![TreeNode {
+                kind: NodeKind::Dir,
+                path: "src".to_string(),
+                badges: Badges::default(),
+                children: vec![TreeNode {
+                    kind: NodeKind::File,
+                    path: "src/renamed.rs".to_string(),
+                    badges: Badges::default(),
+                    children: vec![],
+                }],
+            }],
+        };
+        let actual = build_tree(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_preserve_source_order_of_siblings_before_reordering() {
+        // Discovery order in `report.files` must be preserved (reordering
+        // is a separate concern handled by `crate::order`), even though the
+        // builder uses a BTreeMap internally.
+        let report = Report {
+            files: vec![
+                FileReport {
+                    path: "z.rs".to_string(),
+                    symbols: vec![],
+                },
+                FileReport {
+                    path: "a.rs".to_string(),
+                    symbols: vec![],
+                },
+            ],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        let names: Vec<&str> = tree.roots.iter().map(|n| n.path.as_str()).collect();
+        assert_eq!(vec!["z.rs", "a.rs"], names);
+    }
+
+    #[test]
+    fn should_set_fan_in_badge_from_matching_hotspot_and_aggregate_upward() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol("src/lib.rs::shared", "shared", SymbolKind::Function)],
+            }],
+            hotspots: vec![Hotspot {
+                id: "src/lib.rs::shared".to_string(),
+                path: "src/lib.rs".to_string(),
+                name: "shared".to_string(),
+                used_by: vec!["a".to_string(), "b".to_string()],
+            }],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        // Fan-in of 2 (two referrers) must show on the symbol leaf and
+        // aggregate up through File and Dir.
+        let src = &tree.roots[0];
+        assert_eq!("src", src.path);
+        assert_eq!(2, src.badges.fan_in);
+        let file_node = &src.children[0];
+        assert_eq!(2, file_node.badges.fan_in);
+        let symbol_node = &file_node.children[0];
+        assert_eq!(2, symbol_node.badges.fan_in);
+    }
+
+    #[test]
+    fn should_leave_fan_in_at_zero_when_symbol_has_no_matching_hotspot() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::solo", "solo", SymbolKind::Function)],
+            }],
+            hotspots: vec![],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        assert_eq!(0, tree.roots[0].badges.fan_in);
+    }
+}

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -1,0 +1,367 @@
+//! `ratatui` rendering (stage B, ADR 0015/0016): draws one frame from the
+//! current [`App`] state. This is the crate's thin adapter layer — layout
+//! decisions live here, but every value drawn (row text/style, detail
+//! fields, source lines) comes from a pure view-model computed elsewhere
+//! (`crate::app`, `crate::row_view`, `crate::detail`, `crate::source`).
+//!
+//! Kept deliberately un-unit-tested beyond the coarse `TestBackend`
+//! snapshots in this module's own test block (ADR 0016: "rendering itself
+//! is covered separately... kept few and coarse — enough to catch a broken
+//! layout, not to pin every pixel").
+
+use crate::app::{App, Screen};
+use crate::detail::{DetailView, SignatureView};
+use crate::row_view::{entry_row_line, relative_labels};
+use crate::source::{SourceView, load_symbol_source, visible_window};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph};
+use rinkaku_core::render::Report;
+
+/// Draws one full frame: the entry view (tree + detail pane split) or the
+/// source drill-down, depending on `app.screen()`, with a status/help line
+/// pinned to the bottom either way.
+pub fn draw(frame: &mut Frame, app: &App, report: &Report) {
+    let area = frame.area();
+    let [body, status_area] =
+        Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(area);
+
+    match app.screen() {
+        Screen::Entry => draw_entry_screen(frame, app, report, body),
+        Screen::Source { symbol_id } => draw_source_screen(frame, report, symbol_id, body),
+    }
+
+    draw_status_line(frame, app, status_area);
+}
+
+/// Left entry pane (directory tree) + right detail pane, split 60/40 —
+/// this implementation's own choice (ADR 0015/0016 left the exact ratio
+/// open): the tree is the primary navigation surface and typically has
+/// more rows than the detail pane has fields, so it gets the larger share.
+fn draw_entry_screen(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
+    let [tree_area, detail_area] =
+        Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)]).areas(area);
+
+    draw_tree_pane(frame, app, tree_area);
+    draw_detail_pane(frame, app, report, detail_area);
+}
+
+fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
+    let rows = app.nav().rows(app.tree());
+    let labels = relative_labels(&rows);
+    let cursor = app.nav().cursor();
+
+    let ranks = app.ranks();
+    let lines: Vec<Line<'static>> = rows
+        .iter()
+        .zip(labels.iter())
+        .enumerate()
+        .map(|(index, (row, label))| entry_row_line(row, label, ranks, index == cursor))
+        .collect();
+
+    let block = Block::bordered().title(" Entry ");
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
+    let block = Block::bordered().title(" Detail ");
+
+    let Some(detail) = app.selected_detail(report) else {
+        let paragraph = Paragraph::new("(select a symbol row to see its detail)")
+            .block(block)
+            .wrap(ratatui::widgets::Wrap { trim: false });
+        frame.render_widget(paragraph, area);
+        return;
+    };
+
+    let lines = detail_lines(&detail);
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(ratatui::widgets::Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+/// Formats a [`DetailView`] into displayable lines: classification,
+/// signature (a styled old/new diff when the contract changed, mirroring
+/// `render.rs`'s Markdown ` ```diff ` block decision per
+/// `crate::detail::SignatureView`'s own doc comment), used-by, callers,
+/// callees.
+fn detail_lines(detail: &DetailView) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!("{:?} ", detail.kind),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(detail.name.clone()),
+    ]));
+    lines.push(Line::raw(detail.path.clone()));
+    if let Some(container) = &detail.container {
+        lines.push(Line::raw(format!("in {container}")));
+    }
+    lines.push(Line::raw(""));
+
+    if let Some(classification) = &detail.classification {
+        lines.push(Line::raw(format!("classification: {classification:?}")));
+    }
+
+    lines.push(Line::raw(""));
+    match &detail.signature {
+        SignatureView::Current(signature) => {
+            lines.push(Line::raw(signature.clone()));
+        }
+        SignatureView::Changed { previous, current } => {
+            lines.push(Line::styled(
+                format!("- {previous}"),
+                Style::default().fg(Color::Red),
+            ));
+            lines.push(Line::styled(
+                format!("+ {current}"),
+                Style::default().fg(Color::Green),
+            ));
+        }
+    }
+
+    lines.push(Line::raw(""));
+    lines.push(Line::styled(
+        format!("Used by ({})", detail.used_by.len()),
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+    for mention in &detail.used_by {
+        lines.push(Line::raw(format!("  {} ({})", mention.name, mention.path)));
+    }
+
+    lines.push(Line::raw(""));
+    lines.push(Line::styled(
+        format!("Callees ({})", detail.callees.len()),
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+    for mention in &detail.callees {
+        lines.push(Line::raw(format!("  {} ({})", mention.name, mention.path)));
+    }
+
+    lines
+}
+
+/// Draws the source drill-down for `symbol_id`. Re-reads the file on every
+/// frame (via [`load_symbol_source`]) rather than caching the result on
+/// `App` — a source file read is cheap relative to a terminal redraw, this
+/// module has no cache-invalidation story of its own, and re-reading keeps
+/// the view correct across a terminal resize (which redraws without a new
+/// key event) without the event loop needing to distinguish "just entered
+/// this screen" from "still on it". A read failure here is a fallback
+/// display path only: `crate::run`'s event loop already attempts the same
+/// read when the user first presses `s` and records a failure on `app`'s
+/// status line (`App::set_status`) via that same code path, so a failure
+/// mid-session (e.g. the file was deleted after opening the view) is
+/// shown in the pane itself too, not just silently on the status line.
+fn draw_source_screen(frame: &mut Frame, report: &Report, symbol_id: &str, area: Rect) {
+    let title = format!(" Source: {symbol_id} ");
+    let block = Block::bordered().title(title);
+
+    let source = match load_symbol_source(report, symbol_id) {
+        Ok(source) => source,
+        Err(message) => {
+            let paragraph = Paragraph::new(message).block(block);
+            frame.render_widget(paragraph, area);
+            return;
+        }
+    };
+
+    let viewport_height = area.height.saturating_sub(2) as usize; // borders
+    let (start, end) = visible_window(
+        source.lines.len(),
+        source.highlight_start,
+        source.highlight_end,
+        viewport_height,
+    );
+
+    let lines = source_lines(&source, start, end);
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn source_lines(source: &SourceView, start: usize, end: usize) -> Vec<Line<'static>> {
+    source.lines[start..end]
+        .iter()
+        .enumerate()
+        .map(|(offset, text)| {
+            let line_number = start + offset + 1;
+            let is_highlighted =
+                line_number >= source.highlight_start && line_number <= source.highlight_end;
+            let style = if is_highlighted {
+                Style::default().bg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+            Line::styled(format!("{line_number:>5} | {text}"), style)
+        })
+        .collect()
+}
+
+fn draw_status_line(frame: &mut Frame, app: &App, area: Rect) {
+    let help = match app.screen() {
+        Screen::Entry => {
+            "j/k: move  enter/space: expand  e/c: expand/collapse all  o: order  s: source  q: quit"
+        }
+        Screen::Source { .. } => "esc/q: back",
+    };
+
+    let text = match app.status() {
+        Some(status) => format!("{status}  |  {help}"),
+        None => help.to_string(),
+    };
+
+    let style = if app.status().is_some() {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    frame.render_widget(Paragraph::new(text).style(style), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::App;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+    use rinkaku_core::graph::SymbolGraph;
+    use rinkaku_core::render::FileReport;
+
+    fn symbol(id: &str, name: &str) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature: format!("fn {name}()"),
+            range: LineRange { start: 1, end: 1 },
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        }
+    }
+
+    fn report_with_one_symbol() -> Report {
+        Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo")],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    /// Flattens a `TestBackend`'s buffer into one string (rows joined by
+    /// `\n`), so a snapshot assertion can check for expected substrings
+    /// (pane titles, row content) without pinning every cell — the coarse
+    /// check ADR 0016 asks for, not a pixel-perfect comparison.
+    fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+        let buffer = terminal.backend().buffer();
+        let area = buffer.area;
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn should_draw_entry_and_detail_panes_with_titles_on_entry_screen() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Entry"));
+        assert!(text.contains("Detail"));
+        assert!(text.contains("lib.rs"));
+        // The full "(select a symbol row to see its detail)" message can
+        // legitimately wrap across two buffer rows depending on the
+        // detail pane's width, which would defeat a substring check
+        // against `buffer_text`'s newline-joined rows — "select a symbol"
+        // is short enough to always land on one row regardless of exact
+        // wrap point, which is all this coarse layout check needs.
+        assert!(text.contains("select a symbol"));
+    }
+
+    #[test]
+    fn should_draw_detail_pane_content_when_cursor_is_on_a_symbol_row() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("foo"));
+        assert!(text.contains("Used by"));
+    }
+
+    #[test]
+    fn should_draw_status_line_help_text_on_entry_screen() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        // Wider than the default 80 columns used elsewhere in this test
+        // module: the full help text is ~86 columns and would otherwise
+        // be truncated (the status line intentionally does not wrap),
+        // hiding the "quit" fragment this test checks for.
+        let mut terminal = Terminal::new(TestBackend::new(100, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("quit"));
+    }
+
+    #[test]
+    fn should_draw_source_screen_title_and_error_message_when_file_is_missing() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::Source);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report))
+            .expect("draw");
+
+        // "lib.rs" does not exist relative to the test process's cwd, so
+        // this exercises `draw_source_screen`'s error-message fallback
+        // path rather than needing a real file on disk.
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Source: lib.rs::foo"));
+        assert!(text.contains("failed to read"));
+        assert!(text.contains("back"));
+    }
+}

--- a/rinkaku/Cargo.toml
+++ b/rinkaku/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 rinkaku-core = { path = "../rinkaku-core", version = "0.1.0" }
+rinkaku-tui = { path = "../rinkaku-tui", version = "0.1.0" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 log = { workspace = true }

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -89,8 +89,16 @@ struct Cli {
     pr: Option<String>,
 
     /// Output format.
-    #[arg(long, value_enum, default_value_t = Format::Md)]
+    #[arg(long, value_enum, default_value_t = Format::Md, conflicts_with = "tui")]
     format: Format,
+
+    /// Open the interactive terminal UI (ADR 0015/0016) instead of
+    /// printing Markdown/JSON. The input flow (stdin / `--base` / `--pr`)
+    /// is unchanged — `--tui` only changes the output stage, once a
+    /// `Report` is built. Conflicts with `--format`, since the two are
+    /// mutually exclusive output stages rather than combinable options.
+    #[arg(long, default_value_t = false)]
+    tui: bool,
 
     /// Whether to resolve each changed symbol's 1-hop dependencies
     /// (ADR 0003). `1` (default) runs the tags-based `Resolver` over
@@ -229,6 +237,11 @@ fn main() -> anyhow::Result<()> {
         }
         report
     };
+
+    if cli.tui {
+        rinkaku_tui::run(&report)?;
+        return Ok(());
+    }
 
     let output = render(&report, cli.format.into())?;
     print!("{output}");
@@ -1619,10 +1632,36 @@ mod tests {
             deps: 1,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = Cli::parse_from(["rinkaku"]);
 
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_set_tui_when_tui_flag_given() {
+        let expected = Cli {
+            command: None,
+            base: None,
+            head: "HEAD".to_string(),
+            pr: None,
+            format: Format::Md,
+            deps: 1,
+            include_tests: false,
+            include_generated: false,
+            tui: true,
+        };
+        let actual = Cli::parse_from(["rinkaku", "--tui"]);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_reject_tui_and_format_given_together() {
+        let actual = Cli::try_parse_from(["rinkaku", "--tui", "--format", "json"]);
+
+        assert!(actual.is_err());
     }
 
     #[test]
@@ -1636,6 +1675,7 @@ mod tests {
             deps: 1,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--base", "main"]);
 
@@ -1653,6 +1693,7 @@ mod tests {
             deps: 1,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--base", "main", "--head", "feature-branch"]);
 
@@ -1670,6 +1711,7 @@ mod tests {
             deps: 1,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--format", "json"]);
 
@@ -1694,6 +1736,7 @@ mod tests {
             deps: 0,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--deps", "0"]);
 
@@ -1718,6 +1761,7 @@ mod tests {
             deps: 1,
             include_tests: true,
             include_generated: false,
+            tui: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--include-tests"]);
 
@@ -1735,6 +1779,7 @@ mod tests {
             deps: 1,
             include_tests: false,
             include_generated: true,
+            tui: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--include-generated"]);
 
@@ -1752,6 +1797,7 @@ mod tests {
             deps: 1,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = Cli::parse_from(["rinkaku", "self-update"]);
 
@@ -1769,6 +1815,7 @@ mod tests {
             deps: 1,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = Cli::parse_from(["rinkaku", "self-update", "--yes"]);
 
@@ -1786,6 +1833,7 @@ mod tests {
             deps: 1,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = Cli::parse_from(["rinkaku", "self-update", "-y"]);
 
@@ -1818,6 +1866,7 @@ mod tests {
             deps: 1,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = Cli::parse_from(["rinkaku", "--pr", "76"]);
 
@@ -2647,6 +2696,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             deps: 1,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let changed_paths = vec!["Cargo.lock".to_string()];
         let actual = resolve_generated_paths(&cli, &changed_paths, Some(dir.path()));
@@ -2672,6 +2722,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             deps: 1,
             include_tests: false,
             include_generated: true,
+            tui: false,
         };
         let changed_paths = vec!["Cargo.lock".to_string()];
         let actual = resolve_generated_paths(&cli, &changed_paths, Some(dir.path()));
@@ -3054,6 +3105,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             deps: 0,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         // Never called if `deps == 0` truly short-circuits before doing
         // any work at all — deliberately panics so a regression that
@@ -3086,6 +3138,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             deps: 1,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let read_file = |_: &str| -> std::io::Result<String> { Ok(String::new()) };
 
@@ -3130,6 +3183,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             deps: 1,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = run_base_pipeline(&cli, "HEAD", "HEAD", Some(dir.path()));
 
@@ -3203,6 +3257,7 @@ fn should_add_two_numbers() {
             deps: 0,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()))
             .expect("run_base_pipeline should succeed for a test-only diff");
@@ -3250,6 +3305,7 @@ fn should_add_two_numbers() {
             deps: 0,
             include_tests: false,
             include_generated: false,
+            tui: false,
         };
         let actual = run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()))
             .expect("run_base_pipeline should succeed");

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -1665,6 +1665,18 @@ mod tests {
     }
 
     #[test]
+    fn should_reject_format_and_tui_given_together_regardless_of_argument_order() {
+        // clap's conflicts_with is declared on `format` (see Cli's own
+        // `#[arg(...)]` attribute), but conflicts are symmetric regardless
+        // of which flag declares the attribute or which one is passed
+        // first on the command line — this pins that symmetry rather than
+        // only ever exercising the --tui-first ordering above.
+        let actual = Cli::try_parse_from(["rinkaku", "--format", "json", "--tui"]);
+
+        assert!(actual.is_err());
+    }
+
+    #[test]
     fn should_set_base_when_base_flag_given() {
         let expected = Cli {
             command: None,


### PR DESCRIPTION
## Summary

Implements ADR 0015/0016: the human-facing interactive terminal UI,
with Markdown/JSON staying machine-facing.

- New workspace crate `rinkaku-tui` (ratatui via its crossterm
  re-export), consuming `rinkaku-core`'s `Report` directly; core is
  untouched.
- **Pure view-model layer** (no ratatui types in signatures):
  directory tree with aggregate badges (changed symbols, contract
  changes, fan-in), topological directory ordering via directory-level
  SCC condensation (outermost first, cycles flagged, A-Z toggle),
  navigation state machine with cursor re-targeting on collapse, and
  a detail view-model (signature old→new diff, used-by, callers/
  callees with defensive edge dedup).
- **Shell**: `--tui` flag (conflicts with `--format`; input modes
  unchanged), entry + detail panes, source drill-down reading the
  working tree (isolated adapter-side IO), ASCII-only glyphs,
  terminal restored on exit and panic, clean error path on non-TTY
  (`try_init`).
- README gains an Interactive TUI section (usage + key bindings).

## Review & verification

Per CLAUDE.md's three review angles:
- Two map-assisted + independent review rounds (view-model round and
  shell round; findings recorded in experiment 0001) — all criticals
  and should-fixes addressed with regression tests.
- Dynamic verification: non-TTY invocation exits 1 with a clean error,
  `--format json --tui` rejected both orders, Markdown path
  unchanged, and a tmux pty smoke test (navigate, badges, source
  view, quit → exit 0).

## Test plan

`make test`: 549 tests green (304 core + 139 binary + 106 tui);
`make lint` clean.

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync