### PR TITLE
docs: add an LLM review recipe to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,45 @@ Glyphs are plain ASCII (`~`/`!`/`^`/`+`/`x`, `v`/`>` for expand state)
 rather than Unicode/emoji, for compatibility with plainer terminal
 configurations.
 
+## Using rinkaku with LLM reviewers
+
+rinkaku's output works well as a "map" handed to an LLM before it reads a
+diff: the hotspots, contract markers (added/removed/signature-changed),
+and entry-point trees let the reviewer allocate deep-reading attention
+instead of reconstructing the change's structure itself.
+
+1. Generate the map from a **trusted checkout** — a clean `main` build,
+   never the branch under review, so a malicious or buggy diff can't tamper
+   with the tool inspecting it:
+
+   ```sh
+   rinkaku --pr 123 --format md > map.md
+   # or: rinkaku --base main --format md > map.md
+   ```
+
+2. Paste `map.md` at the top of the reviewer's prompt, followed by the
+   actual diff, with instructions along these lines:
+
+   ```
+   Here is a structural map of this change (hotspots, contract markers,
+   entry-point trees). Use it to decide where to read deeply first, but
+   it is an attention-allocation aid, not a verifier: read the full
+   implementation of anything it flags, and don't assume unflagged code
+   is safe to skip. Then review the diff below.
+   ```
+
+3. Run an **independent pass without the map** alongside the map-assisted
+   one. Across repeated trials, the two passes consistently surface
+   different findings rather than one being a superset of the other — see
+   [`docs/experiments/0001-map-assisted-llm-review.md`](docs/experiments/0001-map-assisted-llm-review.md).
+
+4. Whichever pass(es) you run, always add a **dynamic verification**
+   step: build and actually execute the changed code, including
+   failure-mode invocations (non-TTY stdin, empty input, missing files).
+   Behavioral bugs don't show up on the signature surface the map draws
+   from, and the experiment's own rounds found real defects (a non-TTY
+   panic) only by running the binary.
+
 ## Development
 
 Requires a Rust toolchain (pinned in [`rust-toolchain.toml`](rust-toolchain.toml);


### PR DESCRIPTION
## Summary

Adds a "Using rinkaku with LLM reviewers" section to the README — the map-first recipe validated over four rounds of experiment 0001: generate the map from a trusted checkout, hand it to the reviewer as an attention-allocation aid (not a verifier), pair it with an independent no-map pass, and always include dynamic verification.

This was the standing "Next" item in `docs/experiments/0001-map-assisted-llm-review.md` for two rounds.

## Review

Doc-only change; no code surface for the experiment protocol. Self-reviewed for link validity, heading level consistency, and accuracy against the experiment doc's conclusions.

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync