### PR TITLE
feat: whole-repo outline as the default input mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ not given, `self-update` refuses to run rather than silently proceeding.
 ## Usage
 
 ```sh
+# Bare invocation, run interactively inside a repository: no diff
+# involved, opens the TUI with a whole-repo outline — every symbol and
+# its dependency structure, for onboarding or architecture review
+# (see ADR 0017)
+rinkaku
+
+# Same whole-repo outline, printed as Markdown instead of opening the TUI
+# (this also happens automatically whenever stdout isn't a terminal, e.g.
+# `rinkaku > outline.md`)
+rinkaku --format md
+
 # From a GitHub PR (stdin, no local clone required)
 gh pr diff 123 | rinkaku
 
@@ -426,7 +437,11 @@ rinkaku --base main --tui
 
 `--tui` takes the same input flow as every other mode (stdin / `--base` /
 `--pr`) and only changes the output stage, so it conflicts with `--format`
-rather than combining with it.
+rather than combining with it. Bare `rinkaku`, run on an interactive
+terminal with no `--base`/`--pr`, opens the TUI automatically on a
+whole-repo outline instead of a diff ([ADR 0017](docs/adr/0017-whole-repo-outline-as-default-input-mode.md));
+its diff pane (`d`) has nothing to show in that case and renders a
+placeholder.
 
 ### What it shows
 

--- a/docs/adr/0017-whole-repo-outline-as-default-input-mode.md
+++ b/docs/adr/0017-whole-repo-outline-as-default-input-mode.md
@@ -1,0 +1,73 @@
+# 0017. Whole-repo outline as the default input mode
+
+- Status: proposed
+- Date: 2026-07-12
+
+## Context
+
+Every existing input mode (stdin pipe, `--base`, `--pr`; ADR 0004)
+requires a diff, so rinkaku can only describe a *change*. Dogfooding
+the TUI (ADR 0015) surfaced a second use case: the outline of the
+whole repository — all symbols and their dependency structure — for
+onboarding and architecture review, with no diff involved. Running
+bare `rinkaku` in a terminal today exits with an error demanding
+input, which wastes the most natural invocation of the tool on a
+failure message.
+
+Two mechanisms were considered for producing a whole-repo report.
+A synthetic diff against git's empty tree reuses the existing
+pipeline unchanged, but routes the entire repository through a
+diff-shaped detour: every file's full content is rendered into a
+unified diff only to be re-parsed, every symbol is (mis)classified as
+`Added` (ADR 0014's markers become uniform noise), and the changed-
+line machinery (`changed_ranges`, innermost-definition suppression)
+runs with inputs that make it meaningless. Alternatively, the
+extraction layer already has `extract_all_symbols` — the function
+`TagsResolver` uses to index the repository — which yields all
+definitions directly from file contents.
+
+## Decision
+
+Add a whole-repo mode that builds the report directly from file
+contents via `extract_all_symbols`, bypassing the diff pipeline: a
+pure core function assembles `FileReport`s (classification left
+unknown, as stdin mode already does when no base is available) and
+feeds the existing graph/render/TUI layers. The boundary supplies the
+file list from `git ls-files`, applying the same test/generated-file
+exclusions (ADRs 0009–0011). The 1-hop dependency resolver is skipped
+— every symbol is already in scope. This mode is the default when no
+input is given: stdin is a TTY and neither `--base` nor `--pr` is
+passed. Bare `rinkaku` on an interactive terminal opens the TUI
+(ADR 0015: humans get the TUI); an explicit `--format` or a
+non-TTY stdout still produces Markdown/JSON.
+
+## Alternatives
+
+- **Empty-tree synthetic diff**: minimal wiring, but pays diff
+  generation/parse cost for the whole repository, marks every symbol
+  `Added` (semantically wrong — nothing changed), and exercises
+  change-oriented code paths whose semantics don't apply. Rejected:
+  the mode's meaning is "no diff", so it should not manufacture one.
+- **Explicit flag only (`--all`), no default change**: safer for
+  compatibility, but bare `rinkaku` keeps erroring on the tool's most
+  discoverable invocation. Rejected: the TTY check cleanly separates
+  the new default from every existing piped/flagged invocation, so
+  nothing that works today changes behavior.
+
+## Consequences
+
+- Bare `rinkaku` becomes useful: repository outline in the TUI, no
+  arguments needed. All existing invocations are unaffected (they all
+  either pipe stdin or pass a flag).
+- Fan-in hotspots (ADR 0013) and cycle explanations now describe the
+  whole codebase — the architecture-review use case — but the
+  hotspot threshold (fan-in ≥ 2) was tuned for PR-sized graphs and
+  will over-fire at repo scale; revisit the threshold or switch to a
+  top-N cut if the section proves noisy.
+- Name-match edge collection (`collect_edges`) scales with symbol
+  count times name-collision rate; common names may inflate edges on
+  large repositories. Acceptable for v1; a revisit trigger is TUI
+  startup latency becoming perceptible on real repositories.
+- The TUI's diff pane (`d`) has nothing to show in this mode and
+  renders its placeholder — acceptable until a dedicated whole-repo
+  detail (e.g. full signature listing) replaces it.

--- a/docs/adr/0017-whole-repo-outline-as-default-input-mode.md
+++ b/docs/adr/0017-whole-repo-outline-as-default-input-mode.md
@@ -1,6 +1,6 @@
 # 0017. Whole-repo outline as the default input mode
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-07-12
 
 ## Context

--- a/docs/experiments/0001-map-assisted-llm-review.md
+++ b/docs/experiments/0001-map-assisted-llm-review.md
@@ -212,9 +212,76 @@ executed the binary rather than leaving execution to chance.
   same-named or same-domain symbols appearing in multiple crates —
   where today it needs a reviewer to happen to know both sides exist.
 
+## Results (round 4)
+
+Same two-pass method (dynamic verification mandatory for both arms),
+fourth subject: whole-repo mode per ADR 0017 (4 files, +710/−29 — a
+new pure core entry point `analyze_repo`, a mode-selection change in
+`main.rs`, and a `Format` → `Option<Format>` CLI refactor rippling
+through 19 test literals).
+
+| Metric              | A (map)     | B (control) |
+| ------------------- | ----------- | ----------- |
+| Output tokens       | 98.0k       | 100.5k      |
+| Tool calls          | 37          | 39          |
+| Wall clock          | 288s        | 274s        |
+| Blocker findings    | 0           | 0           |
+| Should-fix findings | 2           | 0           |
+| Nit findings        | 1           | 2           |
+
+- **First cross-arm overlap** in four rounds: both arms found the
+  redundant `is_none()` guard in the new input-mode branch — but
+  rated it differently. A rated it should-fix because it read the
+  surrounding comment and noticed it describes a provably unreachable
+  path (and that the stdin TTY bail it references had become dead
+  code); B rated the same redundancy a harmless nit. Same line,
+  different severity, decided by how much *surrounding contract* each
+  reviewer read — a reminder that finding overlap does not mean
+  judgment overlap.
+- A's second should-fix (whole-repo output saying "N changed symbols"
+  when nothing changed) and its nit (raw `git ls-files` error on the
+  new default invocation path) both came from **executing the
+  binary**, not from the map — as did both of B's nits (silent empty
+  output on an empty repository; deleted-file-between-list-and-read
+  resilience, which passed). With both static surfaces reviewed
+  clean, dynamic verification produced every unique finding this
+  round, on both arms.
+- The map's contribution this round was **negative space**: A
+  reported the map's dependency listing under `fn main` told it which
+  helpers were pre-existing and not worth re-auditing, and its
+  hotspots sent it straight to the `analyze_repo` ↔ `TagsResolver`
+  filter-order parity check (which came back clean, verifying the
+  ADR's core claim cheaply). Attention allocation showed up as
+  *cheaper verification of the contract that mattered*, not as
+  unique findings.
+- Round 3's arm profiles partially inverted: the map arm won the
+  line-level control-flow finding this round. The stable pattern
+  across four rounds is not "map = architecture, control =
+  line-level" but weaker and more durable: **the arms rarely
+  duplicate each other's unique findings, and severity judgment
+  varies even on shared ones** — the case for two passes is
+  redundancy of judgment, not partition of territory.
+
+## Conclusions (after 4 rounds)
+
+- Two-pass review remains justified, but the mechanism is now better
+  understood: independent judgment (severity, contract reading)
+  diverges even when raw findings overlap, and each arm keeps
+  producing unique findings the other misses.
+- Dynamic verification has become the dominant source of unique
+  findings as the codebase's static review surface gets cleaner
+  (rounds 3–4: every should-fix/nit unique to an arm traced to
+  either execution or cross-file contract reading, none to the diff
+  text alone). The CLAUDE.md rule making it mandatory for both arms
+  is doing the heavy lifting.
+- The map's measurable value at this diff size is verification
+  routing: it made the ADR's central parity claim (filter order
+  matching `TagsResolver::new`) cheap to check and marked
+  pre-existing code as safe to skip.
+
 ## Next
 
 - Document the map-first recipe in the README's LLM usage section
   (map from a trusted build, paired with an independent pass).
 - Consider a map feature flagging cross-crate duplicate-domain
-  symbols (see round 3's new hypothesis).
+  symbols (round 3 hypothesis, still open).

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -14,7 +14,7 @@ use crate::extract::{
 };
 use crate::graph::{build_graph, compute_hotspots, stamp_ids};
 use crate::language::{LanguageSupport, language_for_path};
-use crate::render::{FileReport, Report, SkipReason, SkippedFile, TestFileSummary};
+use crate::render::{FileReport, Report, ReportOrigin, SkipReason, SkippedFile, TestFileSummary};
 use thiserror::Error;
 
 /// A `read_file`-shaped port for fetching a changed file's *base*-side
@@ -268,6 +268,7 @@ pub fn analyze_diff(
     let hotspots = compute_hotspots(&graph);
 
     Ok(Report {
+        origin: ReportOrigin::Diff,
         files,
         skipped,
         graph,
@@ -398,6 +399,7 @@ pub fn analyze_repo(
     let hotspots = compute_hotspots(&graph);
 
     Report {
+        origin: ReportOrigin::RepoOutline,
         files,
         skipped: Vec::new(),
         graph,
@@ -608,6 +610,7 @@ mod tests {
         let read_file = fake_reader(HashMap::new());
 
         let expected = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: empty_graph(),
@@ -642,6 +645,7 @@ fn foo(a: i32) -> i32 {
         let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
         let expected = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -696,6 +700,7 @@ index 4b825dc..0000000
         let read_file = fake_reader(HashMap::new());
 
         let expected = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![SkippedFile {
                 path: "src/old.rs".to_string(),
@@ -722,6 +727,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
         let read_file = fake_reader(HashMap::new());
 
         let expected = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![SkippedFile {
                 path: "assets/logo.png".to_string(),
@@ -756,6 +762,7 @@ index e69de29..4b825dc 100644
         let read_file = fake_reader(HashMap::new());
 
         let expected = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![SkippedFile {
                 path: "src/main.rb".to_string(),
@@ -794,6 +801,7 @@ rename to src/new_name.rs
         let read_file = fake_reader(HashMap::new());
 
         let expected = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/new_name.rs".to_string(),
                 symbols: vec![],
@@ -873,6 +881,7 @@ index e69de29..4b825dc 100644
         let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
         let expected = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -1214,6 +1223,7 @@ fn should_add_two_numbers() {
             let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
             let expected = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![ExtractedSymbol {
@@ -1359,6 +1369,7 @@ mod tests {
             let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
             let expected = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![ExtractedSymbol {
@@ -1548,6 +1559,7 @@ func Foo() int { return 2 }
             let read_file = fake_reader(HashMap::from([("models/user.go", source)]));
 
             let expected = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "models/user.go".to_string(),
                     symbols: vec![ExtractedSymbol {
@@ -1606,6 +1618,7 @@ fn foo(a: i32) -> i32 {
             let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
             let expected = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![ExtractedSymbol {
@@ -1671,6 +1684,7 @@ index e69de29..4b825dc 100644
             ]));
 
             let expected = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![ExtractedSymbol {
@@ -2400,6 +2414,7 @@ index e69de29..4b825dc 100644
             let read_file = fake_reader(HashMap::new());
 
             let expected = Report {
+                origin: ReportOrigin::RepoOutline,
                 files: vec![],
                 skipped: vec![],
                 graph: empty_graph(),
@@ -2431,6 +2446,7 @@ struct Point {
             let paths = vec!["src/lib.rs".to_string()];
 
             let expected = Report {
+                origin: ReportOrigin::RepoOutline,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![
@@ -2520,6 +2536,7 @@ struct Point {
             let paths = vec!["src/main.rb".to_string()];
 
             let expected = Report {
+                origin: ReportOrigin::RepoOutline,
                 files: vec![],
                 skipped: vec![],
                 graph: empty_graph(),
@@ -2541,6 +2558,7 @@ struct Point {
             let paths = vec!["src/lib.rs".to_string()];
 
             let expected = Report {
+                origin: ReportOrigin::RepoOutline,
                 files: vec![],
                 skipped: vec![],
                 graph: empty_graph(),
@@ -2566,6 +2584,7 @@ struct Point {
             let generated_paths: HashSet<String> = ["Cargo.lock".to_string()].into_iter().collect();
 
             let expected = Report {
+                origin: ReportOrigin::RepoOutline,
                 files: vec![],
                 skipped: vec![],
                 graph: empty_graph(),
@@ -2586,6 +2605,7 @@ struct Point {
             let paths = vec!["models/user.rs".to_string()];
 
             let expected = Report {
+                origin: ReportOrigin::RepoOutline,
                 files: vec![],
                 skipped: vec![],
                 graph: empty_graph(),
@@ -2623,6 +2643,7 @@ func TestFoo(t *testing.T) {
             let paths = vec!["repo_test.go".to_string()];
 
             let expected = Report {
+                origin: ReportOrigin::RepoOutline,
                 files: vec![],
                 skipped: vec![],
                 graph: empty_graph(),

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -277,6 +277,136 @@ pub fn analyze_diff(
     })
 }
 
+/// Builds a whole-repository outline [`Report`] directly from file
+/// contents, bypassing the diff pipeline entirely (ADR 0017): every symbol
+/// in every supported, non-test, non-generated file is reported, rather
+/// than only the symbols touching a diff's changed lines.
+///
+/// `paths` is the file list (`main.rs` supplies `git ls-files`'s output;
+/// tests supply a fixed list), and `read_file` fetches each path's content
+/// — the same read-file-port shape `analyze_diff` uses, keeping this
+/// module IO-free. A `read_file` failure for one path is treated as "skip
+/// this file" (best-effort, matching `build_resolver`'s working-tree
+/// branch in `main.rs`) rather than failing the whole run: a whole-repo
+/// listing is a best-effort aid, and one unreadable path (e.g. a submodule
+/// gitlink entry `git ls-files` still lists) should not blank out the
+/// entire outline.
+///
+/// No `resolver`/dependency-resolution parameter: ADR 0017 explicitly
+/// skips 1-hop expansion here, since every symbol in the repository is
+/// already in scope — there is no "elsewhere in the repo" left to expand
+/// into. `classification` is left `None` on every symbol, the same value
+/// stdin mode already uses when no base commit is known (`analyze_diff`'s
+/// own `read_base_file: None` case): nothing changed, so there is no base
+/// side to classify against, and `Added` would misrepresent every symbol
+/// in the repository as new.
+///
+/// Per-file filtering mirrors [`crate::deps::TagsResolver::new`]'s
+/// pre-filter exactly, applied in the same order, so a symbol excluded
+/// from the whole-repo outline is excluded from the dependency index for
+/// the same reason a reviewer would expect: unsupported language (no
+/// [`crate::language::LanguageSupport`] for the extension) skips the file
+/// silently — not reported as [`SkippedFile`] at all, since an outline of
+/// "the whole repo" naturally excludes languages rinkaku doesn't parse,
+/// same as `analyze_diff`'s `SkipReason::UnsupportedLanguage` records a
+/// diff's unsupported files but nothing here would gain from repeating
+/// that per-file for every unrelated non-source file in a repository (a
+/// `SkippedFile` entry only exists in `analyze_diff` because the file was
+/// *touched by the diff*, which has no analogue here); a whole-file test
+/// path ([`crate::language::LanguageSupport::is_test_path`]) or a
+/// generated file (`generated_paths` or [`is_generated_content`], ADR
+/// 0010/0011) is skipped from `files` entirely, gated by `include_tests`/
+/// `include_generated` respectively, same as `analyze_diff`. Within a
+/// file that passes those checks, individual AST-detected test symbols
+/// (`ExtractedSymbol::is_test`) are additionally dropped, gated by
+/// `include_tests` — matching `partition_test_symbols`'s per-symbol
+/// filtering exactly, just applied before a `FileReport` is built rather
+/// than after (there is no test-only file case to summarize into
+/// `Report::tests` beyond what per-file skipping already handles, so
+/// `tests` stays empty; a repo-wide "how many test symbols exist" summary
+/// was judged non-essential for v1's outline use case — see ADR 0017). A
+/// file left with zero symbols after that per-symbol filtering (every
+/// definition in it was test code, or it had no definitions at all) is
+/// dropped from `files` entirely rather than kept as an empty
+/// `FileReport` — unlike `analyze_diff`, there is no "pure rename with
+/// nothing to report but still worth noting" case here (ADR 0017: this
+/// mode has no diff, so no rename), so an empty entry would only ever
+/// mean "nothing here", simplest left out of the outline.
+///
+/// Uses [`extract_all_symbols`] (the same function
+/// `crate::deps::TagsResolver::new` uses to build its repo-wide index)
+/// rather than `extract_changed_symbols`, since there is no changed-range
+/// concept to filter by. Unlike `extract_changed_symbols`, this does not
+/// suppress a nested definition in favor of its narrowest enclosing one
+/// (e.g. a Rust `impl` block containing a touched method) — an outline
+/// wants every definition, matching how `TagsResolver`'s index already
+/// treats nesting (both a container and its members are independently
+/// indexable), and `container` on each symbol already records the nesting
+/// relationship for renderers/the TUI to use.
+///
+/// `files`/`graph`/`hotspots` are built the same way `analyze_diff` builds
+/// them (`build_graph`, `stamp_ids`, `compute_hotspots`), so every
+/// downstream renderer (Markdown, JSON, TUI) sees the same `Report` shape
+/// regardless of which pipeline entry point produced it.
+pub fn analyze_repo(
+    paths: &[String],
+    read_file: impl Fn(&str) -> std::io::Result<String>,
+    include_tests: bool,
+    generated_paths: &std::collections::HashSet<String>,
+    include_generated: bool,
+) -> Report {
+    let mut files = Vec::new();
+
+    for path in paths {
+        let Some(lang) = language_for_path(path) else {
+            continue;
+        };
+        if !include_tests && lang.is_test_path(path) {
+            continue;
+        }
+        if !include_generated && generated_paths.contains(path) {
+            continue;
+        }
+        // A path `git ls-files` lists can still fail to read (e.g. a
+        // submodule gitlink entry, or a file deleted in the working tree
+        // but not yet staged) — skipped rather than aborting the whole
+        // outline, same best-effort stance `main.rs`'s `build_resolver`
+        // already takes for its own working-tree read loop.
+        let Ok(content) = read_file(path) else {
+            continue;
+        };
+        if !include_generated && is_generated_content(&content) {
+            continue;
+        }
+
+        let symbols: Vec<ExtractedSymbol> = extract_all_symbols(&content, lang)
+            .into_iter()
+            .filter(|symbol| include_tests || !symbol.is_test)
+            .collect();
+        if symbols.is_empty() {
+            continue;
+        }
+
+        files.push(FileReport {
+            path: path.clone(),
+            symbols,
+        });
+    }
+
+    let graph = build_graph(&files);
+    stamp_ids(&mut files, &graph);
+    let hotspots = compute_hotspots(&graph);
+
+    Report {
+        files,
+        skipped: Vec::new(),
+        graph,
+        tests: Vec::new(),
+        hotspots,
+        removed: Vec::new(),
+    }
+}
+
 /// Shared by both places in `analyze_diff`'s loop that need ADR 0014
 /// classification for one file: the ordinary case (`head_symbols` already
 /// extracted from a non-empty `changed_ranges`) and the "removal-only hunk"
@@ -2257,6 +2387,334 @@ index e69de29..4b825dc 100644
             let actual = collect_referenced_names(diff, read_file);
 
             assert!(matches!(actual, Err(AnalyzeError::Diff(_))));
+        }
+    }
+
+    mod analyze_repo_tests {
+        use super::*;
+        use crate::extract::SymbolKind;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn should_return_empty_report_when_paths_is_empty() {
+            let read_file = fake_reader(HashMap::new());
+
+            let expected = Report {
+                files: vec![],
+                skipped: vec![],
+                graph: empty_graph(),
+                tests: vec![],
+                hotspots: vec![],
+                removed: vec![],
+            };
+            let actual = analyze_repo(&[], read_file, true, &HashSet::new(), true);
+
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn should_extract_every_symbol_when_file_has_no_changes_to_speak_of() {
+            // Unlike `analyze_diff`, there is no diff here at all — every
+            // symbol in the file is reported, not just ones touching a
+            // changed line, since there is no changed-line concept in this
+            // mode (ADR 0017).
+            let source = "\
+fn helper(x: i32) -> i32 {
+    x
+}
+
+struct Point {
+    x: i32,
+}
+";
+            let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+            let paths = vec!["src/lib.rs".to_string()];
+
+            let expected = Report {
+                files: vec![FileReport {
+                    path: "src/lib.rs".to_string(),
+                    symbols: vec![
+                        ExtractedSymbol {
+                            id: "src/lib.rs::helper".to_string(),
+                            name: "helper".to_string(),
+                            kind: SymbolKind::Function,
+                            signature: "fn helper(x: i32) -> i32".to_string(),
+                            range: LineRange { start: 1, end: 3 },
+                            container: None,
+                            referenced_names: vec![],
+                            dependencies: vec![],
+                            omitted_dependency_matches: 0,
+                            is_test: false,
+                            classification: None,
+                            previous_signature: None,
+                        },
+                        ExtractedSymbol {
+                            id: "src/lib.rs::Point".to_string(),
+                            name: "Point".to_string(),
+                            kind: SymbolKind::Struct,
+                            signature: "struct Point { x: i32, }".to_string(),
+                            range: LineRange { start: 5, end: 7 },
+                            container: None,
+                            referenced_names: vec!["Point".to_string()],
+                            dependencies: vec![],
+                            omitted_dependency_matches: 0,
+                            is_test: false,
+                            classification: None,
+                            previous_signature: None,
+                        },
+                    ],
+                }],
+                skipped: vec![],
+                graph: crate::graph::SymbolGraph {
+                    nodes: vec![
+                        crate::graph::Node {
+                            id: "src/lib.rs::helper".to_string(),
+                            path: "src/lib.rs".to_string(),
+                            name: "helper".to_string(),
+                        },
+                        crate::graph::Node {
+                            id: "src/lib.rs::Point".to_string(),
+                            path: "src/lib.rs".to_string(),
+                            name: "Point".to_string(),
+                        },
+                    ],
+                    edges: vec![],
+                    roots: vec![
+                        "src/lib.rs::helper".to_string(),
+                        "src/lib.rs::Point".to_string(),
+                    ],
+                },
+                tests: vec![],
+                hotspots: vec![],
+                removed: vec![],
+            };
+            let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+
+            assert_eq!(expected, actual);
+        }
+
+        // No `classification: Some(Added)`: ADR 0017's whole point is that
+        // whole-repo mode must not mistake "nothing changed" for "every
+        // symbol was just added" the way a synthetic empty-tree diff would.
+        #[test]
+        fn should_leave_classification_none_for_every_symbol() {
+            let source = "fn foo() -> i32 { 1 }\n";
+            let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+            let paths = vec!["src/lib.rs".to_string()];
+
+            let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+
+            let expected: Option<crate::extract::Classification> = None;
+            let actual = report.files[0].symbols[0].classification;
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn should_skip_path_without_registered_language_support() {
+            // `.rb` has no registered `LanguageSupport` (see the note on
+            // `should_skip_file_with_unsupported_language_without_reading_it`
+            // above) — silently excluded from the outline, no `SkippedFile`
+            // entry (unlike `analyze_diff`, there is no diff-touched file to
+            // report a skip reason for; see `analyze_repo`'s doc comment).
+            let read_file = fake_reader(HashMap::new());
+            let paths = vec!["src/main.rb".to_string()];
+
+            let expected = Report {
+                files: vec![],
+                skipped: vec![],
+                graph: empty_graph(),
+                tests: vec![],
+                hotspots: vec![],
+                removed: vec![],
+            };
+            let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn should_skip_path_when_read_file_fails() {
+            // No entry in the map for this path: `read_file` returns `Err`,
+            // which `analyze_repo` treats as best-effort "skip this file"
+            // rather than failing the whole run (see its own doc comment).
+            let read_file = fake_reader(HashMap::new());
+            let paths = vec!["src/lib.rs".to_string()];
+
+            let expected = Report {
+                files: vec![],
+                skipped: vec![],
+                graph: empty_graph(),
+                tests: vec![],
+                hotspots: vec![],
+                removed: vec![],
+            };
+            let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn should_skip_path_in_generated_paths_set_without_reading_it() {
+            // No entry in the map: if `analyze_repo` tried to read a
+            // generated file, this would return `Err` and (being treated as
+            // best-effort) silently produce the same empty result either
+            // way — so this test also pins that the file is excluded
+            // *before* any read is attempted, matching
+            // `TagsResolver::new`'s check ordering (deps.rs).
+            let read_file = fake_reader(HashMap::new());
+            let paths = vec!["Cargo.lock".to_string()];
+            let generated_paths: HashSet<String> = ["Cargo.lock".to_string()].into_iter().collect();
+
+            let expected = Report {
+                files: vec![],
+                skipped: vec![],
+                graph: empty_graph(),
+                tests: vec![],
+                hotspots: vec![],
+                removed: vec![],
+            };
+            let actual = analyze_repo(&paths, read_file, true, &generated_paths, true);
+
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn should_skip_file_with_generated_content_marker_when_include_generated_is_false() {
+            let source =
+                "// Code generated by SQLBoiler 4.19.5. DO NOT EDIT.\n\nfn foo() -> i32 { 1 }\n";
+            let read_file = fake_reader(HashMap::from([("models/user.rs", source)]));
+            let paths = vec!["models/user.rs".to_string()];
+
+            let expected = Report {
+                files: vec![],
+                skipped: vec![],
+                graph: empty_graph(),
+                tests: vec![],
+                hotspots: vec![],
+                removed: vec![],
+            };
+            let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), false);
+
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn should_not_skip_file_with_generated_content_marker_when_include_generated_is_true() {
+            let source =
+                "// Code generated by SQLBoiler 4.19.5. DO NOT EDIT.\n\nfn foo() -> i32 { 1 }\n";
+            let read_file = fake_reader(HashMap::from([("models/user.rs", source)]));
+            let paths = vec!["models/user.rs".to_string()];
+
+            let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+
+            assert_eq!(1, report.files.len());
+        }
+
+        #[test]
+        fn should_drop_whole_file_from_files_when_test_path_has_only_test_symbols() {
+            let source = "\
+package main
+
+func TestFoo(t *testing.T) {
+	1
+}
+";
+            let read_file = fake_reader(HashMap::from([("repo_test.go", source)]));
+            let paths = vec!["repo_test.go".to_string()];
+
+            let expected = Report {
+                files: vec![],
+                skipped: vec![],
+                graph: empty_graph(),
+                tests: vec![],
+                hotspots: vec![],
+                removed: vec![],
+            };
+            let actual = analyze_repo(&paths, read_file, false, &HashSet::new(), true);
+
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn should_keep_test_symbol_when_include_tests_is_true() {
+            let source = "\
+package main
+
+func TestFoo(t *testing.T) {
+	1
+}
+";
+            let read_file = fake_reader(HashMap::from([("repo_test.go", source)]));
+            let paths = vec!["repo_test.go".to_string()];
+
+            let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+
+            assert_eq!(1, report.files.len());
+        }
+
+        #[test]
+        fn should_keep_non_test_symbol_and_drop_test_symbol_when_file_mixes_both() {
+            // A Rust file with one production function and one
+            // `#[cfg(test)] mod tests` function — the production symbol is
+            // kept, the test symbol is dropped, and the file itself is kept
+            // (not emptied entirely) since it still has a non-test symbol
+            // left after filtering.
+            let source = "\
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn should_add_two_numbers() {
+        assert_eq!(3, add(1, 2));
+    }
+}
+";
+            let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+            let paths = vec!["src/lib.rs".to_string()];
+
+            let report = analyze_repo(&paths, read_file, false, &HashSet::new(), true);
+
+            let expected_names = vec!["add".to_string()];
+            let actual_names: Vec<String> = report.files[0]
+                .symbols
+                .iter()
+                .map(|s| s.name.clone())
+                .collect();
+            assert_eq!(expected_names, actual_names);
+        }
+
+        #[test]
+        fn should_populate_hotspots_when_repo_has_a_symbol_with_fan_in_of_two() {
+            // ADR 0017's Consequences: fan-in hotspots are computed over the
+            // whole repository in this mode, same aggregation as diff mode.
+            let source = "\
+fn shared_helper() -> i32 {
+    1
+}
+
+fn caller_one() -> i32 {
+    shared_helper()
+}
+
+fn caller_two() -> i32 {
+    shared_helper()
+}
+";
+            let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+            let paths = vec!["src/lib.rs".to_string()];
+
+            let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+
+            let expected = vec![crate::graph::Hotspot {
+                id: "src/lib.rs::shared_helper".to_string(),
+                path: "src/lib.rs".to_string(),
+                name: "shared_helper".to_string(),
+                used_by: vec!["caller_one".to_string(), "caller_two".to_string()],
+            }];
+            assert_eq!(expected, report.hotspots);
         }
     }
 }

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -1,23 +1,30 @@
 //! Rendering the extraction pipeline's results into an output format.
 //!
-//! [`Report`] is the pipeline-wide result shape produced by
-//! [`crate::pipeline::analyze_diff`]: per-file extracted symbols plus the
-//! files that were skipped (unsupported language, binary, or deleted), plus
-//! the [`crate::graph::SymbolGraph`] built over those symbols (ADR 0008).
-//! This module turns a `Report` into either Markdown (the default, meant
-//! for humans and LLMs) or JSON (`serde`-derived, for machine consumption).
+//! [`Report`] is the pipeline-wide result shape produced by either
+//! [`crate::pipeline::analyze_diff`] (a diff, [`ReportOrigin::Diff`]) or
+//! [`crate::pipeline::analyze_repo`] (a whole-repo outline with no diff
+//! involved, [`ReportOrigin::RepoOutline`] — ADR 0017): per-file extracted
+//! symbols plus the files that were skipped (unsupported language, binary,
+//! or deleted; `analyze_repo` never populates this), plus the
+//! [`crate::graph::SymbolGraph`] built over those symbols (ADR 0008). This
+//! module turns a `Report` into either Markdown (the default, meant for
+//! humans and LLMs) or JSON (`serde`-derived, for machine consumption).
 //!
-//! Markdown renders in this order: a "Change graph" tree (names only,
-//! rooted at the graph's auto-detected entry points) giving the reader a
-//! call-hierarchy reading order, with an optional "Hotspots" sub-section
-//! (ADR 0013) right after it; "Definitions" — the full signature of every
-//! changed symbol, in the same tree order, each shown exactly once (ADR
-//! 0008's decision to avoid duplicating a symbol reachable from multiple
-//! roots); "Removed symbols" — base-side symbols with no head-side
-//! counterpart at all (ADR 0014), omitted when empty; "Tests" — a per-file
-//! count of changed test symbols excluded from the graph/definitions above
-//! by default (ADR 0009); "Other changed files" — files with no
-//! changed-symbol-level content (e.g. pure renames); and "Skipped files".
+//! Markdown renders in this order: a "Change graph" tree for a diff, or
+//! "Repository graph" for a whole-repo outline (names only, rooted at the
+//! graph's auto-detected entry points) giving the reader a call-hierarchy
+//! reading order, with an optional "Hotspots" sub-section (ADR 0013) right
+//! after it; "Definitions" — the full signature of every symbol, in the
+//! same tree order, each shown exactly once (ADR 0008's decision to avoid
+//! duplicating a symbol reachable from multiple roots); "Removed symbols" —
+//! base-side symbols with no head-side counterpart at all (ADR 0014,
+//! diff-only: `report.removed` is always empty for a whole-repo outline),
+//! omitted when empty; "Tests" — a per-file count of changed test symbols
+//! excluded from the graph/definitions above by default (ADR 0009); "Other
+//! changed files" — files with no changed-symbol-level content (e.g. pure
+//! renames); and "Skipped files". A whole-repo outline's wording drops every
+//! "changed" qualifier (`report.origin` picks the noun — see
+//! `change_graph_summary`), since nothing changed in that mode.
 //!
 //! ADR 0014 also marks each "Change graph"/"Hotspots"/"Definitions" line
 //! with its contract-impact classification (`— new` / `— signature
@@ -48,6 +55,22 @@ use thiserror::Error;
 /// The result of running the extraction pipeline over a whole diff.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Report {
+    /// Which pipeline entry point produced this report (ADR 0017):
+    /// [`ReportOrigin::Diff`] (the default — `analyze_diff`, every existing
+    /// input mode) or [`ReportOrigin::RepoOutline`] (`analyze_repo`, the
+    /// whole-repo default with no diff involved at all). Rendering reads
+    /// this to pick change-oriented wording ("changed symbols") vs.
+    /// outline-oriented wording ("symbols") for the same underlying data
+    /// shape — see `render_markdown`'s "## Change graph"/"## Repository
+    /// graph" split.
+    ///
+    /// `#[serde(default, skip_serializing_if = ...)]` keeps every existing
+    /// `analyze_diff`-produced JSON report byte-for-byte unchanged: the
+    /// field is omitted entirely when it's the default `Diff`, and only
+    /// appears (as `"origin": "repo-outline"`) for the new whole-repo mode,
+    /// which has no prior JSON shape to stay compatible with.
+    #[serde(default, skip_serializing_if = "ReportOrigin::is_diff")]
+    pub origin: ReportOrigin,
     pub files: Vec<FileReport>,
     pub skipped: Vec<SkippedFile>,
     /// The dependency graph over `files`' symbols (ADR 0008): edges and
@@ -75,6 +98,28 @@ pub struct Report {
     /// [`crate::pipeline::analyze_diff`]'s `read_base_file` parameter),
     /// same as every symbol's `classification` staying `None` in that case.
     pub removed: Vec<crate::extract::RemovedSymbol>,
+}
+
+/// Which pipeline entry point produced a [`Report`] (ADR 0017). `Default`
+/// is `Diff` — every pre-ADR-0017 caller builds a `Report` via
+/// `analyze_diff`, so defaulting to it is what keeps those `Report { ... }`
+/// literals (and the JSON they serialize to) unchanged without having to
+/// touch every one of them to spell out `origin` explicitly.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReportOrigin {
+    #[default]
+    Diff,
+    RepoOutline,
+}
+
+impl ReportOrigin {
+    /// Predicate form of `matches!(self, ReportOrigin::Diff)`, for
+    /// `#[serde(skip_serializing_if = ...)]`, which needs a `fn(&T) -> bool`
+    /// path rather than an inline expression.
+    fn is_diff(&self) -> bool {
+        matches!(self, ReportOrigin::Diff)
+    }
 }
 
 /// Extracted symbols for a single changed file.
@@ -228,9 +273,17 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
     let mut out = String::new();
 
     if !report.graph.nodes.is_empty() {
-        writeln!(out, "## Change graph")?;
+        let heading = match report.origin {
+            ReportOrigin::Diff => "## Change graph",
+            ReportOrigin::RepoOutline => "## Repository graph",
+        };
+        writeln!(out, "{heading}")?;
         writeln!(out)?;
-        writeln!(out, "{}", change_graph_summary(&report.graph.nodes))?;
+        writeln!(
+            out,
+            "{}",
+            change_graph_summary(&report.graph.nodes, report.origin)
+        )?;
         writeln!(out)?;
         render_change_graph(&mut out, &report.graph, &children, &lookup)?;
         writeln!(out)?;
@@ -325,10 +378,14 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
     Ok(out)
 }
 
-/// Builds the one-line summary shown under the "## Change graph" heading,
-/// e.g. `16 changed symbols in 3 files — most in store/items.go (11)`
-/// (ADR 0012 decision 3). Computed from `nodes` alone (not `edges`/`roots`),
-/// so it stays meaningful even if graph-building changes independently.
+/// Builds the one-line summary shown under the "## Change graph"/
+/// "## Repository graph" heading, e.g. `16 changed symbols in 3 files —
+/// most in store/items.go (11)` for a diff, or `16 symbols in 3 files —
+/// most in store/items.go (11)` for a whole-repo outline (ADR 0017: nothing
+/// changed in that mode, so the "changed" qualifier would misdescribe it —
+/// see `origin`) (ADR 0012 decision 3). Computed from `nodes` alone (not
+/// `edges`/`roots`), so it stays meaningful even if graph-building changes
+/// independently.
 ///
 /// The `— most in ...` suffix is dropped when every node lives in the same
 /// file: naming "the file with the most nodes" is redundant when there is
@@ -338,12 +395,17 @@ fn render_markdown(report: &Report) -> Result<String, RenderError> {
 /// order) rather than an arbitrary path-string sort.
 ///
 /// Callers must not call this with an empty `nodes` — `render_markdown`
-/// only emits the "Change graph" section (and this summary) when
-/// `graph.nodes` is non-empty, matching pre-ADR-0012 behavior for an empty
-/// graph.
-fn change_graph_summary(nodes: &[Node]) -> String {
+/// only emits the "Change graph"/"Repository graph" section (and this
+/// summary) when `graph.nodes` is non-empty, matching pre-ADR-0012 behavior
+/// for an empty graph.
+fn change_graph_summary(nodes: &[Node], origin: ReportOrigin) -> String {
     let total = nodes.len();
-    let symbol_noun = if total == 1 { "symbol" } else { "symbols" };
+    let symbol_noun = match (total, origin) {
+        (1, ReportOrigin::Diff) => "changed symbol",
+        (_, ReportOrigin::Diff) => "changed symbols",
+        (1, ReportOrigin::RepoOutline) => "symbol",
+        (_, ReportOrigin::RepoOutline) => "symbols",
+    };
 
     // First-seen order for paths, with per-path counts, so both the file
     // count and the "most changed" tie-break can be read off in one pass.
@@ -361,7 +423,7 @@ fn change_graph_summary(nodes: &[Node]) -> String {
     let file_noun = if file_count == 1 { "file" } else { "files" };
 
     if file_count <= 1 {
-        return format!("{total} changed {symbol_noun} in {file_count} {file_noun}");
+        return format!("{total} {symbol_noun} in {file_count} {file_noun}");
     }
 
     // `max_by_key` keeps the *last* maximal element on ties, but the
@@ -376,7 +438,7 @@ fn change_graph_summary(nodes: &[Node]) -> String {
         .expect("file_count > 1 implies path_order is non-empty");
 
     format!(
-        "{total} changed {symbol_noun} in {file_count} {file_noun} — most in {hotspot_path} ({hotspot_count})"
+        "{total} {symbol_noun} in {file_count} {file_noun} — most in {hotspot_path} ({hotspot_count})"
     )
 }
 
@@ -900,6 +962,7 @@ mod tests {
     #[test]
     fn should_render_empty_markdown_when_report_has_no_files_and_no_skips() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -930,6 +993,7 @@ mod tests {
     #[test]
     fn should_list_file_with_no_symbols_under_other_changed_files_when_report_has_no_graph_nodes() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/new_name.rs".to_string(),
                 symbols: vec![],
@@ -964,6 +1028,7 @@ mod tests {
         // file with no symbols at all — the pure rename must still show up,
         // in its own section after "Definitions".
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![
                 FileReport {
                     path: "src/lib.rs".to_string(),
@@ -1019,6 +1084,7 @@ fn foo()
     #[test]
     fn should_render_other_changed_files_before_skipped_files_when_report_has_both() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/new_name.rs".to_string(),
                 symbols: vec![],
@@ -1055,6 +1121,7 @@ fn foo()
     #[test]
     fn should_render_tests_section_with_singular_symbol_noun_when_count_is_one() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -1085,6 +1152,7 @@ fn foo()
     #[test]
     fn should_render_tests_section_with_plural_symbols_noun_when_count_is_greater_than_one() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -1116,6 +1184,7 @@ fn foo()
     fn should_render_tests_section_between_definitions_and_other_changed_files_when_report_has_all_sections()
      {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol(
@@ -1176,6 +1245,7 @@ fn foo()
     #[test]
     fn should_omit_generated_skip_entry_from_markdown_output() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![SkippedFile {
                 path: "Cargo.lock".to_string(),
@@ -1203,6 +1273,7 @@ fn foo()
     #[test]
     fn should_omit_only_generated_entries_when_skipped_has_other_reasons_too() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![
                 SkippedFile {
@@ -1244,6 +1315,7 @@ fn foo()
     #[test]
     fn should_keep_generated_entry_in_json_output() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![SkippedFile {
                 path: "Cargo.lock".to_string(),
@@ -1283,9 +1355,53 @@ fn foo()
         assert_eq!(expected, actual);
     }
 
+    // ADR 0017: `origin` must stay invisible in JSON for every existing
+    // `analyze_diff`-produced report (see
+    // `should_keep_generated_entry_in_json_output` above, whose expected
+    // JSON has no `"origin"` key at all) — this is the flip side, pinning
+    // that a whole-repo outline's `RepoOutline` origin *does* serialize, as
+    // `"origin": "repo-outline"`, so JSON consumers can tell the two modes
+    // apart.
+    #[test]
+    fn should_serialize_origin_field_when_report_is_a_repo_outline() {
+        let report = Report {
+            origin: ReportOrigin::RepoOutline,
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        };
+
+        let expected = "\
+{
+  \"origin\": \"repo-outline\",
+  \"files\": [],
+  \"skipped\": [],
+  \"graph\": {
+    \"nodes\": [],
+    \"edges\": [],
+    \"roots\": []
+  },
+  \"tests\": [],
+  \"hotspots\": [],
+  \"removed\": []
+}"
+        .to_string();
+        let actual = render(&report, OutputFormat::Json).expect("json render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
     #[test]
     fn should_render_change_graph_and_definitions_when_report_has_one_symbol() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol(
@@ -1334,6 +1450,7 @@ fn foo(a: i32) -> i32
         // — pins the plural "changed symbols"/"files" wording together with
         // the "— most in ..." suffix and its count.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -1373,12 +1490,63 @@ fn foo(a: i32) -> i32
         assert_eq!(expected, actual);
     }
 
+    // ADR 0017: a whole-repo outline has no diff, so "Change graph"/
+    // "changed symbols" would misdescribe it — this pins the alternate
+    // heading and noun `ReportOrigin::RepoOutline` selects, using the same
+    // multi-file/hotspot shape as
+    // `should_render_summary_with_hotspot_when_report_has_multiple_symbols_and_files`
+    // so the two tests differ only in `origin` and its wording.
+    #[test]
+    fn should_render_repository_graph_heading_and_drop_changed_wording_when_origin_is_repo_outline()
+    {
+        let report = Report {
+            origin: ReportOrigin::RepoOutline,
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("store/items.go::A", "store/items.go", "A"),
+                    node("store/items.go::B", "store/items.go", "B"),
+                    node("store/items.go::C", "store/items.go", "C"),
+                    node("store/db.go::D", "store/db.go", "D"),
+                    node("store/db.go::E", "store/db.go", "E"),
+                ],
+                edges: vec![],
+                roots: vec![
+                    "store/items.go::A".to_string(),
+                    "store/items.go::B".to_string(),
+                    "store/items.go::C".to_string(),
+                    "store/db.go::D".to_string(),
+                    "store/db.go::E".to_string(),
+                ],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        };
+
+        let expected = "\
+## Repository graph
+
+5 symbols in 2 files — most in store/items.go (3)
+
+
+## Definitions
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
     #[test]
     fn should_omit_hotspot_suffix_when_all_symbols_are_in_one_file() {
         // Every node lives in the same file, so naming "the file with the
         // most nodes" would be redundant — the suffix must be dropped
         // entirely, not degenerate into e.g. "(2)".
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -1416,6 +1584,7 @@ fn foo(a: i32) -> i32
         // after it alphabetically — the tie-break is source order, not a
         // path-string comparison.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -1462,6 +1631,7 @@ fn foo(a: i32) -> i32
         // identical-looking `fn foo (src/lib.rs)` entries with no way to
         // tell them apart.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![
@@ -1534,6 +1704,7 @@ fn foo(a: i32, b: i32)
     #[test]
     fn should_nest_callee_under_caller_in_change_graph_when_symbol_references_another() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/main.rs".to_string(),
                 symbols: vec![
@@ -1614,6 +1785,7 @@ fn resolve_pr_base_sha() -> Result<String>
         // rendered string so both the "Change graph" tree and "Definitions"
         // order are asserted together.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![
@@ -1704,6 +1876,7 @@ fn c()
         // full once (under "foo", the first root in source order) and
         // referenced by name only under "bar" (ADR 0008).
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![
@@ -1783,6 +1956,7 @@ fn bar()
     #[test]
     fn should_render_cycle_warning_when_edge_is_marked_as_cycle() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/git.rs".to_string(),
                 symbols: vec![symbol(
@@ -1841,6 +2015,7 @@ fn resolve_pr_base_sha()
         // (a design smell the tool should surface) calls back into
         // itself. `Config` is an unrelated, independent root.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![
                 FileReport {
                     path: "src/main.rs".to_string(),
@@ -1973,6 +2148,7 @@ struct Config { path: String }
         // own nested lines, but both still get full "### ..." entries
         // under "Definitions" (ADR 0012 decision 1).
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "store/items.go".to_string(),
                 symbols: vec![
@@ -2079,6 +2255,7 @@ type UpsertItemsResponse struct { Count int }
         // same `Name (path:line)` form `tree_label` already uses for
         // disambiguated symbols, not the bare name.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![
@@ -2172,6 +2349,7 @@ struct Dup { b: i32 }
         // `— uses: ...` annotation on every parent that references it, and
         // it must never itself get a `(see above)` line.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![
@@ -2254,6 +2432,7 @@ fn bar()
         // its own top-level tree line rather than being folded away
         // entirely (roots are always their own top-level DFS start).
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/config.rs".to_string(),
                 symbols: vec![symbol(
@@ -2306,6 +2485,7 @@ struct Config { path: String }
         // non-function, so it folds into `Wrapper`'s own line instead of
         // getting a third nesting level.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![
@@ -2393,6 +2573,7 @@ struct Inner { x: i32 }
         // outgoing edges at all) and must render as its own nested line
         // with the cycle warning still visible beneath it.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![
@@ -2463,6 +2644,7 @@ struct Node { next: Option<Box<Node>> }
     #[test]
     fn should_render_container_comment_when_symbol_has_container() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -2512,6 +2694,7 @@ fn bar(&self) -> i32
     #[test]
     fn should_render_depends_on_list_when_symbol_has_dependencies() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -2566,6 +2749,7 @@ Depends on:
     #[test]
     fn should_render_multiple_depends_on_entries_when_symbol_has_several_dependencies() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -2627,6 +2811,7 @@ Depends on:
     #[test]
     fn should_render_omitted_matches_note_when_dependency_matches_were_capped() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -2688,6 +2873,7 @@ Depends on:
     #[test]
     fn should_widen_fence_when_signature_contains_a_backtick_run() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol(
@@ -2740,6 +2926,7 @@ fn example_macro() { let s = \"```rust\\nfn f() {}\\n```\"; }
     #[test]
     fn should_widen_fence_when_container_contains_a_backtick_run() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -2789,6 +2976,7 @@ fn bar(&self) -> i32
     #[test]
     fn should_render_skipped_files_section_when_report_has_skips() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![
                 SkippedFile {
@@ -2830,6 +3018,7 @@ fn bar(&self) -> i32
     #[test]
     fn should_render_change_graph_then_skipped_section_when_report_has_both() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol(
@@ -2881,6 +3070,7 @@ fn foo()
     #[test]
     fn should_omit_hotspots_section_when_hotspots_is_empty() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol(
@@ -2934,6 +3124,7 @@ fn foo()
         // in the order `compute_hotspots` already sorted them in (not
         // re-sorted here).
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "store/items.go".to_string(),
                 symbols: vec![
@@ -3048,6 +3239,7 @@ func HandleBar(req UpsertItemsRequest) error
         // `{name} ({path})` label with no kind prefix, rather than being
         // dropped outright.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -3100,6 +3292,7 @@ func HandleBar(req UpsertItemsRequest) error
         // "Definitions" loop; the malformed root must simply be skipped
         // rather than panicking or emitting a broken heading.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -3134,6 +3327,7 @@ func HandleBar(req UpsertItemsRequest) error
         // (the "Change graph" tree-line branch) rather than the
         // "Definitions" loop.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -3174,6 +3368,7 @@ func HandleBar(req UpsertItemsRequest) error
         // non-cycle-edge lookups) — the warning line is simply omitted
         // rather than rendering a broken label.
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol(
@@ -3223,6 +3418,7 @@ fn foo()
     #[test]
     fn should_render_json_with_graph_files_and_skipped_when_report_has_all_three() {
         let report = Report {
+            origin: ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol(
@@ -3308,6 +3504,7 @@ fn foo()
             let mut foo = symbol("src/lib.rs::foo", "foo", SymbolKind::Function, "fn foo()");
             foo.classification = Some(Classification::Added);
             let report = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![foo],
@@ -3356,6 +3553,7 @@ fn foo()
             foo.classification = Some(Classification::SignatureChanged);
             foo.previous_signature = Some("fn foo(a: i32) -> i32".to_string());
             let report = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![foo],
@@ -3411,6 +3609,7 @@ fn foo()
             bar.classification = Some(Classification::SignatureChanged);
             bar.previous_signature = Some("fn bar(&self) -> i32".to_string());
             let report = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![bar],
@@ -3464,6 +3663,7 @@ fn foo()
             let mut foo = symbol("src/lib.rs::foo", "foo", SymbolKind::Function, "fn foo()");
             foo.classification = classification;
             let report = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![foo],
@@ -3512,6 +3712,7 @@ fn foo()
             shared.classification = Some(Classification::SignatureChanged);
             shared.previous_signature = Some("fn shared(a: i32)".to_string());
             let report = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![shared],
@@ -3554,6 +3755,7 @@ fn foo()
         #[test]
         fn should_render_removed_symbols_section_between_definitions_and_tests() {
             let report = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![symbol(
@@ -3622,6 +3824,7 @@ fn foo()
         #[test]
         fn should_render_removed_symbols_section_alone_when_graph_is_empty() {
             let report = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![],
                 skipped: vec![],
                 graph: SymbolGraph {
@@ -3661,6 +3864,7 @@ fn foo()
         #[test]
         fn should_deduplicate_identical_removed_symbol_lines() {
             let report = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![],
                 skipped: vec![],
                 graph: SymbolGraph {
@@ -3712,6 +3916,7 @@ fn foo()
         #[test]
         fn should_omit_removed_symbols_section_when_removed_is_empty() {
             let report = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![symbol(
@@ -3757,6 +3962,7 @@ fn foo()
             foo.previous_signature =
                 Some("fn foo() { let s = \"```rust\\nfn f() {}\\n```\"; }".to_string());
             let report = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![foo],
@@ -3806,6 +4012,7 @@ fn foo()
             foo.classification = Some(Classification::SignatureChanged);
             foo.previous_signature = Some("fn foo(a: i32) -> i32".to_string());
             let report = Report {
+                origin: ReportOrigin::Diff,
                 files: vec![FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![foo],

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -367,6 +367,7 @@ mod tests {
 
     fn empty_report() -> Report {
         Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -382,6 +383,7 @@ mod tests {
 
     fn report_with_one_symbol() -> Report {
         Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![symbol("lib.rs::foo", "foo")],
@@ -551,6 +553,7 @@ mod tests {
     #[test]
     fn should_return_dir_detail_when_cursor_is_on_a_directory_row() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol("src/lib.rs::foo", "foo")],
@@ -610,6 +613,7 @@ mod tests {
     #[test]
     fn should_return_none_diff_target_when_cursor_is_on_a_directory_row() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol("src/lib.rs::foo", "foo")],
@@ -641,6 +645,7 @@ mod tests {
     #[test]
     fn should_return_symbol_diff_target_with_line_range_when_cursor_is_on_a_symbol_row() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {

--- a/rinkaku-tui/src/detail.rs
+++ b/rinkaku-tui/src/detail.rs
@@ -423,6 +423,7 @@ mod tests {
 
     fn empty_report() -> Report {
         Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -448,6 +449,7 @@ mod tests {
     #[test]
     fn should_build_current_signature_when_classification_is_not_signature_changed() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -478,6 +480,7 @@ mod tests {
     #[test]
     fn should_build_changed_signature_when_classification_is_signature_changed() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -505,6 +508,7 @@ mod tests {
         // not happen per `classify_symbols`'s contract) still renders
         // something sane rather than panicking.
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -530,6 +534,7 @@ mod tests {
         // `report.hotspots` has nothing for "callee" — used_by must still
         // show the one caller by reading `graph.edges` directly.
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![
@@ -566,6 +571,7 @@ mod tests {
     #[test]
     fn should_list_every_referrer_as_used_by_when_symbol_is_a_hotspot() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![
@@ -613,6 +619,7 @@ mod tests {
     #[test]
     fn should_list_outgoing_edges_as_callees() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![symbol("lib.rs::a", "a"), symbol("lib.rs::b", "b")],
@@ -646,6 +653,7 @@ mod tests {
     #[test]
     fn should_have_empty_callers_and_callees_when_symbol_has_no_edges() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![symbol("lib.rs::solo", "solo")],
@@ -675,6 +683,7 @@ mod tests {
     #[test]
     fn should_dedup_duplicate_edges_between_the_same_pair_of_symbols() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![
@@ -737,6 +746,7 @@ mod tests {
     #[test]
     fn should_exclude_self_edge_from_callers_callees_and_used_by() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![symbol("lib.rs::recursive", "recursive")],
@@ -775,6 +785,7 @@ mod tests {
     #[test]
     fn should_build_dir_detail_with_badges_and_no_cycle_when_directory_is_not_in_a_cycle() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -810,6 +821,7 @@ mod tests {
     #[test]
     fn should_list_top_fan_in_symbols_sorted_by_fan_in_descending() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![
@@ -881,6 +893,7 @@ mod tests {
             })
             .collect();
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols,
@@ -905,6 +918,7 @@ mod tests {
         // api/ and store/ depend on each other — a directory-level cycle
         // (mirrors crate::order's own cycle test fixtures).
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![
                 FileReport {
                     path: "api/handler.rs".to_string(),
@@ -970,6 +984,7 @@ mod tests {
     #[test]
     fn should_build_file_detail_with_symbol_summaries_and_fan_in() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![
@@ -1025,6 +1040,7 @@ mod tests {
     #[test]
     fn should_include_removed_symbol_in_file_detail_summary() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![],
             removed: vec![rinkaku_core::extract::RemovedSymbol {
                 name: "gone".to_string(),

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -162,6 +162,7 @@ mod tests {
 
     fn empty_report() -> Report {
         Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {

--- a/rinkaku-tui/src/order.rs
+++ b/rinkaku-tui/src/order.rs
@@ -667,6 +667,7 @@ mod tests {
 
     fn report_with_graph(nodes: Vec<Node>, edges: Vec<Edge>) -> Report {
         Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {

--- a/rinkaku-tui/src/source.rs
+++ b/rinkaku-tui/src/source.rs
@@ -230,6 +230,7 @@ mod tests {
 
     fn empty_report() -> Report {
         Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -246,6 +247,7 @@ mod tests {
     #[test]
     fn should_find_symbol_location_from_matching_file() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol(

--- a/rinkaku-tui/src/tree.rs
+++ b/rinkaku-tui/src/tree.rs
@@ -439,6 +439,7 @@ mod tests {
 
     fn empty_report() -> Report {
         Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -465,6 +466,7 @@ mod tests {
     #[test]
     fn should_build_flat_file_node_when_path_has_no_directory() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![symbol("lib.rs::foo", "foo", SymbolKind::Function)],
@@ -509,6 +511,7 @@ mod tests {
         // src/foo/bar/lib.rs — src, foo, bar each have exactly one child,
         // so all three collapse into one Dir node labeled "src/foo/bar".
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/foo/bar/lib.rs".to_string(),
                 symbols: vec![],
@@ -537,6 +540,7 @@ mod tests {
     #[test]
     fn should_not_collapse_directory_with_two_children() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![
                 FileReport {
                     path: "src/a.rs".to_string(),
@@ -582,6 +586,7 @@ mod tests {
         // src is not "just a chain" to reach foo, so it must stay a
         // separate node rather than collapsing with foo.
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![
                 FileReport {
                     path: "src/mod.rs".to_string(),
@@ -629,6 +634,7 @@ mod tests {
     #[test]
     fn should_count_contract_change_for_signature_changed_symbol() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -654,6 +660,7 @@ mod tests {
     #[test]
     fn should_not_count_contract_change_for_body_only_symbol() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![ExtractedSymbol {
@@ -679,6 +686,7 @@ mod tests {
     #[test]
     fn should_add_removed_symbol_as_marked_leaf_under_its_file_without_counting_as_changed() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![],
             removed: vec![RemovedSymbol {
                 name: "gone".to_string(),
@@ -727,6 +735,7 @@ mod tests {
         // and one removed symbol must land under the same File node, not
         // create two separate entries for "lib.rs".
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![symbol("lib.rs::foo", "foo", SymbolKind::Function)],
@@ -801,6 +810,7 @@ mod tests {
     #[test]
     fn should_aggregate_badges_bottom_up_across_nested_directories() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![
                 FileReport {
                     path: "src/a/one.rs".to_string(),
@@ -835,6 +845,7 @@ mod tests {
         // A pure rename (FileReport with empty symbols) must still show up
         // as a File node with zero badges, not be dropped from the tree.
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/renamed.rs".to_string(),
                 symbols: vec![],
@@ -866,6 +877,7 @@ mod tests {
         // is a separate concern handled by `crate::order`), even though the
         // builder uses a BTreeMap internally.
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![
                 FileReport {
                     path: "z.rs".to_string(),
@@ -888,6 +900,7 @@ mod tests {
     #[test]
     fn should_set_fan_in_badge_from_matching_hotspot_and_aggregate_upward() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol("src/lib.rs::shared", "shared", SymbolKind::Function)],
@@ -917,6 +930,7 @@ mod tests {
     #[test]
     fn should_leave_fan_in_at_zero_when_symbol_has_no_matching_hotspot() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![symbol("lib.rs::solo", "solo", SymbolKind::Function)],

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -20,7 +20,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph};
 use rinkaku_core::extract::Classification;
-use rinkaku_core::render::Report;
+use rinkaku_core::render::{Report, ReportOrigin};
 
 /// Draws one full frame: the entry view (tree + right pane split) or the
 /// source drill-down, depending on `app.screen()`, with a status/help line
@@ -96,7 +96,7 @@ fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
 
     let lines = match &detail {
         SelectedDetail::Symbol(detail) => detail_lines(detail),
-        SelectedDetail::Dir(detail) => dir_detail_lines(detail),
+        SelectedDetail::Dir(detail) => dir_detail_lines(detail, report.origin),
         SelectedDetail::File(detail) => file_detail_lines(detail),
     };
     let paragraph = Paragraph::new(lines)
@@ -208,7 +208,14 @@ fn diff_line(line: &DiffLine) -> Line<'static> {
 /// the partner directories and the concrete cross-directory edges forming
 /// it (TUI iteration 2's answer to "cycle と言われても何が cycle してるか
 /// 分からない").
-fn dir_detail_lines(detail: &DirDetail) -> Vec<Line<'static>> {
+///
+/// `origin` picks the first badge's label: `Report::files`' symbol count is
+/// exactly the same aggregation in both modes (`Badges::changed_symbols` is
+/// not renamed — ADR 0017 only asks for the label to stop implying a diff),
+/// but "changed symbols" would misdescribe a whole-repo outline the same
+/// way `render.rs`'s "## Change graph"/"## Repository graph" split avoids
+/// for Markdown.
+fn dir_detail_lines(detail: &DirDetail, origin: ReportOrigin) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
     lines.push(Line::styled(
@@ -216,8 +223,12 @@ fn dir_detail_lines(detail: &DirDetail) -> Vec<Line<'static>> {
         Style::default().add_modifier(Modifier::BOLD),
     ));
     lines.push(Line::raw(""));
+    let symbols_label = match origin {
+        ReportOrigin::Diff => "changed symbols",
+        ReportOrigin::RepoOutline => "symbols",
+    };
     lines.push(Line::raw(format!(
-        "changed symbols: {}",
+        "{symbols_label}: {}",
         detail.badges.changed_symbols
     )));
     lines.push(Line::raw(format!(
@@ -262,9 +273,13 @@ fn dir_detail_lines(detail: &DirDetail) -> Vec<Line<'static>> {
     lines
 }
 
-/// Formats a [`FileDetail`] into displayable lines: every symbol changed
-/// in this file, with the same classification marker convention
-/// `crate::row_view::entry_row_line` uses on symbol rows, plus fan-in.
+/// Formats a [`FileDetail`] into displayable lines: every symbol in this
+/// file (changed symbols for a diff, every symbol for a whole-repo
+/// outline — ADR 0017), with the same classification marker convention
+/// `crate::row_view::entry_row_line` uses on symbol rows, plus fan-in. The
+/// "Symbols (N)" label itself is already origin-neutral, unlike
+/// `dir_detail_lines`'s first badge line, so no `origin` parameter is
+/// needed here.
 fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
@@ -486,6 +501,7 @@ mod tests {
 
     fn report_with_one_symbol() -> Report {
         Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
                 symbols: vec![symbol("lib.rs::foo", "foo")],
@@ -544,6 +560,7 @@ mod tests {
     #[test]
     fn should_draw_placeholder_message_when_there_are_no_rows_at_all() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![],
             skipped: vec![],
             graph: SymbolGraph {
@@ -569,6 +586,7 @@ mod tests {
     #[test]
     fn should_draw_dir_detail_content_when_cursor_is_on_a_directory_row() {
         let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
                 path: "src/lib.rs".to_string(),
                 symbols: vec![symbol("src/lib.rs::foo", "foo")],
@@ -592,7 +610,45 @@ mod tests {
 
         let text = buffer_text(&terminal);
         assert!(text.contains("Dir src"));
+        assert!(text.contains("changed symbols:"));
         assert!(text.contains("Top fan-in"));
+    }
+
+    // ADR 0017: a whole-repo outline's directory detail must not say
+    // "changed symbols" — nothing changed in that mode — so this pins
+    // `dir_detail_lines`'s label switching on `report.origin`, using the
+    // same report shape as
+    // `should_draw_dir_detail_content_when_cursor_is_on_a_directory_row`
+    // above (differing only in `origin`) so the two tests read as a pair.
+    #[test]
+    fn should_draw_symbols_label_without_changed_wording_when_origin_is_repo_outline() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::RepoOutline,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol("src/lib.rs::foo", "foo")],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        };
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &[]))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Dir src"));
+        assert!(text.contains("symbols:"));
+        assert!(!text.contains("changed symbols:"));
     }
 
     #[test]

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -88,9 +88,16 @@ struct Cli {
     #[arg(long)]
     pr: Option<String>,
 
-    /// Output format.
-    #[arg(long, value_enum, default_value_t = Format::Md, conflicts_with = "tui")]
-    format: Format,
+    /// Output format. Defaults to Markdown, or the interactive TUI when
+    /// stdout is a terminal and neither `--format` nor `--tui` was given
+    /// (ADR 0017) — see `resolve_display_mode`.
+    //
+    // `Option` rather than a `default_value_t` is what makes "the user
+    // didn't pass --format" observable at all; a defaulted `Format` field
+    // would look identical to an explicit `--format md`, which
+    // `resolve_display_mode` needs to tell apart (see its own doc comment).
+    #[arg(long, value_enum, conflicts_with = "tui")]
+    format: Option<Format>,
 
     /// Open the interactive terminal UI (ADR 0015/0016) instead of
     /// printing Markdown/JSON. The input flow (stdin / `--base` / `--pr`)
@@ -208,6 +215,38 @@ fn main() -> anyhow::Result<()> {
         run_base_pipeline(&cli, &base_sha, &head_sha, cwd)?
     } else if let Some(base) = &cli.base {
         run_base_pipeline(&cli, base, &cli.head, None)?
+    } else if cli.base.is_none() && cli.pr.is_none() && std::io::stdin().is_terminal() {
+        // ADR 0017: bare `rinkaku` on an interactive terminal, with no
+        // `--base`/`--pr` given, has no diff to read at all — rather than
+        // `read_stdin_diff`'s usual "no diff input" error (which fires
+        // below for every other stdin-is-a-TTY case, e.g. `--base` was
+        // meant but mistyped and this branch's own `cli.base.is_none()`
+        // guard didn't match for some other reason), build a whole-repo
+        // outline instead. `diff_text` is empty: the TUI's diff pane (`d`)
+        // has nothing to slice hunks out of in this mode and falls back to
+        // its placeholder (ADR 0017's Consequences).
+        log::info!("no diff input and stdin is a terminal; building a whole-repo outline");
+        let paths = list_git_files(None)?;
+        // `check_generated_paths_batch`, not `resolve_generated_paths`
+        // (which shells out via `check_generated_paths`'s CLI-argument
+        // form): `paths` here is every tracked file, potentially far more
+        // than a diff's changed-path count, and passing thousands of paths
+        // as CLI arguments risks exceeding the OS's `ARG_MAX` — the same
+        // reason `build_resolver` already uses the batch/stdin form for
+        // its own repo-wide scan (see that function's doc comment).
+        let generated_paths = if cli.include_generated {
+            std::collections::HashSet::new()
+        } else {
+            check_generated_paths_batch(None, &paths)
+        };
+        let report = rinkaku_core::pipeline::analyze_repo(
+            &paths,
+            read_working_tree_file,
+            cli.include_tests,
+            &generated_paths,
+            cli.include_generated,
+        );
+        (report, String::new())
     } else {
         let diff_text = read_stdin_diff()?;
         if diff_text.trim().is_empty() {
@@ -238,15 +277,63 @@ fn main() -> anyhow::Result<()> {
         (report, diff_text)
     };
 
-    if cli.tui {
-        rinkaku_tui::run(&report, &diff_text)?;
-        return Ok(());
+    let stdout_is_tty = std::io::stdout().is_terminal();
+    match resolve_display_mode(cli.tui, cli.format, stdout_is_tty) {
+        DisplayMode::Tui => rinkaku_tui::run(&report, &diff_text)?,
+        DisplayMode::Output(format) => {
+            let output = render(&report, format.into())?;
+            print!("{output}");
+        }
     }
 
-    let output = render(&report, cli.format.into())?;
-    print!("{output}");
-
     Ok(())
+}
+
+/// Which output stage `main` dispatches to, once a `Report` is built —
+/// pulled into its own type (rather than inlining the `if cli.tui`/
+/// `render` branch as before) so the *decision* of which one to use can be
+/// unit-tested as a pure function ([`resolve_display_mode`]) independent
+/// of actually running the TUI or rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DisplayMode {
+    Tui,
+    Output(Format),
+}
+
+/// Decides which [`DisplayMode`] to use from the three inputs that can
+/// influence it: whether `--tui` was passed, whether `--format` was passed
+/// (`Some` — clap's `conflicts_with` already guarantees `tui` and `format`
+/// are never both meaningfully set, see `Cli::format`'s doc comment), and
+/// whether stdout is a terminal.
+///
+/// - `--tui` passed → [`DisplayMode::Tui`], regardless of stdout.
+/// - `--format` passed (and `--tui` wasn't, by the conflict above) →
+///   [`DisplayMode::Output`] with that format — an explicit format request
+///   always wins, whether or not stdout happens to be a terminal (this is
+///   what lets a non-interactive caller force whole-repo mode's Markdown
+///   output even while attached to a terminal, e.g. `rinkaku --format md
+///   > out.md` run interactively, or this project's own dogfooding
+///   `rinkaku --format md` invocations in CI-like scripts).
+/// - Neither passed → ADR 0017's default: [`DisplayMode::Tui`] when stdout
+///   is a terminal (a human is watching, so they get the interactive
+///   view — ADR 0015), [`DisplayMode::Output(Format::Md)`] otherwise (a
+///   pipe/redirect, so Markdown is what a non-interactive consumer can
+///   actually use).
+///
+/// Pure and total over its three `bool`/`Option` inputs — no `IsTerminal`
+/// call here, `main` reads the real streams and passes the results in.
+fn resolve_display_mode(tui: bool, format: Option<Format>, stdout_is_tty: bool) -> DisplayMode {
+    if tui {
+        return DisplayMode::Tui;
+    }
+    if let Some(format) = format {
+        return DisplayMode::Output(format);
+    }
+    if stdout_is_tty {
+        DisplayMode::Tui
+    } else {
+        DisplayMode::Output(Format::Md)
+    }
 }
 
 /// Determines which repository `--pr` mode should run its `git` commands
@@ -1637,7 +1724,7 @@ mod tests {
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -1655,7 +1742,7 @@ mod tests {
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -1685,6 +1772,54 @@ mod tests {
         assert!(actual.is_err());
     }
 
+    #[rstest]
+    #[case::should_choose_tui_when_tui_flag_is_set_and_stdout_is_a_terminal(
+        true,
+        None,
+        true,
+        DisplayMode::Tui
+    )]
+    #[case::should_choose_tui_when_tui_flag_is_set_and_stdout_is_not_a_terminal(
+        true,
+        None,
+        false,
+        DisplayMode::Tui
+    )]
+    #[case::should_choose_explicit_format_over_terminal_stdout(
+        false,
+        Some(Format::Json),
+        true,
+        DisplayMode::Output(Format::Json)
+    )]
+    #[case::should_choose_explicit_format_over_non_terminal_stdout(
+        false,
+        Some(Format::Md),
+        false,
+        DisplayMode::Output(Format::Md)
+    )]
+    #[case::should_default_to_tui_when_neither_flag_is_set_and_stdout_is_a_terminal(
+        false,
+        None,
+        true,
+        DisplayMode::Tui
+    )]
+    #[case::should_default_to_markdown_when_neither_flag_is_set_and_stdout_is_not_a_terminal(
+        false,
+        None,
+        false,
+        DisplayMode::Output(Format::Md)
+    )]
+    fn resolve_display_mode_cases(
+        #[case] tui: bool,
+        #[case] format: Option<Format>,
+        #[case] stdout_is_tty: bool,
+        #[case] expected: DisplayMode,
+    ) {
+        let actual = resolve_display_mode(tui, format, stdout_is_tty);
+
+        assert_eq!(expected, actual);
+    }
+
     #[test]
     fn should_set_base_when_base_flag_given() {
         let expected = Cli {
@@ -1692,7 +1827,7 @@ mod tests {
             base: Some("main".to_string()),
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -1710,7 +1845,7 @@ mod tests {
             base: Some("main".to_string()),
             head: "feature-branch".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -1728,7 +1863,7 @@ mod tests {
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Json,
+            format: Some(Format::Json),
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -1753,7 +1888,7 @@ mod tests {
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 0,
             include_tests: false,
             include_generated: false,
@@ -1778,7 +1913,7 @@ mod tests {
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: true,
             include_generated: false,
@@ -1796,7 +1931,7 @@ mod tests {
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: true,
@@ -1814,7 +1949,7 @@ mod tests {
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -1832,7 +1967,7 @@ mod tests {
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -1850,7 +1985,7 @@ mod tests {
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -1883,7 +2018,7 @@ mod tests {
             base: None,
             head: "HEAD".to_string(),
             pr: Some("76".to_string()),
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -2713,7 +2848,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -2739,7 +2874,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: true,
@@ -3122,7 +3257,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 0,
             include_tests: false,
             include_generated: false,
@@ -3155,7 +3290,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -3200,7 +3335,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 1,
             include_tests: false,
             include_generated: false,
@@ -3276,7 +3411,7 @@ fn should_add_two_numbers() {
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 0,
             include_tests: false,
             include_generated: false,
@@ -3324,7 +3459,7 @@ fn should_add_two_numbers() {
             base: None,
             head: "HEAD".to_string(),
             pr: None,
-            format: Format::Md,
+            format: None,
             deps: 0,
             include_tests: false,
             include_generated: false,

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -215,18 +215,24 @@ fn main() -> anyhow::Result<()> {
         run_base_pipeline(&cli, &base_sha, &head_sha, cwd)?
     } else if let Some(base) = &cli.base {
         run_base_pipeline(&cli, base, &cli.head, None)?
-    } else if cli.base.is_none() && cli.pr.is_none() && std::io::stdin().is_terminal() {
-        // ADR 0017: bare `rinkaku` on an interactive terminal, with no
-        // `--base`/`--pr` given, has no diff to read at all — rather than
-        // `read_stdin_diff`'s usual "no diff input" error (which fires
-        // below for every other stdin-is-a-TTY case, e.g. `--base` was
-        // meant but mistyped and this branch's own `cli.base.is_none()`
-        // guard didn't match for some other reason), build a whole-repo
-        // outline instead. `diff_text` is empty: the TUI's diff pane (`d`)
-        // has nothing to slice hunks out of in this mode and falls back to
-        // its placeholder (ADR 0017's Consequences).
+    } else if std::io::stdin().is_terminal() {
+        // ADR 0017: this is the third arm of an `if let Some(pr) ... else if
+        // let Some(base) ... else if <here>` chain, so reaching it already
+        // means `cli.pr` and `cli.base` are both `None` — no need to check
+        // again. With no `--base`/`--pr` and stdin attached to a terminal,
+        // there is no diff to read at all, so a whole-repo outline is built
+        // instead of falling through to `read_stdin_diff`'s "no diff input"
+        // error. `diff_text` is empty: the TUI's diff pane (`d`) has nothing
+        // to slice hunks out of in this mode and falls back to its
+        // placeholder (ADR 0017's Consequences).
+        //
+        // `read_stdin_diff`'s own `is_terminal()` bail is unreachable via
+        // this chain today (every stdin-is-a-TTY case is caught here first),
+        // but is kept as a defensive check in case this `if`/`else if` chain
+        // is ever restructured — e.g. a future flag added between this arm
+        // and the plain stdin-read fallback below.
         log::info!("no diff input and stdin is a terminal; building a whole-repo outline");
-        let paths = list_git_files(None)?;
+        let paths = list_repo_files_for_outline(None)?;
         // `check_generated_paths_batch`, not `resolve_generated_paths`
         // (which shells out via `check_generated_paths`'s CLI-argument
         // form): `paths` here is every tracked file, potentially far more
@@ -246,6 +252,9 @@ fn main() -> anyhow::Result<()> {
             &generated_paths,
             cli.include_generated,
         );
+        if let Some(note) = repo_outline_empty_note(&report) {
+            eprintln!("{note}");
+        }
         (report, String::new())
     } else {
         let diff_text = read_stdin_diff()?;
@@ -458,6 +467,7 @@ fn run_base_pipeline(
         eprintln!("note: diff is empty, nothing to analyze");
         return Ok((
             rinkaku_core::render::Report {
+                origin: rinkaku_core::render::ReportOrigin::Diff,
                 files: Vec::new(),
                 skipped: Vec::new(),
                 graph: rinkaku_core::graph::SymbolGraph {
@@ -578,6 +588,25 @@ fn garbage_input_note(
         return None;
     }
     Some("note: no file changes recognized in input; expected a unified diff")
+}
+
+/// Returns a note for ADR 0017's whole-repo outline when it found nothing
+/// to show — every tracked file was either unsupported, a whole test file,
+/// generated, or unreadable (`analyze_repo`'s own doc comment: all of these
+/// are dropped silently, with no `SkippedFile`/`TestFileSummary` entry to
+/// record why, unlike diff mode) — so an empty `stdout` would otherwise
+/// look identical to "ran fine, nothing to say" with no indication that a
+/// git repository with zero recognizable source files is likely a
+/// misconfiguration (wrong directory, `.gitignore`-only repo, etc.).
+///
+/// Unlike `garbage_input_note`, only `files`/`removed` are checked:
+/// `analyze_repo` never populates `skipped`/`tests` at all, so those two
+/// fields carry no information in this mode to check against.
+fn repo_outline_empty_note(report: &rinkaku_core::render::Report) -> Option<&'static str> {
+    if !report.files.is_empty() || !report.removed.is_empty() {
+        return None;
+    }
+    Some("note: no supported source files found in the repository")
 }
 
 /// Builds the `TagsResolver` used for `--deps 1` (the default), or `None`
@@ -711,6 +740,25 @@ fn list_git_files(cwd: Option<&std::path::Path>) -> anyhow::Result<Vec<String>> 
         .lines()
         .map(str::to_string)
         .collect())
+}
+
+/// Lists tracked files for ADR 0017's whole-repo outline, same as
+/// `list_git_files(cwd)`, but with guidance attached to a failure via
+/// `anyhow::Context`: bare `rinkaku` (this mode's default, the first thing
+/// a new user is likely to try) run outside a git repository would
+/// otherwise surface only `list_git_files`'s raw `git ls-files` stderr
+/// (e.g. "fatal: not a git repository ..."), which does not tell the reader
+/// what rinkaku itself expects instead. Kept as its own function (rather
+/// than adding this message inside `list_git_files` itself) since that
+/// function's error is reused as-is by every other caller (`--base`/`--pr`'s
+/// own indexing pass in `build_resolver`) where this specific guidance
+/// would not apply.
+fn list_repo_files_for_outline(cwd: Option<&std::path::Path>) -> anyhow::Result<Vec<String>> {
+    use anyhow::Context;
+    list_git_files(cwd).context(
+        "run rinkaku inside a git repository, or pipe a diff (e.g. `gh pr diff 123 | rinkaku`) \
+         or pass --base <ref>",
+    )
 }
 
 /// Resolves which of `paths` are marked "not worth diffing" in
@@ -901,6 +949,12 @@ fn parse_generated_paths(output: &str) -> std::collections::HashSet<String> {
 /// Reads the diff from stdin. Errors with a clear message if stdin is a
 /// terminal (interactive), since there is nothing to read in that case and
 /// `--base` should be used instead.
+///
+/// In practice, `main`'s `if`/`else if` chain already routes every
+/// stdin-is-a-TTY, no-`--base`/`--pr` invocation to ADR 0017's whole-repo
+/// outline before this function is ever called, so this bail is currently
+/// unreachable from that chain. Kept anyway as a defensive check against
+/// future callers of this function or a restructured chain in `main`.
 fn read_stdin_diff() -> anyhow::Result<String> {
     if std::io::stdin().is_terminal() {
         anyhow::bail!(
@@ -3355,6 +3409,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             actual.expect("empty diff must not touch the repository-wide index scan");
         assert_eq!(
             rinkaku_core::render::Report {
+                origin: rinkaku_core::render::ReportOrigin::Diff,
                 files: Vec::new(),
                 skipped: Vec::new(),
                 graph: rinkaku_core::graph::SymbolGraph {
@@ -3494,6 +3549,7 @@ fn should_add_two_numbers() {
 
         fn empty_report() -> Report {
             Report {
+                origin: rinkaku_core::render::ReportOrigin::Diff,
                 files: vec![],
                 skipped: vec![],
                 graph: empty_graph(),
@@ -3505,6 +3561,7 @@ fn should_add_two_numbers() {
 
         fn non_empty_report() -> Report {
             Report {
+                origin: rinkaku_core::render::ReportOrigin::Diff,
                 files: vec![rinkaku_core::render::FileReport {
                     path: "src/lib.rs".to_string(),
                     symbols: vec![],
@@ -3551,6 +3608,7 @@ fn should_add_two_numbers() {
         #[test]
         fn should_return_none_when_report_has_only_skipped_entries() {
             let report = Report {
+                origin: rinkaku_core::render::ReportOrigin::Diff,
                 files: vec![],
                 skipped: vec![rinkaku_core::render::SkippedFile {
                     path: "assets/logo.png".to_string(),
@@ -3576,6 +3634,7 @@ fn should_add_two_numbers() {
         #[test]
         fn should_return_none_when_report_has_only_test_summary_entries() {
             let report = Report {
+                origin: rinkaku_core::render::ReportOrigin::Diff,
                 files: vec![],
                 skipped: vec![],
                 graph: empty_graph(),
@@ -3607,6 +3666,7 @@ fn should_add_two_numbers() {
         #[test]
         fn should_return_none_when_report_has_only_generated_skip_entries() {
             let report = Report {
+                origin: rinkaku_core::render::ReportOrigin::Diff,
                 files: vec![],
                 skipped: vec![
                     rinkaku_core::render::SkippedFile {
@@ -3627,6 +3687,115 @@ fn should_add_two_numbers() {
             let actual = garbage_input_note("some diff text", &report);
 
             assert_eq!(None, actual);
+        }
+    }
+
+    mod repo_outline_empty_note_tests {
+        use super::*;
+        use pretty_assertions::assert_eq;
+        use rinkaku_core::render::Report;
+
+        fn empty_graph() -> rinkaku_core::graph::SymbolGraph {
+            rinkaku_core::graph::SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            }
+        }
+
+        fn empty_report() -> Report {
+            Report {
+                origin: rinkaku_core::render::ReportOrigin::RepoOutline,
+                files: vec![],
+                skipped: vec![],
+                graph: empty_graph(),
+                tests: vec![],
+                hotspots: vec![],
+                removed: vec![],
+            }
+        }
+
+        #[test]
+        fn should_return_note_when_report_has_no_files_and_no_removed() {
+            let actual = repo_outline_empty_note(&empty_report());
+
+            assert_eq!(
+                Some("note: no supported source files found in the repository"),
+                actual
+            );
+        }
+
+        #[test]
+        fn should_return_none_when_report_has_file_entries() {
+            let report = Report {
+                files: vec![rinkaku_core::render::FileReport {
+                    path: "src/lib.rs".to_string(),
+                    symbols: vec![],
+                }],
+                ..empty_report()
+            };
+
+            let actual = repo_outline_empty_note(&report);
+
+            assert_eq!(None, actual);
+        }
+
+        // Regression test: `analyze_repo` leaves `removed` empty on every
+        // path today (ADR 0017's whole point is that nothing changed, so
+        // there is no base side to diff against), but the check still
+        // covers it explicitly so a future extension to `analyze_repo`
+        // doesn't silently regress this note into firing on a report that
+        // does have something to show.
+        #[test]
+        fn should_return_none_when_report_has_removed_entries() {
+            let report = Report {
+                removed: vec![rinkaku_core::extract::RemovedSymbol {
+                    name: "old_helper".to_string(),
+                    kind: rinkaku_core::extract::SymbolKind::Function,
+                    path: "src/lib.rs".to_string(),
+                    signature: "fn old_helper()".to_string(),
+                }],
+                ..empty_report()
+            };
+
+            let actual = repo_outline_empty_note(&report);
+
+            assert_eq!(None, actual);
+        }
+    }
+
+    mod list_repo_files_for_outline_tests {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        // Regression test for the unfriendly-error fix: running whole-repo
+        // mode outside a git repository must not surface only
+        // `list_git_files`'s raw `git ls-files` stderr — the wrapped
+        // message must guide the reader toward what rinkaku actually
+        // expects (a git repo, a piped diff, or `--base`).
+        #[test]
+        fn should_include_guidance_in_error_when_cwd_is_not_a_git_repository() {
+            let dir = tempfile::TempDir::new().expect("create tempdir");
+
+            let actual = list_repo_files_for_outline(Some(dir.path()));
+
+            let error = actual.expect_err("a non-git directory must fail");
+            let message = format!("{error:#}");
+            assert!(
+                message.contains("run rinkaku inside a git repository"),
+                "error message did not contain the expected guidance: {message}"
+            );
+        }
+
+        #[test]
+        fn should_return_tracked_paths_when_cwd_is_a_git_repository() {
+            let dir = tempfile::TempDir::new().expect("create tempdir");
+            init_repo_with_committed_file(dir.path(), "fn foo() {}\n");
+
+            let actual = list_repo_files_for_outline(Some(dir.path()))
+                .expect("a git repository must succeed");
+
+            assert_eq!(vec!["src/lib.rs".to_string()], actual);
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements ADR 0017 (included in this PR, status accepted): running bare `rinkaku` — stdin on a TTY, no `--base`/`--pr` — now builds an outline of the **entire repository** (all symbols + dependency graph) instead of erroring, and opens the TUI when stdout is interactive.

- **Core**: new pure `analyze_repo` builds the report directly from file contents via `extract_all_symbols` — no synthetic empty-tree diff, no diff detour. Classification stays unknown (same semantics as stdin mode without a base); the 1-hop resolver is skipped since every symbol is already in scope.
- **CLI**: mode fires only when stdin is a TTY, so every existing invocation (piped diff, `--base`, `--pr`, empty/garbage stdin) behaves exactly as before. Presentation: `--tui` wins, explicit `--format` wins, otherwise TTY stdout → TUI, piped stdout → Markdown. `Cli.format` became `Option<Format>` to make "not passed" observable.
- **Output vocabulary**: reports now carry a `ReportOrigin` (`Diff`/`RepoOutline`); outlines render "## Repository graph" / "N symbols in M files" instead of "changed" wording. Diff-mode JSON stays byte-identical (origin field is skipped when `Diff`).
- Friendlier failure modes: guided error outside a git repository; stderr note on an empty/all-unsupported repository.

## Review

Three-angle policy per CLAUDE.md (map-assisted, independent, dynamic verification incl. bare TUI run, empty repo, outside-git, deleted-file race). All findings (2 should-fix, 2 nits) fixed in follow-up commits. Round 4 of experiment 0001 recorded.

## Test plan

- `make test` (150 + 318 + 144, all green) / `make lint` clean
- Live: bare `rinkaku` opens whole-repo TUI and quits cleanly; `--format md/json` outline verified; piped-diff and `--base` outputs byte-for-byte unchanged; clap conflicts intact

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync