### PR TITLE
feat(tui): syntax-highlight the diff pane via tree-sitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,12 @@ dependencies = [
  "ratatui",
  "rinkaku-core",
  "rstest",
+ "tree-sitter",
+ "tree-sitter-go",
+ "tree-sitter-highlight",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-typescript",
  "unicode-width",
 ]
 
@@ -2839,6 +2845,18 @@ checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
 dependencies = [
  "cc",
  "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-highlight"
+version = "0.26.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d5c68e5dba9c2818166330961143812b22a286e51a107a0733766b50dfc87d"
+dependencies = [
+ "regex",
+ "streaming-iterator",
+ "thiserror 2.0.18",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -469,7 +469,11 @@ placeholder.
   unified-diff hunks instead of the detail view — every hunk of the file
   for a file row, or just the hunks intersecting a symbol's own line range
   for a symbol row (a directory row has no single diff to show, since it
-  spans multiple files).
+  spans multiple files). Hunks in the four built-in languages are
+  syntax-highlighted (keywords, strings, types, ...); added/removed lines
+  keep their green/red diff signal as a background tint so it doesn't
+  compete with token colors, and any other file falls back to plain
+  green/red text.
 - **Scrolling the right-hand pane:** `J`/`K` scroll the Detail/Diff pane
   down/up by one line when its content is too long to fit — the pane's
   title grows a `(first-last/total)` suffix (e.g. `Detail (1-17/43)`)

--- a/docs/adr/0018-syntax-highlight-diff-pane-via-tree-sitter.md
+++ b/docs/adr/0018-syntax-highlight-diff-pane-via-tree-sitter.md
@@ -1,0 +1,65 @@
+# 0018. Syntax-highlight the TUI diff pane via tree-sitter-highlight
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+The diff pane (`d`, since PR #51) renders hunks as whole-line green/red/
+plain text. Users read code in that pane, and uniform per-line coloring
+throws away the structure every editor gives them; the request for
+syntax highlighting came from dogfooding. rinkaku already parses every
+supported language with tree-sitter (ADR 0002), and each grammar crate
+in use ships a `HIGHLIGHTS_QUERY`, so a highlighting stack is nearly
+free — the design questions are which stack, what unit to parse, how to
+compose token colors with the diff's added/removed signal, and where
+the code lives.
+
+A hunk is a slice of a file, not a parseable file, and single lines
+parse even worse. But each hunk cleanly reconstructs into two texts:
+the new side (context + added lines) and the old side (context +
+removed lines), each of which is contiguous source the parser can
+handle with tree-sitter's usual error tolerance.
+
+## Decision
+
+Highlight the diff pane with the `tree-sitter-highlight` crate and the
+grammar crates' bundled `HIGHLIGHTS_QUERY`, entirely inside
+`rinkaku-tui` (presentation concern; ADR 0015/0016 split —
+`rinkaku-core`'s `LanguageSupport` is untouched, and the TUI keeps its
+own path→grammar/query table for the four built-in languages). Per
+hunk, reconstruct the new-side and old-side texts, highlight each side
+once, and map token styles back to the display lines: token colors set
+the foreground; the added/removed signal moves to a 256-color
+background tint (dark green/red) with the `+`/`-` marker keeping its
+bold foreground color; hunk headers stay dim. Highlighting runs once
+per run alongside the existing once-per-run hunk parse (never inside
+the render loop), and any failure — unknown extension, query error —
+falls back per file to the current plain green/red styling.
+
+## Alternatives
+
+- **syntect (Sublime grammars), as delta uses**: mature highlighting,
+  but introduces a second, regex-based parsing stack alongside
+  tree-sitter in a project whose identity is tree-sitter. Rejected.
+- **Per-line parsing**: simplest mapping, but single lines misparse
+  constantly (unclosed delimiters, missing context). Rejected for
+  quality; side-reconstruction costs little more.
+- **Extending core's `LanguageSupport` with a highlight query**: keeps
+  one language registry, but grows a core port for a purely
+  presentational need. Rejected; revisit if the built-in language
+  count grows enough that the TUI-side table hurts.
+
+## Consequences
+
+- The diff pane reads like an editor; body-only changes become easier
+  to scan, which is the pane's whole purpose.
+- Two new TUI-only dependencies (`tree-sitter-highlight`, the grammar
+  crates moving into `rinkaku-tui`'s dependency set as well) and a
+  small duplicated language table (4 entries) to keep core pure.
+- Background tints assume a 256-color terminal; on true 16-color
+  terminals the tint degrades but the `+`/`-` markers and gutter keep
+  the diff signal legible.
+- Old-side reconstruction means removed lines get highlighted in
+  old-code context — correct, at the cost of parsing each hunk twice.
+  Hunks are small; the once-per-run budget absorbs it.

--- a/docs/experiments/0001-map-assisted-llm-review.md
+++ b/docs/experiments/0001-map-assisted-llm-review.md
@@ -345,11 +345,71 @@ genuine blockers.
   Reviewer instructions should explicitly license reading beyond the
   diff (and the CLAUDE.md three-angle policy already does).
 
+## Results (round 6)
+
+Same two-pass method, sixth subject: diff-pane syntax highlighting per
+ADR 0018 (7 files, +1,266/−35 — a new pure highlight module, render
+wiring, two new dependencies). Both passes' prompts explicitly carried
+round 5's lesson (read beyond the diff at the wrap/offset seams) and
+named the highest-risk failure shape (tree-sitter's byte offsets
+crossing into char/display-width code).
+
+| Metric              | A (map)     | B (control) |
+| ------------------- | ----------- | ----------- |
+| Output tokens       | 125.0k      | 112.5k      |
+| Tool calls          | 51          | 53          |
+| Wall clock          | 352s        | 351s        |
+| Blocker findings    | 0           | 0           |
+| Should-fix findings | 0           | 0           |
+| Nit findings        | 2           | 2           |
+
+- **First fully clean round on a code subject** — and not for lack of
+  probing: both arms independently built multibyte fixtures (Japanese
+  comments, emoji), drove interleaved add/remove hunks through a live
+  TUI with ANSI capture, and traced the byte-offset → char-width
+  handoff line by line before concluding it safe. Convergent clean
+  verification of the same high-risk seam, reached by different
+  routes, is the round's real output: confidence, not findings.
+- Process lessons visibly compounded. The implementation had already
+  absorbed round 3's defect class — highlighting is precomputed once
+  per run because the spec said so, citing the earlier per-frame
+  re-parse finding — and both reviewers verified that guarantee
+  rather than discovering its absence. Encoding past rounds' lessons
+  into implementer and reviewer prompts converts them from findings
+  into non-events.
+- All four nits (two from each arm, no overlap) were
+  documentation-precision and test-coverage items (a doc comment
+  describing its own lookup backwards; four palette entries with no
+  pinned style test); all fixed before merge.
+- The orchestrator's third angle contributed the only quantitative
+  gap: highlighting adds ~2.8s of once-per-run startup on an
+  unusually large 4.5k-line diff (release build, ~2.4s → ~5.2s).
+  Both reviewers verified the once-per-run *placement* qualitatively;
+  neither measured its cost. Accepted for v1 — typical PR diffs are
+  an order of magnitude smaller — with lazy per-file highlighting as
+  the follow-up if it bites.
+
+## Conclusions (after 6 rounds)
+
+- The two-pass + mandatory-execution protocol now has both failure
+  and success calibration: it finds real blockers when they exist
+  (round 5, both arms) and comes back clean when the implementation
+  is sound (round 6, both arms probing the same worst-case inputs) —
+  the clean verdict is trustworthy *because* the probing was visible
+  and adversarial.
+- Feeding each round's lessons forward — into implementer specs and
+  reviewer prompts alike — measurably moves defect classes from
+  "found in review" to "prevented at implementation." The experiment
+  doc itself has become part of the quality mechanism.
+- Standing gap: none of the review angles measures performance
+  unprompted. Worth adding an explicit cost-measurement note to the
+  dynamic-verification instruction for changes that add per-run work.
+
 ## Next
 
 - Consider a map feature flagging cross-crate duplicate-domain
   symbols (round 3 hypothesis, still open).
-- The round-5 blockers suggest a second tool hypothesis: listing the
-  *unchanged* symbols that changed symbols newly depend on (the map
-  currently draws edges only among changed/1-hop symbols) might have
-  surfaced `retarget_cursor` as blast-radius context for `handle_key`.
+- Round 5's second tool hypothesis (list unchanged symbols that
+  changed symbols newly depend on) also remains open.
+- Add an explicit performance-measurement step to the
+  dynamic-verification angle for changes introducing per-run work.

--- a/rinkaku-tui/Cargo.toml
+++ b/rinkaku-tui/Cargo.toml
@@ -24,6 +24,16 @@ rinkaku-core = { path = "../rinkaku-core", version = "0.1.0" }
 # just be a second, redundant version to keep in sync.
 ratatui = { workspace = true }
 unicode-width = { workspace = true }
+# Diff-pane syntax highlighting (ADR 0018): a TUI-only presentation
+# concern, so the grammar crates are duplicated here rather than adding a
+# highlight-query method to rinkaku-core's `LanguageSupport` port (ADR
+# 0018's rejected "extend core" alternative).
+tree-sitter = { workspace = true }
+tree-sitter-highlight = "0.26"
+tree-sitter-rust = { workspace = true }
+tree-sitter-go = { workspace = true }
+tree-sitter-python = { workspace = true }
+tree-sitter-typescript = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/rinkaku-tui/src/highlight.rs
+++ b/rinkaku-tui/src/highlight.rs
@@ -30,9 +30,10 @@ use crate::diff_view::{DiffLine, DiffLineKind, Hunk};
 /// The token palette this module recognizes, in the order passed to
 /// `HighlightConfiguration::configure` — a capture's resolved `Highlight`
 /// index is a position into this slice, so `crate::ui`'s palette-to-style
-/// lookup and this list must stay in lockstep (matched by index, not by
-/// name, at the point where `crate::ui` turns a [`TokenSpan`] into a
-/// `ratatui::style::Style`). A deliberately small subset of the capture
+/// lookup and this list must stay in lockstep: `crate::ui` resolves a
+/// [`TokenSpan`]'s index back to its name via this slice before matching
+/// on the name, so reordering entries here silently re-colors tokens even
+/// though nothing fails to compile. A deliberately small subset of the capture
 /// names the four bundled grammars' `HIGHLIGHTS_QUERY` files actually
 /// emit that a reviewer benefits from distinguishing, not every capture
 /// name `tree_sitter_highlight::STANDARD_CAPTURE_NAMES` documents.

--- a/rinkaku-tui/src/highlight.rs
+++ b/rinkaku-tui/src/highlight.rs
@@ -1,0 +1,715 @@
+//! Syntax highlighting for the diff pane (ADR 0018).
+//!
+//! Kept in `rinkaku-tui`, not `rinkaku-core`: this is a presentation
+//! concern layered on top of the raw hunks `crate::diff_view` already
+//! parses, not a change to the extraction pipeline. `rinkaku-core`'s
+//! `LanguageSupport` port stays untouched (ADR 0018's rejected
+//! "extend core" alternative) — this module keeps its own small
+//! extension -> grammar/query table for the same four built-in languages,
+//! mirroring `rinkaku_core::language`'s registry style without depending
+//! on it.
+//!
+//! Pipeline per hunk (`highlight_hunk`):
+//! 1. Reconstruct the hunk's new-side text (context + added lines) and
+//!    old-side text (context + removed lines) — a hunk itself is a slice
+//!    of a file and does not parse well; each side is contiguous source
+//!    tree-sitter's usual error tolerance can handle.
+//! 2. Highlight each side once with `tree-sitter-highlight`.
+//! 3. Map the resulting token spans back onto each display line's
+//!    original position (new-side lines get their new-side highlight,
+//!    old-side lines get their old-side highlight).
+//!
+//! Any failure along the way — unrecognized extension, query/parse error —
+//! falls back to `None` per line, which `crate::ui` renders with the
+//! existing plain green/red styling rather than losing the diff entirely.
+
+use tree_sitter_highlight::{Highlight, HighlightConfiguration, HighlightEvent, Highlighter};
+
+use crate::diff_view::{DiffLine, DiffLineKind, Hunk};
+
+/// The token palette this module recognizes, in the order passed to
+/// `HighlightConfiguration::configure` — a capture's resolved `Highlight`
+/// index is a position into this slice, so `crate::ui`'s palette-to-style
+/// lookup and this list must stay in lockstep (matched by index, not by
+/// name, at the point where `crate::ui` turns a [`TokenSpan`] into a
+/// `ratatui::style::Style`). A deliberately small subset of the capture
+/// names the four bundled grammars' `HIGHLIGHTS_QUERY` files actually
+/// emit that a reviewer benefits from distinguishing, not every capture
+/// name `tree_sitter_highlight::STANDARD_CAPTURE_NAMES` documents.
+pub const PALETTE: &[&str] = &[
+    "keyword", "string", "comment", "function", "type", "number", "constant", "property",
+    "variable",
+];
+
+/// One highlighted token span within a line, in byte offsets against that
+/// line's own text (not the reconstructed side text) — `content` in
+/// [`DiffLine`] terms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenSpan {
+    pub start: usize,
+    pub end: usize,
+    /// Index into [`PALETTE`] naming which token kind this span is.
+    pub palette_index: usize,
+}
+
+/// Per-line highlight result: `Some(spans)` when highlighting succeeded
+/// for the file's language (an empty `Vec` is a valid, meaningful result —
+/// a blank line has no tokens), `None` when this line's file/hunk could
+/// not be highlighted at all (unknown extension, parse/query failure) —
+/// `crate::ui` reads `None` as "fall back to the plain diff style for this
+/// line".
+pub type LineHighlight = Option<Vec<TokenSpan>>;
+
+/// Looks up the tree-sitter grammar and highlights query for `path`'s
+/// extension, mirroring `rinkaku_core::language::language_for_path`'s
+/// extension-dispatch style without depending on that crate's registry
+/// (ADR 0018: kept as a separate, TUI-only table).
+fn config_for_path(path: &str) -> Option<HighlightConfiguration> {
+    let extension = path.rsplit('.').next()?;
+    let (language, highlights_query, injection_query, locals_query) = match extension {
+        "rs" => (
+            tree_sitter_rust::LANGUAGE.into(),
+            tree_sitter_rust::HIGHLIGHTS_QUERY,
+            tree_sitter_rust::INJECTIONS_QUERY,
+            "",
+        ),
+        "go" => (
+            tree_sitter_go::LANGUAGE.into(),
+            tree_sitter_go::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+        "py" => (
+            tree_sitter_python::LANGUAGE.into(),
+            tree_sitter_python::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+        "ts" => (
+            tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            tree_sitter_typescript::HIGHLIGHTS_QUERY,
+            "",
+            tree_sitter_typescript::LOCALS_QUERY,
+        ),
+        "tsx" => (
+            tree_sitter_typescript::LANGUAGE_TSX.into(),
+            tree_sitter_typescript::HIGHLIGHTS_QUERY,
+            "",
+            tree_sitter_typescript::LOCALS_QUERY,
+        ),
+        _ => return None,
+    };
+
+    let mut config = HighlightConfiguration::new(
+        language,
+        extension,
+        highlights_query,
+        injection_query,
+        locals_query,
+    )
+    .ok()?;
+    config.configure(PALETTE);
+    Some(config)
+}
+
+/// Reconstructs a hunk's new-side text: every `Context`/`Added` line's
+/// content, joined with `\n` — the text tree-sitter parses to highlight
+/// what the file looks like *after* the change. Returns the joined text
+/// plus, for each `Added`/`Context` line's original index in `hunk.lines`,
+/// the byte range of that line's content within the joined text (so
+/// highlight spans can be mapped back to the right display line).
+fn reconstruct_side(
+    lines: &[DiffLine],
+    keep: DiffLineKind,
+) -> (String, Vec<(usize, usize, usize)>) {
+    let mut text = String::new();
+    // (original line index, start byte, end byte) per kept line.
+    let mut offsets = Vec::new();
+
+    for (index, line) in lines.iter().enumerate() {
+        let included = match keep {
+            DiffLineKind::Added => matches!(line.kind, DiffLineKind::Added | DiffLineKind::Context),
+            DiffLineKind::Removed => {
+                matches!(line.kind, DiffLineKind::Removed | DiffLineKind::Context)
+            }
+            DiffLineKind::Context => unreachable!("keep is always Added or Removed"),
+        };
+        if !included {
+            continue;
+        }
+
+        let start = text.len();
+        text.push_str(&line.content);
+        let end = text.len();
+        offsets.push((index, start, end));
+        text.push('\n');
+    }
+
+    (text, offsets)
+}
+
+/// Highlights `text` with `config`, returning the resolved token spans in
+/// byte-offset order, or `None` on any parse/highlight failure — the
+/// caller's cue to fall back to the plain diff style for every line this
+/// text covers.
+fn highlight_text(config: &HighlightConfiguration, text: &str) -> Option<Vec<TokenSpan>> {
+    let mut highlighter = Highlighter::new();
+    let events = highlighter
+        .highlight(config, text.as_bytes(), None, |_| None)
+        .ok()?;
+
+    let mut spans = Vec::new();
+    let mut active: Vec<Highlight> = Vec::new();
+    for event in events {
+        match event.ok()? {
+            HighlightEvent::HighlightStart(highlight) => active.push(highlight),
+            HighlightEvent::HighlightEnd => {
+                active.pop();
+            }
+            HighlightEvent::Source { start, end } => {
+                // The innermost (most specific) active capture wins when
+                // queries nest — tree-sitter-highlight already resolves
+                // overlapping captures via its own precedence rules before
+                // emitting events, so the last-pushed (topmost) highlight
+                // on the stack is the one to render.
+                if let Some(highlight) = active.last() {
+                    spans.push(TokenSpan {
+                        start,
+                        end,
+                        palette_index: highlight.0,
+                    });
+                }
+            }
+        }
+    }
+
+    Some(spans)
+}
+
+/// Slices `spans` (byte offsets into the reconstructed side text) down to
+/// the sub-range `[line_start, line_end)` belonging to one display line,
+/// rebasing each span's offsets to be relative to that line's own text —
+/// the coordinate space [`TokenSpan`] documents.
+fn spans_for_line(spans: &[TokenSpan], line_start: usize, line_end: usize) -> Vec<TokenSpan> {
+    spans
+        .iter()
+        .filter_map(|span| {
+            let start = span.start.max(line_start);
+            let end = span.end.min(line_end);
+            if start >= end {
+                return None;
+            }
+            Some(TokenSpan {
+                start: start - line_start,
+                end: end - line_start,
+                palette_index: span.palette_index,
+            })
+        })
+        .collect()
+}
+
+/// Highlights every line of `hunk`, keyed by `path`'s extension, returning
+/// one [`LineHighlight`] per entry in `hunk.lines` (same length, same
+/// order). Falls back to `vec![None; hunk.lines.len()]` when `path`'s
+/// extension is unrecognized or either side fails to highlight — the
+/// whole hunk degrades together rather than partially, since a
+/// parse/query failure on one side says nothing useful about whether the
+/// other would have looked visually consistent next to it.
+pub fn highlight_hunk(path: &str, hunk: &Hunk) -> Vec<LineHighlight> {
+    let fallback = || vec![None; hunk.lines.len()];
+
+    let Some(config) = config_for_path(path) else {
+        return fallback();
+    };
+
+    let (new_text, new_offsets) = reconstruct_side(&hunk.lines, DiffLineKind::Added);
+    let (old_text, old_offsets) = reconstruct_side(&hunk.lines, DiffLineKind::Removed);
+
+    let Some(new_spans) = highlight_text(&config, &new_text) else {
+        return fallback();
+    };
+    let Some(old_spans) = highlight_text(&config, &old_text) else {
+        return fallback();
+    };
+
+    let mut result: Vec<LineHighlight> = vec![None; hunk.lines.len()];
+    for (index, start, end) in new_offsets {
+        result[index] = Some(spans_for_line(&new_spans, start, end));
+    }
+    for (index, start, end) in old_offsets {
+        result[index] = Some(spans_for_line(&old_spans, start, end));
+    }
+
+    result
+}
+
+/// One file's hunks, each already highlighted — `hunks[i]` corresponds
+/// positionally to `crate::diff_view::FileHunks::hunks[i]` for the same
+/// path (see [`highlight_diff_files`]'s doc comment on why this crate
+/// keeps the association by position/pointer rather than growing
+/// `crate::diff_view::Hunk` itself with a highlight field).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HighlightedFile {
+    pub path: String,
+    pub hunks: Vec<Vec<LineHighlight>>,
+}
+
+/// Highlights every hunk of every file in `files` once. Called exactly
+/// once per TUI session, immediately after `crate::diff_view::parse_diff_hunks`
+/// (`crate::run_app`'s doc comment on why parsing itself is once-per-run,
+/// not per-frame) — highlighting is strictly more expensive than parsing
+/// (a full tree-sitter parse per hunk side, twice), so it must not run
+/// inside the render loop either.
+///
+/// Kept as a separate, parallel `Vec<HighlightedFile>` rather than adding
+/// a highlight field onto `crate::diff_view::Hunk` itself: `diff_view` is
+/// a pure, dependency-free diff-text parser predating this feature, and
+/// this module is the one new dependency on `tree-sitter-highlight` (ADR
+/// 0018) — keeping them separate means a parse failure in this module can
+/// never affect `diff_view`'s own parsing, and `diff_view`'s existing
+/// tests stay untouched.
+pub fn highlight_diff_files(files: &[crate::diff_view::FileHunks]) -> Vec<HighlightedFile> {
+    files
+        .iter()
+        .map(|file| HighlightedFile {
+            path: file.path.clone(),
+            hunks: file
+                .hunks
+                .iter()
+                .map(|hunk| highlight_hunk(&file.path, hunk))
+                .collect(),
+        })
+        .collect()
+}
+
+/// Looks up the precomputed highlight for `hunk`, matching it against
+/// `highlighted.hunks` by pointer identity against `file_hunks.hunks`
+/// (rather than by value/`header` text, which is not guaranteed unique
+/// within a file) — valid because every `&Hunk` `crate::ui` ever holds for
+/// a given file (via `crate::diff_view::hunks_for_range` or a direct
+/// `file.hunks.iter()`) is borrowed straight through from that same
+/// `FileHunks`, never cloned, so its address always matches one entry of
+/// `file_hunks.hunks`. Returns `None` when no match is found (defensive —
+/// would only happen if a caller passed a `Hunk` from a different
+/// `FileHunks` than the one `highlighted` was computed from) or when
+/// `highlighted` itself is `None` (path not found in the precomputed
+/// set), both of which fall back to the plain diff style exactly like an
+/// unrecognized extension does.
+pub fn lookup_hunk_highlight<'a>(
+    highlighted: Option<&'a HighlightedFile>,
+    file_hunks: &crate::diff_view::FileHunks,
+    hunk: &Hunk,
+) -> Option<&'a [LineHighlight]> {
+    let highlighted = highlighted?;
+    let index = file_hunks
+        .hunks
+        .iter()
+        .position(|candidate| std::ptr::eq(candidate, hunk))?;
+    highlighted.hunks.get(index).map(|lines| lines.as_slice())
+}
+
+/// Finds the [`HighlightedFile`] for `path` in the precomputed set, or
+/// `None` when the diff has no entry for it — mirrors
+/// `crate::diff_view::file_hunks`'s own lookup-by-path convention.
+pub fn highlighted_file<'a>(
+    files: &'a [HighlightedFile],
+    path: &str,
+) -> Option<&'a HighlightedFile> {
+    files.iter().find(|f| f.path == path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff_view::DiffLineKind;
+    use pretty_assertions::assert_eq;
+
+    fn line(kind: DiffLineKind, content: &str) -> DiffLine {
+        DiffLine {
+            kind,
+            content: content.to_string(),
+        }
+    }
+
+    // --- reconstruct_side ---
+
+    #[test]
+    fn should_reconstruct_new_side_from_context_and_added_lines_only() {
+        let lines = vec![
+            line(DiffLineKind::Context, "fn a() {}"),
+            line(DiffLineKind::Added, "fn b() {}"),
+            line(DiffLineKind::Removed, "fn old() {}"),
+            line(DiffLineKind::Context, "fn c() {}"),
+        ];
+
+        let (text, offsets) = reconstruct_side(&lines, DiffLineKind::Added);
+
+        assert_eq!("fn a() {}\nfn b() {}\nfn c() {}\n", text);
+        assert_eq!(vec![(0, 0, 9), (1, 10, 19), (3, 20, 29)], offsets);
+    }
+
+    #[test]
+    fn should_reconstruct_old_side_from_context_and_removed_lines_only() {
+        let lines = vec![
+            line(DiffLineKind::Context, "fn a() {}"),
+            line(DiffLineKind::Added, "fn b() {}"),
+            line(DiffLineKind::Removed, "fn old() {}"),
+            line(DiffLineKind::Context, "fn c() {}"),
+        ];
+
+        let (text, offsets) = reconstruct_side(&lines, DiffLineKind::Removed);
+
+        assert_eq!("fn a() {}\nfn old() {}\nfn c() {}\n", text);
+        assert_eq!(vec![(0, 0, 9), (2, 10, 21), (3, 22, 31)], offsets);
+    }
+
+    #[test]
+    fn should_return_empty_text_when_no_lines_match_the_requested_side() {
+        let lines = vec![line(DiffLineKind::Added, "fn b() {}")];
+
+        let (text, offsets) = reconstruct_side(&lines, DiffLineKind::Removed);
+
+        assert_eq!("", text);
+        assert_eq!(Vec::<(usize, usize, usize)>::new(), offsets);
+    }
+
+    // --- spans_for_line ---
+
+    #[test]
+    fn should_rebase_and_clip_spans_to_the_requested_line_range() {
+        let spans = vec![
+            TokenSpan {
+                start: 0,
+                end: 2,
+                palette_index: 0,
+            },
+            TokenSpan {
+                start: 5,
+                end: 9,
+                palette_index: 1,
+            },
+            TokenSpan {
+                start: 20,
+                end: 25,
+                palette_index: 2,
+            },
+        ];
+
+        let actual = spans_for_line(&spans, 5, 10);
+
+        assert_eq!(
+            vec![TokenSpan {
+                start: 0,
+                end: 4,
+                palette_index: 1,
+            }],
+            actual
+        );
+    }
+
+    #[test]
+    fn should_return_empty_when_no_span_overlaps_the_line_range() {
+        let spans = vec![TokenSpan {
+            start: 0,
+            end: 2,
+            palette_index: 0,
+        }];
+
+        let actual = spans_for_line(&spans, 5, 10);
+
+        assert_eq!(Vec::<TokenSpan>::new(), actual);
+    }
+
+    // --- highlight_hunk: fallback ---
+
+    #[test]
+    fn should_fall_back_to_all_none_when_extension_is_unrecognized() {
+        let hunk = Hunk {
+            header: "@@ -1,1 +1,1 @@".to_string(),
+            new_range: Some((1, 1)),
+            lines: vec![line(DiffLineKind::Context, "some: yaml")],
+        };
+
+        let actual = highlight_hunk("config.yaml", &hunk);
+
+        assert_eq!(vec![None], actual);
+    }
+
+    #[test]
+    fn should_fall_back_to_all_none_when_path_has_no_extension() {
+        let hunk = Hunk {
+            header: "@@ -1,1 +1,1 @@".to_string(),
+            new_range: Some((1, 1)),
+            lines: vec![line(DiffLineKind::Context, "text")],
+        };
+
+        let actual = highlight_hunk("Makefile", &hunk);
+
+        assert_eq!(vec![None], actual);
+    }
+
+    // --- highlight_hunk: real highlighting ---
+
+    #[test]
+    fn should_highlight_rust_keyword_and_string_tokens_in_an_added_line() {
+        let hunk = Hunk {
+            header: "@@ -0,0 +1,1 @@".to_string(),
+            new_range: Some((1, 1)),
+            lines: vec![line(DiffLineKind::Added, r#"fn foo() { let x = "s"; }"#)],
+        };
+
+        let actual = highlight_hunk("src/lib.rs", &hunk);
+
+        assert_eq!(1, actual.len());
+        let spans = actual[0]
+            .clone()
+            .expect("expected Some(spans) for a .rs file");
+
+        // NOTE: partial assert — pinning every punctuation/variable span
+        // tree-sitter-highlight's Rust query happens to emit would make
+        // this test brittle to upstream query-file changes; instead this
+        // asserts that the two tokens central to this feature's value
+        // (`fn` as a keyword, `"s"` as a string) both resolved to their
+        // expected palette entries at their expected byte offsets, which
+        // is the guarantee `crate::ui` actually depends on.
+        let keyword_index = PALETTE.iter().position(|p| *p == "keyword").unwrap();
+        let string_index = PALETTE.iter().position(|p| *p == "string").unwrap();
+
+        let text = r#"fn foo() { let x = "s"; }"#;
+        let fn_start = text.find("fn").unwrap();
+        let fn_span = spans
+            .iter()
+            .find(|s| s.start == fn_start)
+            .expect("expected a span starting at 'fn'");
+        assert_eq!(fn_start + 2, fn_span.end);
+        assert_eq!(keyword_index, fn_span.palette_index);
+
+        let string_start = text.find("\"s\"").unwrap();
+        let string_span = spans
+            .iter()
+            .find(|s| s.start == string_start)
+            .expect("expected a span starting at the string literal");
+        assert_eq!(string_start + 3, string_span.end);
+        assert_eq!(string_index, string_span.palette_index);
+    }
+
+    #[test]
+    fn should_highlight_removed_line_in_old_side_context() {
+        let hunk = Hunk {
+            header: "@@ -1,1 +0,0 @@".to_string(),
+            new_range: None,
+            lines: vec![line(DiffLineKind::Removed, "fn foo() {}")],
+        };
+
+        let actual = highlight_hunk("src/lib.rs", &hunk);
+
+        assert_eq!(1, actual.len());
+        let spans = actual[0]
+            .clone()
+            .expect("expected Some(spans) for a .rs file");
+        let keyword_index = PALETTE.iter().position(|p| *p == "keyword").unwrap();
+        assert!(
+            spans
+                .iter()
+                .any(|s| s.start == 0 && s.end == 2 && s.palette_index == keyword_index)
+        );
+    }
+
+    #[test]
+    fn should_highlight_go_keyword_tokens_in_an_added_line() {
+        let hunk = Hunk {
+            header: "@@ -0,0 +1,1 @@".to_string(),
+            new_range: Some((1, 1)),
+            lines: vec![line(DiffLineKind::Added, "func foo() {}")],
+        };
+
+        let actual = highlight_hunk("main.go", &hunk);
+
+        let spans = actual[0]
+            .clone()
+            .expect("expected Some(spans) for a .go file");
+        let keyword_index = PALETTE.iter().position(|p| *p == "keyword").unwrap();
+        assert!(
+            spans
+                .iter()
+                .any(|s| s.start == 0 && s.end == 4 && s.palette_index == keyword_index)
+        );
+    }
+
+    #[test]
+    fn should_highlight_python_keyword_tokens_in_an_added_line() {
+        let hunk = Hunk {
+            header: "@@ -0,0 +1,1 @@".to_string(),
+            new_range: Some((1, 1)),
+            lines: vec![line(DiffLineKind::Added, "def foo(): pass")],
+        };
+
+        let actual = highlight_hunk("main.py", &hunk);
+
+        let spans = actual[0]
+            .clone()
+            .expect("expected Some(spans) for a .py file");
+        let keyword_index = PALETTE.iter().position(|p| *p == "keyword").unwrap();
+        assert!(
+            spans
+                .iter()
+                .any(|s| s.start == 0 && s.end == 3 && s.palette_index == keyword_index)
+        );
+    }
+
+    #[test]
+    fn should_highlight_typescript_keyword_and_type_tokens_in_an_added_line() {
+        // "function"/"const"/"if"/"return" are plain JavaScript keywords:
+        // `tree-sitter-typescript`'s own `HIGHLIGHTS_QUERY` only adds the
+        // TS-specific extras on top of a JS highlights query this grammar
+        // crate does not bundle (`tree-sitter-javascript` is a separate,
+        // undeclared dependency), so this crate's query captures
+        // TS-specific keywords like `interface` but not `function`
+        // (confirmed by inspecting `queries/highlights.scm` directly).
+        // This test asserts on what the query actually recognizes rather
+        // than a plain-JS keyword it would silently fail to highlight.
+        let hunk = Hunk {
+            header: "@@ -0,0 +1,1 @@".to_string(),
+            new_range: Some((1, 1)),
+            lines: vec![line(DiffLineKind::Added, "interface Foo { x: string; }")],
+        };
+
+        let actual = highlight_hunk("main.ts", &hunk);
+
+        let spans = actual[0]
+            .clone()
+            .expect("expected Some(spans) for a .ts file");
+        let keyword_index = PALETTE.iter().position(|p| *p == "keyword").unwrap();
+        let type_index = PALETTE.iter().position(|p| *p == "type").unwrap();
+        assert!(
+            spans
+                .iter()
+                .any(|s| s.start == 0 && s.end == 9 && s.palette_index == keyword_index)
+        );
+        let string_type_start = "interface Foo { x: ".len();
+        assert!(spans.iter().any(|s| s.start == string_type_start
+            && s.end == string_type_start + 6
+            && s.palette_index == type_index));
+    }
+
+    #[test]
+    fn should_return_empty_spans_for_a_blank_context_line() {
+        let hunk = Hunk {
+            header: "@@ -1,2 +1,2 @@".to_string(),
+            new_range: Some((1, 2)),
+            lines: vec![
+                line(DiffLineKind::Context, "fn a() {}"),
+                line(DiffLineKind::Context, ""),
+            ],
+        };
+
+        let actual = highlight_hunk("src/lib.rs", &hunk);
+
+        assert_eq!(2, actual.len());
+        assert_eq!(Some(Vec::new()), actual[1].clone());
+    }
+
+    // --- highlight_diff_files / lookup_hunk_highlight ---
+
+    use crate::diff_view::FileHunks;
+
+    #[test]
+    fn should_highlight_every_hunk_of_every_file_when_computing_the_whole_diff() {
+        let files = vec![
+            FileHunks {
+                path: "src/lib.rs".to_string(),
+                hunks: vec![Hunk {
+                    header: "@@ -0,0 +1,1 @@".to_string(),
+                    new_range: Some((1, 1)),
+                    lines: vec![line(DiffLineKind::Added, "fn a() {}")],
+                }],
+            },
+            FileHunks {
+                path: "config.yaml".to_string(),
+                hunks: vec![Hunk {
+                    header: "@@ -0,0 +1,1 @@".to_string(),
+                    new_range: Some((1, 1)),
+                    lines: vec![line(DiffLineKind::Added, "key: value")],
+                }],
+            },
+        ];
+
+        let actual = highlight_diff_files(&files);
+
+        assert_eq!(2, actual.len());
+        assert_eq!("src/lib.rs", actual[0].path);
+        // .rs highlights successfully (Some), .yaml falls back (None) —
+        // pins that per-file extension dispatch survives the whole-diff
+        // batch path, not just the single-hunk `highlight_hunk` path.
+        assert!(actual[0].hunks[0][0].is_some());
+        assert_eq!(None, actual[1].hunks[0][0]);
+    }
+
+    #[test]
+    fn should_look_up_highlight_by_hunk_pointer_identity() {
+        let file_hunks = FileHunks {
+            path: "src/lib.rs".to_string(),
+            hunks: vec![
+                Hunk {
+                    header: "@@ -0,0 +1,1 @@".to_string(),
+                    new_range: Some((1, 1)),
+                    lines: vec![line(DiffLineKind::Added, "fn a() {}")],
+                },
+                Hunk {
+                    header: "@@ -10,0 +11,1 @@".to_string(),
+                    new_range: Some((11, 11)),
+                    lines: vec![line(DiffLineKind::Added, "fn b() {}")],
+                },
+            ],
+        };
+        let highlighted = highlight_diff_files(std::slice::from_ref(&file_hunks));
+
+        // Look up the *second* hunk specifically, to pin that the index
+        // returned matches the hunk passed in, not just hunk 0.
+        let target = &file_hunks.hunks[1];
+        let actual = lookup_hunk_highlight(
+            highlighted_file(&highlighted, "src/lib.rs"),
+            &file_hunks,
+            target,
+        );
+
+        assert_eq!(Some(highlighted[0].hunks[1].as_slice()), actual);
+    }
+
+    #[test]
+    fn should_return_none_when_highlighted_file_is_absent() {
+        let file_hunks = FileHunks {
+            path: "src/lib.rs".to_string(),
+            hunks: vec![Hunk {
+                header: "@@ -0,0 +1,1 @@".to_string(),
+                new_range: Some((1, 1)),
+                lines: vec![line(DiffLineKind::Added, "fn a() {}")],
+            }],
+        };
+
+        let actual = lookup_hunk_highlight(None, &file_hunks, &file_hunks.hunks[0]);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_find_highlighted_file_by_path() {
+        let files = vec![HighlightedFile {
+            path: "src/lib.rs".to_string(),
+            hunks: vec![],
+        }];
+
+        let actual = highlighted_file(&files, "src/lib.rs");
+
+        assert_eq!(Some(&files[0]), actual);
+    }
+
+    #[test]
+    fn should_return_none_when_highlighted_file_path_not_found() {
+        let files: Vec<HighlightedFile> = vec![];
+
+        let actual = highlighted_file(&files, "missing.rs");
+
+        assert_eq!(None, actual);
+    }
+}

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -31,6 +31,7 @@
 pub mod app;
 pub mod detail;
 pub mod diff_view;
+pub mod highlight;
 pub mod nav;
 pub mod order;
 pub mod row_view;

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -88,9 +88,14 @@ fn run_app(
     // re-walk the whole diff (unbounded in PR size) roughly ten times a
     // second even while idle.
     let diff_hunks = diff_view::parse_diff_hunks(diff_text);
+    // Highlighted once immediately after, for the same reason (ADR 0018):
+    // highlighting is a full tree-sitter parse per hunk side, strictly
+    // more expensive than the hunk parse above, so it must not run inside
+    // the render loop either.
+    let diff_highlights = highlight::highlight_diff_files(&diff_hunks);
 
     loop {
-        terminal.draw(|frame| ui::draw(frame, &app, report, &diff_hunks))?;
+        terminal.draw(|frame| ui::draw(frame, &app, report, &diff_hunks, &diff_highlights))?;
 
         if app.should_quit() {
             return Ok(());

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -509,9 +509,10 @@ fn styled_content_spans(
         result.push(gap_span(&content[cursor..], bg));
     }
     if result.is_empty() {
-        // An empty `content` (blank line) still needs one span so the
-        // line's background tint renders across at least the marker
-        // column boundary consistently with non-empty lines.
+        // Only reachable when `content` is empty AND no token spans exist
+        // (a blank added/removed line): non-empty content always yields at
+        // least one gap or token span above. The empty span keeps the
+        // line's background tint rendering on blank lines too.
         result.push(gap_span("", bg));
     }
 
@@ -1695,5 +1696,36 @@ index e69de29..4b825dc 100644
         // would have produced.
         assert!(text.contains("Detail (1-"));
         assert!(!text.contains("/2)"));
+    }
+
+    #[test]
+    fn should_map_every_palette_entry_to_its_pinned_style_when_resolved_by_index() {
+        // Pins the full palette-index → style table: `palette_style` falls
+        // back to unstyled on an unmapped name, so dropping one arm during
+        // a future palette edit would otherwise pass `make test` silently.
+        let expected = vec![
+            ("keyword", Style::default().fg(Color::Magenta)),
+            ("string", Style::default().fg(Color::Yellow)),
+            (
+                "comment",
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+            ),
+            ("function", Style::default().fg(Color::Blue)),
+            ("type", Style::default().fg(Color::Cyan)),
+            ("number", Style::default().fg(Color::LightRed)),
+            ("constant", Style::default().fg(Color::LightRed)),
+            ("property", Style::default().fg(Color::LightBlue)),
+            ("variable", Style::default()),
+        ];
+
+        let actual: Vec<(&str, Style)> = crate::highlight::PALETTE
+            .iter()
+            .enumerate()
+            .map(|(index, name)| (*name, palette_style(index)))
+            .collect();
+
+        assert_eq!(expected, actual);
     }
 }

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -12,6 +12,7 @@
 use crate::app::{App, DiffTarget, RightPane, Screen, SelectedDetail};
 use crate::detail::{DetailView, DirDetail, FileDetail, SignatureView};
 use crate::diff_view::{DiffLine, DiffLineKind, FileHunks, Hunk, file_hunks, hunks_for_range};
+use crate::highlight::{self, HighlightedFile, PALETTE, TokenSpan};
 use crate::row_view::{entry_row_line, relative_labels};
 use crate::source::{SourceView, load_symbol_source, visible_window};
 use ratatui::Frame;
@@ -28,15 +29,23 @@ use unicode_width::UnicodeWidthChar;
 /// pinned to the bottom either way. `diff_files` is the whole diff already
 /// parsed into per-file hunks once by `crate::run_app` (not re-parsed here
 /// on every frame — see that function's doc comment on why parsing lives
-/// outside the draw loop) — only consulted when the right pane is in
-/// [`RightPane::Diff`] mode.
-pub fn draw(frame: &mut Frame, app: &App, report: &Report, diff_files: &[FileHunks]) {
+/// outside the draw loop), and `diff_highlights` is that same diff's
+/// per-line syntax highlighting, computed once alongside it (ADR 0018) —
+/// both are only consulted when the right pane is in [`RightPane::Diff`]
+/// mode.
+pub fn draw(
+    frame: &mut Frame,
+    app: &App,
+    report: &Report,
+    diff_files: &[FileHunks],
+    diff_highlights: &[HighlightedFile],
+) {
     let area = frame.area();
     let [body, status_area] =
         Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(area);
 
     match app.screen() {
-        Screen::Entry => draw_entry_screen(frame, app, report, diff_files, body),
+        Screen::Entry => draw_entry_screen(frame, app, report, diff_files, diff_highlights, body),
         Screen::Source { symbol_id } => draw_source_screen(frame, report, symbol_id, body),
     }
 
@@ -54,6 +63,7 @@ fn draw_entry_screen(
     app: &App,
     report: &Report,
     diff_files: &[FileHunks],
+    diff_highlights: &[HighlightedFile],
     area: Rect,
 ) {
     let [tree_area, right_area] =
@@ -62,7 +72,9 @@ fn draw_entry_screen(
     draw_tree_pane(frame, app, tree_area);
     match app.right_pane() {
         RightPane::Detail => draw_detail_pane(frame, app, report, right_area),
-        RightPane::Diff => draw_diff_pane(frame, app, report, diff_files, right_area),
+        RightPane::Diff => {
+            draw_diff_pane(frame, app, report, diff_files, diff_highlights, right_area)
+        }
     }
 }
 
@@ -108,14 +120,15 @@ fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
 /// range for a symbol row (`App::selected_diff_target`'s own doc comment).
 /// A directory row, or a row with nothing to show (no hunks found, e.g. a
 /// mismatch between `report` and the diff), falls back to a placeholder
-/// message rather than an empty pane. `diff_files` is already parsed
-/// (`crate::run_app` parses the raw diff text once, up front, not on every
-/// call to this function).
+/// message rather than an empty pane. `diff_files` is already parsed and
+/// `diff_highlights` already highlighted (`crate::run_app` does both once,
+/// up front, not on every call to this function — ADR 0018).
 fn draw_diff_pane(
     frame: &mut Frame,
     app: &App,
     report: &Report,
     diff_files: &[FileHunks],
+    diff_highlights: &[HighlightedFile],
     area: Rect,
 ) {
     let Some(target) = app.selected_diff_target(report) else {
@@ -155,7 +168,16 @@ fn draw_diff_pane(
         return;
     }
 
-    let lines = diff_pane_lines(&hunks);
+    // `file_hunks` was already resolved above via `DiffTarget`'s match arm,
+    // but `hunks_for_range`/the file-row arm both return `&Hunk`s borrowed
+    // from it — re-resolving it here (rather than threading it out of the
+    // match above) keeps `highlight::lookup_hunk_highlight`'s pointer-
+    // identity lookup working against the exact same `FileHunks` the
+    // `&Hunk`s in `hunks` were borrowed from.
+    let source_file_hunks = file_hunks(diff_files, path);
+    let highlighted_file = highlight::highlighted_file(diff_highlights, path);
+
+    let lines = diff_pane_lines(&hunks, source_file_hunks, highlighted_file);
     render_scrollable_pane(frame, " Diff ", &lines, app.right_pane_scroll(), area);
 }
 
@@ -329,12 +351,27 @@ fn scroll_indicator(content_len: usize, viewport_height: usize, scroll: usize) -
     Some(format!(" ({first_visible}-{last_visible}/{content_len})"))
 }
 
-/// Formats a list of [`Hunk`]s into styled lines: hunk headers dim, `+`
-/// lines green, `-` lines red, context lines unstyled — mirrors the
-/// existing signature-diff styling `detail_lines`' `SignatureView::Changed`
-/// arm already uses (`Color::Green`/`Color::Red`) so the two diff-styled
-/// panes in this crate read consistently.
-fn diff_pane_lines(hunks: &[&Hunk]) -> Vec<Line<'static>> {
+/// Formats a list of [`Hunk`]s into styled lines: hunk headers dim, `+`/`-`
+/// marker glyphs keep their existing bold green/red foreground, and each
+/// line's own code tokens are colored by [`highlight::lookup_hunk_highlight`]
+/// when available (ADR 0018) — falling back to the plain green/red/unstyled
+/// line style this pane always had when a hunk has no highlight (unknown
+/// extension, parse/query failure) so highlighting can never make a diff
+/// harder to read than before.
+///
+/// `source_file_hunks`/`highlighted_file` are `None` exactly when `hunks`
+/// itself would already be empty (`draw_diff_pane` returns before calling
+/// this function in that case), so in practice they are always `Some` here
+/// — kept as `Option`s anyway (rather than unwrapped) since `file_hunks`
+/// returning `None` is a defensive, not-supposed-to-happen case elsewhere
+/// in this module too, and threading the same shape through keeps this
+/// function's fallback path uniform with `highlight::lookup_hunk_highlight`'s
+/// own `None` handling.
+fn diff_pane_lines(
+    hunks: &[&Hunk],
+    source_file_hunks: Option<&FileHunks>,
+    highlighted_file: Option<&HighlightedFile>,
+) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     for (index, hunk) in hunks.iter().enumerate() {
         if index > 0 {
@@ -346,14 +383,62 @@ fn diff_pane_lines(hunks: &[&Hunk]) -> Vec<Line<'static>> {
                 .fg(Color::DarkGray)
                 .add_modifier(Modifier::DIM),
         ));
-        for line in &hunk.lines {
-            lines.push(diff_line(line));
+
+        let hunk_highlight = source_file_hunks
+            .and_then(|fh| highlight::lookup_hunk_highlight(highlighted_file, fh, hunk));
+
+        for (line_index, line) in hunk.lines.iter().enumerate() {
+            // `hunk_highlight` is `Option<&[LineHighlight]>`, and
+            // `LineHighlight` is itself `Option<Vec<TokenSpan>>` (per-line
+            // fallback within an otherwise-highlighted hunk) — `flatten`
+            // collapses "no highlight data at all for this hunk" and
+            // "this specific line had no highlight" into the same `None`
+            // `diff_line` already treats as its fallback signal.
+            let token_spans = hunk_highlight
+                .and_then(|lines| lines.get(line_index).cloned())
+                .flatten();
+            lines.push(diff_line(line, token_spans));
         }
     }
     lines
 }
 
-fn diff_line(line: &DiffLine) -> Line<'static> {
+/// Background tint for an `Added`/`Removed` line (ADR 0018 decision: diff
+/// signal moves to the background so a token's own color can carry the
+/// foreground). 256-color indexed dark green/red rather than the named
+/// `Color::Green`/`Color::Red` used for the `+`/`-` marker itself — a
+/// named-color *background* at full saturation would fight with the
+/// foreground token colors for attention, whereas these dim indexed tones
+/// (in the xterm 256 palette's grayscale-adjacent dark green/red range)
+/// stay legible as "this line changed" without competing with the text.
+const ADDED_BG: Color = Color::Indexed(22);
+const REMOVED_BG: Color = Color::Indexed(52);
+
+/// Builds one display line for a hunk body line, coloring its code tokens
+/// per `token_spans` (`None` when highlighting is unavailable for this
+/// line — falls back to the pane's original plain style). The `+`/`-`
+/// marker glyph itself is always pushed as its own bold-colored span, kept
+/// outside of `line.content`'s token coloring so it is never masked by a
+/// token span that happens to start at byte 0.
+fn diff_line(line: &DiffLine, token_spans: Option<Vec<TokenSpan>>) -> Line<'static> {
+    match &token_spans {
+        Some(spans) => {
+            let bg = match line.kind {
+                DiffLineKind::Added => Some(ADDED_BG),
+                DiffLineKind::Removed => Some(REMOVED_BG),
+                DiffLineKind::Context => None,
+            };
+            let mut result_spans = vec![marker_span(line.kind, bg)];
+            result_spans.extend(styled_content_spans(&line.content, spans, bg));
+            Line::from(result_spans)
+        }
+        None => plain_diff_line(line),
+    }
+}
+
+/// The pane's original (pre-ADR-0018) plain green/red/unstyled line style —
+/// the fallback for a line highlighting could not cover.
+fn plain_diff_line(line: &DiffLine) -> Line<'static> {
     match line.kind {
         DiffLineKind::Added => Line::styled(
             format!("+{}", line.content),
@@ -364,6 +449,104 @@ fn diff_line(line: &DiffLine) -> Line<'static> {
             Style::default().fg(Color::Red),
         ),
         DiffLineKind::Context => Line::raw(format!(" {}", line.content)),
+    }
+}
+
+/// The leading `+`/`-`/` ` marker glyph as its own span: bold green/red for
+/// `+`/`-` (unchanged from the pane's original style) with the line's
+/// background tint applied so the marker doesn't visually break from the
+/// rest of a tinted line; a plain space (no bg) for a context line.
+fn marker_span(kind: DiffLineKind, bg: Option<Color>) -> Span<'static> {
+    let (glyph, fg) = match kind {
+        DiffLineKind::Added => ("+", Some(Color::Green)),
+        DiffLineKind::Removed => ("-", Some(Color::Red)),
+        DiffLineKind::Context => (" ", None),
+    };
+    let mut style = Style::default().add_modifier(Modifier::BOLD);
+    if let Some(fg) = fg {
+        style = style.fg(fg);
+    }
+    if let Some(bg) = bg {
+        style = style.bg(bg);
+    }
+    Span::styled(glyph, style)
+}
+
+/// Splits `content` into styled spans per `spans` (byte-offset [`TokenSpan`]s
+/// already rebased to `content`'s own coordinates by
+/// `highlight::spans_for_line`), coloring each token's foreground by its
+/// palette entry (`palette_style`) and applying `bg` uniformly (the diff
+/// signal) — any byte range `spans` doesn't cover (whitespace, punctuation
+/// the query didn't capture) becomes an unstyled-foreground span with just
+/// `bg` applied, so the line's background tint is always contiguous even
+/// where token coloring has gaps.
+fn styled_content_spans(
+    content: &str,
+    spans: &[TokenSpan],
+    bg: Option<Color>,
+) -> Vec<Span<'static>> {
+    let mut result = Vec::new();
+    let mut cursor = 0usize;
+
+    let mut sorted_spans = spans.to_vec();
+    sorted_spans.sort_by_key(|span| span.start);
+
+    for span in &sorted_spans {
+        if span.start > cursor {
+            result.push(gap_span(&content[cursor..span.start], bg));
+        }
+        let mut style = palette_style(span.palette_index);
+        if let Some(bg) = bg {
+            style = style.bg(bg);
+        }
+        result.push(Span::styled(
+            content[span.start..span.end].to_string(),
+            style,
+        ));
+        cursor = span.end;
+    }
+    if cursor < content.len() {
+        result.push(gap_span(&content[cursor..], bg));
+    }
+    if result.is_empty() {
+        // An empty `content` (blank line) still needs one span so the
+        // line's background tint renders across at least the marker
+        // column boundary consistently with non-empty lines.
+        result.push(gap_span("", bg));
+    }
+
+    result
+}
+
+fn gap_span(text: &str, bg: Option<Color>) -> Span<'static> {
+    let mut style = Style::default();
+    if let Some(bg) = bg {
+        style = style.bg(bg);
+    }
+    Span::styled(text.to_string(), style)
+}
+
+/// Maps a [`PALETTE`] index to its display style — the minimal token
+/// palette ADR 0018 asks for. Falls back to the default (unstyled)
+/// foreground for a palette index this match doesn't special-case (there
+/// are none today; `PALETTE`'s entries are all listed below, but keeping
+/// this a `match` with a wildcard rather than a same-length array means
+/// adding a `PALETTE` entry without a style here degrades to unstyled
+/// rather than panicking on an out-of-bounds array index).
+fn palette_style(palette_index: usize) -> Style {
+    match PALETTE.get(palette_index).copied() {
+        Some("keyword") => Style::default().fg(Color::Magenta),
+        Some("string") => Style::default().fg(Color::Yellow),
+        Some("comment") => Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::DIM),
+        Some("function") => Style::default().fg(Color::Blue),
+        Some("type") => Style::default().fg(Color::Cyan),
+        Some("number") => Style::default().fg(Color::LightRed),
+        Some("constant") => Style::default().fg(Color::LightRed),
+        Some("property") => Style::default().fg(Color::LightBlue),
+        Some("variable") => Style::default(),
+        _ => Style::default(),
     }
 }
 
@@ -706,7 +889,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -740,7 +923,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -769,7 +952,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -806,7 +989,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -831,15 +1014,245 @@ index e69de29..4b825dc 100644
 +fn foo() {}
 ";
         let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+        let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &diff_files))
+            .draw(|frame| draw(frame, &app, &report, &diff_files, &diff_highlights))
             .expect("draw");
 
         let text = buffer_text(&terminal);
         assert!(text.contains("Diff"));
         assert!(text.contains("+fn foo() {}"));
+    }
+
+    /// Finds the buffer cell for `token`'s first character within the row
+    /// that contains `line_needle`, scanning row by row — used by the
+    /// highlight tests below to inspect a specific token's actual `Style`
+    /// (`buffer_text` only exposes glyphs, not styling). `line_needle`
+    /// disambiguates which row to sample when `token` alone could match
+    /// more than one (e.g. the left tree pane's cursor row also happens to
+    /// render a truncated "fn foo" label for this test module's one-symbol
+    /// fixture).
+    ///
+    /// Deliberately indexes by *character* position, not `str::find`'s byte
+    /// offset: this pane's border glyphs (`│`) are multi-byte UTF-8, so a
+    /// byte offset into the flattened row string does not line up with the
+    /// buffer's `x` column once even one border character precedes the
+    /// match — using `char_indices`/`chars().count()` keeps this aligned
+    /// with the single-width-per-cell column space `TestBackend` itself
+    /// uses (every char in this test module's fixtures is single-width
+    /// ASCII, so column count and char count coincide).
+    fn find_cell_style(terminal: &Terminal<TestBackend>, line_needle: &str, token: &str) -> Style {
+        let buffer = terminal.backend().buffer();
+        let area = buffer.area;
+        for y in 0..area.height {
+            let row: String = (0..area.width)
+                .map(|x| buffer[(x, y)].symbol().to_string())
+                .collect();
+            let Some(needle_byte_offset) = row.find(line_needle) else {
+                continue;
+            };
+            // Search for `token` starting from `line_needle`'s own match,
+            // not row-wide: this pane's two side-by-side panes can each
+            // contain `token` (e.g. the left tree pane's cursor row renders
+            // a truncated "fn foo" label that also contains "fn"), so a
+            // row-wide `find` could resolve to the wrong pane entirely.
+            let Some(token_byte_offset) = row[needle_byte_offset..].find(token) else {
+                continue;
+            };
+            let byte_offset = needle_byte_offset + token_byte_offset;
+            // Convert the byte offset `str::find` returned into a char
+            // (= column) index by counting chars before it — this pane's
+            // border glyphs (`│`) are multi-byte UTF-8, so the byte offset
+            // itself does not line up with the buffer's `x` column once
+            // even one border character precedes the match.
+            let column = row[..byte_offset].chars().count() as u16;
+            return buffer[(column, y)].style();
+        }
+        panic!("expected to find {token:?} within a row containing {line_needle:?}");
+    }
+
+    #[test]
+    fn should_apply_added_background_tint_and_keyword_foreground_in_diff_pane() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::ToggleDiff);
+        let diff_text = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,1 +1,2 @@
+ fn a() {}
++fn foo() {}
+";
+        let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+        let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &diff_files, &diff_highlights))
+            .expect("draw");
+
+        // The added line's "fn" keyword: foreground colored by the keyword
+        // palette entry, background tinted with `ADDED_BG` — both signals
+        // present on the same cell, per ADR 0018's "fg is token color, bg is
+        // diff signal" decision. Disambiguated against the row via
+        // "+fn foo() {}" (the marker plus full added line): the left-hand
+        // tree pane's cursor row also happens to render a truncated "fn
+        // foo" label for this fixture's one symbol.
+        let keyword_style = find_cell_style(&terminal, "+fn foo() {}", "fn");
+        assert_eq!(Some(ADDED_BG), keyword_style.bg);
+        assert_eq!(Some(Color::Magenta), keyword_style.fg);
+    }
+
+    #[test]
+    fn should_apply_removed_background_tint_in_diff_pane() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::ToggleDiff);
+        let diff_text = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,2 +1,1 @@
+ fn a() {}
+-fn foo() {}
+";
+        let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+        let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &diff_files, &diff_highlights))
+            .expect("draw");
+
+        let keyword_style = find_cell_style(&terminal, "-fn foo() {}", "fn");
+        assert_eq!(Some(REMOVED_BG), keyword_style.bg);
+        assert_eq!(Some(Color::Magenta), keyword_style.fg);
+    }
+
+    #[test]
+    fn should_keep_context_line_unstyled_background_in_diff_pane() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::ToggleDiff);
+        let diff_text = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,1 +1,2 @@
+ fn a() {}
++fn foo() {}
+";
+        let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+        let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &diff_files, &diff_highlights))
+            .expect("draw");
+
+        // Context line "fn a() {}" keeps its keyword token color but must
+        // not carry either diff background tint (`Style::bg` reports an
+        // unset background as `Some(Color::Reset)`, not `None` — ratatui's
+        // own `Cell` defaults every cell's `bg` field to `Color::Reset`
+        // rather than leaving it absent). Disambiguated the same way as
+        // the added-line test above (a leading space marker rather than
+        // `+`/`-`, matching `diff_line`'s context-line rendering).
+        let context_style = find_cell_style(&terminal, " fn a() {}", "fn");
+        assert_eq!(Some(Color::Reset), context_style.bg);
+        assert_eq!(Some(Color::Magenta), context_style.fg);
+    }
+
+    #[test]
+    fn should_keep_hunk_header_dim_when_diff_pane_is_highlighted() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::ToggleDiff);
+        let diff_text = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,1 +1,2 @@
+ fn a() {}
++fn foo() {}
+";
+        let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+        let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &diff_files, &diff_highlights))
+            .expect("draw");
+
+        let header_style = find_cell_style(&terminal, "@@ -1,1 +1,2 @@", "@@");
+        assert_eq!(Some(Color::DarkGray), header_style.fg);
+        assert!(header_style.add_modifier.contains(Modifier::DIM));
+    }
+
+    #[test]
+    fn should_fall_back_to_plain_diff_style_when_file_extension_is_unrecognized() {
+        // A symbol whose path has no known extension (mirrors an unbuilt
+        // language, e.g. YAML): `App::selected_diff_target` reads the path
+        // straight off the symbol/file row, so this only needs a report
+        // whose file path is unrecognized by `highlight::config_for_path`,
+        // not a real diff for an actual YAML grammar.
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "config.yaml".to_string(),
+                symbols: vec![symbol("config.yaml::foo", "foo")],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        };
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::ToggleDiff);
+        let diff_text = "\
+diff --git a/config.yaml b/config.yaml
+index e69de29..4b825dc 100644
+--- a/config.yaml
++++ b/config.yaml
+@@ -1,1 +1,2 @@
+ a: 1
++b: 2
+";
+        let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+        let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| draw(frame, &app, &report, &diff_files, &diff_highlights))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("+b: 2"));
+
+        // Falls back to the pane's original plain green foreground with no
+        // background tint at all (`Some(Color::Reset)` is ratatui's
+        // "unset" — see the context-line test above for why this isn't
+        // `None`) — highlighting failing (or, here, never applying) must
+        // never break the pre-existing diff styling.
+        let added_style = find_cell_style(&terminal, "+b: 2", "b");
+        assert_eq!(Some(Color::Reset), added_style.bg);
+        assert_eq!(Some(Color::Green), added_style.fg);
     }
 
     #[test]
@@ -849,7 +1262,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -869,7 +1282,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(110, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -885,7 +1298,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         // "lib.rs" does not exist relative to the test process's cwd, so
@@ -1005,7 +1418,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -1024,7 +1437,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -1039,7 +1452,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -1064,7 +1477,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -1086,7 +1499,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -1235,7 +1648,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(34, 12)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -1273,7 +1686,7 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(34, 12)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[]))
+            .draw(|frame| draw(frame, &app, &report, &[], &[]))
             .expect("draw");
 
         let text = buffer_text(&terminal);


### PR DESCRIPTION
## Summary

Implements ADR 0018 (included, accepted): the TUI diff pane now syntax-highlights code using `tree-sitter-highlight` and the grammar crates' bundled highlight queries — the user-requested follow-up to the diff pane from #51.

- New pure `rinkaku-tui/src/highlight.rs`: per-hunk **side reconstruction** (new side = context+added, old side = context+removed) so the parser sees contiguous source instead of single lines; token spans mapped back to display lines; per-file fallback to the previous plain green/red styling on unknown extensions or parse/query failure.
- Token colors go on the foreground; the diff signal moves to a 256-color background tint (dark green/red) with the `+`/`-` marker keeping its bold color; hunk headers stay dim; context lines get token colors with no tint.
- Highlighting runs **once per run** right after the existing once-per-run hunk parse — never in the render loop (lesson from a prior round's per-frame re-parse finding, verified by both review passes).
- TUI-only: `rinkaku-core`'s `LanguageSupport` is untouched (presentation concern per ADR 0015/0016).

Known accepted gaps (documented): TypeScript's bundled query only captures TS-specific keywords (it's additive over a JS query the crate doesn't bundle); highlighting adds ~2.8s once-per-run startup on an unusually large 4.5k-line diff (typical PR diffs are an order of magnitude smaller — lazy per-file highlighting is the follow-up if it bites).

## Review

Three-angle policy per CLAUDE.md. Both passes came back with zero blockers and zero should-fix — each independently built multibyte fixtures (Japanese comments, emoji), drove interleaved add/remove hunks through a live TUI with ANSI capture, and traced the byte-offset → display-width seam before concluding it safe. Four documentation/test-precision nits, all fixed. Round 6 of experiment 0001 recorded (first fully clean round on a code subject).

## Test plan

- `make test` (675 tests, 207 in rinkaku-tui) / `make lint` clean
- Live tmux verification incl. Japanese + emoji in changed lines: token colors correctly aligned, added/removed bg tints, dim headers, clean fallback, no panics; non-TTY failure path unchanged

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync