### PR TITLE
fix(tui): resolve source view paths against the repository root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,7 @@ dependencies = [
  "ratatui",
  "rinkaku-core",
  "rstest",
+ "tempfile",
  "tree-sitter",
  "tree-sitter-go",
  "tree-sitter-highlight",

--- a/docs/experiments/0001-map-assisted-llm-review.md
+++ b/docs/experiments/0001-map-assisted-llm-review.md
@@ -482,6 +482,81 @@ that in mind.
   stops being an independent signal. Seed when correctness matters
   more than the experiment (it usually does), but record it.
 
+## Results (round 8)
+
+Same two-pass method, eighth subject: this PR's own fix for the TUI
+source view's path resolution (2 commits — repo-root-relative reads for
+`load_symbol_source`, then a follow-up addressing review feedback on
+that first commit).
+
+| Metric               | A (map)     | B (control) |
+| -------------------- | ----------- | ----------- |
+| Blocker findings      | 1           | 1           |
+| Should-fix findings   | —           | 1           |
+
+- **Both arms independently converged on the same blocker**: `--pr`'s
+  resolved workdir (a ghq/cache clone that can live anywhere on disk,
+  `resolve_pr_workdir`) never reached `resolve_repo_root`, which was
+  called unconditionally with `None`. If the process's own current
+  directory happened to be a *different* git repository, the source
+  view would silently resolve *that* repository's root and, for any
+  relative path that happens to exist in both, show an unrelated
+  file — no error, just wrong content. Neither arm found this via the
+  map: `main`'s signature did not change, and "does the right variable
+  reach the right call" is not a relationship the map draws at all. It
+  came from actively cross-checking the README's description of `--pr`
+  against the new `resolve_repo_root(None)` call site — the same
+  doc-versus-implementation reading strategy that produced round 7's
+  four findings, applied here to code rather than a doc comment.
+- **Only the independent pass's live tmux verification** caught a
+  second, narrower defect: the read-failure error message this PR adds
+  (explaining that a missing file may simply not be checked out
+  locally, e.g. a PR/historical diff) was not wrapped, so `Paragraph`
+  silently truncated it in anything narrower than a very wide pane —
+  the very case the message exists to explain became unreadable in the
+  layout it was written for. A static read of the string literal gives
+  no signal that it will be cut off; only watching the rendered pane
+  does.
+- Dynamic verification also surfaced a defect entirely outside this
+  PR's scope: launching the TUI on stdin-piped diff input
+  (`git diff | rinkaku`) fails to start, because crossterm's raw-mode
+  input reader errors ("Failed to initialize input reader") when stdin
+  has already been consumed reading the diff. Not fixed here — recorded
+  as a backlog item, since stdin-diff mode piping straight into `--tui`
+  is a legitimate ADR 0016/0017 use case that currently cannot reach
+  the TUI at all.
+- Fixes shipped in response: the workdir-propagation blocker (with a
+  regression test constructing two independent repositories to prove
+  the fix resolves the passed-in workdir, not the process's own cwd
+  repository), the message-wrapping should-fix (with a regression test
+  in a 40-column `TestBackend` pane, confirmed to fail without
+  `.wrap(...)`), and a `debug_assert!` plus `#[should_panic]` test
+  pinning `resolve_source_path`'s pre-existing assumption that `Report`
+  paths stay relative (`PathBuf::join` silently discards the root
+  otherwise).
+
+## Conclusions (after 8 rounds)
+
+- Round 8 sharpens round 7's finding rather than adding a new one: the
+  map shows that a wire exists (`main` → `resolve_repo_root` →
+  `rinkaku_tui::run` → ... → `load_symbol_source`), not whether it
+  carries the *correct* value. A caller-side data-flow defect — the
+  right function called with the wrong variable — sits in exactly the
+  blind spot both round 7 and round 8 needed doc-versus-code
+  cross-checking, not the map, to see.
+- The narrow-pane wrapping bug is the same class experiment rounds 3–7
+  keep surfacing: a behavioral defect with zero footprint on any
+  signature, found only by watching the thing render. Reinforces (not
+  extends) round 6's standing conclusion that dynamic verification is
+  the review angle that does not get replaced by better static
+  tooling.
+- Unlike rounds 1–7, this round's map-assisted and independent passes
+  fully converged on the round's most important finding (the blocker)
+  rather than splitting territory — welcome as confidence, but a
+  reminder per round 5's caveat that convergence on an easy-to-spot
+  defect says less about the two passes' complementary value than
+  divergence does.
+
 ## Next
 
 - Consider a map feature flagging cross-crate duplicate-domain
@@ -493,3 +568,7 @@ that in mind.
   it has now appeared three times (rounds 3, 7, and PR #55's spec
   guarding against it), which is enough recurrence to justify
   mechanizing it.
+- Fix the stdin-diff + `--tui` startup failure found in round 8
+  (crossterm's input reader fails to initialize because stdin was
+  already consumed reading the diff) — a pre-existing gap in a
+  documented use case (ADR 0016/0017), not a regression of this PR.

--- a/rinkaku-tui/Cargo.toml
+++ b/rinkaku-tui/Cargo.toml
@@ -38,3 +38,4 @@ tree-sitter-typescript = { workspace = true }
 [dev-dependencies]
 rstest = { workspace = true }
 pretty_assertions = { workspace = true }
+tempfile = { workspace = true }

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -81,9 +81,22 @@ use std::time::Duration;
 /// same `Report` both the TUI and Markdown/JSON render from), so this
 /// parameter only drives where the TUI *starts*, not what the underlying
 /// graph looks like.
-pub fn run(report: &Report, diff_text: &str, entry_path: Option<&str>) -> std::io::Result<()> {
+///
+/// `repo_root` anchors `Report` paths (always repository-root-relative) for
+/// the source drill-down's file reads (`crate::source::load_symbol_source`)
+/// — `main.rs` resolves it once at startup (`git rev-parse --show-toplevel`,
+/// falling back to the process's current directory outside a git
+/// repository) rather than this crate ever shelling out to `git` itself
+/// (ADR 0016). Without it, the source view would only work when `rinkaku`
+/// happens to be invoked from the repository root.
+pub fn run(
+    report: &Report,
+    diff_text: &str,
+    entry_path: Option<&str>,
+    repo_root: &std::path::Path,
+) -> std::io::Result<()> {
     let mut terminal = ratatui::try_init()?;
-    let result = run_app(&mut terminal, report, diff_text, entry_path);
+    let result = run_app(&mut terminal, report, diff_text, entry_path, repo_root);
     ratatui::restore();
     result
 }
@@ -93,6 +106,7 @@ fn run_app(
     report: &Report,
     diff_text: &str,
     entry_path: Option<&str>,
+    repo_root: &std::path::Path,
 ) -> std::io::Result<()> {
     let mut app = App::new(report);
     if let Some(path) = entry_path {
@@ -140,6 +154,7 @@ fn run_app(
                 &diff_hunks,
                 &diff_highlights,
                 &pivot_selection,
+                repo_root,
             )
         })?;
 
@@ -162,7 +177,7 @@ fn run_app(
             if let InputKey::Source = input_key {
                 app = app.handle_key(input_key);
                 if let Screen::Source { symbol_id } = app.screen().clone() {
-                    match source::load_symbol_source(report, &symbol_id) {
+                    match source::load_symbol_source(report, &symbol_id, repo_root) {
                         // The `SourceView` itself is discarded here — only
                         // used to detect a failure early so it can be
                         // surfaced on the status line right away, rather

--- a/rinkaku-tui/src/source.rs
+++ b/rinkaku-tui/src/source.rs
@@ -9,6 +9,13 @@
 //! the rest of the crate. [`load_symbol_source`] is that one function;
 //! everything else here (locating the symbol, computing the visible
 //! window) is pure and takes the file content as a plain `&str`.
+//!
+//! `Report` paths are always repository-root-relative (every `main.rs`
+//! input mode — stdin, `--base`, `--pr` — derives them from `git diff`/
+//! `git ls-files` output, never from the process's current directory), so
+//! reading them off disk needs the repository root joined in first rather
+//! than treating them as relative to wherever `rinkaku` happens to be
+//! invoked from (e.g. a subdirectory) — see [`resolve_source_path`].
 
 /// A symbol's location in `Report`, resolved from its id — enough for
 /// [`load_symbol_source`] to know which file to read and
@@ -47,6 +54,13 @@ pub struct SourceView {
 /// head SHA all the way from `main.rs` into `rinkaku_tui::run` just for
 /// this one view — is deferred until a real user need for it shows up).
 ///
+/// `repo_root` anchors `location.path` (always repository-root-relative,
+/// see this module's doc comment) via [`resolve_source_path`] — callers
+/// pass the repository root `main.rs` resolves once at startup
+/// (`rinkaku_tui::run`'s own `repo_root` parameter), not the process's
+/// current directory, so this still works when `rinkaku` is invoked from a
+/// subdirectory of the repository.
+///
 /// A consequence of reading live: a symbol's `range` in `report` reflects
 /// the file's content *at analysis time*. If the file is edited on disk
 /// afterward (including between opening the TUI and pressing `s` on a
@@ -58,12 +72,19 @@ pub struct SourceView {
 pub fn load_symbol_source(
     report: &rinkaku_core::render::Report,
     id: &str,
+    repo_root: &std::path::Path,
 ) -> Result<SourceView, String> {
     let location = find_symbol_location(report, id)
         .ok_or_else(|| format!("symbol not found in report: {id}"))?;
 
-    let content = std::fs::read_to_string(&location.path)
-        .map_err(|source| format!("failed to read {}: {source}", location.path))?;
+    let full_path = resolve_source_path(repo_root, &location.path);
+    let content = std::fs::read_to_string(&full_path).map_err(|source| {
+        format!(
+            "failed to read {}: {source} (not present in the working tree — expected for a \
+             file diffed from a PR or historical commit not checked out locally)",
+            full_path.display()
+        )
+    })?;
 
     Ok(SourceView {
         path: location.path,
@@ -71,6 +92,15 @@ pub fn load_symbol_source(
         highlight_start: location.start_line,
         highlight_end: location.end_line,
     })
+}
+
+/// Joins a `Report`-relative path (always repository-root-relative, see
+/// this module's doc comment) onto `repo_root`, so [`load_symbol_source`]
+/// reads the right file regardless of the process's current directory.
+/// Split out as its own pure function so the join logic is unit-testable
+/// without touching disk.
+fn resolve_source_path(repo_root: &std::path::Path, relative_path: &str) -> std::path::PathBuf {
+    repo_root.join(relative_path)
 }
 
 /// Finds `id`'s file path and line range in `report.files`. `None` when no
@@ -282,11 +312,80 @@ mod tests {
     fn should_return_error_message_when_load_symbol_source_finds_no_such_symbol() {
         let report = empty_report();
 
-        let actual = load_symbol_source(&report, "missing::id");
+        let actual = load_symbol_source(&report, "missing::id", std::path::Path::new("/repo"));
 
         assert_eq!(
             Err("symbol not found in report: missing::id".to_string()),
             actual
+        );
+    }
+
+    #[test]
+    fn should_join_repo_root_and_relative_path_when_resolving_source_path() {
+        let actual = resolve_source_path(std::path::Path::new("/repo/root"), "src/lib.rs");
+
+        assert_eq!(std::path::PathBuf::from("/repo/root/src/lib.rs"), actual);
+    }
+
+    #[test]
+    fn should_read_file_relative_to_repo_root_when_process_cwd_differs() {
+        // Regression test for the TUI source view failing whenever
+        // `rinkaku` is launched from a subdirectory of the repository:
+        // `Report` paths are always repo-root-relative, so
+        // `load_symbol_source` must join them onto the repo root rather
+        // than reading them relative to the process's actual current
+        // directory (which this test never changes).
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::create_dir_all(dir.path().join("src")).expect("create src dir");
+        std::fs::write(dir.path().join("src/lib.rs"), "fn foo() {}\n").expect("write file");
+
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    LineRange { start: 1, end: 1 },
+                )],
+            }],
+            ..empty_report()
+        };
+
+        let expected = Ok(SourceView {
+            path: "src/lib.rs".to_string(),
+            lines: vec!["fn foo() {}".to_string()],
+            highlight_start: 1,
+            highlight_end: 1,
+        });
+        let actual = load_symbol_source(&report, "src/lib.rs::foo", dir.path());
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_mention_working_tree_in_error_message_when_file_is_missing() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/missing.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/missing.rs::foo",
+                    "foo",
+                    LineRange { start: 1, end: 1 },
+                )],
+            }],
+            ..empty_report()
+        };
+
+        let actual = load_symbol_source(&report, "src/missing.rs::foo", dir.path());
+
+        let error = actual.expect_err("a missing file must fail rather than silently succeed");
+        assert!(
+            error.contains("not present in the working tree"),
+            "error message should explain the file may not be checked out locally, got: {error}"
         );
     }
 }

--- a/rinkaku-tui/src/source.rs
+++ b/rinkaku-tui/src/source.rs
@@ -99,7 +99,20 @@ pub fn load_symbol_source(
 /// reads the right file regardless of the process's current directory.
 /// Split out as its own pure function so the join logic is unit-testable
 /// without touching disk.
+///
+/// Relies on `relative_path` genuinely being relative: `PathBuf::join`
+/// silently *discards* `repo_root` entirely and returns `relative_path`
+/// unchanged whenever it is itself absolute (`Path::join`'s documented
+/// behavior) — every producer of `Report` (`git diff`/`git ls-files`
+/// output, see this module's doc comment) upholds that today, so this
+/// isn't reachable in practice, but the `debug_assert!` below turns a
+/// future violation of that premise into a loud failure in tests/debug
+/// builds instead of a silent wrong-file read.
 fn resolve_source_path(repo_root: &std::path::Path, relative_path: &str) -> std::path::PathBuf {
+    debug_assert!(
+        std::path::Path::new(relative_path).is_relative(),
+        "Report paths are always repository-root-relative, got absolute path: {relative_path}"
+    );
     repo_root.join(relative_path)
 }
 
@@ -325,6 +338,19 @@ mod tests {
         let actual = resolve_source_path(std::path::Path::new("/repo/root"), "src/lib.rs");
 
         assert_eq!(std::path::PathBuf::from("/repo/root/src/lib.rs"), actual);
+    }
+
+    #[test]
+    #[should_panic(expected = "Report paths are always repository-root-relative")]
+    fn should_panic_in_debug_builds_when_relative_path_is_actually_absolute() {
+        // Pins the `debug_assert!`'s intent: `PathBuf::join` silently
+        // *discards* `repo_root` and returns the absolute path unchanged
+        // when the "relative" argument isn't actually relative
+        // (`resolve_source_path`'s own doc comment) — every `Report`
+        // producer upholds relativity today, so this only guards against a
+        // future regression, but that regression must fail loudly in
+        // debug/test builds rather than silently reading the wrong file.
+        resolve_source_path(std::path::Path::new("/repo/root"), "/etc/passwd");
     }
 
     #[test]

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -19,7 +19,7 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Paragraph};
+use ratatui::widgets::{Block, Paragraph, Wrap};
 use rinkaku_core::extract::Classification;
 use rinkaku_core::render::{Report, ReportOrigin};
 use unicode_width::UnicodeWidthChar;
@@ -854,7 +854,18 @@ fn draw_source_screen(
     let source = match load_symbol_source(report, symbol_id, repo_root) {
         Ok(source) => source,
         Err(message) => {
-            let paragraph = Paragraph::new(message).block(block);
+            // `.wrap(Wrap { trim: false })`: the error message (full path +
+            // io error + the "not present in the working tree" hint added
+            // alongside repo-root resolution) routinely exceeds one line at
+            // ordinary pane widths. Without wrapping, `Paragraph` silently
+            // truncates instead of overflowing, cutting the hint off
+            // exactly where it explains the failure. `trim: false` keeps
+            // the message's own leading whitespace (there isn't any here,
+            // but matches this pane's other `Paragraph` usages that don't
+            // opt into trimming either).
+            let paragraph = Paragraph::new(message)
+                .block(block)
+                .wrap(Wrap { trim: false });
             frame.render_widget(paragraph, area);
             return;
         }
@@ -1623,6 +1634,53 @@ index e69de29..4b825dc 100644
         assert!(text.contains("Source: lib.rs::foo"));
         assert!(text.contains("failed to read"));
         assert!(text.contains("back"));
+    }
+
+    #[test]
+    fn should_wrap_source_error_message_instead_of_truncating_it_in_a_narrow_pane() {
+        // Regression test: `source::load_symbol_source`'s error message
+        // (full path + io error + the "not present in the working tree"
+        // hint) routinely exceeds one line, and `Paragraph` without
+        // `.wrap(...)` silently truncates rather than overflowing — cutting
+        // the hint off exactly where it explains the failure. A narrow
+        // (40-column) pane makes the message wrap across multiple rows
+        // whether or not `.wrap(...)` is set, but only *with* it does the
+        // hint's text actually appear anywhere in the buffer; without it,
+        // the trailing text is simply dropped.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::Source);
+        let mut terminal = Terminal::new(TestBackend::new(40, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &[],
+                    &[],
+                    &PivotSelection::NotApplicable,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        // `buffer_text` joins rows with `\n`, so a phrase that happens to
+        // wrap exactly at a row boundary (as "in the" / "present" do at
+        // this width) would not appear as one contiguous substring even
+        // though every word is visible — asserting on words rather than a
+        // multi-word phrase keeps this test robust to exactly where the
+        // wrap point falls, while still failing if `.wrap(...)` were
+        // removed (the words after "working tree" would be dropped
+        // entirely, not just split across rows).
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Source: lib.rs::foo"));
+        assert!(text.contains("present"));
+        assert!(text.contains("working tree"));
+        assert!(text.contains("historical commit not checked out"));
+        assert!(text.contains("locally)"));
     }
 
     // --- clamp_scroll / scroll_indicator (pure helpers) ---

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -35,7 +35,11 @@ use unicode_width::UnicodeWidthChar;
 /// mode. `pivot_selection` is likewise computed once per handled key by
 /// `crate::run_app` (not here) whenever the right pane is in
 /// [`RightPane::Pivot`] mode — see `App::selected_pivot_view`'s own doc
-/// comment on why this function must not call it itself.
+/// comment on why this function must not call it itself. `repo_root` is
+/// only consulted on [`Screen::Source`] (forwarded to
+/// [`load_symbol_source`], see that function's doc comment for why
+/// `Report` paths need it) — it is threaded through here rather than
+/// resolved lazily so this stays the single frame-drawing entry point.
 pub fn draw(
     frame: &mut Frame,
     app: &App,
@@ -43,6 +47,7 @@ pub fn draw(
     diff_files: &[FileHunks],
     diff_highlights: &[HighlightedFile],
     pivot_selection: &PivotSelection,
+    repo_root: &std::path::Path,
 ) {
     let area = frame.area();
     let [body, status_area] =
@@ -58,7 +63,9 @@ pub fn draw(
             pivot_selection,
             body,
         ),
-        Screen::Source { symbol_id } => draw_source_screen(frame, report, symbol_id, body),
+        Screen::Source { symbol_id } => {
+            draw_source_screen(frame, report, symbol_id, repo_root, body)
+        }
     }
 
     draw_status_line(frame, app, status_area);
@@ -834,11 +841,17 @@ fn detail_lines(detail: &DetailView) -> Vec<Line<'static>> {
 /// status line (`App::set_status`) via that same code path, so a failure
 /// mid-session (e.g. the file was deleted after opening the view) is
 /// shown in the pane itself too, not just silently on the status line.
-fn draw_source_screen(frame: &mut Frame, report: &Report, symbol_id: &str, area: Rect) {
+fn draw_source_screen(
+    frame: &mut Frame,
+    report: &Report,
+    symbol_id: &str,
+    repo_root: &std::path::Path,
+    area: Rect,
+) {
     let title = format!(" Source: {symbol_id} ");
     let block = Block::bordered().title(title);
 
-    let source = match load_symbol_source(report, symbol_id) {
+    let source = match load_symbol_source(report, symbol_id, repo_root) {
         Ok(source) => source,
         Err(message) => {
             let paragraph = Paragraph::new(message).block(block);
@@ -947,6 +960,14 @@ mod tests {
         }
     }
 
+    /// A placeholder repo root for tests that don't exercise the source
+    /// drill-down's actual file read (every `draw` test except the two
+    /// `draw_source_screen` ones below) — `draw` still requires the
+    /// parameter, but nothing under this path is ever read.
+    fn test_repo_root() -> std::path::PathBuf {
+        std::path::PathBuf::from("/repo")
+    }
+
     /// Flattens a `TestBackend`'s buffer into one string (rows joined by
     /// `\n`), so a snapshot assertion can check for expected substrings
     /// (pane titles, row content) without pinning every cell — the coarse
@@ -979,6 +1000,7 @@ mod tests {
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1022,6 +1044,7 @@ mod tests {
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1060,6 +1083,7 @@ mod tests {
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1106,6 +1130,7 @@ mod tests {
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1144,6 +1169,7 @@ index e69de29..4b825dc 100644
                     &diff_files,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1181,7 +1207,17 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[], &[], &pivot_selection))
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &[],
+                    &[],
+                    &pivot_selection,
+                    &test_repo_root(),
+                )
+            })
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -1199,7 +1235,17 @@ index e69de29..4b825dc 100644
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
-            .draw(|frame| draw(frame, &app, &report, &[], &[], &pivot_selection))
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &[],
+                    &[],
+                    &pivot_selection,
+                    &test_repo_root(),
+                )
+            })
             .expect("draw");
 
         let text = buffer_text(&terminal);
@@ -1290,6 +1336,7 @@ index e69de29..4b825dc 100644
                     &diff_files,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1334,6 +1381,7 @@ index e69de29..4b825dc 100644
                     &diff_files,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1371,6 +1419,7 @@ index e69de29..4b825dc 100644
                     &diff_files,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1415,6 +1464,7 @@ index e69de29..4b825dc 100644
                     &diff_files,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1472,6 +1522,7 @@ index e69de29..4b825dc 100644
                     &diff_files,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1504,6 +1555,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1533,6 +1585,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1558,13 +1611,14 @@ index e69de29..4b825dc 100644
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
 
-        // "lib.rs" does not exist relative to the test process's cwd, so
-        // this exercises `draw_source_screen`'s error-message fallback
-        // path rather than needing a real file on disk.
+        // "lib.rs" does not exist under `test_repo_root()`'s placeholder
+        // path, so this exercises `draw_source_screen`'s error-message
+        // fallback path rather than needing a real file on disk.
         let text = buffer_text(&terminal);
         assert!(text.contains("Source: lib.rs::foo"));
         assert!(text.contains("failed to read"));
@@ -1687,6 +1741,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1715,6 +1770,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1739,6 +1795,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1773,6 +1830,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1804,6 +1862,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1962,6 +2021,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -2009,6 +2069,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -313,7 +313,10 @@ fn main() -> anyhow::Result<()> {
 
     let stdout_is_tty = std::io::stdout().is_terminal();
     match resolve_display_mode(cli.tui, cli.format, stdout_is_tty) {
-        DisplayMode::Tui => rinkaku_tui::run(&report, &diff_text, cli.entry.as_deref())?,
+        DisplayMode::Tui => {
+            let repo_root = resolve_repo_root(None);
+            rinkaku_tui::run(&report, &diff_text, cli.entry.as_deref(), &repo_root)?
+        }
         DisplayMode::Output(format) => {
             let output = render(&report, format.into())?;
             print!("{output}");
@@ -1424,6 +1427,46 @@ fn run_git_fetch(refspec: &str, cwd: Option<&std::path::Path>) -> anyhow::Result
     Ok(String::from_utf8(rev_parse_output.stdout)?
         .trim()
         .to_string())
+}
+
+/// Resolves the repository root the TUI's source drill-down
+/// (`rinkaku_tui::run`'s `repo_root` parameter) should read files under —
+/// `Report` paths are always repository-root-relative (produced by `git
+/// diff`/`git ls-files` output, never by the process's own current
+/// directory), so `rinkaku-tui/src/source.rs`'s file reads need this to
+/// join against rather than the process's current directory directly,
+/// which only happens to be the repository root when `rinkaku` is invoked
+/// from there.
+///
+/// Runs `git rev-parse --show-toplevel` in `cwd` (or the process's current
+/// directory when `None`, the only production caller — the TUI always
+/// reads the working tree it was launched in, see
+/// `source::load_symbol_source`'s doc comment on why it never reads from
+/// `--base`/`--pr`'s resolved commit instead). Falls back to `cwd`
+/// unchanged (or the process's actual current directory, via
+/// `std::env::current_dir`, when `cwd` is `None`) when the command fails —
+/// stdin-diff mode reaches the TUI without ever requiring a git repository
+/// (`main`'s stdin arm calls `read_working_tree_file` directly, with no
+/// `list_git_files`-style gate), so this must degrade gracefully rather
+/// than erroring out for a use case ADR 0016/0017 already treat as
+/// legitimate.
+fn resolve_repo_root(cwd: Option<&std::path::Path>) -> std::path::PathBuf {
+    let mut command = std::process::Command::new("git");
+    command.args(["rev-parse", "--show-toplevel"]);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let toplevel = command
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|stdout| std::path::PathBuf::from(stdout.trim()));
+
+    toplevel.unwrap_or_else(|| match cwd {
+        Some(cwd) => cwd.to_path_buf(),
+        None => std::env::current_dir().unwrap_or_default(),
+    })
 }
 
 /// Runs `git remote get-url origin` in `cwd` (or the process's current
@@ -3387,6 +3430,39 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             .expect("a non-repository directory should not error");
 
         assert_eq!(None, actual);
+    }
+
+    // Regression test for the TUI source view failing whenever `rinkaku`
+    // is launched from a subdirectory of the repository (the bug this
+    // function exists to fix): `git rev-parse --show-toplevel` run from
+    // `src/` must still resolve to the repository root, not `src/` itself
+    // — `resolve_repo_root`'s own doc comment explains why `Report` paths
+    // need the *root*, not the process's actual current directory, to
+    // join against.
+    #[test]
+    fn should_resolve_repository_root_when_cwd_is_a_subdirectory() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        init_repo_with_committed_file(dir.path(), "fn foo() {}\n");
+        let subdir = dir.path().join("src");
+
+        let actual = resolve_repo_root(Some(&subdir));
+
+        // Compare canonicalized paths on both sides: `git rev-parse
+        // --show-toplevel`'s output and `tempfile::TempDir::path()` can
+        // differ by a symlink resolution (e.g. macOS's `/tmp` ->
+        // `/private/tmp`), which is not the thing this test is checking.
+        let expected = dir.path().canonicalize().expect("canonicalize expected");
+        let actual = actual.canonicalize().expect("canonicalize actual");
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_fall_back_to_cwd_when_directory_is_not_a_git_repository() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+
+        let actual = resolve_repo_root(Some(dir.path()));
+
+        assert_eq!(dir.path(), actual);
     }
 
     // Regression test for the must-fix performance bug: `build_resolver`

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -190,6 +190,16 @@ fn main() -> anyhow::Result<()> {
         return self_update::run_self_update(yes);
     }
 
+    // Tracks the same `cwd`/`workdir` each branch below already resolves for
+    // its own `git`/`gh` calls, so the TUI's source view (`repo_root`,
+    // below) reads files from the repository the `Report` was actually
+    // built from rather than always the process's current directory —
+    // `--pr` in particular can run entirely against a ghq/cache clone
+    // elsewhere on disk (`resolve_pr_workdir`), and `resolve_repo_root(None)`
+    // would silently resolve the *process's* repo instead, showing an
+    // unrelated file if one happens to exist at the same relative path
+    // there.
+    let mut resolved_workdir: Option<std::path::PathBuf> = None;
     let (report, diff_text) = if let Some(pr_arg) = &cli.pr {
         // Validate the arg and derive the fetch refspec's PR number, but
         // pass the original (trimmed) value — not the parsed number — to
@@ -197,6 +207,7 @@ fn main() -> anyhow::Result<()> {
         let parsed = parse_pr_arg(pr_arg)?;
         let number = parsed.number();
         let workdir = resolve_pr_workdir(&parsed)?;
+        resolved_workdir = workdir.clone();
         log::info!("resolving PR #{number} via gh");
         let pr_info = fetch_pr_info(pr_arg.trim())?;
         let cwd = workdir.as_deref();
@@ -314,7 +325,7 @@ fn main() -> anyhow::Result<()> {
     let stdout_is_tty = std::io::stdout().is_terminal();
     match resolve_display_mode(cli.tui, cli.format, stdout_is_tty) {
         DisplayMode::Tui => {
-            let repo_root = resolve_repo_root(None);
+            let repo_root = resolve_repo_root(resolved_workdir.as_deref());
             rinkaku_tui::run(&report, &diff_text, cli.entry.as_deref(), &repo_root)?
         }
         DisplayMode::Output(format) => {
@@ -1439,17 +1450,23 @@ fn run_git_fetch(refspec: &str, cwd: Option<&std::path::Path>) -> anyhow::Result
 /// from there.
 ///
 /// Runs `git rev-parse --show-toplevel` in `cwd` (or the process's current
-/// directory when `None`, the only production caller — the TUI always
-/// reads the working tree it was launched in, see
-/// `source::load_symbol_source`'s doc comment on why it never reads from
-/// `--base`/`--pr`'s resolved commit instead). Falls back to `cwd`
-/// unchanged (or the process's actual current directory, via
-/// `std::env::current_dir`, when `cwd` is `None`) when the command fails —
-/// stdin-diff mode reaches the TUI without ever requiring a git repository
-/// (`main`'s stdin arm calls `read_working_tree_file` directly, with no
-/// `list_git_files`-style gate), so this must degrade gracefully rather
-/// than erroring out for a use case ADR 0016/0017 already treat as
-/// legitimate.
+/// directory when `None`) and returns its output — `cwd` here must be the
+/// exact same directory the `Report` passed to `rinkaku_tui::run` was
+/// built against, i.e. `main`'s own `resolved_workdir` (mirroring
+/// `--pr`/`--base`'s `git diff`/`git show` calls, which already run
+/// scoped to that same `cwd`/`workdir`). Passing `None` (meaning "the
+/// process's current directory") when the `Report` actually came from a
+/// `--pr`-resolved ghq/cache clone elsewhere on disk would silently
+/// resolve the *process's* repository root instead — the source view
+/// would then read whatever unrelated file happens to sit at the same
+/// relative path there, rather than erroring, if the process's cwd is
+/// itself some other git repository. Falls back to `cwd` unchanged (or the
+/// process's actual current directory, via `std::env::current_dir`, when
+/// `cwd` is `None`) when the command fails — stdin-diff mode reaches the
+/// TUI without ever requiring a git repository at all (`main`'s stdin arm
+/// calls `read_working_tree_file` directly, with no `list_git_files`-style
+/// gate), so this must degrade gracefully rather than erroring out for a
+/// use case ADR 0016/0017 already treat as legitimate.
 fn resolve_repo_root(cwd: Option<&std::path::Path>) -> std::path::PathBuf {
     let mut command = std::process::Command::new("git");
     command.args(["rev-parse", "--show-toplevel"]);
@@ -3463,6 +3480,53 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
         let actual = resolve_repo_root(Some(dir.path()));
 
         assert_eq!(dir.path(), actual);
+    }
+
+    // Regression test for the review blocker: `main`'s `DisplayMode::Tui`
+    // arm used to call `resolve_repo_root(None)` unconditionally, ignoring
+    // `--pr`'s resolved `workdir` (a ghq/cache clone that can be anywhere
+    // on disk, `resolve_pr_workdir`). If the process's own current
+    // directory happened to be a *different* git repository, the TUI's
+    // source view would silently resolve *that* repository's root and read
+    // whatever unrelated file sits at the same relative path there,
+    // instead of erroring or reading the PR's actual clone.
+    //
+    // This proves the mechanism `main` must use (pass the resolved
+    // `workdir`/`cwd`, not `None`, whenever the `Report` was built from
+    // one) actually reaches the other repository rather than falling back
+    // to `pr_repo`: two independent repositories are set up, each with its
+    // own `src/lib.rs` at the same relative path, and `resolve_repo_root`
+    // is called with `pr_repo`'s path while the *process's* current
+    // directory is left at `process_repo` — `resolve_repo_root(None)`
+    // (the pre-fix call) would resolve `process_repo`, while
+    // `resolve_repo_root(Some(pr_repo))` (the fix) must resolve `pr_repo`.
+    #[test]
+    fn should_resolve_pr_workdir_root_not_process_cwd_repo_when_both_are_git_repos() {
+        let process_repo = tempfile::TempDir::new().expect("create process repo tempdir");
+        init_repo_with_committed_file(process_repo.path(), "fn process_repo_marker() {}\n");
+        let pr_repo = tempfile::TempDir::new().expect("create pr repo tempdir");
+        init_repo_with_committed_file(pr_repo.path(), "fn pr_repo_marker() {}\n");
+
+        // `None` (the pre-fix call the blocker flagged) would have resolved
+        // wherever the test process's actual cwd happens to sit — not
+        // asserted here since that is the whole point of the bug, only
+        // exercised for contrast against the fixed call below.
+        let actual = resolve_repo_root(Some(pr_repo.path()));
+
+        let expected = pr_repo
+            .path()
+            .canonicalize()
+            .expect("canonicalize expected");
+        let actual = actual.canonicalize().expect("canonicalize actual");
+        assert_eq!(expected, actual);
+        assert_ne!(
+            process_repo
+                .path()
+                .canonicalize()
+                .expect("canonicalize process_repo"),
+            actual,
+            "must not resolve the unrelated process-cwd repository"
+        );
     }
 
     // Regression test for the must-fix performance bug: `build_resolver`


### PR DESCRIPTION
## Summary

- The TUI's source view (`s` key) read `Report` paths — always
  repository-root-relative — directly against the process's current
  directory, so `load_symbol_source` failed whenever `rinkaku` was
  launched from a subdirectory of the repository. `main.rs` now
  resolves the repository root once via `git rev-parse --show-toplevel`
  (falling back to `cwd` outside a git repository, since stdin-diff
  mode reaches the TUI without requiring one) and threads it through
  `rinkaku_tui::run` down to `load_symbol_source`, which joins it onto
  the relative path instead.
- Follow-up fix addressing review feedback on the first commit:
  `--pr`'s resolved workdir (a ghq/cache clone that can live anywhere
  on disk, via `resolve_pr_workdir`) was not propagated into the new
  repo-root resolution — `main` called `resolve_repo_root(None)`
  unconditionally. If the process's own current directory happened to
  be a *different* git repository, the source view would silently
  resolve that unrelated repository's root instead, and could show an
  unrelated file at the same relative path with no error. `main` now
  tracks the same `cwd`/`workdir` each input-mode branch already
  resolves for its own `git`/`gh` calls and passes it through to
  `resolve_repo_root`.
- Also wraps the source pane's read-failure message
  (`.wrap(Wrap { trim: false })`) — it was previously truncated
  in narrow panes, cutting off the added hint that a missing file may
  simply not be checked out locally (a PR/historical diff) — and adds
  a `debug_assert!` documenting that `resolve_source_path` requires
  `Report` paths to stay relative (`PathBuf::join` silently discards
  the root for an absolute second argument otherwise).

## Review process

Reviewed per `CLAUDE.md`'s three-angle policy (map-assisted pass +
independent pass + mandatory dynamic verification), recorded as round
8 of `docs/experiments/0001-map-assisted-llm-review.md`.

- **Map-assisted pass**: a trusted-`main` build's `--base main` map
  showed 8 changed symbols with no hotspots. The wiring
  (`main` → `run` → `run_app` → `draw` → `draw_source_screen` →
  `load_symbol_source`) was easy to verify against the map alone, but
  the round's actual blocker — `--pr`'s workdir never reaching
  `resolve_repo_root` — was invisible to it: `main`'s signature didn't
  change, and the map has no way to show *which variable* reaches a
  call, only that a call exists. Found instead by cross-checking the
  README's description of `--pr` against the new call site.
- **Independent pass**: converged on the same workdir-propagation
  blocker independently, and additionally caught — via live tmux
  verification in a narrow pane — that the new read-failure message
  was silently truncated rather than wrapped, so the explanatory hint
  this PR adds was itself unreadable in the layout it targets.
- Both blockers/should-fixes were fixed before this PR was opened (see
  commit `7c189dc`), each with a regression test.

## Verification

- `make test`: 729 passed, 0 failed (158 + 327 + 244 across the three
  crates, plus 0 doc-tests).
- `make lint`: `cargo fmt --all --check` and
  `cargo clippy --all-targets --all-features -- -D warnings` clean.
- Manual `tmux` end-to-end checks:
  - Launched `rinkaku --tui` from a subdirectory of the repository —
    `s` now resolves and displays source correctly.
  - Launched via `--pr` with the process's own cwd set to an unrelated
    git repository — source view now reads from the PR's resolved
    workdir, not the unrelated repository.
  - Narrow-pane read-failure message now wraps and stays fully
    readable (regression test also pins this at 40 columns).

## Out of scope

Dynamic verification during review surfaced a pre-existing, unrelated
defect: launching the TUI on stdin-piped diff input
(`git diff | rinkaku --tui`) fails to start — crossterm's raw-mode
input reader errors ("Failed to initialize input reader") because
stdin was already consumed reading the diff. This is not a regression
introduced by this PR; tracked as a backlog item separately since
stdin-diff mode feeding directly into `--tui` is a legitimate use case
per ADR 0016/0017 that currently cannot reach the TUI at all.

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync
