### PR TITLE
feat(tui): add right-pane scrolling with an overflow indicator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,7 @@ dependencies = [
  "ratatui",
  "rinkaku-core",
  "rstest",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,9 @@ self_update = { version = "0.42", default-features = false, features = ["archive
 # rinkaku-tui uses ratatui's own `ratatui::crossterm` re-export instead of
 # depending on crossterm directly (see rinkaku-tui/Cargo.toml).
 ratatui = "0.30"
+# Already pulled in transitively by ratatui (its own line-wrapping widget
+# uses it), but declared directly here too: rinkaku-tui's own `wrap_lines`
+# (crate::ui) needs the same display-width calculation to make its manual
+# wrap match ratatui's scroll unit exactly, so it must not rely on staying
+# an un-pinned transitive dep.
+unicode-width = "0.2"

--- a/README.md
+++ b/README.md
@@ -470,6 +470,14 @@ placeholder.
   for a file row, or just the hunks intersecting a symbol's own line range
   for a symbol row (a directory row has no single diff to show, since it
   spans multiple files).
+- **Scrolling the right-hand pane:** `J`/`K` scroll the Detail/Diff pane
+  down/up by one line when its content is too long to fit — the pane's
+  title grows a `(first-last/total)` suffix (e.g. `Detail (1-17/43)`)
+  whenever there's more to see, so a long cycle-edge list or a large
+  file's diff doesn't quietly get cut off. The scroll position resets to
+  the top whenever the underlying content could have changed: moving the
+  cursor, toggling between the detail and diff views, or returning from
+  the source view.
 - **Source view:** `s` on a symbol row opens that file, scrolled to and
   highlighting the symbol's line range; `esc`/`q` returns to the entry
   view. Reads the working tree directly (not the historical commit a
@@ -489,6 +497,7 @@ placeholder.
 | `c` / `C` | Collapse every row |
 | `o` / `O` | Toggle topological / alphabetical ordering |
 | `d` / `D` | Toggle the right-hand pane between detail and diff |
+| `J` / `K` | Scroll the right-hand pane (Detail/Diff) down/up |
 | `s` / `S` | Open the source view for the symbol under the cursor |
 | `esc` / `q` | Return to the entry view (from the source view) |
 | `q` / `ctrl-c` | Quit (from the entry view) |

--- a/docs/experiments/0001-map-assisted-llm-review.md
+++ b/docs/experiments/0001-map-assisted-llm-review.md
@@ -279,9 +279,77 @@ through 19 test literals).
   matching `TagsResolver::new`) cheap to check and marked
   pre-existing code as safe to skip.
 
+## Results (round 5)
+
+Same two-pass method, fifth subject: right-pane scrolling in the TUI
+(4 files, +493/−15 — new scroll state in `App`, draw-time clamping and
+an overflow indicator in `ui.rs`). The first subject to contain
+genuine blockers.
+
+| Metric              | A (map)     | B (control) |
+| ------------------- | ----------- | ----------- |
+| Output tokens       | 115.2k      | 108.1k      |
+| Tool calls          | 66          | 53          |
+| Wall clock          | 558s        | 397s        |
+| Blocker findings    | 2           | 2           |
+| Should-fix findings | 1           | 2           |
+| Nit findings        | 0           | 1           |
+
+- **Both arms independently found — and live-reproduced — the same
+  two blockers**: (1) the scroll clamp and indicator count logical
+  lines while ratatui's `Paragraph` scrolls wrapped rows, so any
+  wrapped long line makes tail content permanently unreachable while
+  the indicator claims everything is shown; (2) collapse/expand/select
+  never reset the scroll offset even though a collapse can re-target
+  the cursor to a different node, opening the new content pre-scrolled
+  past its own header. First full cross-arm convergence in five
+  rounds, and it happened on the first subject with real blockers —
+  encouraging evidence that the process converges on defects that
+  matter regardless of reading strategy.
+- Both discoveries were made by **interacting with the running
+  binary** (narrow terminals, scroll-then-collapse sequences), then
+  explained by code reading. The orchestrator's own third-angle
+  spot-check had exercised only short lines and cursor-reset paths
+  and pronounced the feature working — a concrete demonstration that
+  a hands-on smoke test by the coordinating agent is not a substitute
+  for adversarial reviewers with time to probe edges.
+- Map metadata cuts both ways this round: the map's dependency edges
+  under `draw_detail_pane` pointed A at `cycle_edges`' full-path lines
+  — exactly the realistic trigger for blocker 1 — but the defect's
+  *mechanism* lives in the ratatui dependency's wrap-vs-scroll
+  semantics, outside anything a change map can show. And blocker 2's
+  mechanism (`nav.rs`'s cursor re-targeting) sits in **unchanged**
+  code, which the change map by design does not draw — the map
+  actively lacked the one edge that made the regression provable. A
+  change-scoped map cannot flag regressions whose mechanism is
+  pre-existing; only reading beyond the diff does.
+- Unique findings were extensions rather than independent defects:
+  A added the `ToggleOrder` reset gap (same root cause as blocker 2);
+  B added missing-test observations and a clone-per-frame nit.
+- Both blockers (and the reset gap) were fixed before merge; the fix
+  re-verified against each pass's original reproduction steps.
+
+## Conclusions (after 5 rounds)
+
+- On the first subject with genuine blockers, both arms found both,
+  independently and with live reproductions — the two-pass design's
+  redundancy paid off as confidence, not just coverage.
+- The strongest single predictor of finding real defects across all
+  five rounds is **hands-on execution with hostile inputs** (narrow
+  terminals, malformed diffs, non-TTY environments), not reading
+  strategy. The map's role stays what round 4 concluded:
+  verification routing and attention allocation.
+- New limit identified: the change map cannot surface regressions
+  whose mechanism lies in unchanged code or in a dependency's
+  semantics — both blockers this round had exactly that shape.
+  Reviewer instructions should explicitly license reading beyond the
+  diff (and the CLAUDE.md three-angle policy already does).
+
 ## Next
 
-- Document the map-first recipe in the README's LLM usage section
-  (map from a trusted build, paired with an independent pass).
 - Consider a map feature flagging cross-crate duplicate-domain
   symbols (round 3 hypothesis, still open).
+- The round-5 blockers suggest a second tool hypothesis: listing the
+  *unchanged* symbols that changed symbols newly depend on (the map
+  currently draws edges only among changed/1-hop symbols) might have
+  surfaced `retarget_cursor` as blast-radius context for `handle_key`.

--- a/rinkaku-tui/Cargo.toml
+++ b/rinkaku-tui/Cargo.toml
@@ -23,6 +23,7 @@ rinkaku-core = { path = "../rinkaku-core", version = "0.1.0" }
 # version internally (see ratatui-crossterm) — declaring it here too would
 # just be a second, redundant version to keep in sync.
 ratatui = { workspace = true }
+unicode-width = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -44,6 +44,13 @@ pub enum InputKey {
     /// then moving the cursor keeps showing the diff pane for the newly
     /// selected row instead of resetting on every cursor move.
     ToggleDiff,
+    /// `J`: scroll the right-hand pane (Detail/Diff) down by one line.
+    /// Uppercase specifically so it does not collide with `j`'s existing
+    /// cursor-move binding (`crate::run`'s `translate_key` matches
+    /// `KeyCode::Char` case-sensitively).
+    ScrollDown,
+    /// `K`: scroll the right-hand pane up by one line (see [`Self::ScrollDown`]).
+    ScrollUp,
     /// Esc or `q` while in the source view: return to the entry view.
     /// A no-op on the entry view itself (`q`'s quit behavior on the entry
     /// view is `InputKey::Quit`, a separate variant, since Esc has no
@@ -123,6 +130,21 @@ pub struct App {
     order_mode: OrderMode,
     screen: Screen,
     right_pane: RightPane,
+    /// The user's requested scroll offset (in lines) into the right-hand
+    /// pane's content, as an unclamped "how far down would the user like to
+    /// be" value rather than an authoritative display position: `App` has
+    /// no notion of the pane's rendered height (that is a `ratatui::Rect`
+    /// only `crate::ui` sees at draw time), so clamping this to
+    /// `content_len.saturating_sub(pane_height)` is `crate::ui`'s
+    /// responsibility (`ui::clamp_scroll`) — keeping this module free of
+    /// any layout concern, matching the rest of `App`'s pure-state
+    /// discipline. Reset to 0 whenever the pane's underlying content could
+    /// have changed out from under the current offset: cursor movement
+    /// (`InputKey::Up`/`Down`, a different row's detail/diff), the
+    /// Detail/Diff toggle (a different content stream entirely), and any
+    /// screen transition (`InputKey::Source`/`Back`) — see `handle_key`'s
+    /// match arms for exactly which trigger each reset.
+    right_pane_scroll: usize,
     /// A transient message for the status line (e.g. a source-read
     /// failure) — cleared on the next action that doesn't re-set it, so a
     /// stale error doesn't linger forever once the user has moved on.
@@ -151,6 +173,7 @@ impl App {
             order_mode,
             screen: Screen::Entry,
             right_pane: RightPane::default(),
+            right_pane_scroll: 0,
             status: None,
             should_quit: false,
         }
@@ -183,6 +206,13 @@ impl App {
 
     pub fn right_pane(&self) -> RightPane {
         self.right_pane
+    }
+
+    /// The user's requested scroll offset into the right-hand pane — see
+    /// the `right_pane_scroll` field's own doc comment on why this is an
+    /// unclamped request rather than an authoritative display position.
+    pub fn right_pane_scroll(&self) -> usize {
+        self.right_pane_scroll
     }
 
     pub fn status(&self) -> Option<&str> {
@@ -270,6 +300,11 @@ impl App {
         match (&self.screen, key) {
             (Screen::Source { .. }, InputKey::Back) => {
                 self.screen = Screen::Entry;
+                // The right pane was last showing whatever row was under
+                // the cursor before `s` opened the source view; returning
+                // here should not carry over an old scroll position for
+                // content the user has not looked at yet in this session.
+                self.right_pane_scroll = 0;
             }
             // Every other key is a no-op while the source view is open —
             // navigation/reordering only make sense against the entry
@@ -282,9 +317,11 @@ impl App {
             }
             (Screen::Entry, InputKey::Up) => {
                 self.nav = self.nav.handle(Action::CursorUp, &self.tree);
+                self.right_pane_scroll = 0;
             }
             (Screen::Entry, InputKey::Down) => {
                 self.nav = self.nav.handle(Action::CursorDown, &self.tree);
+                self.right_pane_scroll = 0;
             }
             (Screen::Entry, InputKey::Select) => {
                 self.nav = self.nav.handle(Action::ToggleExpand, &self.tree);
@@ -318,6 +355,13 @@ impl App {
                     RightPane::Detail => RightPane::Diff,
                     RightPane::Diff => RightPane::Detail,
                 };
+                self.right_pane_scroll = 0;
+            }
+            (Screen::Entry, InputKey::ScrollDown) => {
+                self.right_pane_scroll = self.right_pane_scroll.saturating_add(1);
+            }
+            (Screen::Entry, InputKey::ScrollUp) => {
+                self.right_pane_scroll = self.right_pane_scroll.saturating_sub(1);
             }
             (Screen::Entry, InputKey::Back) => {
                 // No-op: Esc/q-as-back on the entry view has nowhere to
@@ -666,6 +710,123 @@ mod tests {
                 range_end: 7,
             }),
             actual
+        );
+    }
+
+    #[test]
+    fn should_start_with_zero_right_pane_scroll() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_increment_right_pane_scroll_when_scroll_down_is_pressed() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let app = app
+            .handle_key(InputKey::ScrollDown)
+            .handle_key(InputKey::ScrollDown);
+
+        assert_eq!(2, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_decrement_right_pane_scroll_when_scroll_up_is_pressed() {
+        let report = empty_report();
+        let app = App::new(&report)
+            .handle_key(InputKey::ScrollDown)
+            .handle_key(InputKey::ScrollDown);
+        assert_eq!(2, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::ScrollUp);
+
+        assert_eq!(1, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_not_scroll_up_past_zero() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let app = app.handle_key(InputKey::ScrollUp);
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_reset_right_pane_scroll_when_cursor_moves_down() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::ScrollDown)
+            .handle_key(InputKey::ScrollDown);
+        assert_eq!(2, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::Down);
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_reset_right_pane_scroll_when_cursor_moves_up() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::ScrollDown);
+        assert_eq!(1, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::Up);
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_reset_right_pane_scroll_when_toggling_diff_pane() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ScrollDown);
+        assert_eq!(1, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::ToggleDiff);
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_reset_right_pane_scroll_when_returning_from_source_screen() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::ScrollDown)
+            .handle_key(InputKey::Source);
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string()
+            },
+            *app.screen()
+        );
+
+        let app = app.handle_key(InputKey::Back);
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_ignore_scroll_keys_while_source_screen_is_open() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Source);
+
+        let app = app.handle_key(InputKey::ScrollDown);
+
+        assert_eq!(0, app.right_pane_scroll());
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string()
+            },
+            *app.screen()
         );
     }
 }

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -138,12 +138,12 @@ pub struct App {
     /// `content_len.saturating_sub(pane_height)` is `crate::ui`'s
     /// responsibility (`ui::clamp_scroll`) — keeping this module free of
     /// any layout concern, matching the rest of `App`'s pure-state
-    /// discipline. Reset to 0 whenever the pane's underlying content could
-    /// have changed out from under the current offset: cursor movement
-    /// (`InputKey::Up`/`Down`, a different row's detail/diff), the
-    /// Detail/Diff toggle (a different content stream entirely), and any
-    /// screen transition (`InputKey::Source`/`Back`) — see `handle_key`'s
-    /// match arms for exactly which trigger each reset.
+    /// discipline. Reset to 0 by every key `handle_key` processes *except*
+    /// `InputKey::ScrollDown`/`ScrollUp` on [`Screen::Entry`] (`handle_key`'s
+    /// own doc comment on why this is a blanket rule rather than an
+    /// enumerated list of "actions that change the pane's content" — the
+    /// cursor can move *indirectly*, e.g. a collapse retargeting it onto a
+    /// different row, which an enumerated list is prone to missing).
     right_pane_scroll: usize,
     /// A transient message for the status line (e.g. a source-read
     /// failure) — cleared on the next action that doesn't re-set it, so a
@@ -294,17 +294,29 @@ impl App {
     /// cursor is a present symbol before switching screens — the actual
     /// file read happens later, in `crate::run`, once `Screen::Source` is
     /// active) and is otherwise unused.
+    ///
+    /// `right_pane_scroll` is reset to 0 by every key *except*
+    /// `ScrollDown`/`ScrollUp` on [`Screen::Entry`] — a uniform rule applied
+    /// once below, rather than each action deciding individually whether it
+    /// might change the right pane's content. The per-action approach used
+    /// to miss cases where the cursor moves *indirectly*: collapsing a
+    /// directory (`Select`/`CollapseAll`) can retarget the cursor onto a
+    /// different row via `Nav::retarget_cursor`, and reordering
+    /// (`ToggleOrder`) can do the same simply by changing which row now
+    /// sits at the same cursor index — both used to leave a stale nonzero
+    /// scroll offset pointing into the *new* row's unrelated content. Only
+    /// `ScrollDown`/`ScrollUp` are exempt, since they are the two actions
+    /// whose entire purpose is to set this value.
     pub fn handle_key(mut self, key: InputKey) -> Self {
         self.status = None;
+        let preserve_scroll = matches!(
+            (&self.screen, key),
+            (Screen::Entry, InputKey::ScrollDown) | (Screen::Entry, InputKey::ScrollUp)
+        );
 
         match (&self.screen, key) {
             (Screen::Source { .. }, InputKey::Back) => {
                 self.screen = Screen::Entry;
-                // The right pane was last showing whatever row was under
-                // the cursor before `s` opened the source view; returning
-                // here should not carry over an old scroll position for
-                // content the user has not looked at yet in this session.
-                self.right_pane_scroll = 0;
             }
             // Every other key is a no-op while the source view is open —
             // navigation/reordering only make sense against the entry
@@ -317,11 +329,9 @@ impl App {
             }
             (Screen::Entry, InputKey::Up) => {
                 self.nav = self.nav.handle(Action::CursorUp, &self.tree);
-                self.right_pane_scroll = 0;
             }
             (Screen::Entry, InputKey::Down) => {
                 self.nav = self.nav.handle(Action::CursorDown, &self.tree);
-                self.right_pane_scroll = 0;
             }
             (Screen::Entry, InputKey::Select) => {
                 self.nav = self.nav.handle(Action::ToggleExpand, &self.tree);
@@ -355,7 +365,6 @@ impl App {
                     RightPane::Detail => RightPane::Diff,
                     RightPane::Diff => RightPane::Detail,
                 };
-                self.right_pane_scroll = 0;
             }
             (Screen::Entry, InputKey::ScrollDown) => {
                 self.right_pane_scroll = self.right_pane_scroll.saturating_add(1);
@@ -368,6 +377,10 @@ impl App {
                 // return to. Quitting from the entry view is the
                 // dedicated `InputKey::Quit` variant instead.
             }
+        }
+
+        if !preserve_scroll {
+            self.right_pane_scroll = 0;
         }
 
         self
@@ -828,5 +841,98 @@ mod tests {
             },
             *app.screen()
         );
+    }
+
+    /// Two independent top-level directories, each with one file holding
+    /// one symbol — deep/wide enough that `Nav::retarget_cursor` can land
+    /// the cursor on a genuinely different node after a collapse, matching
+    /// `nav.rs`'s own `should_not_move_cursor_when_collapse_happens_elsewhere_in_the_tree`
+    /// fixture shape. Expanded row order: a(0), a/one.rs(1), foo(2), b(3),
+    /// b/two.rs(4), bar(5).
+    fn report_with_two_directories() -> Report {
+        Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![
+                FileReport {
+                    path: "a/one.rs".to_string(),
+                    symbols: vec![symbol("a/one.rs::foo", "foo")],
+                },
+                FileReport {
+                    path: "b/two.rs".to_string(),
+                    symbols: vec![symbol("b/two.rs::bar", "bar")],
+                },
+            ],
+            ..empty_report()
+        }
+    }
+
+    #[test]
+    fn should_reset_right_pane_scroll_when_select_collapses_the_row_under_the_cursor() {
+        // Row 0 is "a" itself; collapsing it via `Select` hides its
+        // children but the cursor's own row survives unmoved — still a
+        // case the blanket reset rule must cover, since a directory row's
+        // own detail content (fan-in/badges) does not depend on which of
+        // its children are currently shown, but this pins the simplest
+        // Select case regardless.
+        let report = report_with_two_directories();
+        let app = App::new(&report).handle_key(InputKey::ScrollDown);
+        assert_eq!(1, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::Select);
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_reset_right_pane_scroll_when_collapse_all_retargets_cursor_onto_a_different_node() {
+        // Cursor starts on "bar" (row 5, under "b/two.rs"); CollapseAll
+        // hides every file/symbol row, and `Nav::retarget_cursor` lands the
+        // cursor on "b" (the nearest still-visible ancestor) — a genuinely
+        // different node's detail than the one the pre-collapse scroll
+        // offset was scrolled into.
+        let report = report_with_two_directories();
+        let mut app = App::new(&report);
+        for _ in 0..5 {
+            app = app.handle_key(InputKey::Down);
+        }
+        let rows = app.nav().rows(app.tree());
+        assert_eq!("b/two.rs", rows[app.nav().cursor()].node.path);
+        let app = app
+            .handle_key(InputKey::ScrollDown)
+            .handle_key(InputKey::ScrollDown);
+        assert_eq!(2, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::CollapseAll);
+
+        let rows = app.nav().rows(app.tree());
+        assert_eq!("b", rows[app.nav().cursor()].node.path);
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_reset_right_pane_scroll_when_expand_all_is_pressed() {
+        let report = report_with_two_directories();
+        let app = App::new(&report)
+            .handle_key(InputKey::CollapseAll)
+            .handle_key(InputKey::ScrollDown);
+        assert_eq!(1, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::ExpandAll);
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_reset_right_pane_scroll_when_toggle_order_is_pressed() {
+        // ToggleOrder can change which row now sits at the same cursor
+        // index (reordering siblings), so it must reset the scroll offset
+        // even though it never calls into `Nav` at all.
+        let report = report_with_two_directories();
+        let app = App::new(&report).handle_key(InputKey::ScrollDown);
+        assert_eq!(1, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::ToggleOrder);
+
+        assert_eq!(0, app.right_pane_scroll());
     }
 }

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -147,6 +147,13 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         KeyCode::Char('c') | KeyCode::Char('C') => Some(InputKey::CollapseAll),
         KeyCode::Char('o') | KeyCode::Char('O') => Some(InputKey::ToggleOrder),
         KeyCode::Char('d') | KeyCode::Char('D') => Some(InputKey::ToggleDiff),
+        // Uppercase specifically: `j`/`k` already move the tree cursor, so
+        // the right-pane scroll needs a key that doesn't collide with
+        // them. Shift+j/k arrives here as the distinct `Char('J')`/`Char('K')`
+        // values (crossterm folds Shift into the char itself for plain
+        // letter keys), so this needs no separate modifier check.
+        KeyCode::Char('J') => Some(InputKey::ScrollDown),
+        KeyCode::Char('K') => Some(InputKey::ScrollUp),
         KeyCode::Char('s') | KeyCode::Char('S') => Some(InputKey::Source),
         KeyCode::Esc if on_source_screen => Some(InputKey::Back),
         KeyCode::Char('q') if on_source_screen => Some(InputKey::Back),
@@ -207,5 +214,38 @@ mod tests {
         let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
 
         assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_translate_uppercase_j_to_scroll_down() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('J'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ScrollDown), actual);
+    }
+
+    #[test]
+    fn should_translate_uppercase_k_to_scroll_up() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('K'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ScrollUp), actual);
+    }
+
+    #[test]
+    fn should_translate_lowercase_j_to_down_not_scroll() {
+        // Regression guard: lowercase j/k must keep moving the tree cursor
+        // (InputKey::Down/Up) rather than being swallowed by the new
+        // uppercase-only scroll bindings.
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::Down), actual);
     }
 }

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -84,9 +84,8 @@ fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
-    let block = Block::bordered().title(" Detail ");
-
     let Some(detail) = app.selected_detail(report) else {
+        let block = Block::bordered().title(" Detail ");
         let paragraph = Paragraph::new("(select a row to see its detail)")
             .block(block)
             .wrap(ratatui::widgets::Wrap { trim: false });
@@ -99,10 +98,7 @@ fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
         SelectedDetail::Dir(detail) => dir_detail_lines(detail, report.origin),
         SelectedDetail::File(detail) => file_detail_lines(detail),
     };
-    let paragraph = Paragraph::new(lines)
-        .block(block)
-        .wrap(ratatui::widgets::Wrap { trim: false });
-    frame.render_widget(paragraph, area);
+    render_scrollable_pane(frame, " Detail ", &lines, app.right_pane_scroll(), area);
 }
 
 /// Draws the diff pane (TUI iteration 2, [`RightPane::Diff`]): the raw
@@ -121,9 +117,8 @@ fn draw_diff_pane(
     diff_files: &[FileHunks],
     area: Rect,
 ) {
-    let block = Block::bordered().title(" Diff ");
-
     let Some(target) = app.selected_diff_target(report) else {
+        let block = Block::bordered().title(" Diff ");
         let paragraph = Paragraph::new("(select a symbol or file row to see its diff)")
             .block(block)
             .wrap(ratatui::widgets::Wrap { trim: false });
@@ -151,6 +146,7 @@ fn draw_diff_pane(
     };
 
     if hunks.is_empty() {
+        let block = Block::bordered().title(" Diff ");
         let paragraph = Paragraph::new(format!("(no diff hunks found for {path})"))
             .block(block)
             .wrap(ratatui::widgets::Wrap { trim: false });
@@ -159,10 +155,81 @@ fn draw_diff_pane(
     }
 
     let lines = diff_pane_lines(&hunks);
-    let paragraph = Paragraph::new(lines)
+    render_scrollable_pane(frame, " Diff ", &lines, app.right_pane_scroll(), area);
+}
+
+/// Renders `lines` into a bordered pane titled `title`, scrolled to
+/// `requested_scroll` lines down and clamped to what actually fits
+/// (`clamp_scroll`'s own doc comment on why clamping only happens here,
+/// not in `crate::app`). When the content overflows the pane's inner
+/// height, the title grows a `(first-last/total)` suffix so the reviewer
+/// knows more content exists below/above without needing to scroll blind
+/// (this iteration's answer to "全部が見えているように見えて実は続きがある"
+/// — the same concern `crate::source`'s highlighted-window view sidesteps
+/// by auto-centering instead of paginating).
+///
+/// Both the Detail and Diff panes share this one function rather than each
+/// duplicating the clamp-then-scroll-then-indicator sequence, since the two
+/// panes' only difference is which `Vec<Line>` and title they pass in.
+fn render_scrollable_pane(
+    frame: &mut Frame,
+    title: &str,
+    lines: &[Line<'static>],
+    requested_scroll: usize,
+    area: Rect,
+) {
+    // 2 rows for the top/bottom border, matching `draw_source_screen`'s
+    // own `saturating_sub(2)` convention for a bordered pane's inner
+    // height.
+    let viewport_height = area.height.saturating_sub(2) as usize;
+    let scroll = clamp_scroll(lines.len(), viewport_height, requested_scroll);
+
+    // Callers pass a title already padded with a leading/trailing space
+    // (e.g. `" Detail "`, matching every other `Block` title in this
+    // module) — trim the trailing one before appending the indicator so
+    // the two don't produce a double space (`"Detail  (1-17/43)"`).
+    let title = match scroll_indicator(lines.len(), viewport_height, scroll) {
+        Some(indicator) => format!("{}{indicator} ", title.trim_end()),
+        None => title.to_string(),
+    };
+
+    let block = Block::bordered().title(title);
+    let paragraph = Paragraph::new(lines.to_vec())
         .block(block)
-        .wrap(ratatui::widgets::Wrap { trim: false });
+        .wrap(ratatui::widgets::Wrap { trim: false })
+        .scroll((scroll as u16, 0));
     frame.render_widget(paragraph, area);
+}
+
+/// Clamps a requested scroll offset (lines) to `[0, content_len -
+/// viewport_height]` — the largest offset that still leaves the viewport
+/// full of content rather than trailing off into blank space below the
+/// last line. Returns 0 whenever the content already fits entirely
+/// (`content_len <= viewport_height`, including `viewport_height == 0`
+/// defensively), so a pane that has nothing to scroll can never report a
+/// nonzero offset.
+///
+/// Deliberately pure and free of any `ratatui`/ `Rect` type (just the three
+/// `usize`s a caller already has in hand) so it is unit-testable without a
+/// `TestBackend` — `crate::app::App` intentionally does not do this
+/// clamping itself (see `right_pane_scroll`'s own doc comment): only
+/// `crate::ui`, at draw time, knows the pane's actual rendered height.
+fn clamp_scroll(content_len: usize, viewport_height: usize, requested_scroll: usize) -> usize {
+    let max_scroll = content_len.saturating_sub(viewport_height);
+    requested_scroll.min(max_scroll)
+}
+
+/// Builds the `(first-last/total)` title suffix for a pane whose content
+/// overflows its viewport, or `None` when everything already fits (nothing
+/// to indicate). `scroll` must already be clamped (`clamp_scroll`) — this
+/// function does not re-clamp, it only formats.
+fn scroll_indicator(content_len: usize, viewport_height: usize, scroll: usize) -> Option<String> {
+    if content_len <= viewport_height {
+        return None;
+    }
+    let first_visible = scroll + 1;
+    let last_visible = (scroll + viewport_height).min(content_len);
+    Some(format!(" ({first_visible}-{last_visible}/{content_len})"))
 }
 
 /// Formats a list of [`Hunk`]s into styled lines: hunk headers dim, `+`
@@ -452,7 +519,7 @@ fn source_lines(source: &SourceView, start: usize, end: usize) -> Vec<Line<'stat
 fn draw_status_line(frame: &mut Frame, app: &App, area: Rect) {
     let help = match app.screen() {
         Screen::Entry => {
-            "j/k: move  enter/space: expand  e/c: expand/collapse all  o: order  d: diff  s: source  q: quit"
+            "j/k: move  enter/space: expand  e/c: expand/collapse  o: order  d: diff  J/K: scroll  s: source  q: quit"
         }
         Screen::Source { .. } => "esc/q: back",
     };
@@ -698,10 +765,11 @@ index e69de29..4b825dc 100644
         let report = report_with_one_symbol();
         let app = App::new(&report);
         // Wider than the default 80 columns used elsewhere in this test
-        // module: the full help text is ~86 columns and would otherwise
-        // be truncated (the status line intentionally does not wrap),
-        // hiding the "quit" fragment this test checks for.
-        let mut terminal = Terminal::new(TestBackend::new(100, 20)).expect("terminal");
+        // module: the full help text (now including the J/K scroll hint)
+        // is ~104 columns and would otherwise be truncated (the status
+        // line intentionally does not wrap), hiding the "quit" fragment
+        // this test checks for.
+        let mut terminal = Terminal::new(TestBackend::new(110, 20)).expect("terminal");
 
         terminal
             .draw(|frame| draw(frame, &app, &report, &[]))
@@ -730,5 +798,205 @@ index e69de29..4b825dc 100644
         assert!(text.contains("Source: lib.rs::foo"));
         assert!(text.contains("failed to read"));
         assert!(text.contains("back"));
+    }
+
+    // --- clamp_scroll / scroll_indicator (pure helpers) ---
+
+    #[test]
+    fn should_return_zero_scroll_when_content_fits_entirely() {
+        let actual = clamp_scroll(5, 10, 3);
+
+        assert_eq!(0, actual);
+    }
+
+    #[test]
+    fn should_clamp_requested_scroll_to_max_scroll_when_it_overshoots() {
+        // 20 lines of content in a 10-row viewport: max_scroll = 10, so a
+        // request of 15 clamps down to 10 (the last full page).
+        let actual = clamp_scroll(20, 10, 15);
+
+        assert_eq!(10, actual);
+    }
+
+    #[test]
+    fn should_pass_through_requested_scroll_when_within_bounds() {
+        let actual = clamp_scroll(20, 10, 4);
+
+        assert_eq!(4, actual);
+    }
+
+    #[test]
+    fn should_return_zero_scroll_when_viewport_height_is_zero() {
+        // A degenerate (zero-height) pane can never scroll — `max_scroll`
+        // saturates at `content_len` itself, but a requested scroll of 0
+        // (the only value `App` ever starts at) still clamps to 0.
+        let actual = clamp_scroll(20, 0, 0);
+
+        assert_eq!(0, actual);
+    }
+
+    #[test]
+    fn should_return_none_indicator_when_content_fits_entirely() {
+        let actual = scroll_indicator(5, 10, 0);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_return_indicator_at_top_when_content_overflows_and_scroll_is_zero() {
+        let actual = scroll_indicator(20, 10, 0);
+
+        assert_eq!(Some(" (1-10/20)".to_string()), actual);
+    }
+
+    #[test]
+    fn should_return_indicator_reflecting_scroll_position() {
+        let actual = scroll_indicator(20, 10, 4);
+
+        assert_eq!(Some(" (5-14/20)".to_string()), actual);
+    }
+
+    #[test]
+    fn should_clamp_last_visible_to_content_len_at_max_scroll() {
+        // scroll=10, viewport=10 would naively suggest last_visible=20,
+        // which happens to equal content_len here anyway; this pins the
+        // `.min(content_len)` clamp directly rather than relying on the
+        // coincidence.
+        let actual = scroll_indicator(20, 10, 10);
+
+        assert_eq!(Some(" (11-20/20)".to_string()), actual);
+    }
+
+    // --- rendered scroll behavior (TestBackend) ---
+
+    /// A report whose single file has `count` symbols, each referencing
+    /// `report_with_one_symbol`'s pattern but repeated enough times that
+    /// `file_detail_lines` produces more lines than a typical test
+    /// viewport's height — used to exercise `draw_detail_pane`'s scrolling
+    /// and overflow-indicator paths, which need content that does not fit
+    /// in one screen.
+    fn report_with_many_symbols(count: usize) -> Report {
+        let symbols: Vec<ExtractedSymbol> = (0..count)
+            .map(|i| symbol(&format!("lib.rs::sym{i}"), &format!("sym{i}")))
+            .collect();
+        Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols,
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    #[test]
+    fn should_show_overflow_indicator_in_detail_pane_title_when_content_exceeds_viewport() {
+        // Row 0 is the "lib.rs" file row itself: `file_detail_lines` lists
+        // a "File lib.rs" header, a blank line, a "Symbols (40)" header,
+        // then all 40 symbols (43 lines total) — comfortably more than a
+        // 20-row terminal's inner pane height can show at once.
+        let report = report_with_many_symbols(40);
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &[]))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        // Exact bounds depend on the pane's inner height (20 - 2 for the
+        // status line/border layout), so this only pins the shape/start
+        // rather than the literal end number, keeping the test robust to
+        // an unrelated layout tweak elsewhere in this module.
+        assert!(text.contains("Detail (1-"));
+        assert!(text.contains("/43)"));
+    }
+
+    #[test]
+    fn should_not_show_overflow_indicator_when_content_fits_the_viewport() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &[]))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains(" Detail "));
+        assert!(!text.contains("Detail ("));
+    }
+
+    #[test]
+    fn should_scroll_detail_pane_content_down_when_scroll_down_is_pressed() {
+        let report = report_with_many_symbols(40);
+        let app = App::new(&report).handle_key(crate::app::InputKey::ScrollDown);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &[]))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        // One line scrolled down: the first visible content line is now 2
+        // instead of 1, and the "File lib.rs" header line (the very first
+        // content line, before the two blank/"Symbols (40)" header lines
+        // that precede the actual symbol list) has scrolled out of view.
+        assert!(text.contains("Detail (2-"));
+        assert!(!text.contains("File lib.rs"));
+    }
+
+    #[test]
+    fn should_clamp_detail_pane_scroll_at_the_last_page() {
+        // Request an enormous scroll far past the end of a 40-symbol
+        // report; the pane must clamp to its last full page rather than
+        // showing a mostly-blank pane past the end of the content.
+        let report = report_with_many_symbols(40);
+        let mut app = App::new(&report);
+        for _ in 0..1000 {
+            app = app.handle_key(crate::app::InputKey::ScrollDown);
+        }
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &[]))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        // The last symbol must be visible once clamped to the final page.
+        assert!(text.contains("sym39"));
+    }
+
+    #[test]
+    fn should_reset_scroll_indicator_when_cursor_moves_to_a_different_row() {
+        // Scroll down on the file row's detail, then move the cursor onto
+        // a symbol row: `App::handle_key`'s reset-on-cursor-move rule means
+        // the newly selected row's own (short) detail must render from the
+        // top, not carry over the file row's scroll offset.
+        let report = report_with_many_symbols(40);
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::ScrollDown)
+            .handle_key(crate::app::InputKey::ScrollDown)
+            .handle_key(crate::app::InputKey::Down);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &[]))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        // A single symbol's own detail (used-by/callees, both empty here)
+        // fits well within the viewport, so no overflow indicator should
+        // appear even though the file row's detail definitely overflowed.
+        assert!(text.contains(" Detail "));
+        assert!(!text.contains("Detail ("));
     }
 }

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -21,6 +21,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph};
 use rinkaku_core::extract::Classification;
 use rinkaku_core::render::{Report, ReportOrigin};
+use unicode_width::UnicodeWidthChar;
 
 /// Draws one full frame: the entry view (tree + right pane split) or the
 /// source drill-down, depending on `app.screen()`, with a status/help line
@@ -171,6 +172,19 @@ fn draw_diff_pane(
 /// Both the Detail and Diff panes share this one function rather than each
 /// duplicating the clamp-then-scroll-then-indicator sequence, since the two
 /// panes' only difference is which `Vec<Line>` and title they pass in.
+///
+/// `lines` is wrapped (via [`wrap_lines`]) to the pane's inner width
+/// *before* `clamp_scroll`/`scroll_indicator` run and *before* handing it to
+/// `Paragraph`, and `Paragraph::wrap` is deliberately not used here: that
+/// widget's own line-wrapping happens after `Paragraph::scroll` has already
+/// consumed `scroll.y` as an offset into the *unwrapped* logical lines, so
+/// any logical line long enough to wrap desyncs the scroll unit from the
+/// rendered unit — content past the first wrapped line of such a line
+/// becomes unreachable at any scroll offset, and the overflow indicator
+/// (computed from logical line count) undercounts and falsely claims
+/// everything is visible. Wrapping first makes every one of
+/// `clamp_scroll`/`scroll_indicator`/`Paragraph::scroll` operate on the same
+/// "one rendered terminal row" unit.
 fn render_scrollable_pane(
     frame: &mut Frame,
     title: &str,
@@ -178,27 +192,110 @@ fn render_scrollable_pane(
     requested_scroll: usize,
     area: Rect,
 ) {
-    // 2 rows for the top/bottom border, matching `draw_source_screen`'s
-    // own `saturating_sub(2)` convention for a bordered pane's inner
-    // height.
+    // 2 columns/rows for the left/right and top/bottom border, matching
+    // `draw_source_screen`'s own `saturating_sub(2)` convention for a
+    // bordered pane's inner height.
+    let viewport_width = area.width.saturating_sub(2) as usize;
     let viewport_height = area.height.saturating_sub(2) as usize;
-    let scroll = clamp_scroll(lines.len(), viewport_height, requested_scroll);
+    let wrapped = wrap_lines(lines, viewport_width);
+    let scroll = clamp_scroll(wrapped.len(), viewport_height, requested_scroll);
 
     // Callers pass a title already padded with a leading/trailing space
     // (e.g. `" Detail "`, matching every other `Block` title in this
     // module) — trim the trailing one before appending the indicator so
     // the two don't produce a double space (`"Detail  (1-17/43)"`).
-    let title = match scroll_indicator(lines.len(), viewport_height, scroll) {
+    let title = match scroll_indicator(wrapped.len(), viewport_height, scroll) {
         Some(indicator) => format!("{}{indicator} ", title.trim_end()),
         None => title.to_string(),
     };
 
     let block = Block::bordered().title(title);
-    let paragraph = Paragraph::new(lines.to_vec())
+    let paragraph = Paragraph::new(wrapped)
         .block(block)
-        .wrap(ratatui::widgets::Wrap { trim: false })
         .scroll((scroll as u16, 0));
     frame.render_widget(paragraph, area);
+}
+
+/// Wraps each of `lines` to `width` display columns, splitting a logical
+/// [`Line`] into as many output lines as needed while keeping each [`Span`]'s
+/// style attached to the fragment it contributed (a wrap point can fall
+/// mid-span, in which case the span itself is split and both fragments keep
+/// the original span's style). Width is measured with
+/// [`UnicodeWidthChar::width`] (falling back to 1 column for the zero-width/
+/// control-character case `width()` returns `None` for) rather than byte or
+/// `char` count, so a wide (e.g. full-width CJK) character that would
+/// overflow `width` on its own wraps onto the next line instead of being
+/// sliced in half.
+///
+/// A pure, unit-testable stand-in for `ratatui::widgets::Wrap`'s own
+/// char-wrapping (`trim: false` mode) — needed because this crate must know
+/// the *wrapped* line count up front, before `Paragraph::scroll` ever runs
+/// (see `render_scrollable_pane`'s doc comment on why `Paragraph::wrap`
+/// itself cannot be used for a scrollable pane). Deliberately does not
+/// attempt `ratatui::widgets::Wrap`'s word-boundary trimming behavior —
+/// content here is source/diff text, not prose, so a plain character wrap
+/// (breaking wherever the width limit is hit, mid-word if needed) is the
+/// right fidelity, not an approximation to chase.
+///
+/// `width == 0` returns `lines` unchanged (nothing meaningful to wrap
+/// into — an actual zero-width pane cannot render any column anyway, and
+/// looping without ever advancing would otherwise be a defensive infinite-
+/// loop risk).
+fn wrap_lines(lines: &[Line<'static>], width: usize) -> Vec<Line<'static>> {
+    if width == 0 {
+        return lines.to_vec();
+    }
+
+    let mut output = Vec::new();
+    for line in lines {
+        output.extend(wrap_one_line(line, width));
+    }
+    output
+}
+
+/// Wraps a single logical [`Line`] into one or more output lines, per
+/// [`wrap_lines`]'s doc comment. A line with no spans at all (a blank line)
+/// produces exactly one empty output line, matching `ratatui::widgets::Wrap`
+/// rendering a blank logical line as one blank row rather than zero rows.
+fn wrap_one_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
+    let mut result_lines = Vec::new();
+    let mut current_spans: Vec<Span<'static>> = Vec::new();
+    let mut current_width = 0usize;
+
+    for span in &line.spans {
+        let style = span.style;
+        let mut fragment = String::new();
+        let mut fragment_width = 0usize;
+
+        for ch in span.content.chars() {
+            let char_width = ch.width().unwrap_or(1);
+
+            if current_width + fragment_width + char_width > width {
+                // Flush the fragment accumulated so far (if any) onto the
+                // current output line, then start a brand-new output line —
+                // the char that overflowed becomes the first char of the
+                // next fragment.
+                if !fragment.is_empty() {
+                    current_spans.push(Span::styled(fragment.clone(), style));
+                    fragment.clear();
+                    fragment_width = 0;
+                }
+                result_lines.push(Line::from(std::mem::take(&mut current_spans)).style(line.style));
+                current_width = 0;
+            }
+
+            fragment.push(ch);
+            fragment_width += char_width;
+        }
+
+        if !fragment.is_empty() {
+            current_spans.push(Span::styled(fragment, style));
+            current_width += fragment_width;
+        }
+    }
+
+    result_lines.push(Line::from(current_spans).style(line.style));
+    result_lines
 }
 
 /// Clamps a requested scroll offset (lines) to `[0, content_len -
@@ -998,5 +1095,192 @@ index e69de29..4b825dc 100644
         // appear even though the file row's detail definitely overflowed.
         assert!(text.contains(" Detail "));
         assert!(!text.contains("Detail ("));
+    }
+
+    // --- wrap_lines (pure helper) ---
+
+    #[test]
+    fn should_return_lines_unchanged_when_width_is_zero() {
+        let lines = vec![Line::raw("hello world")];
+
+        let actual = wrap_lines(&lines, 0);
+
+        assert_eq!(lines, actual);
+    }
+
+    #[test]
+    fn should_return_one_empty_line_when_input_line_is_blank() {
+        let lines = vec![Line::raw("")];
+
+        let actual = wrap_lines(&lines, 10);
+
+        assert_eq!(vec![Line::raw("")], actual);
+    }
+
+    #[test]
+    fn should_not_wrap_when_line_fits_exactly_within_width() {
+        let lines = vec![Line::raw("abcde")];
+
+        let actual = wrap_lines(&lines, 5);
+
+        assert_eq!(vec![Line::raw("abcde")], actual);
+    }
+
+    #[test]
+    fn should_split_long_ascii_line_into_multiple_lines_at_the_width_boundary() {
+        let lines = vec![Line::raw("abcdefghij")];
+
+        let actual = wrap_lines(&lines, 4);
+
+        assert_eq!(
+            vec![Line::raw("abcd"), Line::raw("efgh"), Line::raw("ij"),],
+            actual
+        );
+    }
+
+    #[test]
+    fn should_wrap_full_width_characters_without_splitting_a_double_width_char_across_lines() {
+        // Each "あ" is 2 columns wide; a width-3 pane can fit "あ" (2) plus
+        // one more column, but the second "あ" would overflow to column 4,
+        // so it wraps onto the next line rather than being sliced in half.
+        let lines = vec![Line::raw("ああa")];
+
+        let actual = wrap_lines(&lines, 3);
+
+        assert_eq!(vec![Line::raw("あ"), Line::raw("あa")], actual);
+    }
+
+    #[test]
+    fn should_preserve_span_style_on_both_fragments_when_a_styled_span_is_split_by_wrapping() {
+        let style = Style::default().fg(Color::Red);
+        let lines = vec![Line::from(vec![Span::styled("abcdef", style)])];
+
+        let actual = wrap_lines(&lines, 4);
+
+        assert_eq!(
+            vec![
+                Line::from(vec![Span::styled("abcd", style)]),
+                Line::from(vec![Span::styled("ef", style)]),
+            ],
+            actual
+        );
+    }
+
+    #[test]
+    fn should_preserve_distinct_span_styles_when_a_multi_span_line_wraps_across_span_boundaries() {
+        // "ab" (unstyled) + "cdef" (red): a width-3 wrap must split after
+        // "abc" (2 unstyled chars + 1 red char) and carry each fragment's
+        // own style into the split, not just the first span's.
+        let red = Style::default().fg(Color::Red);
+        let lines = vec![Line::from(vec![Span::raw("ab"), Span::styled("cdef", red)])];
+
+        let actual = wrap_lines(&lines, 3);
+
+        assert_eq!(
+            vec![
+                Line::from(vec![Span::raw("ab"), Span::styled("c", red)]),
+                Line::from(vec![Span::styled("def", red)]),
+            ],
+            actual
+        );
+    }
+
+    #[test]
+    fn should_wrap_each_logical_line_independently_when_multiple_lines_are_passed() {
+        let lines = vec![Line::raw("abcdef"), Line::raw("xy")];
+
+        let actual = wrap_lines(&lines, 4);
+
+        assert_eq!(
+            vec![Line::raw("abcd"), Line::raw("ef"), Line::raw("xy")],
+            actual
+        );
+    }
+
+    // --- long-line scroll reachability regression (TestBackend) ---
+
+    #[test]
+    fn should_reach_the_last_wrapped_line_of_content_via_scrolling_when_a_logical_line_is_long_enough_to_wrap()
+     {
+        // A narrow pane (30 inner columns after the 2-column border) with a
+        // single logical line far longer than that — mirrors a real fan-in
+        // entry's full path being too long for the pane. Before wrapping was
+        // applied before the scroll offset, the scroll unit (logical lines)
+        // and the render unit (wrapped rows) disagreed, so a marker placed
+        // near the end of this one long logical line was unreachable at any
+        // scroll offset. Regression coverage for that desync.
+        let long_line = format!("{}TAIL_MARKER", "x".repeat(200));
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: long_line.clone(),
+                symbols: vec![],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        };
+        let mut app = App::new(&report);
+        // Scroll far enough down to reach the wrapped tail of the long path
+        // line, however many wrapped rows that turns out to be.
+        for _ in 0..200 {
+            app = app.handle_key(crate::app::InputKey::ScrollDown);
+        }
+        let mut terminal = Terminal::new(TestBackend::new(34, 12)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &[]))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("TAIL_MARKER"));
+    }
+
+    #[test]
+    fn should_report_indicator_total_as_wrapped_row_count_not_logical_line_count_when_a_line_wraps()
+    {
+        // Same narrow pane/long-path setup as the reachability regression
+        // above: the file row's detail is exactly 2 logical lines ("File
+        // <path>" plus a blank line, since this report has no symbols), but
+        // the long path line wraps into several rows — the indicator's
+        // "/total" must count wrapped rows, not the 2 logical lines, or the
+        // indicator would (wrongly) claim everything fits and hide it
+        // entirely.
+        let long_line = format!("{}TAIL_MARKER", "x".repeat(200));
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: long_line,
+                symbols: vec![],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        };
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(34, 12)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &[]))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        // Inner width is 34 - 2 = 32 columns; the long line alone wraps into
+        // ceil(211 / 32) = 7 rows, well over the "/2" a logical-line count
+        // would have produced.
+        assert!(text.contains("Detail (1-"));
+        assert!(!text.contains("/2)"));
     }
 }


### PR DESCRIPTION
## Summary

Adds scrolling to the TUI's right-hand pane (Detail and Diff), closing the gap found in the PR #51 review: long whole-file diffs and cycle-edge lists were silently cut off at the pane height with no indication more content existed.

- `J`/`K` scroll the right pane one line down/up (uppercase — lowercase `j`/`k` keep moving the tree cursor).
- The pane title gains a `(first-last/total)` indicator whenever content overflows the viewport.
- `App` holds an unclamped requested offset; clamping happens at draw time (`App` stays free of layout concerns). Scroll resets to top on every entry-screen key except the scroll keys themselves, so no action can carry a stale offset onto different content.
- Lines are pre-wrapped (style-preserving, display-width aware via `unicode-width`) before scroll math, so the scroll unit, clamp, indicator, and rendered rows all agree exactly.

## Review

Three-angle policy per CLAUDE.md. Both review passes independently found and live-reproduced **two blockers** in the initial implementation (wrap-vs-scroll unit mismatch making tail content unreachable; missing scroll reset on collapse/expand cursor re-targeting) — both fixed in follow-up commits and re-verified against each pass's original reproduction steps. Round 5 of experiment 0001 recorded, including a newly identified limit of change-scoped maps.

## Test plan

- `make test` (183 TUI tests among them) / `make lint` clean
- Live tmux verification at 90x12: wrapped long lines reachable to the last row, indicator counts wrapped rows, reset on CollapseAll, clean quit

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync