### PR TITLE
feat(tui): add diff pane and directory/file detail views

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,9 +442,19 @@ rather than combining with it.
   alphabetical order. Symbol rows show a kind abbreviation (`fn`, `struct`,
   ...) and a classification marker: `+` added, `~` signature-changed, `x`
   removed (dimmed and crossed out).
-- **Detail pane (right):** the symbol under the cursor — its
+- **Detail pane (right):** what the cursor is on. A symbol row shows its
   classification, signature (an old/new diff when the contract changed),
-  who depends on it ("used by"), and its callees.
+  who depends on it ("used by"), and its callees. A file row shows every
+  symbol changed in that file with its classification marker and fan-in. A
+  directory row shows its badge breakdown and top fan-in symbols, plus —
+  when it participates in a dependency cycle — exactly which other
+  directories it cycles with and the concrete symbol-to-symbol edges
+  forming that cycle.
+- **Diff pane (right):** `d`/`D` toggles the right-hand pane to the raw
+  unified-diff hunks instead of the detail view — every hunk of the file
+  for a file row, or just the hunks intersecting a symbol's own line range
+  for a symbol row (a directory row has no single diff to show, since it
+  spans multiple files).
 - **Source view:** `s` on a symbol row opens that file, scrolled to and
   highlighting the symbol's line range; `esc`/`q` returns to the entry
   view. Reads the working tree directly (not the historical commit a
@@ -463,6 +473,7 @@ rather than combining with it.
 | `e` / `E` | Expand every row |
 | `c` / `C` | Collapse every row |
 | `o` / `O` | Toggle topological / alphabetical ordering |
+| `d` / `D` | Toggle the right-hand pane between detail and diff |
 | `s` / `S` | Open the source view for the symbol under the cursor |
 | `esc` / `q` | Return to the entry view (from the source view) |
 | `q` / `ctrl-c` | Quit (from the entry view) |

--- a/docs/experiments/0001-map-assisted-llm-review.md
+++ b/docs/experiments/0001-map-assisted-llm-review.md
@@ -131,10 +131,90 @@ carried 2 `signature changed` markers and a removed-symbols section).
 - Token efficiency is not a selling point of the map at PR scale;
   attention allocation is.
 
+## Results (round 3)
+
+Same two-pass method, third subject: TUI iteration 2 (the `d`-key diff
+pane and directory/file detail views; 8 files, +2,016/−118 — a
+brownfield diff layering a new pure module and view-models onto the
+iteration-1 TUI). One protocol change from rounds 1–2: dynamic
+verification was **mandatory for both arms** this round (per the
+CLAUDE.md rule adopted after round 2), so both agents built and
+executed the binary rather than leaving execution to chance.
+
+| Metric              | A (map)     | B (control) |
+| ------------------- | ----------- | ----------- |
+| Output tokens       | 173.4k      | 173.2k      |
+| Tool calls          | 38          | 51          |
+| Wall clock          | 301s        | 413s        |
+| Blocker findings    | 0           | 0           |
+| Should-fix findings | 0           | 2           |
+| Nit findings        | 2           | 1           |
+
+- **Only B** found both should-fix issues, and both are the same
+  *class*: line-level behavior invisible on the signature surface.
+  (1) The diff pane re-parsed the entire raw diff text inside the
+  render closure — roughly ten times per second on idle poll ticks —
+  found by reading the event-loop body. (2) The new hunk parser
+  trusted the `@@` header's declared line count without validating it
+  against the actual body, silently diverging from
+  `rinkaku-core::diff::parse_hunk`'s strict `HunkBodyMismatch`
+  contract on the same failure mode; found by *comparing the two
+  parsers side by side*, an association the map draws no edge for.
+- **Only A** found the self-consistency defect: `build_dir_detail`
+  called `cycle_partners` and `cycle_edges` as two independent entry
+  points, each rebuilding the Tarjan condensation that
+  `DirCondensation`'s own doc comment says exists to be built once.
+  The map's dependency arrows under `build_dir_detail` (two arrows
+  into `order.rs`) are what prompted reading both callees' bodies —
+  attention allocation working as designed, though the defect itself
+  still required reading past the signatures.
+- A's second unique finding (no scroll support in the detail/diff
+  panes, a pre-existing gap the new whole-file diff view makes easier
+  to hit) came from its **dynamic-verification step**, not the map —
+  evidence that making execution mandatory for both arms, rather than
+  a lucky extra, pays off. With both arms executing, round 2's
+  asymmetry (only the executing arm finding the runtime defect) did
+  not recur; neither arm found any runtime defect this round, and
+  their live checks independently confirmed the same behaviors.
+- A third angle outside both arms — the orchestrator's own fixture
+  testing during dynamic verification — surfaced a limitation neither
+  reviewer saw: name-match edge collection produces **no edges for
+  qualified cross-package references** (e.g. Go's `store.Save()`), so
+  the new cycle explanation can be silently empty for Go code. A
+  pre-existing core behavior, not a defect of this diff, but it
+  bounds the feature's usefulness per language and neither static
+  pass had a reason to test it.
+- Token costs converged this round (under 0.2% apart); B spent ~34%
+  more tool calls and wall clock, mostly on its parser-comparison and
+  convention sweeps.
+- All four findings were fixed before merge; fixing the hunk-count
+  finding immediately caught a miscounted header in one of the new
+  module's own test fixtures — small, direct evidence the defensive
+  check pays for itself.
+
+## Conclusions (after 3 rounds)
+
+- Three rounds, one stable pattern: the map arm keeps winning on
+  **self-consistency and cross-module contracts** (doc/impl drift in
+  round 2, a module contradicting its own stated rationale in round
+  3), while the unassisted arm keeps winning on **line-level and
+  behavioral findings** (conventions in round 1, the non-TTY panic in
+  round 2, the render-loop re-parse and parser divergence in round
+  3). Neither arm has ever produced a superset of the other; the
+  two-pass default stands.
+- Making dynamic verification mandatory for both arms removed round
+  2's luck factor without erasing the arms' complementary profiles —
+  the differentiation comes from *reading strategy*, not from who
+  executes.
+- New hypothesis for the tool itself (from round 3's should-fix #2):
+  duplicated responsibility between crates (two unified-diff parsers)
+  is a defect class the map could surface directly — e.g. by flagging
+  same-named or same-domain symbols appearing in multiple crates —
+  where today it needs a reviewer to happen to know both sides exist.
+
 ## Next
 
-- Optional round 3 with a review pass that combines the map with an
-  explicit "execute the binary" instruction, to test whether one
-  agent can cover both axes without losing either.
 - Document the map-first recipe in the README's LLM usage section
   (map from a trusted build, paired with an independent pass).
+- Consider a map feature flagging cross-crate duplicate-domain
+  symbols (see round 3's new hypothesis).

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -9,7 +9,9 @@
 //! `crossterm::event::KeyEvent` into this module's [`InputKey`] and calls
 //! into `ratatui` to draw.
 
-use crate::detail::{DetailView, build_detail};
+use crate::detail::{
+    DetailView, DirDetail, FileDetail, build_detail, build_dir_detail, build_file_detail,
+};
 use crate::nav::{Action, Nav};
 use crate::order::{DirRank, OrderMode, rank_directories};
 use crate::tree::{NodeKind, Tree, build_tree};
@@ -36,6 +38,12 @@ pub enum InputKey {
     /// `s`: open the source view on the row under the cursor (a symbol
     /// row only — see `App::handle_key`).
     Source,
+    /// `d`/`D`: toggle the right-hand pane between [`RightPane::Detail`]
+    /// and [`RightPane::Diff`] (TUI iteration 2) — a per-`App` mode rather
+    /// than a per-row one, so switching to the diff pane on one row and
+    /// then moving the cursor keeps showing the diff pane for the newly
+    /// selected row instead of resetting on every cursor move.
+    ToggleDiff,
     /// Esc or `q` while in the source view: return to the entry view.
     /// A no-op on the entry view itself (`q`'s quit behavior on the entry
     /// view is `InputKey::Quit`, a separate variant, since Esc has no
@@ -62,6 +70,46 @@ pub enum Screen {
     },
 }
 
+/// Which content the right-hand pane shows on [`Screen::Entry`] (TUI
+/// iteration 2): the existing signature/used-by/callers detail, or the raw
+/// diff hunks touching the selected row. Independent of [`Screen`] — it is
+/// a display mode for the entry view's right pane, not a separate screen
+/// reached via drill-down the way [`Screen::Source`] is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RightPane {
+    #[default]
+    Detail,
+    Diff,
+}
+
+/// The right-hand pane's content for the row currently under the cursor
+/// (TUI iteration 2), unifying what used to be [`App::selected_detail`]'s
+/// symbol-only contract: a directory or file row now has its own detail
+/// too (`crate::detail::build_dir_detail`/`build_file_detail`), rather than
+/// falling through to the placeholder every non-symbol row used to show.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SelectedDetail {
+    Symbol(DetailView),
+    Dir(DirDetail),
+    File(FileDetail),
+}
+
+/// What [`App::selected_diff_target`] resolved the cursor's row to — plain
+/// data describing which file (and, for a symbol, which 1-based inclusive
+/// line range) the diff pane should slice hunks from; `crate::ui` combines
+/// this with the raw diff text (via `crate::diff_view`) at draw time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiffTarget {
+    Symbol {
+        path: String,
+        range_start: usize,
+        range_end: usize,
+    },
+    File {
+        path: String,
+    },
+}
+
 /// The whole interactive application's state: the stage-A view-models
 /// composed together, plus which screen is active and a status-line
 /// message for the caller to render. Rebuilt once per `Report` (in
@@ -74,6 +122,7 @@ pub struct App {
     ranks: HashMap<String, DirRank>,
     order_mode: OrderMode,
     screen: Screen,
+    right_pane: RightPane,
     /// A transient message for the status line (e.g. a source-read
     /// failure) — cleared on the next action that doesn't re-set it, so a
     /// stale error doesn't linger forever once the user has moved on.
@@ -101,6 +150,7 @@ impl App {
             ranks,
             order_mode,
             screen: Screen::Entry,
+            right_pane: RightPane::default(),
             status: None,
             should_quit: false,
         }
@@ -131,6 +181,10 @@ impl App {
         &self.screen
     }
 
+    pub fn right_pane(&self) -> RightPane {
+        self.right_pane
+    }
+
     pub fn status(&self) -> Option<&str> {
         self.status.as_deref()
     }
@@ -139,22 +193,69 @@ impl App {
         self.should_quit
     }
 
-    /// The detail view for the row currently under the cursor, or `None`
-    /// when the cursor is not on a present (non-removed) symbol row, there
-    /// are no rows at all, or `report` no longer contains that symbol
-    /// (defensive — `report` should be the same one `App::new` was built
-    /// from). `report` is threaded in per call rather than stored on `App`
-    /// itself, since `build_detail` is already a cheap pure lookup and
-    /// storing a whole `Report` on every `App` would duplicate data the
-    /// caller (`crate::run`) already owns for the process's lifetime.
-    pub fn selected_detail(&self, report: &Report) -> Option<DetailView> {
+    /// The detail-pane content for the row currently under the cursor
+    /// (TUI iteration 2): a symbol's [`DetailView`], or a directory/file
+    /// row's own [`DirDetail`]/[`FileDetail`] — `None` only when there are
+    /// no rows at all, the cursor sits on a *removed* symbol (no detail to
+    /// build, see `build_detail`'s doc comment), or `report`/`tree` no
+    /// longer agree with each other (defensive — both should come from the
+    /// same `App::new` call). `report` is threaded in per call rather than
+    /// stored on `App` itself, since every `build_*` function here is
+    /// already a cheap pure lookup and storing a whole `Report` on every
+    /// `App` would duplicate data the caller (`crate::run`) already owns
+    /// for the process's lifetime.
+    pub fn selected_detail(&self, report: &Report) -> Option<SelectedDetail> {
         let rows = self.nav.rows(&self.tree);
         let row = rows.get(self.nav.cursor())?;
         match &row.node.kind {
             NodeKind::Symbol(symbol_ref) if !symbol_ref.removed => {
-                build_detail(report, &symbol_ref.id)
+                build_detail(report, &symbol_ref.id).map(SelectedDetail::Symbol)
             }
-            _ => None,
+            NodeKind::Symbol(_) => None,
+            NodeKind::Dir => {
+                build_dir_detail(&self.tree, report, &row.node.path).map(SelectedDetail::Dir)
+            }
+            NodeKind::File => {
+                build_file_detail(&self.tree, report, &row.node.path).map(SelectedDetail::File)
+            }
+        }
+    }
+
+    /// What the diff pane (TUI iteration 2, [`RightPane::Diff`]) should
+    /// slice out of the raw diff text for the row currently under the
+    /// cursor: a symbol row scopes to just its own line range (looked up
+    /// from `report`, since `crate::tree::SymbolRef` itself carries no line
+    /// range — only `id`/`name`/`kind`/`classification`/`removed`), a file
+    /// row to the whole file, and a directory row has nothing diff-specific
+    /// to show (a directory spans multiple files with no single line range
+    /// to highlight — showing "every hunk under this directory" was
+    /// considered and deferred, since it would just be the concatenation
+    /// of every file's own diff, better browsed file by file). `None` when
+    /// there are no rows at all, the cursor sits on a removed symbol (no
+    /// line range to scope to, same as `selected_detail`'s handling), or
+    /// (defensively) `report` no longer contains the selected symbol.
+    pub fn selected_diff_target(&self, report: &Report) -> Option<DiffTarget> {
+        let rows = self.nav.rows(&self.tree);
+        let row = rows.get(self.nav.cursor())?;
+        match &row.node.kind {
+            NodeKind::Symbol(symbol_ref) if !symbol_ref.removed => {
+                let range = report
+                    .files
+                    .iter()
+                    .find(|file| file.path == row.node.path)
+                    .and_then(|file| file.symbols.iter().find(|s| s.id == symbol_ref.id))
+                    .map(|s| s.range)?;
+                Some(DiffTarget::Symbol {
+                    path: row.node.path.clone(),
+                    range_start: range.start,
+                    range_end: range.end,
+                })
+            }
+            NodeKind::Symbol(_) => None,
+            NodeKind::File => Some(DiffTarget::File {
+                path: row.node.path.clone(),
+            }),
+            NodeKind::Dir => None,
         }
     }
 
@@ -211,6 +312,12 @@ impl App {
                         symbol_id: symbol_ref.id.clone(),
                     };
                 }
+            }
+            (Screen::Entry, InputKey::ToggleDiff) => {
+                self.right_pane = match self.right_pane {
+                    RightPane::Detail => RightPane::Diff,
+                    RightPane::Diff => RightPane::Detail,
+                };
             }
             (Screen::Entry, InputKey::Back) => {
                 // No-op: Esc/q-as-back on the entry view has nowhere to
@@ -406,13 +513,15 @@ mod tests {
     }
 
     #[test]
-    fn should_return_none_detail_when_cursor_is_on_a_directory_row() {
+    fn should_return_file_detail_when_cursor_is_on_a_file_row() {
+        // Row 0 is the "lib.rs" file itself, not a symbol (TUI iteration
+        // 2: a file row now gets its own detail instead of `None`).
         let report = report_with_one_symbol();
         let app = App::new(&report);
 
         let actual = app.selected_detail(&report);
 
-        assert_eq!(None, actual);
+        assert!(matches!(actual, Some(SelectedDetail::File(_))));
     }
 
     #[test]
@@ -422,6 +531,114 @@ mod tests {
 
         let actual = app.selected_detail(&report);
 
-        assert_eq!("foo", actual.expect("detail for selected symbol").name);
+        match actual.expect("detail for selected symbol") {
+            SelectedDetail::Symbol(detail) => assert_eq!("foo", detail.name),
+            other => panic!("expected SelectedDetail::Symbol, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_return_dir_detail_when_cursor_is_on_a_directory_row() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol("src/lib.rs::foo", "foo")],
+            }],
+            ..empty_report()
+        };
+        let app = App::new(&report);
+
+        let actual = app.selected_detail(&report);
+
+        assert!(matches!(actual, Some(SelectedDetail::Dir(_))));
+    }
+
+    #[test]
+    fn should_toggle_right_pane_between_detail_and_diff() {
+        let report = empty_report();
+        let app = App::new(&report);
+        assert_eq!(RightPane::Detail, app.right_pane());
+
+        let app = app.handle_key(InputKey::ToggleDiff);
+        assert_eq!(RightPane::Diff, app.right_pane());
+
+        let app = app.handle_key(InputKey::ToggleDiff);
+        assert_eq!(RightPane::Detail, app.right_pane());
+    }
+
+    #[test]
+    fn should_ignore_toggle_diff_while_source_screen_is_open() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Source);
+        assert_eq!(RightPane::Detail, app.right_pane());
+
+        let app = app.handle_key(InputKey::ToggleDiff);
+
+        assert_eq!(RightPane::Detail, app.right_pane());
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string()
+            },
+            *app.screen()
+        );
+    }
+
+    #[test]
+    fn should_return_none_diff_target_when_cursor_is_on_a_directory_row() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol("src/lib.rs::foo", "foo")],
+            }],
+            ..empty_report()
+        };
+        let app = App::new(&report);
+
+        let actual = app.selected_diff_target(&report);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_return_file_diff_target_when_cursor_is_on_a_file_row() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+
+        let actual = app.selected_diff_target(&report);
+
+        assert_eq!(
+            Some(DiffTarget::File {
+                path: "lib.rs".to_string()
+            }),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_return_symbol_diff_target_with_line_range_when_cursor_is_on_a_symbol_row() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    range: LineRange { start: 3, end: 7 },
+                    ..symbol("lib.rs::foo", "foo")
+                }],
+            }],
+            ..empty_report()
+        };
+        let app = App::new(&report).handle_key(InputKey::Down);
+
+        let actual = app.selected_diff_target(&report);
+
+        assert_eq!(
+            Some(DiffTarget::Symbol {
+                path: "lib.rs".to_string(),
+                range_start: 3,
+                range_end: 7,
+            }),
+            actual
+        );
     }
 }

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -341,6 +341,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::detail::FileSymbolSummary;
     use pretty_assertions::assert_eq;
     use rinkaku_core::diff::LineRange;
     use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
@@ -521,7 +522,17 @@ mod tests {
 
         let actual = app.selected_detail(&report);
 
-        assert!(matches!(actual, Some(SelectedDetail::File(_))));
+        let expected = SelectedDetail::File(FileDetail {
+            path: "lib.rs".to_string(),
+            symbols: vec![FileSymbolSummary {
+                name: "foo".to_string(),
+                kind: SymbolKind::Function,
+                classification: None,
+                removed: false,
+                fan_in: 0,
+            }],
+        });
+        assert_eq!(Some(expected), actual);
     }
 
     #[test]
@@ -550,7 +561,18 @@ mod tests {
 
         let actual = app.selected_detail(&report);
 
-        assert!(matches!(actual, Some(SelectedDetail::Dir(_))));
+        let expected = SelectedDetail::Dir(DirDetail {
+            path: "src".to_string(),
+            badges: crate::tree::Badges {
+                changed_symbols: 1,
+                contract_changes: 0,
+                fan_in: 0,
+            },
+            top_fan_in: vec![],
+            cycle_partners: vec![],
+            cycle_edges: vec![],
+        });
+        assert_eq!(Some(expected), actual);
     }
 
     #[test]

--- a/rinkaku-tui/src/detail.rs
+++ b/rinkaku-tui/src/detail.rs
@@ -6,7 +6,18 @@
 //!
 //! [`build_detail`] is a pure function of a symbol id plus [`Report`]: no
 //! IO, no `ratatui` types.
+//!
+//! [`build_dir_detail`]/[`build_file_detail`] (TUI iteration 2) extend the
+//! same detail pane to directory and file rows, which previously showed
+//! only a placeholder ("select a symbol row to see its detail"). A
+//! directory's detail is a badge breakdown plus, when it participates in a
+//! directory-level cycle, an explanation of exactly which directories it
+//! cycles with and which concrete symbol-to-symbol edges form that cycle —
+//! the entry view's `(cycle)` marker on its own only says *that* a
+//! directory cycles, not *with what*.
 
+use crate::order::{CycleEdge, cycle_edges, cycle_partners};
+use crate::tree::{Badges, NodeKind, SymbolRef, Tree, TreeNode};
 use rinkaku_core::extract::{Classification, SymbolKind};
 use rinkaku_core::render::Report;
 use std::collections::HashSet;
@@ -171,6 +182,224 @@ pub fn build_detail(report: &Report, id: &str) -> Option<DetailView> {
         callees,
         callers,
     })
+}
+
+/// A cross-directory edge forming part of a directory cycle, as displayed
+/// text — `crate::order::CycleEdge`'s fields pre-joined into the
+/// `path::name -> path::name` shape the detail pane renders directly,
+/// keeping `crate::ui` free of string-formatting decisions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CycleEdgeView {
+    pub from: String,
+    pub to: String,
+}
+
+impl From<&CycleEdge> for CycleEdgeView {
+    fn from(edge: &CycleEdge) -> Self {
+        Self {
+            from: format!("{}::{}", edge.from_path, edge.from_name),
+            to: format!("{}::{}", edge.to_path, edge.to_name),
+        }
+    }
+}
+
+/// The detail-pane view-model for a selected [`NodeKind::Dir`] row
+/// (TUI iteration 2): a badge breakdown (already aggregated bottom-up onto
+/// the node by `crate::tree::build_tree`), the directory's own top fan-in
+/// symbols, and — only when this directory participates in a
+/// directory-level cycle — which other directories it cycles with and the
+/// concrete symbol-to-symbol edges that make up that cycle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirDetail {
+    pub path: String,
+    pub badges: Badges,
+    /// This directory's own hotspot symbols (fan-in >= 2), sorted by
+    /// fan-in descending then `(path, name)` ascending for determinism —
+    /// mirrors `compute_hotspots`'s own tie-break in `rinkaku-core::graph`.
+    /// Capped at 5: this is a "what stands out" summary, not an exhaustive
+    /// listing (the badge's `fan_in` count already carries the full
+    /// aggregate).
+    pub top_fan_in: Vec<SymbolMention>,
+    /// Other directories sharing this directory's cycle (empty when this
+    /// directory is not in a cycle at all), sorted ascending.
+    pub cycle_partners: Vec<String>,
+    /// Concrete cross-directory edges forming the cycle this directory
+    /// participates in, restricted to edges touching this directory as
+    /// either endpoint (empty when not in a cycle) — the answer to "cycle
+    /// と言われても何が cycle してるか分からない".
+    pub cycle_edges: Vec<CycleEdgeView>,
+}
+
+/// One symbol summary line for a [`FileDetail`]: enough to render a
+/// classification marker and fan-in without duplicating the full
+/// [`DetailView`] a reviewer gets by selecting that symbol row directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileSymbolSummary {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub classification: Option<Classification>,
+    pub removed: bool,
+    pub fan_in: usize,
+}
+
+/// The detail-pane view-model for a selected [`NodeKind::File`] row (TUI
+/// iteration 2): the list of symbols changed in this file, each with its
+/// classification marker and fan-in — a compact index of "what changed
+/// here" before drilling into an individual symbol row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileDetail {
+    pub path: String,
+    pub symbols: Vec<FileSymbolSummary>,
+}
+
+/// Builds a [`DirDetail`] for the directory at `path` in `tree`, or `None`
+/// when no such directory node exists. `report` supplies the cycle
+/// explanation (`crate::order::cycle_partners`/`cycle_edges`) and the
+/// hotspot lookup for `top_fan_in` — both computed fresh per call, same
+/// "recompute rather than cache" philosophy the rest of this view-model
+/// layer already follows (ADR 0016 decision 1).
+pub fn build_dir_detail(tree: &Tree, report: &Report, path: &str) -> Option<DirDetail> {
+    let node = find_dir_node(tree, path)?;
+
+    let hotspot_by_id: std::collections::HashMap<&str, &rinkaku_core::graph::Hotspot> = report
+        .hotspots
+        .iter()
+        .map(|hotspot| (hotspot.id.as_str(), hotspot))
+        .collect();
+
+    let mut symbol_ids = Vec::new();
+    collect_symbol_ids(node, &mut symbol_ids);
+
+    let mut top_fan_in: Vec<SymbolMention> = symbol_ids
+        .iter()
+        .filter_map(|id| hotspot_by_id.get(id.as_str()).map(|h| (*h, id)))
+        .map(|(hotspot, id)| SymbolMention {
+            id: id.clone(),
+            name: hotspot.name.clone(),
+            path: hotspot.path.clone(),
+        })
+        .collect();
+    // Sort by fan-in descending (looked up again per entry rather than
+    // carried alongside — the list is small, capped at 5 below, so a
+    // second map lookup per comparison is not worth avoiding via a tuple),
+    // ties broken by (path, name) ascending, mirroring
+    // `compute_hotspots`'s own tie-break in `rinkaku-core::graph`.
+    top_fan_in.sort_by(|a, b| {
+        let fan_in_of = |mention: &SymbolMention| {
+            hotspot_by_id
+                .get(mention.id.as_str())
+                .map(|h| h.used_by.len())
+                .unwrap_or(0)
+        };
+        fan_in_of(b)
+            .cmp(&fan_in_of(a))
+            .then_with(|| a.path.cmp(&b.path))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    top_fan_in.truncate(5);
+
+    let partners = cycle_partners(report).remove(path).unwrap_or_default();
+    let edges: Vec<CycleEdgeView> = if partners.is_empty() {
+        Vec::new()
+    } else {
+        cycle_edges(report)
+            .iter()
+            .filter(|edge| dir_of(&edge.from_path) == path || dir_of(&edge.to_path) == path)
+            .map(CycleEdgeView::from)
+            .collect()
+    };
+
+    Some(DirDetail {
+        path: node.path.clone(),
+        badges: node.badges,
+        top_fan_in,
+        cycle_partners: partners,
+        cycle_edges: edges,
+    })
+}
+
+/// Builds a [`FileDetail`] for the file at `path` in `tree`, or `None` when
+/// no such file node exists.
+pub fn build_file_detail(tree: &Tree, report: &Report, path: &str) -> Option<FileDetail> {
+    let node = find_file_node(tree, path)?;
+
+    let fan_in_by_id: std::collections::HashMap<&str, usize> = report
+        .hotspots
+        .iter()
+        .map(|hotspot| (hotspot.id.as_str(), hotspot.used_by.len()))
+        .collect();
+
+    let symbols: Vec<FileSymbolSummary> = node
+        .children
+        .iter()
+        .filter_map(|child| match &child.kind {
+            NodeKind::Symbol(symbol_ref) => Some(file_symbol_summary(symbol_ref, &fan_in_by_id)),
+            _ => None,
+        })
+        .collect();
+
+    Some(FileDetail {
+        path: node.path.clone(),
+        symbols,
+    })
+}
+
+fn file_symbol_summary(
+    symbol_ref: &SymbolRef,
+    fan_in_by_id: &std::collections::HashMap<&str, usize>,
+) -> FileSymbolSummary {
+    FileSymbolSummary {
+        name: symbol_ref.name.clone(),
+        kind: symbol_ref.kind,
+        classification: symbol_ref.classification,
+        removed: symbol_ref.removed,
+        fan_in: fan_in_by_id
+            .get(symbol_ref.id.as_str())
+            .copied()
+            .unwrap_or(0),
+    }
+}
+
+/// The parent directory of a slash-separated `path` — mirrors
+/// `crate::order`'s own private `parent_dir` (not reused directly since
+/// that one is private to `order.rs`; duplicating one small line here is
+/// cheaper than making it `pub(crate)` for a single call site).
+fn dir_of(path: &str) -> &str {
+    path.rsplit_once('/').map(|(dir, _)| dir).unwrap_or("")
+}
+
+fn find_dir_node<'a>(tree: &'a Tree, path: &str) -> Option<&'a TreeNode> {
+    tree.roots
+        .iter()
+        .find_map(|root| find_node(root, path, |kind| matches!(kind, NodeKind::Dir)))
+}
+
+fn find_file_node<'a>(tree: &'a Tree, path: &str) -> Option<&'a TreeNode> {
+    tree.roots
+        .iter()
+        .find_map(|root| find_node(root, path, |kind| matches!(kind, NodeKind::File)))
+}
+
+fn find_node<'a>(
+    node: &'a TreeNode,
+    path: &str,
+    matches_kind: impl Fn(&NodeKind) -> bool + Copy,
+) -> Option<&'a TreeNode> {
+    if node.path == path && matches_kind(&node.kind) {
+        return Some(node);
+    }
+    node.children
+        .iter()
+        .find_map(|child| find_node(child, path, matches_kind))
+}
+
+fn collect_symbol_ids(node: &TreeNode, ids: &mut Vec<String>) {
+    if let NodeKind::Symbol(symbol_ref) = &node.kind {
+        ids.push(symbol_ref.id.clone());
+    }
+    for child in &node.children {
+        collect_symbol_ids(child, ids);
+    }
 }
 
 #[cfg(test)]
@@ -544,5 +773,296 @@ mod tests {
         assert_eq!(Vec::<SymbolMention>::new(), actual.callees);
         assert_eq!(Vec::<SymbolMention>::new(), actual.callers);
         assert_eq!(Vec::<SymbolMention>::new(), actual.used_by);
+    }
+
+    // build_dir_detail / build_file_detail tests (TUI iteration 2).
+
+    #[test]
+    fn should_return_none_when_dir_path_is_not_found() {
+        let report = empty_report();
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_dir_detail(&tree, &report, "missing");
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_build_dir_detail_with_badges_and_no_cycle_when_directory_is_not_in_a_cycle() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    classification: Some(Classification::SignatureChanged),
+                    ..symbol("src/lib.rs::foo", "foo")
+                }],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
+            ..empty_report()
+        };
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_dir_detail(&tree, &report, "src").expect("dir found");
+
+        let expected = DirDetail {
+            path: "src".to_string(),
+            badges: crate::tree::Badges {
+                changed_symbols: 1,
+                contract_changes: 1,
+                fan_in: 0,
+            },
+            top_fan_in: vec![],
+            cycle_partners: vec![],
+            cycle_edges: vec![],
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_list_top_fan_in_symbols_sorted_by_fan_in_descending() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![
+                    symbol("src/lib.rs::a", "a"),
+                    symbol("src/lib.rs::b", "b"),
+                    symbol("src/lib.rs::shared_low", "shared_low"),
+                    symbol("src/lib.rs::shared_high", "shared_high"),
+                ],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("src/lib.rs::a", "src/lib.rs", "a"),
+                    node("src/lib.rs::b", "src/lib.rs", "b"),
+                    node("src/lib.rs::shared_low", "src/lib.rs", "shared_low"),
+                    node("src/lib.rs::shared_high", "src/lib.rs", "shared_high"),
+                ],
+                edges: vec![],
+                roots: vec![],
+            },
+            hotspots: vec![
+                Hotspot {
+                    id: "src/lib.rs::shared_low".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "shared_low".to_string(),
+                    used_by: vec!["a".to_string(), "b".to_string()],
+                },
+                Hotspot {
+                    id: "src/lib.rs::shared_high".to_string(),
+                    path: "src/lib.rs".to_string(),
+                    name: "shared_high".to_string(),
+                    used_by: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+                },
+            ],
+            ..empty_report()
+        };
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_dir_detail(&tree, &report, "src").expect("dir found");
+
+        let expected_top_fan_in = vec![
+            SymbolMention {
+                id: "src/lib.rs::shared_high".to_string(),
+                name: "shared_high".to_string(),
+                path: "src/lib.rs".to_string(),
+            },
+            SymbolMention {
+                id: "src/lib.rs::shared_low".to_string(),
+                name: "shared_low".to_string(),
+                path: "src/lib.rs".to_string(),
+            },
+        ];
+        assert_eq!(expected_top_fan_in, actual.top_fan_in);
+    }
+
+    #[test]
+    fn should_truncate_top_fan_in_to_five_entries() {
+        let symbols: Vec<ExtractedSymbol> = (0..7)
+            .map(|i| symbol(&format!("src/lib.rs::s{i}"), &format!("s{i}")))
+            .collect();
+        let nodes: Vec<Node> = (0..7)
+            .map(|i| node(&format!("src/lib.rs::s{i}"), "src/lib.rs", &format!("s{i}")))
+            .collect();
+        let hotspots: Vec<Hotspot> = (0..7)
+            .map(|i| Hotspot {
+                id: format!("src/lib.rs::s{i}"),
+                path: "src/lib.rs".to_string(),
+                name: format!("s{i}"),
+                used_by: vec!["x".to_string(), "y".to_string()],
+            })
+            .collect();
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols,
+            }],
+            graph: SymbolGraph {
+                nodes,
+                edges: vec![],
+                roots: vec![],
+            },
+            hotspots,
+            ..empty_report()
+        };
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_dir_detail(&tree, &report, "src").expect("dir found");
+
+        assert_eq!(5, actual.top_fan_in.len());
+    }
+
+    #[test]
+    fn should_explain_cycle_partners_and_edges_when_directory_participates_in_a_cycle() {
+        // api/ and store/ depend on each other — a directory-level cycle
+        // (mirrors crate::order's own cycle test fixtures).
+        let report = Report {
+            files: vec![
+                FileReport {
+                    path: "api/handler.rs".to_string(),
+                    symbols: vec![symbol("api/handler.rs::handle", "handle")],
+                },
+                FileReport {
+                    path: "store/db.rs".to_string(),
+                    symbols: vec![symbol("store/db.rs::save", "save")],
+                },
+            ],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("api/handler.rs::handle", "api/handler.rs", "handle"),
+                    node("store/db.rs::save", "store/db.rs", "save"),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "api/handler.rs::handle".to_string(),
+                        to: "store/db.rs::save".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "store/db.rs::save".to_string(),
+                        to: "api/handler.rs::handle".to_string(),
+                        is_cycle: false,
+                    },
+                ],
+                roots: vec![],
+            },
+            ..empty_report()
+        };
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_dir_detail(&tree, &report, "api").expect("dir found");
+
+        assert_eq!(vec!["store".to_string()], actual.cycle_partners);
+        // Both directed edges touch "api" as an endpoint (api -> store and
+        // store -> api), so both are part of the cycle explanation shown
+        // for "api" — not just the one where "api" is the source.
+        let expected_edges = vec![
+            CycleEdgeView {
+                from: "api/handler.rs::handle".to_string(),
+                to: "store/db.rs::save".to_string(),
+            },
+            CycleEdgeView {
+                from: "store/db.rs::save".to_string(),
+                to: "api/handler.rs::handle".to_string(),
+            },
+        ];
+        assert_eq!(expected_edges, actual.cycle_edges);
+    }
+
+    #[test]
+    fn should_return_none_when_file_path_is_not_found() {
+        let report = empty_report();
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_file_detail(&tree, &report, "missing.rs");
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_build_file_detail_with_symbol_summaries_and_fan_in() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![
+                    ExtractedSymbol {
+                        classification: Some(Classification::Added),
+                        ..symbol("lib.rs::foo", "foo")
+                    },
+                    symbol("lib.rs::bar", "bar"),
+                ],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("lib.rs::foo", "lib.rs", "foo"),
+                    node("lib.rs::bar", "lib.rs", "bar"),
+                ],
+                edges: vec![],
+                roots: vec![],
+            },
+            hotspots: vec![Hotspot {
+                id: "lib.rs::bar".to_string(),
+                path: "lib.rs".to_string(),
+                name: "bar".to_string(),
+                used_by: vec!["foo".to_string(), "baz".to_string()],
+            }],
+            ..empty_report()
+        };
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_file_detail(&tree, &report, "lib.rs").expect("file found");
+
+        let expected = FileDetail {
+            path: "lib.rs".to_string(),
+            symbols: vec![
+                FileSymbolSummary {
+                    name: "foo".to_string(),
+                    kind: SymbolKind::Function,
+                    classification: Some(Classification::Added),
+                    removed: false,
+                    fan_in: 0,
+                },
+                FileSymbolSummary {
+                    name: "bar".to_string(),
+                    kind: SymbolKind::Function,
+                    classification: None,
+                    removed: false,
+                    fan_in: 2,
+                },
+            ],
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_include_removed_symbol_in_file_detail_summary() {
+        let report = Report {
+            files: vec![],
+            removed: vec![rinkaku_core::extract::RemovedSymbol {
+                name: "gone".to_string(),
+                kind: SymbolKind::Function,
+                path: "lib.rs".to_string(),
+                signature: "fn gone()".to_string(),
+            }],
+            ..empty_report()
+        };
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_file_detail(&tree, &report, "lib.rs").expect("file found");
+
+        let expected = FileDetail {
+            path: "lib.rs".to_string(),
+            symbols: vec![FileSymbolSummary {
+                name: "gone".to_string(),
+                kind: SymbolKind::Function,
+                classification: None,
+                removed: true,
+                fan_in: 0,
+            }],
+        };
+        assert_eq!(expected, actual);
     }
 }

--- a/rinkaku-tui/src/detail.rs
+++ b/rinkaku-tui/src/detail.rs
@@ -16,7 +16,7 @@
 //! the entry view's `(cycle)` marker on its own only says *that* a
 //! directory cycles, not *with what*.
 
-use crate::order::{CycleEdge, cycle_edges, cycle_partners};
+use crate::order::{CycleEdge, cycle_explanation};
 use crate::tree::{Badges, NodeKind, SymbolRef, Tree, TreeNode};
 use rinkaku_core::extract::{Classification, SymbolKind};
 use rinkaku_core::render::Report;
@@ -254,10 +254,11 @@ pub struct FileDetail {
 
 /// Builds a [`DirDetail`] for the directory at `path` in `tree`, or `None`
 /// when no such directory node exists. `report` supplies the cycle
-/// explanation (`crate::order::cycle_partners`/`cycle_edges`) and the
-/// hotspot lookup for `top_fan_in` — both computed fresh per call, same
-/// "recompute rather than cache" philosophy the rest of this view-model
-/// layer already follows (ADR 0016 decision 1).
+/// explanation (`crate::order::cycle_explanation`, which builds the
+/// directory-level SCC condensation exactly once rather than once per
+/// piece of information) and the hotspot lookup for `top_fan_in` — both
+/// computed fresh per call, same "recompute rather than cache" philosophy
+/// the rest of this view-model layer already follows (ADR 0016 decision 1).
 pub fn build_dir_detail(tree: &Tree, report: &Report, path: &str) -> Option<DirDetail> {
     let node = find_dir_node(tree, path)?;
 
@@ -298,16 +299,8 @@ pub fn build_dir_detail(tree: &Tree, report: &Report, path: &str) -> Option<DirD
     });
     top_fan_in.truncate(5);
 
-    let partners = cycle_partners(report).remove(path).unwrap_or_default();
-    let edges: Vec<CycleEdgeView> = if partners.is_empty() {
-        Vec::new()
-    } else {
-        cycle_edges(report)
-            .iter()
-            .filter(|edge| dir_of(&edge.from_path) == path || dir_of(&edge.to_path) == path)
-            .map(CycleEdgeView::from)
-            .collect()
-    };
+    let (partners, cycle_edges) = cycle_explanation(report, path);
+    let edges: Vec<CycleEdgeView> = cycle_edges.iter().map(CycleEdgeView::from).collect();
 
     Some(DirDetail {
         path: node.path.clone(),
@@ -358,14 +351,6 @@ fn file_symbol_summary(
             .copied()
             .unwrap_or(0),
     }
-}
-
-/// The parent directory of a slash-separated `path` — mirrors
-/// `crate::order`'s own private `parent_dir` (not reused directly since
-/// that one is private to `order.rs`; duplicating one small line here is
-/// cheaper than making it `pub(crate)` for a single call site).
-fn dir_of(path: &str) -> &str {
-    path.rsplit_once('/').map(|(dir, _)| dir).unwrap_or("")
 }
 
 fn find_dir_node<'a>(tree: &'a Tree, path: &str) -> Option<&'a TreeNode> {

--- a/rinkaku-tui/src/diff_view.rs
+++ b/rinkaku-tui/src/diff_view.rs
@@ -161,7 +161,20 @@ fn parse_one_hunk(lines: &[&str], start: usize) -> (Hunk, usize) {
         i += 1;
     }
 
-    let new_range = new_start_count.and_then(|(start, count)| {
+    // The header's declared new-side count is a claim, not a fact —
+    // `rinkaku_core::diff::parse_hunk` walks the body and errors out
+    // (`HunkBodyMismatch`) when it doesn't match, but this module's parser
+    // degrades instead of erroring (module doc comment), so an inflated
+    // header count must not silently propagate into `new_range`: it would
+    // let `hunks_for_range` match a symbol whose lines the hunk body never
+    // actually touched. `Added` and `Context` lines are exactly the ones
+    // that occupy a new-side line number; `Removed` lines don't.
+    let actual_new_line_count = body
+        .iter()
+        .filter(|line| line.kind != DiffLineKind::Removed)
+        .count();
+    let new_range = new_start_count.and_then(|(start, declared_count)| {
+        let count = declared_count.min(actual_new_line_count);
         if count == 0 {
             None
         } else {
@@ -247,7 +260,7 @@ diff --git a/src/lib.rs b/src/lib.rs
 index e69de29..4b825dc 100644
 --- a/src/lib.rs
 +++ b/src/lib.rs
-@@ -1,3 +1,4 @@
+@@ -1,3 +1,3 @@
  fn a() {}
 +fn b() {}
 -fn old() {}
@@ -256,8 +269,8 @@ index e69de29..4b825dc 100644
         let expected = vec![FileHunks {
             path: "src/lib.rs".to_string(),
             hunks: vec![Hunk {
-                header: "@@ -1,3 +1,4 @@".to_string(),
-                new_range: Some((1, 4)),
+                header: "@@ -1,3 +1,3 @@".to_string(),
+                new_range: Some((1, 3)),
                 lines: vec![
                     DiffLine {
                         kind: DiffLineKind::Context,
@@ -408,6 +421,32 @@ index e69de29..4b825dc 100644
 
         assert_eq!(1, actual.len());
         assert_eq!(None, actual[0].hunks[0].new_range);
+    }
+
+    // SHOULD-FIX: the header's declared new-side count is untrustworthy on
+    // its own — this module's doc comment claims malformed input "degrades
+    // to no hunks shown", but before this fix a header declaring more lines
+    // than the body actually contains produced an inflated `new_range` that
+    // could wrongly match unrelated symbols further down the file (see
+    // `hunks_for_range`). The body's own actually-parsed new-side line count
+    // must cap whatever the header claims.
+    #[test]
+    fn should_cap_new_range_when_hunk_body_is_shorter_than_declared_count() {
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,100 @@
+ fn a() {}
++fn b() {}
+";
+        let actual = parse_diff_hunks(diff);
+
+        // The header claims 100 new-side lines starting at 1, but the body
+        // only actually contains 2 (one context, one added) — the range
+        // must reflect the body's real extent, not the header's claim.
+        assert_eq!(Some((1, 2)), actual[0].hunks[0].new_range);
     }
 
     #[test]

--- a/rinkaku-tui/src/diff_view.rs
+++ b/rinkaku-tui/src/diff_view.rs
@@ -1,0 +1,488 @@
+//! Raw unified-diff hunk view-model (TUI iteration 2, "diff" pane): given
+//! the raw diff text `main.rs` already has in hand for every input mode
+//! (stdin / `--base` / `--pr` — all three end up with a `String` of diff
+//! text before `rinkaku_core::pipeline::analyze_diff` consumes it), slices
+//! it into per-file hunks with styled lines, so a reviewer can see *what
+//! changed* in the lines under a selected symbol/file, not just the
+//! post-change signature.
+//!
+//! [`rinkaku_core::diff::parse_unified_diff`] already parses a unified diff
+//! but only keeps the *line ranges* that changed (`ChangedFile`), not the
+//! hunk text itself — that's all `rinkaku-core`'s extraction pipeline needs.
+//! This module needs the actual `+`/`-`/context lines to render, which
+//! `rinkaku-core`'s parser doesn't expose, so it re-walks the raw diff text
+//! itself with a small, focused parser rather than reaching into
+//! `rinkaku-core` for something it doesn't publish. This keeps `rinkaku-core`
+//! untouched (CLAUDE.md: core logic changes are out of scope for this
+//! feature) and keeps the parsing pure — a `&str` in, plain data out, no IO.
+
+/// One line inside a hunk body, classified by its leading diff marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffLineKind {
+    Added,
+    Removed,
+    Context,
+}
+
+/// One line of a hunk's body, with its marker stripped (`content` never
+/// includes the leading `+`/`-`/` `) so a renderer can prepend its own
+/// styled marker glyph rather than displaying git's raw prefix twice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffLine {
+    pub kind: DiffLineKind,
+    pub content: String,
+}
+
+/// One `@@ ... @@` hunk: its header text (shown dim, mirrors a diff tool's
+/// own convention) and body lines, plus the new-side line range it covers —
+/// used to test intersection against a symbol's [`rinkaku_core::diff::LineRange`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Hunk {
+    pub header: String,
+    /// 1-based inclusive new-side line range this hunk's `+`/context lines
+    /// span. `None` when the hunk adds/removes zero new-side lines (a
+    /// hunk that is pure deletion) — there is then no new-side range to
+    /// intersect a symbol's line range against at all.
+    pub new_range: Option<(usize, usize)>,
+    pub lines: Vec<DiffLine>,
+}
+
+/// Every hunk touching one file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileHunks {
+    /// New-side path (matches `rinkaku_core::render::FileReport::path`).
+    pub path: String,
+    pub hunks: Vec<Hunk>,
+}
+
+/// Parses raw unified diff text into per-file hunk blocks. Malformed input
+/// (a hunk header this parser can't read) is skipped rather than erroring —
+/// this view is a best-effort visual aid layered on top of the report the
+/// core pipeline already successfully built from the same text, so a
+/// parsing hiccup here should degrade to "no hunks shown for that file"
+/// rather than taking down the whole TUI.
+pub fn parse_diff_hunks(diff_text: &str) -> Vec<FileHunks> {
+    let lines: Vec<&str> = diff_text.lines().collect();
+    let mut files = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        if lines[i].starts_with("diff --git ") {
+            let (path, next) = extract_path(&lines, i);
+            let (hunks, next) = parse_hunks(&lines, next);
+            files.push(FileHunks { path, hunks });
+            i = next;
+        } else {
+            i += 1;
+        }
+    }
+
+    files
+}
+
+/// Extracts the new-side (`b/`) path from a `diff --git a/x b/y` header,
+/// honoring a later `rename to`/`copy to` line the same way
+/// `rinkaku_core::diff`'s own parser does, then returns the index of the
+/// first hunk header (or the next file's header / end of input).
+fn extract_path(lines: &[&str], start: usize) -> (String, usize) {
+    let header = lines[start];
+    let mut path = header
+        .strip_prefix("diff --git ")
+        .and_then(|rest| rest.find(" b/").map(|idx| rest[idx + 3..].to_string()))
+        .unwrap_or_default();
+
+    let mut i = start + 1;
+    while i < lines.len() {
+        let line = lines[i];
+        if line.starts_with("diff --git ") || line.starts_with("@@") {
+            break;
+        }
+        if let Some(rest) = line.strip_prefix("rename to ") {
+            path = rest.to_string();
+        } else if let Some(rest) = line.strip_prefix("copy to ") {
+            path = rest.to_string();
+        }
+        i += 1;
+    }
+
+    (path, i)
+}
+
+/// Parses every `@@ ... @@` hunk starting at `start`, stopping at the next
+/// `diff --git` entry or end of input. Returns the parsed hunks and the
+/// index following the last one consumed.
+fn parse_hunks(lines: &[&str], start: usize) -> (Vec<Hunk>, usize) {
+    let mut hunks = Vec::new();
+    let mut i = start;
+
+    while i < lines.len() && !lines[i].starts_with("diff --git ") {
+        if lines[i].starts_with("@@") {
+            let (hunk, next) = parse_one_hunk(lines, i);
+            hunks.push(hunk);
+            i = next;
+        } else {
+            i += 1;
+        }
+    }
+
+    (hunks, i)
+}
+
+/// Parses one hunk starting at its `@@ -a,b +c,d @@` header line, returning
+/// the hunk and the index following its body (the next `@@`, `diff --git`,
+/// or end of input).
+fn parse_one_hunk(lines: &[&str], start: usize) -> (Hunk, usize) {
+    let header = lines[start];
+    let new_start_count = parse_new_side_header(header);
+
+    let mut body = Vec::new();
+    let mut i = start + 1;
+    while i < lines.len() && !lines[i].starts_with("@@") && !lines[i].starts_with("diff --git ") {
+        let line = lines[i];
+        if let Some(content) = line.strip_prefix('+') {
+            body.push(DiffLine {
+                kind: DiffLineKind::Added,
+                content: content.to_string(),
+            });
+        } else if let Some(content) = line.strip_prefix('-') {
+            body.push(DiffLine {
+                kind: DiffLineKind::Removed,
+                content: content.to_string(),
+            });
+        } else if line.starts_with('\\') {
+            // "\ No newline at end of file" — not a content line, skipped
+            // the same way rinkaku-core's own hunk parser skips it.
+        } else {
+            body.push(DiffLine {
+                kind: DiffLineKind::Context,
+                content: line.strip_prefix(' ').unwrap_or(line).to_string(),
+            });
+        }
+        i += 1;
+    }
+
+    let new_range = new_start_count.and_then(|(start, count)| {
+        if count == 0 {
+            None
+        } else {
+            Some((start, start + count - 1))
+        }
+    });
+
+    (
+        Hunk {
+            header: header.to_string(),
+            new_range,
+            lines: body,
+        },
+        i,
+    )
+}
+
+/// Parses a `@@ -a,b +c,d @@` header's new side only, returning
+/// `(start, count)`, or `None` when the header doesn't match the expected
+/// shape at all (defensive — this view degrades to "no range to intersect"
+/// for a hunk it can't read rather than erroring the whole parse).
+fn parse_new_side_header(header: &str) -> Option<(usize, usize)> {
+    let body = header.strip_prefix("@@ ")?.split(" @@").next()?;
+    let new_part = body.split(' ').nth(1)?;
+    let new_part = new_part.strip_prefix('+')?;
+    let (start_str, count_str) = match new_part.split_once(',') {
+        Some((s, c)) => (s, c),
+        None => (new_part, "1"),
+    };
+    let start: usize = start_str.parse().ok()?;
+    let count: usize = count_str.parse().ok()?;
+    Some((start, count))
+}
+
+/// Whether `hunk` intersects the 1-based inclusive new-side range
+/// `[range_start, range_end]` — used to filter a file's hunks down to just
+/// the ones touching a selected symbol's line range.
+pub fn hunk_intersects(hunk: &Hunk, range_start: usize, range_end: usize) -> bool {
+    match hunk.new_range {
+        Some((hunk_start, hunk_end)) => hunk_start <= range_end && range_start <= hunk_end,
+        None => false,
+    }
+}
+
+/// Every hunk in `file_hunks` intersecting `[range_start, range_end]`
+/// (1-based inclusive, matching [`rinkaku_core::diff::LineRange`]'s own
+/// convention) — the symbol-row view: "just the hunks touching this
+/// symbol's lines", per the feature's own requirement that a symbol
+/// selection show only intersecting hunks rather than the whole file's
+/// diff.
+pub fn hunks_for_range(file_hunks: &FileHunks, range_start: usize, range_end: usize) -> Vec<&Hunk> {
+    file_hunks
+        .hunks
+        .iter()
+        .filter(|hunk| hunk_intersects(hunk, range_start, range_end))
+        .collect()
+}
+
+/// Finds the [`FileHunks`] for `path`, or `None` when the diff has no
+/// entry for it (e.g. the file wasn't part of the diff at all, or the path
+/// slipped through some other mismatch between `report` and `diff_text` —
+/// defensive, since both are supposed to come from the same input).
+pub fn file_hunks<'a>(files: &'a [FileHunks], path: &str) -> Option<&'a FileHunks> {
+    files.iter().find(|f| f.path == path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_return_empty_vec_when_diff_text_is_empty() {
+        let actual = parse_diff_hunks("");
+
+        assert_eq!(Vec::<FileHunks>::new(), actual);
+    }
+
+    #[test]
+    fn should_parse_one_file_with_one_hunk_and_mixed_line_kinds() {
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,4 @@
+ fn a() {}
++fn b() {}
+-fn old() {}
+ fn c() {}
+";
+        let expected = vec![FileHunks {
+            path: "src/lib.rs".to_string(),
+            hunks: vec![Hunk {
+                header: "@@ -1,3 +1,4 @@".to_string(),
+                new_range: Some((1, 4)),
+                lines: vec![
+                    DiffLine {
+                        kind: DiffLineKind::Context,
+                        content: "fn a() {}".to_string(),
+                    },
+                    DiffLine {
+                        kind: DiffLineKind::Added,
+                        content: "fn b() {}".to_string(),
+                    },
+                    DiffLine {
+                        kind: DiffLineKind::Removed,
+                        content: "fn old() {}".to_string(),
+                    },
+                    DiffLine {
+                        kind: DiffLineKind::Context,
+                        content: "fn c() {}".to_string(),
+                    },
+                ],
+            }],
+        }];
+        let actual = parse_diff_hunks(diff);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_use_renamed_path_when_file_was_renamed_with_content_change() {
+        let diff = "\
+diff --git a/src/old_name.rs b/src/new_name.rs
+similarity index 90%
+rename from src/old_name.rs
+rename to src/new_name.rs
+index e69de29..4b825dc 100644
+--- a/src/old_name.rs
++++ b/src/new_name.rs
+@@ -1,2 +1,3 @@
+ fn a() {}
++fn b() {}
+ fn c() {}
+";
+        let actual = parse_diff_hunks(diff);
+
+        assert_eq!(1, actual.len());
+        assert_eq!("src/new_name.rs", actual[0].path);
+    }
+
+    #[test]
+    fn should_parse_multiple_hunks_in_one_file() {
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,2 +1,3 @@
+ fn a() {}
++fn b() {}
+ fn c() {}
+@@ -10,2 +11,3 @@
+ fn x() {}
++fn y() {}
+ fn z() {}
+";
+        let actual = parse_diff_hunks(diff);
+
+        assert_eq!(1, actual.len());
+        assert_eq!(2, actual[0].hunks.len());
+        assert_eq!(Some((1, 3)), actual[0].hunks[0].new_range);
+        assert_eq!(Some((11, 13)), actual[0].hunks[1].new_range);
+    }
+
+    #[test]
+    fn should_parse_multiple_files_in_one_diff() {
+        let diff = "\
+diff --git a/src/a.rs b/src/a.rs
+index e69de29..4b825dc 100644
+--- a/src/a.rs
++++ b/src/a.rs
+@@ -1,1 +1,2 @@
+ fn a() {}
++fn a2() {}
+diff --git a/src/b.rs b/src/b.rs
+index e69de29..4b825dc 100644
+--- a/src/b.rs
++++ b/src/b.rs
+@@ -1,1 +1,2 @@
+ fn b() {}
++fn b2() {}
+";
+        let actual = parse_diff_hunks(diff);
+
+        let paths: Vec<&str> = actual.iter().map(|f| f.path.as_str()).collect();
+        assert_eq!(vec!["src/a.rs", "src/b.rs"], paths);
+    }
+
+    #[test]
+    fn should_ignore_no_newline_marker_line() {
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,2 +1,2 @@
+ fn a() {}
+-fn b() {}
+\\ No newline at end of file
++fn b2() {}
+\\ No newline at end of file
+";
+        let actual = parse_diff_hunks(diff);
+
+        assert_eq!(1, actual.len());
+        let lines = &actual[0].hunks[0].lines;
+        assert_eq!(3, lines.len());
+        assert_eq!(DiffLineKind::Context, lines[0].kind);
+        assert_eq!(DiffLineKind::Removed, lines[1].kind);
+        assert_eq!(DiffLineKind::Added, lines[2].kind);
+    }
+
+    #[test]
+    fn should_return_none_new_range_when_hunk_is_pure_deletion() {
+        let diff = "\
+diff --git a/src/old.rs b/src/old.rs
+deleted file mode 100644
+index 4b825dc..0000000
+--- a/src/old.rs
++++ /dev/null
+@@ -1,2 +0,0 @@
+-fn a() {}
+-fn b() {}
+";
+        let actual = parse_diff_hunks(diff);
+
+        assert_eq!(1, actual.len());
+        assert_eq!(None, actual[0].hunks[0].new_range);
+    }
+
+    #[test]
+    fn should_return_none_new_range_when_hunk_header_is_malformed() {
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ garbage @@
+ fn a() {}
+";
+        let actual = parse_diff_hunks(diff);
+
+        assert_eq!(1, actual.len());
+        assert_eq!(None, actual[0].hunks[0].new_range);
+    }
+
+    #[test]
+    fn should_report_hunk_intersects_when_ranges_overlap() {
+        let hunk = Hunk {
+            header: "@@ -1,3 +1,4 @@".to_string(),
+            new_range: Some((5, 10)),
+            lines: vec![],
+        };
+
+        assert_eq!(true, hunk_intersects(&hunk, 8, 20));
+        assert_eq!(true, hunk_intersects(&hunk, 1, 5));
+        assert_eq!(false, hunk_intersects(&hunk, 11, 20));
+        assert_eq!(false, hunk_intersects(&hunk, 1, 4));
+    }
+
+    #[test]
+    fn should_report_no_intersection_when_hunk_has_no_new_range() {
+        let hunk = Hunk {
+            header: "@@ -1,2 +0,0 @@".to_string(),
+            new_range: None,
+            lines: vec![],
+        };
+
+        assert_eq!(false, hunk_intersects(&hunk, 1, 100));
+    }
+
+    #[test]
+    fn should_return_only_hunks_intersecting_the_given_range() {
+        let file_hunks = FileHunks {
+            path: "src/lib.rs".to_string(),
+            hunks: vec![
+                Hunk {
+                    header: "@@ -1,1 +1,2 @@".to_string(),
+                    new_range: Some((1, 2)),
+                    lines: vec![],
+                },
+                Hunk {
+                    header: "@@ -10,1 +11,2 @@".to_string(),
+                    new_range: Some((11, 12)),
+                    lines: vec![],
+                },
+            ],
+        };
+
+        let actual = hunks_for_range(&file_hunks, 11, 12);
+
+        assert_eq!(1, actual.len());
+        assert_eq!("@@ -10,1 +11,2 @@", actual[0].header);
+    }
+
+    #[test]
+    fn should_find_file_hunks_by_path() {
+        let files = vec![
+            FileHunks {
+                path: "a.rs".to_string(),
+                hunks: vec![],
+            },
+            FileHunks {
+                path: "b.rs".to_string(),
+                hunks: vec![],
+            },
+        ];
+
+        let actual = file_hunks(&files, "b.rs");
+
+        assert_eq!(Some(&files[1]), actual);
+    }
+
+    #[test]
+    fn should_return_none_when_path_not_found() {
+        let files: Vec<FileHunks> = vec![];
+
+        let actual = file_hunks(&files, "missing.rs");
+
+        assert_eq!(None, actual);
+    }
+}

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -80,9 +80,16 @@ fn run_app(
     diff_text: &str,
 ) -> std::io::Result<()> {
     let mut app = App::new(report);
+    // Parsed once up front rather than inside the draw loop: `diff_text`
+    // does not change for the lifetime of this session, but the loop below
+    // redraws on every ~100ms poll timeout (not just on an actual key
+    // press), so re-running `parse_diff_hunks` inside `ui::draw` would
+    // re-walk the whole diff (unbounded in PR size) roughly ten times a
+    // second even while idle.
+    let diff_hunks = diff_view::parse_diff_hunks(diff_text);
 
     loop {
-        terminal.draw(|frame| ui::draw(frame, &app, report, diff_text))?;
+        terminal.draw(|frame| ui::draw(frame, &app, report, &diff_hunks))?;
 
         if app.should_quit() {
             return Ok(());

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -21,10 +21,16 @@
 //!
 //! [`run`] is the crate's single public entry point for the CLI binary:
 //! `rinkaku`'s `main.rs` hands it a [`rinkaku_core::render::Report`] once
-//! `--tui` is passed, in place of rendering Markdown/JSON.
+//! `--tui` is passed, in place of rendering Markdown/JSON. It also hands in
+//! the raw unified diff text `main.rs` already has in hand for every input
+//! mode (stdin / `--base` / `--pr`) — TUI iteration 2's diff pane
+//! (`d`/`D`, `crate::diff_view`) slices hunks straight out of that same
+//! string rather than reconstructing a diff from `Report` (which no longer
+//! carries hunk text once extraction has run).
 
 pub mod app;
 pub mod detail;
+pub mod diff_view;
 pub mod nav;
 pub mod order;
 pub mod row_view;
@@ -54,18 +60,29 @@ use std::time::Duration;
 /// blocks on input; everything it calls into (`App`, `row_view`, `ui`,
 /// `source`) is either pure or an isolated, narrowly-scoped IO call (a
 /// single source-file read).
-pub fn run(report: &Report) -> std::io::Result<()> {
+///
+/// `diff_text` is the exact same raw diff string every `main.rs` input mode
+/// already holds before handing it to `rinkaku_core::pipeline::analyze_diff`
+/// — passed through unchanged, not re-fetched or re-derived here, so this
+/// crate never runs `git` itself (ADR 0016: `rinkaku-core`/adapters own IO,
+/// not `rinkaku-tui`'s view layer beyond the one source-file read
+/// `crate::source` already makes).
+pub fn run(report: &Report, diff_text: &str) -> std::io::Result<()> {
     let mut terminal = ratatui::try_init()?;
-    let result = run_app(&mut terminal, report);
+    let result = run_app(&mut terminal, report, diff_text);
     ratatui::restore();
     result
 }
 
-fn run_app(terminal: &mut ratatui::DefaultTerminal, report: &Report) -> std::io::Result<()> {
+fn run_app(
+    terminal: &mut ratatui::DefaultTerminal,
+    report: &Report,
+    diff_text: &str,
+) -> std::io::Result<()> {
     let mut app = App::new(report);
 
     loop {
-        terminal.draw(|frame| ui::draw(frame, &app, report))?;
+        terminal.draw(|frame| ui::draw(frame, &app, report, diff_text))?;
 
         if app.should_quit() {
             return Ok(());
@@ -122,6 +139,7 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::Quit),
         KeyCode::Char('c') | KeyCode::Char('C') => Some(InputKey::CollapseAll),
         KeyCode::Char('o') | KeyCode::Char('O') => Some(InputKey::ToggleOrder),
+        KeyCode::Char('d') | KeyCode::Char('D') => Some(InputKey::ToggleDiff),
         KeyCode::Char('s') | KeyCode::Char('S') => Some(InputKey::Source),
         KeyCode::Esc if on_source_screen => Some(InputKey::Back),
         KeyCode::Char('q') if on_source_screen => Some(InputKey::Back),

--- a/rinkaku-tui/src/order.rs
+++ b/rinkaku-tui/src/order.rs
@@ -42,13 +42,17 @@ pub struct DirRank {
     pub in_cycle: bool,
 }
 
-/// The directory-level condensation shared by [`rank_directories`] and
-/// [`cycle_partners`]/[`cycle_edges`]: every directory that owns at least
-/// one graph node, the inter-directory adjacency derived from
-/// `report.graph.edges`, and the Tarjan SCC grouping over that adjacency.
-/// Built once so the two public functions (ranking directories for display
-/// order, and explaining *which* directories cycle with a given one) don't
-/// each re-run Tarjan and re-derive the same directory index independently.
+/// The directory-level condensation used by [`rank_directories`],
+/// [`cycle_partners`], [`cycle_edges`], and [`cycle_explanation`]: every
+/// directory that owns at least one graph node, the inter-directory
+/// adjacency derived from `report.graph.edges`, and the Tarjan SCC grouping
+/// over that adjacency. Each of the four public functions above builds its
+/// own `DirCondensation` from a fresh `report` — the type itself doesn't
+/// cache across calls — but a single call that needs more than one piece of
+/// derived information (partners *and* edges, [`cycle_explanation`]'s case)
+/// builds exactly one `DirCondensation` and reads both off it, rather than
+/// re-running Tarjan and re-deriving the same directory index twice within
+/// that one call.
 struct DirCondensation<'a> {
     /// Directory paths, sorted, indexed by position — `dirs[i]` is the
     /// directory `scc_of[i]`/`adjacency[i]` refer to by index `i`.
@@ -197,18 +201,30 @@ pub fn rank_directories(report: &Report) -> HashMap<String, DirRank> {
 /// one-member cycle" (impossible, since Tarjan's own SCCs are only >1
 /// member when there's an actual back edge) are the same "nothing to
 /// report" case either way.
+///
+/// Builds its own [`DirCondensation`] — kept as its own public function
+/// (rather than folded away entirely) since it has independent unit test
+/// coverage and callers that only need partners, not edges too. A caller
+/// that needs both (`build_dir_detail`) should use [`cycle_explanation`]
+/// instead, which builds the condensation once rather than once per
+/// function.
 pub fn cycle_partners(report: &Report) -> HashMap<String, Vec<String>> {
     let condensation = DirCondensation::build(report);
-    let DirCondensation { dirs, sccs, .. } = condensation;
+    partners_from_condensation(&condensation)
+}
 
+fn partners_from_condensation(condensation: &DirCondensation) -> HashMap<String, Vec<String>> {
     let mut result = HashMap::new();
-    for scc in &sccs {
+    for scc in &condensation.sccs {
         if scc.len() < 2 {
             continue;
         }
-        let members: Vec<String> = scc.iter().map(|&i| dirs[i].to_string()).collect();
+        let members: Vec<String> = scc
+            .iter()
+            .map(|&i| condensation.dirs[i].to_string())
+            .collect();
         for &node_index in scc {
-            let this_dir = dirs[node_index];
+            let this_dir = condensation.dirs[node_index];
             let mut partners: Vec<String> = members
                 .iter()
                 .filter(|m| m.as_str() != this_dir)
@@ -241,7 +257,16 @@ pub struct CycleEdge {
 /// lines. An edge within a single directory, or between two directories
 /// that merely both happen to exist without forming a cycle together, is
 /// excluded — only edges between two SCC-mates count.
+///
+/// Builds its own [`DirCondensation`], same "kept as its own function"
+/// reasoning as [`cycle_partners`]'s doc comment — see [`cycle_explanation`]
+/// for the shared-build alternative.
 pub fn cycle_edges(report: &Report) -> Vec<CycleEdge> {
+    let condensation = DirCondensation::build(report);
+    edges_from_condensation(report, &condensation)
+}
+
+fn edges_from_condensation(report: &Report, condensation: &DirCondensation) -> Vec<CycleEdge> {
     let node_by_id: HashMap<&str, &rinkaku_core::graph::Node> = report
         .graph
         .nodes
@@ -249,7 +274,6 @@ pub fn cycle_edges(report: &Report) -> Vec<CycleEdge> {
         .map(|node| (node.id.as_str(), node))
         .collect();
 
-    let condensation = DirCondensation::build(report);
     let dir_index: HashMap<&str, usize> = condensation
         .dirs
         .iter()
@@ -285,6 +309,29 @@ pub fn cycle_edges(report: &Report) -> Vec<CycleEdge> {
         });
     }
     edges
+}
+
+/// One directory's cycle explanation: the other directories it cycles
+/// with, and the concrete cross-directory edges forming that cycle —
+/// exactly the two pieces [`crate::detail::build_dir_detail`] needs.
+/// Builds [`DirCondensation`] (a Tarjan SCC run over the whole directory
+/// graph) exactly once and derives both results from that single build,
+/// unlike calling [`cycle_partners`] and [`cycle_edges`] separately, which
+/// would each re-run the same condensation from scratch.
+pub fn cycle_explanation(report: &Report, path: &str) -> (Vec<String>, Vec<CycleEdge>) {
+    let condensation = DirCondensation::build(report);
+    let partners = partners_from_condensation(&condensation)
+        .remove(path)
+        .unwrap_or_default();
+    let edges = if partners.is_empty() {
+        Vec::new()
+    } else {
+        edges_from_condensation(report, &condensation)
+            .into_iter()
+            .filter(|edge| parent_dir(&edge.from_path) == path || parent_dir(&edge.to_path) == path)
+            .collect()
+    };
+    (partners, edges)
 }
 
 /// The parent directory of a slash-separated `path` — everything before

--- a/rinkaku-tui/src/order.rs
+++ b/rinkaku-tui/src/order.rs
@@ -42,16 +42,90 @@ pub struct DirRank {
     pub in_cycle: bool,
 }
 
+/// The directory-level condensation shared by [`rank_directories`] and
+/// [`cycle_partners`]/[`cycle_edges`]: every directory that owns at least
+/// one graph node, the inter-directory adjacency derived from
+/// `report.graph.edges`, and the Tarjan SCC grouping over that adjacency.
+/// Built once so the two public functions (ranking directories for display
+/// order, and explaining *which* directories cycle with a given one) don't
+/// each re-run Tarjan and re-derive the same directory index independently.
+struct DirCondensation<'a> {
+    /// Directory paths, sorted, indexed by position — `dirs[i]` is the
+    /// directory `scc_of[i]`/`adjacency[i]` refer to by index `i`.
+    dirs: Vec<&'a str>,
+    /// Adjacency between directories (by index into `dirs`), edges within
+    /// the same directory already dropped (see `build`'s doc comment).
+    adjacency: Vec<Vec<usize>>,
+    sccs: Vec<Vec<usize>>,
+    /// `scc_of[i]` is the SCC index (into `sccs`) directory `dirs[i]`
+    /// belongs to.
+    scc_of: Vec<usize>,
+}
+
+impl<'a> DirCondensation<'a> {
+    /// Builds the condensation from `report.graph`: remaps every
+    /// [`rinkaku_core::graph::Edge`] from its endpoints' node ids to the
+    /// parent directory of each endpoint's file path (the empty string for
+    /// a root-level file, e.g. `"lib.rs"` condenses to `""`), dropping any
+    /// edge whose two endpoints condense to the *same* directory — it says
+    /// nothing about inter-directory dependency, only intra-directory
+    /// structure (a directory doesn't depend on itself).
+    fn build(report: &'a Report) -> Self {
+        let dir_of_node: HashMap<&str, &str> = report
+            .graph
+            .nodes
+            .iter()
+            .map(|node| (node.id.as_str(), parent_dir(&node.path)))
+            .collect();
+
+        let mut dirs: Vec<&str> = dir_of_node
+            .values()
+            .copied()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        dirs.sort_unstable();
+        let dir_index: HashMap<&str, usize> =
+            dirs.iter().enumerate().map(|(i, &d)| (d, i)).collect();
+
+        let mut adjacency: Vec<HashSet<usize>> = vec![HashSet::new(); dirs.len()];
+        for edge in &report.graph.edges {
+            let (Some(&from_dir), Some(&to_dir)) = (
+                dir_of_node.get(edge.from.as_str()),
+                dir_of_node.get(edge.to.as_str()),
+            ) else {
+                continue;
+            };
+            if from_dir == to_dir {
+                continue;
+            }
+            let (from_i, to_i) = (dir_index[from_dir], dir_index[to_dir]);
+            adjacency[from_i].insert(to_i);
+        }
+        let adjacency: Vec<Vec<usize>> = adjacency
+            .into_iter()
+            .map(|targets| targets.into_iter().collect())
+            .collect();
+
+        let sccs = tarjan_sccs(&adjacency);
+        let mut scc_of = vec![0usize; dirs.len()];
+        for (scc_index, scc) in sccs.iter().enumerate() {
+            for &node_index in scc {
+                scc_of[node_index] = scc_index;
+            }
+        }
+
+        Self {
+            dirs,
+            adjacency,
+            sccs,
+            scc_of,
+        }
+    }
+}
+
 /// Computes each directory's [`DirRank`] from `report.graph`'s edges,
 /// condensed from symbol-level to directory-level.
-///
-/// Condensation: every [`rinkaku_core::graph::Edge`] is remapped from its
-/// endpoints' node ids to the parent directory of each endpoint's file path
-/// (the empty string for a root-level file, e.g. `"lib.rs"` condenses to
-/// `""`). An edge whose two endpoints condense to the *same* directory is
-/// dropped — it says nothing about inter-directory dependency, only
-/// intra-directory structure, which is not this module's concern (a
-/// directory doesn't depend on itself).
 ///
 /// Ranking: Tarjan SCCs the condensed directory graph, then orders SCCs by
 /// a Kahn topological sort starting from in-degree-0 SCCs — the same
@@ -80,48 +154,13 @@ pub struct DirRank {
 /// `order_tree`/`order_siblings` sort those after every ranked directory,
 /// A-Z (ADR 0016 decision 4).
 pub fn rank_directories(report: &Report) -> HashMap<String, DirRank> {
-    let dir_of_node: HashMap<&str, &str> = report
-        .graph
-        .nodes
-        .iter()
-        .map(|node| (node.id.as_str(), parent_dir(&node.path)))
-        .collect();
-
-    let mut dirs: Vec<&str> = dir_of_node
-        .values()
-        .copied()
-        .collect::<HashSet<_>>()
-        .into_iter()
-        .collect();
-    dirs.sort_unstable();
-    let dir_index: HashMap<&str, usize> = dirs.iter().enumerate().map(|(i, &d)| (d, i)).collect();
-
-    let mut adjacency: Vec<HashSet<usize>> = vec![HashSet::new(); dirs.len()];
-    for edge in &report.graph.edges {
-        let (Some(&from_dir), Some(&to_dir)) = (
-            dir_of_node.get(edge.from.as_str()),
-            dir_of_node.get(edge.to.as_str()),
-        ) else {
-            continue;
-        };
-        if from_dir == to_dir {
-            continue;
-        }
-        let (from_i, to_i) = (dir_index[from_dir], dir_index[to_dir]);
-        adjacency[from_i].insert(to_i);
-    }
-    let adjacency: Vec<Vec<usize>> = adjacency
-        .into_iter()
-        .map(|targets| targets.into_iter().collect())
-        .collect();
-
-    let sccs = tarjan_sccs(&adjacency);
-    let mut scc_of = vec![0usize; dirs.len()];
-    for (scc_index, scc) in sccs.iter().enumerate() {
-        for &node_index in scc {
-            scc_of[node_index] = scc_index;
-        }
-    }
+    let condensation = DirCondensation::build(report);
+    let DirCondensation {
+        dirs,
+        adjacency,
+        sccs,
+        scc_of,
+    } = condensation;
 
     let scc_order = topological_scc_order(&sccs, &scc_of, &adjacency);
 
@@ -144,6 +183,108 @@ pub fn rank_directories(report: &Report) -> HashMap<String, DirRank> {
         }
     }
     result
+}
+
+/// For every directory that participates in a directory-level cycle (an
+/// SCC of size > 1 in the condensation [`rank_directories`] already
+/// computes), the sorted list of *other* directories sharing that cycle —
+/// the answer to "cycle と言われても何が cycle してるか分からない" (the dir
+/// detail view's own motivating complaint): a directory marked `(cycle)`
+/// in the entry view names its actual partners here, rather than leaving
+/// the reviewer to guess. A directory with no `ranks` entry, or whose SCC
+/// has only itself as a member, is simply absent from the returned map
+/// (not present with an empty `Vec`) — "not in a cycle" and "in a
+/// one-member cycle" (impossible, since Tarjan's own SCCs are only >1
+/// member when there's an actual back edge) are the same "nothing to
+/// report" case either way.
+pub fn cycle_partners(report: &Report) -> HashMap<String, Vec<String>> {
+    let condensation = DirCondensation::build(report);
+    let DirCondensation { dirs, sccs, .. } = condensation;
+
+    let mut result = HashMap::new();
+    for scc in &sccs {
+        if scc.len() < 2 {
+            continue;
+        }
+        let members: Vec<String> = scc.iter().map(|&i| dirs[i].to_string()).collect();
+        for &node_index in scc {
+            let this_dir = dirs[node_index];
+            let mut partners: Vec<String> = members
+                .iter()
+                .filter(|m| m.as_str() != this_dir)
+                .cloned()
+                .collect();
+            partners.sort_unstable();
+            result.insert(this_dir.to_string(), partners);
+        }
+    }
+    result
+}
+
+/// One directed cross-directory edge forming part of a cycle — the
+/// concrete `path::name -> path::name` line the dir detail view renders,
+/// derived from `report.graph.edges` rather than the directory-level
+/// condensation directly, since a reviewer wants to see the actual symbols
+/// involved, not just "these two directories cycle".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CycleEdge {
+    pub from_path: String,
+    pub from_name: String,
+    pub to_path: String,
+    pub to_name: String,
+}
+
+/// Every `report.graph.edges` entry whose two endpoints' parent
+/// directories are distinct members of the same cycle-forming SCC (per
+/// [`cycle_partners`]) — the edges that concretely *make up* a directory
+/// cycle, for the dir detail view to render as `path::name -> path::name`
+/// lines. An edge within a single directory, or between two directories
+/// that merely both happen to exist without forming a cycle together, is
+/// excluded — only edges between two SCC-mates count.
+pub fn cycle_edges(report: &Report) -> Vec<CycleEdge> {
+    let node_by_id: HashMap<&str, &rinkaku_core::graph::Node> = report
+        .graph
+        .nodes
+        .iter()
+        .map(|node| (node.id.as_str(), node))
+        .collect();
+
+    let condensation = DirCondensation::build(report);
+    let dir_index: HashMap<&str, usize> = condensation
+        .dirs
+        .iter()
+        .enumerate()
+        .map(|(i, &d)| (d, i))
+        .collect();
+    let scc_of_dir = |dir: &str| dir_index.get(dir).map(|&i| condensation.scc_of[i]);
+
+    let mut edges = Vec::new();
+    for edge in &report.graph.edges {
+        let (Some(from_node), Some(to_node)) = (
+            node_by_id.get(edge.from.as_str()),
+            node_by_id.get(edge.to.as_str()),
+        ) else {
+            continue;
+        };
+        let from_dir = parent_dir(&from_node.path);
+        let to_dir = parent_dir(&to_node.path);
+        if from_dir == to_dir {
+            continue;
+        }
+        let (Some(from_scc), Some(to_scc)) = (scc_of_dir(from_dir), scc_of_dir(to_dir)) else {
+            continue;
+        };
+        if from_scc != to_scc {
+            continue;
+        }
+        edges.push(CycleEdge {
+            from_path: from_node.path.clone(),
+            from_name: from_node.name.clone(),
+            to_path: to_node.path.clone(),
+            to_name: to_node.name.clone(),
+        });
+    }
+    edges
 }
 
 /// The parent directory of a slash-separated `path` — everything before
@@ -607,6 +748,202 @@ mod tests {
         assert_eq!(ranks["api"].rank, ranks["store"].rank);
         assert_eq!(true, ranks["api"].in_cycle);
         assert_eq!(true, ranks["store"].in_cycle);
+    }
+
+    #[test]
+    fn should_list_cycle_partners_for_each_directory_in_a_two_directory_cycle() {
+        let report = report_with_graph(
+            vec![
+                node("api/handler.rs::handle", "api/handler.rs", "handle"),
+                node("store/db.rs::save", "store/db.rs", "save"),
+            ],
+            vec![
+                Edge {
+                    from: "api/handler.rs::handle".to_string(),
+                    to: "store/db.rs::save".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "store/db.rs::save".to_string(),
+                    to: "api/handler.rs::handle".to_string(),
+                    is_cycle: false,
+                },
+            ],
+        );
+
+        let partners = cycle_partners(&report);
+
+        let mut expected = HashMap::new();
+        expected.insert("api".to_string(), vec!["store".to_string()]);
+        expected.insert("store".to_string(), vec!["api".to_string()]);
+        assert_eq!(expected, partners);
+    }
+
+    #[test]
+    fn should_return_empty_map_when_no_directory_is_in_a_cycle() {
+        let report = report_with_graph(
+            vec![
+                node("api/a.rs::a", "api/a.rs", "a"),
+                node("store/db.rs::save", "store/db.rs", "save"),
+            ],
+            vec![Edge {
+                from: "api/a.rs::a".to_string(),
+                to: "store/db.rs::save".to_string(),
+                is_cycle: false,
+            }],
+        );
+
+        let partners = cycle_partners(&report);
+
+        let expected: HashMap<String, Vec<String>> = HashMap::new();
+        assert_eq!(expected, partners);
+    }
+
+    #[test]
+    fn should_list_every_partner_when_three_directories_form_one_cycle() {
+        // api -> store -> service -> api: a three-directory cycle, so every
+        // directory's partner list must contain the other two.
+        let report = report_with_graph(
+            vec![
+                node("api/a.rs::a", "api/a.rs", "a"),
+                node("store/s.rs::s", "store/s.rs", "s"),
+                node("service/v.rs::v", "service/v.rs", "v"),
+            ],
+            vec![
+                Edge {
+                    from: "api/a.rs::a".to_string(),
+                    to: "store/s.rs::s".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "store/s.rs::s".to_string(),
+                    to: "service/v.rs::v".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "service/v.rs::v".to_string(),
+                    to: "api/a.rs::a".to_string(),
+                    is_cycle: false,
+                },
+            ],
+        );
+
+        let partners = cycle_partners(&report);
+
+        let mut expected = HashMap::new();
+        expected.insert(
+            "api".to_string(),
+            vec!["service".to_string(), "store".to_string()],
+        );
+        expected.insert(
+            "service".to_string(),
+            vec!["api".to_string(), "store".to_string()],
+        );
+        expected.insert(
+            "store".to_string(),
+            vec!["api".to_string(), "service".to_string()],
+        );
+        assert_eq!(expected, partners);
+    }
+
+    #[test]
+    fn should_return_cross_directory_edges_forming_a_two_directory_cycle() {
+        let report = report_with_graph(
+            vec![
+                node("api/handler.rs::handle", "api/handler.rs", "handle"),
+                node("store/db.rs::save", "store/db.rs", "save"),
+            ],
+            vec![
+                Edge {
+                    from: "api/handler.rs::handle".to_string(),
+                    to: "store/db.rs::save".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "store/db.rs::save".to_string(),
+                    to: "api/handler.rs::handle".to_string(),
+                    is_cycle: false,
+                },
+            ],
+        );
+
+        let mut edges = cycle_edges(&report);
+        edges.sort_by(|a, b| a.from_path.cmp(&b.from_path));
+
+        let expected = vec![
+            CycleEdge {
+                from_path: "api/handler.rs".to_string(),
+                from_name: "handle".to_string(),
+                to_path: "store/db.rs".to_string(),
+                to_name: "save".to_string(),
+            },
+            CycleEdge {
+                from_path: "store/db.rs".to_string(),
+                from_name: "save".to_string(),
+                to_path: "api/handler.rs".to_string(),
+                to_name: "handle".to_string(),
+            },
+        ];
+        assert_eq!(expected, edges);
+    }
+
+    #[test]
+    fn should_exclude_edge_from_cycle_edges_when_directories_do_not_cycle() {
+        // api -> store, but store does not depend back on api: no cycle,
+        // so this edge must not show up as a "cycle edge".
+        let report = report_with_graph(
+            vec![
+                node("api/a.rs::a", "api/a.rs", "a"),
+                node("store/db.rs::save", "store/db.rs", "save"),
+            ],
+            vec![Edge {
+                from: "api/a.rs::a".to_string(),
+                to: "store/db.rs::save".to_string(),
+                is_cycle: false,
+            }],
+        );
+
+        let edges = cycle_edges(&report);
+
+        assert_eq!(Vec::<CycleEdge>::new(), edges);
+    }
+
+    #[test]
+    fn should_exclude_intra_directory_edge_from_cycle_edges() {
+        // Both symbols live in "api" itself; even if api participates in a
+        // cycle with another directory, an edge fully inside api is not a
+        // cross-directory cycle edge.
+        let report = report_with_graph(
+            vec![
+                node("api/a.rs::a", "api/a.rs", "a"),
+                node("api/b.rs::b", "api/b.rs", "b"),
+                node("store/db.rs::save", "store/db.rs", "save"),
+            ],
+            vec![
+                Edge {
+                    from: "api/a.rs::a".to_string(),
+                    to: "api/b.rs::b".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "api/a.rs::a".to_string(),
+                    to: "store/db.rs::save".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "store/db.rs::save".to_string(),
+                    to: "api/a.rs::a".to_string(),
+                    is_cycle: false,
+                },
+            ],
+        );
+
+        let edges = cycle_edges(&report);
+
+        // Only the two cross-directory edges (api <-> store) qualify; the
+        // intra-"api" edge (a -> b) must be excluded.
+        assert_eq!(2, edges.len());
+        assert!(edges.iter().all(|e| e.from_path != e.to_path));
     }
 
     #[test]

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -24,17 +24,18 @@ use rinkaku_core::render::Report;
 
 /// Draws one full frame: the entry view (tree + right pane split) or the
 /// source drill-down, depending on `app.screen()`, with a status/help line
-/// pinned to the bottom either way. `diff_text` is the raw unified diff the
-/// caller built `report` from (threaded through from `main.rs`, same string
-/// for every input mode — see `crate::run`'s doc comment) — only consulted
-/// when the right pane is in [`RightPane::Diff`] mode.
-pub fn draw(frame: &mut Frame, app: &App, report: &Report, diff_text: &str) {
+/// pinned to the bottom either way. `diff_files` is the whole diff already
+/// parsed into per-file hunks once by `crate::run_app` (not re-parsed here
+/// on every frame — see that function's doc comment on why parsing lives
+/// outside the draw loop) — only consulted when the right pane is in
+/// [`RightPane::Diff`] mode.
+pub fn draw(frame: &mut Frame, app: &App, report: &Report, diff_files: &[FileHunks]) {
     let area = frame.area();
     let [body, status_area] =
         Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(area);
 
     match app.screen() {
-        Screen::Entry => draw_entry_screen(frame, app, report, diff_text, body),
+        Screen::Entry => draw_entry_screen(frame, app, report, diff_files, body),
         Screen::Source { symbol_id } => draw_source_screen(frame, report, symbol_id, body),
     }
 
@@ -47,14 +48,20 @@ pub fn draw(frame: &mut Frame, app: &App, report: &Report, diff_text: &str) {
 /// than the right pane has fields, so it gets the larger share. The right
 /// pane itself shows either the detail view or the diff view depending on
 /// `app.right_pane()` (`d`/`D` toggles between them, TUI iteration 2).
-fn draw_entry_screen(frame: &mut Frame, app: &App, report: &Report, diff_text: &str, area: Rect) {
+fn draw_entry_screen(
+    frame: &mut Frame,
+    app: &App,
+    report: &Report,
+    diff_files: &[FileHunks],
+    area: Rect,
+) {
     let [tree_area, right_area] =
         Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)]).areas(area);
 
     draw_tree_pane(frame, app, tree_area);
     match app.right_pane() {
         RightPane::Detail => draw_detail_pane(frame, app, report, right_area),
-        RightPane::Diff => draw_diff_pane(frame, app, report, diff_text, right_area),
+        RightPane::Diff => draw_diff_pane(frame, app, report, diff_files, right_area),
     }
 }
 
@@ -103,9 +110,17 @@ fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
 /// file for a file row, or just the hunks intersecting a symbol's own line
 /// range for a symbol row (`App::selected_diff_target`'s own doc comment).
 /// A directory row, or a row with nothing to show (no hunks found, e.g. a
-/// mismatch between `report` and `diff_text`), falls back to a placeholder
-/// message rather than an empty pane.
-fn draw_diff_pane(frame: &mut Frame, app: &App, report: &Report, diff_text: &str, area: Rect) {
+/// mismatch between `report` and the diff), falls back to a placeholder
+/// message rather than an empty pane. `diff_files` is already parsed
+/// (`crate::run_app` parses the raw diff text once, up front, not on every
+/// call to this function).
+fn draw_diff_pane(
+    frame: &mut Frame,
+    app: &App,
+    report: &Report,
+    diff_files: &[FileHunks],
+    area: Rect,
+) {
     let block = Block::bordered().title(" Diff ");
 
     let Some(target) = app.selected_diff_target(report) else {
@@ -116,20 +131,19 @@ fn draw_diff_pane(frame: &mut Frame, app: &App, report: &Report, diff_text: &str
         return;
     };
 
-    let files = crate::diff_view::parse_diff_hunks(diff_text);
     let (path, hunks): (&str, Vec<&Hunk>) = match &target {
         DiffTarget::Symbol {
             path,
             range_start,
             range_end,
         } => {
-            let hunks = file_hunks(&files, path)
+            let hunks = file_hunks(diff_files, path)
                 .map(|fh| hunks_for_range(fh, *range_start, *range_end))
                 .unwrap_or_default();
             (path.as_str(), hunks)
         }
         DiffTarget::File { path } => {
-            let hunks = file_hunks(&files, path)
+            let hunks = file_hunks(diff_files, path)
                 .map(|fh: &FileHunks| fh.hunks.iter().collect())
                 .unwrap_or_default();
             (path.as_str(), hunks)
@@ -512,7 +526,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, ""))
+            .draw(|frame| draw(frame, &app, &report, &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -545,7 +559,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, ""))
+            .draw(|frame| draw(frame, &app, &report, &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -573,7 +587,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, ""))
+            .draw(|frame| draw(frame, &app, &report, &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -596,10 +610,11 @@ index e69de29..4b825dc 100644
  fn a() {}
 +fn foo() {}
 ";
+        let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, diff_text))
+            .draw(|frame| draw(frame, &app, &report, &diff_files))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -614,7 +629,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, ""))
+            .draw(|frame| draw(frame, &app, &report, &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -633,7 +648,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(100, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, ""))
+            .draw(|frame| draw(frame, &app, &report, &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -649,7 +664,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, ""))
+            .draw(|frame| draw(frame, &app, &report, &[]))
             .expect("draw");
 
         // "lib.rs" does not exist relative to the test process's cwd, so

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -9,8 +9,9 @@
 //! is covered separately... kept few and coarse — enough to catch a broken
 //! layout, not to pin every pixel").
 
-use crate::app::{App, Screen};
-use crate::detail::{DetailView, SignatureView};
+use crate::app::{App, DiffTarget, RightPane, Screen, SelectedDetail};
+use crate::detail::{DetailView, DirDetail, FileDetail, SignatureView};
+use crate::diff_view::{DiffLine, DiffLineKind, FileHunks, Hunk, file_hunks, hunks_for_range};
 use crate::row_view::{entry_row_line, relative_labels};
 use crate::source::{SourceView, load_symbol_source, visible_window};
 use ratatui::Frame;
@@ -18,34 +19,43 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph};
+use rinkaku_core::extract::Classification;
 use rinkaku_core::render::Report;
 
-/// Draws one full frame: the entry view (tree + detail pane split) or the
+/// Draws one full frame: the entry view (tree + right pane split) or the
 /// source drill-down, depending on `app.screen()`, with a status/help line
-/// pinned to the bottom either way.
-pub fn draw(frame: &mut Frame, app: &App, report: &Report) {
+/// pinned to the bottom either way. `diff_text` is the raw unified diff the
+/// caller built `report` from (threaded through from `main.rs`, same string
+/// for every input mode — see `crate::run`'s doc comment) — only consulted
+/// when the right pane is in [`RightPane::Diff`] mode.
+pub fn draw(frame: &mut Frame, app: &App, report: &Report, diff_text: &str) {
     let area = frame.area();
     let [body, status_area] =
         Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(area);
 
     match app.screen() {
-        Screen::Entry => draw_entry_screen(frame, app, report, body),
+        Screen::Entry => draw_entry_screen(frame, app, report, diff_text, body),
         Screen::Source { symbol_id } => draw_source_screen(frame, report, symbol_id, body),
     }
 
     draw_status_line(frame, app, status_area);
 }
 
-/// Left entry pane (directory tree) + right detail pane, split 60/40 —
-/// this implementation's own choice (ADR 0015/0016 left the exact ratio
-/// open): the tree is the primary navigation surface and typically has
-/// more rows than the detail pane has fields, so it gets the larger share.
-fn draw_entry_screen(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
-    let [tree_area, detail_area] =
+/// Left entry pane (directory tree) + right pane, split 60/40 — this
+/// implementation's own choice (ADR 0015/0016 left the exact ratio open):
+/// the tree is the primary navigation surface and typically has more rows
+/// than the right pane has fields, so it gets the larger share. The right
+/// pane itself shows either the detail view or the diff view depending on
+/// `app.right_pane()` (`d`/`D` toggles between them, TUI iteration 2).
+fn draw_entry_screen(frame: &mut Frame, app: &App, report: &Report, diff_text: &str, area: Rect) {
+    let [tree_area, right_area] =
         Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)]).areas(area);
 
     draw_tree_pane(frame, app, tree_area);
-    draw_detail_pane(frame, app, report, detail_area);
+    match app.right_pane() {
+        RightPane::Detail => draw_detail_pane(frame, app, report, right_area),
+        RightPane::Diff => draw_diff_pane(frame, app, report, diff_text, right_area),
+    }
 }
 
 fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
@@ -70,18 +80,225 @@ fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
     let block = Block::bordered().title(" Detail ");
 
     let Some(detail) = app.selected_detail(report) else {
-        let paragraph = Paragraph::new("(select a symbol row to see its detail)")
+        let paragraph = Paragraph::new("(select a row to see its detail)")
             .block(block)
             .wrap(ratatui::widgets::Wrap { trim: false });
         frame.render_widget(paragraph, area);
         return;
     };
 
-    let lines = detail_lines(&detail);
+    let lines = match &detail {
+        SelectedDetail::Symbol(detail) => detail_lines(detail),
+        SelectedDetail::Dir(detail) => dir_detail_lines(detail),
+        SelectedDetail::File(detail) => file_detail_lines(detail),
+    };
     let paragraph = Paragraph::new(lines)
         .block(block)
         .wrap(ratatui::widgets::Wrap { trim: false });
     frame.render_widget(paragraph, area);
+}
+
+/// Draws the diff pane (TUI iteration 2, [`RightPane::Diff`]): the raw
+/// unified-diff hunks touching the row under the cursor — every hunk of the
+/// file for a file row, or just the hunks intersecting a symbol's own line
+/// range for a symbol row (`App::selected_diff_target`'s own doc comment).
+/// A directory row, or a row with nothing to show (no hunks found, e.g. a
+/// mismatch between `report` and `diff_text`), falls back to a placeholder
+/// message rather than an empty pane.
+fn draw_diff_pane(frame: &mut Frame, app: &App, report: &Report, diff_text: &str, area: Rect) {
+    let block = Block::bordered().title(" Diff ");
+
+    let Some(target) = app.selected_diff_target(report) else {
+        let paragraph = Paragraph::new("(select a symbol or file row to see its diff)")
+            .block(block)
+            .wrap(ratatui::widgets::Wrap { trim: false });
+        frame.render_widget(paragraph, area);
+        return;
+    };
+
+    let files = crate::diff_view::parse_diff_hunks(diff_text);
+    let (path, hunks): (&str, Vec<&Hunk>) = match &target {
+        DiffTarget::Symbol {
+            path,
+            range_start,
+            range_end,
+        } => {
+            let hunks = file_hunks(&files, path)
+                .map(|fh| hunks_for_range(fh, *range_start, *range_end))
+                .unwrap_or_default();
+            (path.as_str(), hunks)
+        }
+        DiffTarget::File { path } => {
+            let hunks = file_hunks(&files, path)
+                .map(|fh: &FileHunks| fh.hunks.iter().collect())
+                .unwrap_or_default();
+            (path.as_str(), hunks)
+        }
+    };
+
+    if hunks.is_empty() {
+        let paragraph = Paragraph::new(format!("(no diff hunks found for {path})"))
+            .block(block)
+            .wrap(ratatui::widgets::Wrap { trim: false });
+        frame.render_widget(paragraph, area);
+        return;
+    }
+
+    let lines = diff_pane_lines(&hunks);
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(ratatui::widgets::Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+/// Formats a list of [`Hunk`]s into styled lines: hunk headers dim, `+`
+/// lines green, `-` lines red, context lines unstyled — mirrors the
+/// existing signature-diff styling `detail_lines`' `SignatureView::Changed`
+/// arm already uses (`Color::Green`/`Color::Red`) so the two diff-styled
+/// panes in this crate read consistently.
+fn diff_pane_lines(hunks: &[&Hunk]) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    for (index, hunk) in hunks.iter().enumerate() {
+        if index > 0 {
+            lines.push(Line::raw(""));
+        }
+        lines.push(Line::styled(
+            hunk.header.clone(),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
+        ));
+        for line in &hunk.lines {
+            lines.push(diff_line(line));
+        }
+    }
+    lines
+}
+
+fn diff_line(line: &DiffLine) -> Line<'static> {
+    match line.kind {
+        DiffLineKind::Added => Line::styled(
+            format!("+{}", line.content),
+            Style::default().fg(Color::Green),
+        ),
+        DiffLineKind::Removed => Line::styled(
+            format!("-{}", line.content),
+            Style::default().fg(Color::Red),
+        ),
+        DiffLineKind::Context => Line::raw(format!(" {}", line.content)),
+    }
+}
+
+/// Formats a [`DirDetail`] into displayable lines: a badge breakdown, its
+/// own top fan-in symbols, and — only when this directory is in a cycle —
+/// the partner directories and the concrete cross-directory edges forming
+/// it (TUI iteration 2's answer to "cycle と言われても何が cycle してるか
+/// 分からない").
+fn dir_detail_lines(detail: &DirDetail) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+
+    lines.push(Line::styled(
+        format!("Dir {}", detail.path),
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+    lines.push(Line::raw(""));
+    lines.push(Line::raw(format!(
+        "changed symbols: {}",
+        detail.badges.changed_symbols
+    )));
+    lines.push(Line::raw(format!(
+        "contract changes: {}",
+        detail.badges.contract_changes
+    )));
+    lines.push(Line::raw(format!("fan-in: {}", detail.badges.fan_in)));
+
+    lines.push(Line::raw(""));
+    lines.push(Line::styled(
+        format!("Top fan-in ({})", detail.top_fan_in.len()),
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+    for mention in &detail.top_fan_in {
+        lines.push(Line::raw(format!("  {} ({})", mention.name, mention.path)));
+    }
+
+    if !detail.cycle_partners.is_empty() {
+        lines.push(Line::raw(""));
+        lines.push(Line::styled(
+            "Cycles with",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+        for partner in &detail.cycle_partners {
+            lines.push(Line::raw(format!("  {partner}")));
+        }
+
+        lines.push(Line::raw(""));
+        lines.push(Line::styled(
+            "Cycle edges",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+        for edge in &detail.cycle_edges {
+            lines.push(Line::raw(format!("  {} -> {}", edge.from, edge.to)));
+        }
+    }
+
+    lines
+}
+
+/// Formats a [`FileDetail`] into displayable lines: every symbol changed
+/// in this file, with the same classification marker convention
+/// `crate::row_view::entry_row_line` uses on symbol rows, plus fan-in.
+fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+
+    lines.push(Line::styled(
+        format!("File {}", detail.path),
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+    lines.push(Line::raw(""));
+    lines.push(Line::styled(
+        format!("Symbols ({})", detail.symbols.len()),
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+    for symbol in &detail.symbols {
+        let marker = if symbol.removed {
+            "x"
+        } else {
+            match symbol.classification {
+                Some(Classification::Added) => "+",
+                Some(Classification::SignatureChanged) => "~",
+                Some(Classification::BodyOnly) | None => " ",
+            }
+        };
+        let fan_in = if symbol.fan_in > 0 {
+            format!(" ^{}", symbol.fan_in)
+        } else {
+            String::new()
+        };
+        lines.push(Line::raw(format!(
+            "  {marker} {} {}{fan_in}",
+            kind_abbrev(symbol.kind),
+            symbol.name,
+        )));
+    }
+
+    lines
+}
+
+fn kind_abbrev(kind: rinkaku_core::extract::SymbolKind) -> &'static str {
+    use rinkaku_core::extract::SymbolKind;
+    match kind {
+        SymbolKind::Function => "fn",
+        SymbolKind::Struct => "struct",
+        SymbolKind::Enum => "enum",
+        SymbolKind::Trait => "trait",
+        SymbolKind::Class => "class",
+        SymbolKind::Interface => "iface",
+        SymbolKind::TypeAlias => "type",
+    }
 }
 
 /// Formats a [`DetailView`] into displayable lines: classification,
@@ -206,7 +423,7 @@ fn source_lines(source: &SourceView, start: usize, end: usize) -> Vec<Line<'stat
 fn draw_status_line(frame: &mut Frame, app: &App, area: Rect) {
     let help = match app.screen() {
         Screen::Entry => {
-            "j/k: move  enter/space: expand  e/c: expand/collapse all  o: order  s: source  q: quit"
+            "j/k: move  enter/space: expand  e/c: expand/collapse all  o: order  d: diff  s: source  q: quit"
         }
         Screen::Source { .. } => "esc/q: back",
     };
@@ -295,20 +512,99 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report))
+            .draw(|frame| draw(frame, &app, &report, ""))
             .expect("draw");
 
         let text = buffer_text(&terminal);
         assert!(text.contains("Entry"));
         assert!(text.contains("Detail"));
         assert!(text.contains("lib.rs"));
-        // The full "(select a symbol row to see its detail)" message can
-        // legitimately wrap across two buffer rows depending on the
-        // detail pane's width, which would defeat a substring check
-        // against `buffer_text`'s newline-joined rows — "select a symbol"
-        // is short enough to always land on one row regardless of exact
-        // wrap point, which is all this coarse layout check needs.
-        assert!(text.contains("select a symbol"));
+        // The cursor starts on row 0, the "lib.rs" file row (TUI iteration
+        // 2: a file row now renders its own `FileDetail` instead of the
+        // "select a row" placeholder), so this coarse layout check confirms
+        // the detail pane actually rendered file-detail content rather than
+        // asserting on the placeholder text that used to show here.
+        assert!(text.contains("Symbols"));
+    }
+
+    #[test]
+    fn should_draw_placeholder_message_when_there_are_no_rows_at_all() {
+        let report = Report {
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        };
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, ""))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("select a row"));
+    }
+
+    #[test]
+    fn should_draw_dir_detail_content_when_cursor_is_on_a_directory_row() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol("src/lib.rs::foo", "foo")],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        };
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, ""))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Dir src"));
+        assert!(text.contains("Top fan-in"));
+    }
+
+    #[test]
+    fn should_draw_diff_pane_with_hunk_lines_when_toggled_on_a_symbol_row() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::ToggleDiff);
+        let diff_text = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,1 +1,2 @@
+ fn a() {}
++fn foo() {}
+";
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, diff_text))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Diff"));
+        assert!(text.contains("+fn foo() {}"));
     }
 
     #[test]
@@ -318,7 +614,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report))
+            .draw(|frame| draw(frame, &app, &report, ""))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -337,7 +633,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(100, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report))
+            .draw(|frame| draw(frame, &app, &report, ""))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -353,7 +649,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report))
+            .draw(|frame| draw(frame, &app, &report, ""))
             .expect("draw");
 
         // "lib.rs" does not exist relative to the test process's cwd, so

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -168,7 +168,7 @@ fn main() -> anyhow::Result<()> {
         return self_update::run_self_update(yes);
     }
 
-    let report = if let Some(pr_arg) = &cli.pr {
+    let (report, diff_text) = if let Some(pr_arg) = &cli.pr {
         // Validate the arg and derive the fetch refspec's PR number, but
         // pass the original (trimmed) value — not the parsed number — to
         // `gh pr view` (see that function's doc comment for why).
@@ -235,11 +235,11 @@ fn main() -> anyhow::Result<()> {
         if let Some(note) = garbage_input_note(&diff_text, &report) {
             eprintln!("{note}");
         }
-        report
+        (report, diff_text)
     };
 
     if cli.tui {
-        rinkaku_tui::run(&report)?;
+        rinkaku_tui::run(&report, &diff_text)?;
         return Ok(());
     }
 
@@ -353,28 +353,37 @@ fn resolve_pr_workdir(parsed: &PrArg) -> anyhow::Result<Option<std::path::PathBu
 /// (same rationale as `read_git_show_file`'s `cwd`: `None` uses the
 /// process's current directory for `--base` and cwd-clone `--pr` runs,
 /// `Some(dir)` targets a cache clone (ADR 0005) or a test fixture).
+///
+/// Returns the raw diff text alongside the `Report` (TUI iteration 2): the
+/// `--tui` diff pane needs the same unified diff `analyze_diff` was built
+/// from to slice hunks out of, and this is the only place that owns it for
+/// `--base`/`--pr` mode — `main`'s stdin branch already has `diff_text` in
+/// a local variable, so it needs no such plumbing.
 fn run_base_pipeline(
     cli: &Cli,
     base: &str,
     head: &str,
     cwd: Option<&std::path::Path>,
-) -> anyhow::Result<rinkaku_core::render::Report> {
+) -> anyhow::Result<(rinkaku_core::render::Report, String)> {
     log::info!("diffing {base}...{head}");
     let diff_text = run_git_diff(base, head, cwd)?;
     if diff_text.trim().is_empty() {
         eprintln!("note: diff is empty, nothing to analyze");
-        return Ok(rinkaku_core::render::Report {
-            files: Vec::new(),
-            skipped: Vec::new(),
-            graph: rinkaku_core::graph::SymbolGraph {
-                nodes: Vec::new(),
-                edges: Vec::new(),
-                roots: Vec::new(),
+        return Ok((
+            rinkaku_core::render::Report {
+                files: Vec::new(),
+                skipped: Vec::new(),
+                graph: rinkaku_core::graph::SymbolGraph {
+                    nodes: Vec::new(),
+                    edges: Vec::new(),
+                    roots: Vec::new(),
+                },
+                tests: Vec::new(),
+                hotspots: Vec::new(),
+                removed: Vec::new(),
             },
-            tests: Vec::new(),
-            hotspots: Vec::new(),
-            removed: Vec::new(),
-        });
+            diff_text,
+        ));
     }
 
     let read_file = {
@@ -411,7 +420,7 @@ fn run_base_pipeline(
     if let Some(note) = garbage_input_note(&diff_text, &report) {
         eprintln!("{note}");
     }
-    Ok(report)
+    Ok((report, diff_text))
 }
 
 /// Parses `diff_text` and extracts just the changed paths, for callers that
@@ -3207,6 +3216,8 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
         std::os::unix::fs::PermissionsExt::set_mode(&mut permissions, original_mode);
         std::fs::set_permissions(&index_path, permissions).expect("restore .git/index permissions");
 
+        let (actual_report, _actual_diff_text) =
+            actual.expect("empty diff must not touch the repository-wide index scan");
         assert_eq!(
             rinkaku_core::render::Report {
                 files: Vec::new(),
@@ -3220,7 +3231,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
                 hotspots: Vec::new(),
                 removed: Vec::new(),
             },
-            actual.expect("empty diff must not touch the repository-wide index scan")
+            actual_report
         );
     }
 
@@ -3271,7 +3282,7 @@ fn should_add_two_numbers() {
             include_generated: false,
             tui: false,
         };
-        let actual = run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()))
+        let (actual, _diff_text) = run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()))
             .expect("run_base_pipeline should succeed for a test-only diff");
 
         let expected_files: Vec<rinkaku_core::render::FileReport> = Vec::new();
@@ -3319,7 +3330,7 @@ fn should_add_two_numbers() {
             include_generated: false,
             tui: false,
         };
-        let actual = run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()))
+        let (actual, _diff_text) = run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()))
             .expect("run_base_pipeline should succeed");
 
         let symbol = &actual.files[0].symbols[0];


### PR DESCRIPTION
## Summary

TUI iteration 2, addressing two gaps found while dogfooding the entry view:

- **`d`-key diff pane**: the right pane now toggles between Detail and Diff. On a symbol row it shows only the hunks intersecting that symbol's line range; on a file row, all of the file's hunks. Raw unified diff text is threaded from the binary boundary (`main.rs`) into `rinkaku_tui::run` — `rinkaku-core` is untouched. Motivation: body-only symbols previously gave no way to see *what* changed.
- **Directory/file detail views**: selecting a directory row now shows its badge breakdown (changed symbols, contract changes, top fan-in) and — when the directory is part of a dependency cycle — *which* directories it cycles with and the concrete `path::name -> path::name` edges forming the cycle. Selecting a file row shows a compact symbol index with classification markers and fan-in. Motivation: user feedback that "(cycle)" alone doesn't explain what is cycling.

## Implementation notes

- New pure module `rinkaku-tui/src/diff_view.rs` parses diff text into per-file hunks; it deliberately degrades (no hunks / capped ranges) instead of erroring, since `rinkaku-core`'s strict parser has already validated the input upstream.
- `order.rs`'s Tarjan SCC condensation is factored into `DirCondensation`, shared by directory ranking and the new `cycle_explanation`.
- Diff hunks are parsed once per run, not per frame.

## Review

Reviewed per the three-angle policy in CLAUDE.md (map-assisted pass, independent pass, dynamic verification incl. a synthetic cross-directory-cycle fixture and failure modes). All four findings (2 should-fix, 2 nits) fixed in follow-up commits. Round 3 of experiment 0001 recorded in `docs/experiments/0001-map-assisted-llm-review.md`.

## Test plan

- `make test` (139 + 304 + 143, all green) / `make lint` clean
- Live TUI verification: d-toggle on symbol/file/dir rows, cycle explanation on a synthetic two-directory cycle, source-screen no-op, clean quit, non-TTY and conflicting-flag failure modes

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync