### PR TITLE
feat(tui): show skipped and test-only files in the entry tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,15 +491,24 @@ placeholder.
   uses in Markdown, condensed to the directory level; `o` toggles to plain
   alphabetical order. Symbol rows show a kind abbreviation (`fn`, `struct`,
   ...) and a classification marker: `+` added, `~` signature-changed, `x`
-  removed (dimmed and crossed out).
+  removed (dimmed and crossed out). A file rinkaku could not extract
+  symbols from (unsupported language, binary, deleted) still shows up as a
+  dimmed row marked `(skipped: <reason>)`, same reasons as `--format
+  json`'s `skipped[].reason` — the same as Markdown's own "Skipped files"
+  list, `SkipReason::Generated` entries are omitted by default (ADR
+  0010/0011). A file whose changed symbols were *all* test code (ADR 0009)
+  shows up too, marked `[test] (N symbols)`, instead of the pre-existing
+  gap where such a file had no row at all and was only summarized in
+  Markdown's "Tests" section.
 - **Detail pane (right):** what the cursor is on. A symbol row shows its
   classification, signature (an old/new diff when the contract changed),
   who depends on it ("used by"), and its callees. A file row shows every
-  symbol changed in that file with its classification marker and fan-in. A
-  directory row shows its badge breakdown and top fan-in symbols, plus —
-  when it participates in a dependency cycle — exactly which other
-  directories it cycles with and the concrete symbol-to-symbol edges
-  forming that cycle.
+  symbol changed in that file with its classification marker and fan-in —
+  or, for a skipped file, why rinkaku didn't analyze it; or, for a
+  whole-test file, the changed test-symbol count. A directory row shows
+  its badge breakdown and top fan-in symbols, plus — when it participates
+  in a dependency cycle — exactly which other directories it cycles with
+  and the concrete symbol-to-symbol edges forming that cycle.
 - **Diff pane (right):** `d`/`D` toggles the right-hand pane to the raw
   unified-diff hunks instead of the detail view — every hunk of the file
   for a file row, or just the hunks intersecting a symbol's own line range

--- a/docs/experiments/0001-map-assisted-llm-review.md
+++ b/docs/experiments/0001-map-assisted-llm-review.md
@@ -557,6 +557,83 @@ that first commit).
   defect says less about the two passes' complementary value than
   divergence does.
 
+## Results (round 9)
+
+Same two-pass method, ninth subject: showing skipped and whole-test
+files in the TUI entry tree (2 commits — the feature itself, then a
+follow-up addressing review feedback).
+
+| Metric               | A (map)     | B (control) |
+| --------------------- | ----------- | ----------- |
+| Blocker findings      | 0           | 0           |
+| Should-fix findings   | 1           | 1           |
+
+- The map for this diff was small: 15 changed symbols across 5 files,
+  with `TreeNode` and `FileDetail` (a `signature changed` node) as its
+  two hotspots. Allocating attention by hotspot and walking outward to
+  consumers (`nav`, `order`, `app`, `detail`, `ui`, `row_view`) worked
+  as intended — A's one should-fix came from actually reading the
+  `TreeNode` the map pointed at: the same file path can be inserted
+  from `report.files`, `report.tests`, and `report.skipped`
+  independently, and nothing stopped a later insert from silently
+  overwriting an earlier one's fields, producing a row that both lists
+  real symbols and claims to be skipped/test-only. What the map could
+  not show is the root cause underneath that finding — the three
+  insert paths share a private `file_at` get-or-insert helper, a
+  structural fact invisible to a signature-level diff.
+- B's finding was unrelated and came from plain reading, not
+  execution: a leftover duplicate doc comment above `file_detail_lines`
+  (an old block describing the pre-change behavior, superseded by a
+  new block but never deleted, left the two concatenated and
+  self-contradictory).
+- B also carried this round's dynamic-verification step: a synthetic
+  Go repository (a whole test-only file, a binary file, and an
+  unsupported-language text file) driven end-to-end through the real
+  TUI binary in tmux — every navigation key, the detail pane for both
+  new row kinds, the diff pane for both (including the binary file's
+  correct "no diff hunks found" fallback, since git itself reports no
+  hunks for binaries), and a check that whole-repo/non-TTY paths
+  weren't regressed. No behavioral defect turned up; this pass's value
+  here was confirming the feature, not finding a bug.
+- Zero overlap between the two passes' findings, and neither
+  finding was the kind the other pass's method could realistically
+  have produced: the map routed A to a structural risk sitting one
+  level of indirection below the diff's own signatures; B's finding
+  was a textual leftover a signature-level map has no reason to flag
+  at all, plus a clean bill of health from actually running the thing.
+- Fixes shipped in response: `debug_assert!` guards (plus two
+  `#[should_panic]` regression tests) on the three insert paths
+  pinning the "one path, one source" invariant explicitly rather than
+  leaving it as an unstated assumption of the shared `file_at` helper;
+  the duplicate doc comment removed; and, as a related consistency fix
+  neither pass explicitly flagged but both findings motivated once
+  looked at together, the entry-row badge's skip-reason-vs-test-badge
+  priority was aligned with the detail pane's own priority (`if`/`else
+  if` instead of two independent `if let`s).
+
+## Conclusions (after 9 rounds)
+
+- Round 9 adds a variant to round 8's "the map shows a wire exists,
+  not whether it's correct" lesson: here the map correctly pointed at
+  the *node* where the defect lived (`TreeNode`), but the defect's
+  cause was a shared private helper one layer beneath anything the
+  map's symbol-level view represents. A hotspot is still a good place
+  to look; it is not a guarantee the map has shown you everything
+  worth seeing at that location.
+- This is the first round with **zero overlap and no shared theme**
+  between the two passes' findings — a sharper case of round 8's
+  point that convergence is not itself evidence of complementary
+  value, restated from the other side: divergence this clean (a
+  structural-invariant gap vs. a leftover comment, found by
+  fundamentally different means) is closer to what "two
+  complementary angles" was supposed to produce than any prior round.
+- Dynamic verification's role keeps shifting round to round — round 8
+  used it to *find* a defect (unwrapped text truncated in a narrow
+  pane); here it *confirmed the absence* of one across every new
+  interactive surface. Both outcomes are the step earning its keep:
+  the point is that someone actually drove the binary, not that doing
+  so must always turn up a bug.
+
 ## Next
 
 - Consider a map feature flagging cross-crate duplicate-domain
@@ -572,3 +649,10 @@ that first commit).
   (crossterm's input reader fails to initialize because stdin was
   already consumed reading the diff) — a pre-existing gap in a
   documented use case (ADR 0016/0017), not a regression of this PR.
+- Round 9's near-miss (a shared private helper causing a display bug
+  invisible to a symbol-level map) suggests a possible map feature:
+  flag when two or more independent top-level `Report` fields
+  (`files`/`tests`/`skipped`/`removed`) feed into the same
+  downstream construction function, since that shape recurs whenever
+  a `Report` consumer merges several "list of things about a path"
+  fields back into one per-path structure.

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -913,7 +913,13 @@ fn longest_backtick_run(text: &str) -> Option<usize> {
         .max()
 }
 
-fn skip_reason_label(reason: SkipReason) -> &'static str {
+/// The short label shown for a [`SkipReason`] — `"unsupported language"`,
+/// `"binary"`, `"deleted"`, `"generated"`. `pub` (rather than private to
+/// this module) so other renderers of the same [`Report`] data — currently
+/// `rinkaku-tui`'s entry-tree view — can show the identical wording instead
+/// of maintaining a second copy of this match that could drift from
+/// Markdown's.
+pub fn skip_reason_label(reason: SkipReason) -> &'static str {
     match reason {
         SkipReason::UnsupportedLanguage => "unsupported language",
         SkipReason::Binary => "binary",

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -725,6 +725,8 @@ mod tests {
                 removed: false,
                 fan_in: 0,
             }],
+            skip_reason: None,
+            test_symbol_count: None,
         });
         assert_eq!(Some(expected), actual);
     }
@@ -1084,6 +1086,36 @@ mod tests {
         assert_eq!(
             Some(DiffTarget::File {
                 path: "lib.rs".to_string()
+            }),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_return_file_diff_target_when_cursor_is_on_a_skipped_file_row() {
+        // A skipped file has no symbols, but `selected_diff_target` scopes
+        // a file row's diff to the whole file regardless of `skip_reason`
+        // (only the entry-tree label/detail pane change for a skipped
+        // file) — the raw diff hunks for it still exist and should still
+        // be reachable via the diff pane.
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            skipped: vec![rinkaku_core::render::SkippedFile {
+                path: "assets/logo.png".to_string(),
+                reason: rinkaku_core::render::SkipReason::Binary,
+            }],
+            ..empty_report()
+        };
+        // Row 0 is the collapsing "assets" dir (single child, see
+        // `crate::tree::build_tree`'s collapsing rule); row 1 is the
+        // skipped "logo.png" file itself.
+        let app = App::new(&report).handle_key(InputKey::Down);
+
+        let actual = app.selected_diff_target(&report);
+
+        assert_eq!(
+            Some(DiffTarget::File {
+                path: "assets/logo.png".to_string()
             }),
             actual
         );

--- a/rinkaku-tui/src/detail.rs
+++ b/rinkaku-tui/src/detail.rs
@@ -246,10 +246,19 @@ pub struct FileSymbolSummary {
 /// iteration 2): the list of symbols changed in this file, each with its
 /// classification marker and fan-in — a compact index of "what changed
 /// here" before drilling into an individual symbol row.
+///
+/// `skip_reason`/`test_symbol_count` mirror `crate::tree::TreeNode`'s own
+/// fields of the same name (copied straight from the tree node this detail
+/// was built from — see `build_file_detail`) so the detail pane can explain
+/// *why* a skipped or whole-test file has no `symbols` entries instead of
+/// silently showing an empty list, which used to read as "this file changed
+/// nothing" rather than "rinkaku did not analyze this file's symbols".
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileDetail {
     pub path: String,
     pub symbols: Vec<FileSymbolSummary>,
+    pub skip_reason: Option<rinkaku_core::render::SkipReason>,
+    pub test_symbol_count: Option<usize>,
 }
 
 /// Builds a [`DirDetail`] for the directory at `path` in `tree`, or `None`
@@ -334,6 +343,8 @@ pub fn build_file_detail(tree: &Tree, report: &Report, path: &str) -> Option<Fil
     Some(FileDetail {
         path: node.path.clone(),
         symbols,
+        skip_reason: node.skip_reason,
+        test_symbol_count: node.test_symbol_count,
     })
 }
 
@@ -1033,6 +1044,8 @@ mod tests {
                     fan_in: 2,
                 },
             ],
+            skip_reason: None,
+            test_symbol_count: None,
         };
         assert_eq!(expected, actual);
     }
@@ -1063,6 +1076,54 @@ mod tests {
                 removed: true,
                 fan_in: 0,
             }],
+            skip_reason: None,
+            test_symbol_count: None,
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_carry_skip_reason_into_file_detail_when_file_row_is_skipped() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            skipped: vec![rinkaku_core::render::SkippedFile {
+                path: "assets/logo.png".to_string(),
+                reason: rinkaku_core::render::SkipReason::Binary,
+            }],
+            ..empty_report()
+        };
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_file_detail(&tree, &report, "assets/logo.png").expect("file found");
+
+        let expected = FileDetail {
+            path: "assets/logo.png".to_string(),
+            symbols: vec![],
+            skip_reason: Some(rinkaku_core::render::SkipReason::Binary),
+            test_symbol_count: None,
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_carry_test_symbol_count_into_file_detail_when_file_row_is_a_whole_test_file() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            tests: vec![rinkaku_core::render::TestFileSummary {
+                path: "src/lib_test.go".to_string(),
+                symbol_count: 4,
+            }],
+            ..empty_report()
+        };
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_file_detail(&tree, &report, "src/lib_test.go").expect("file found");
+
+        let expected = FileDetail {
+            path: "src/lib_test.go".to_string(),
+            symbols: vec![],
+            skip_reason: None,
+            test_symbol_count: Some(4),
         };
         assert_eq!(expected, actual);
     }

--- a/rinkaku-tui/src/nav.rs
+++ b/rinkaku-tui/src/nav.rs
@@ -313,6 +313,8 @@ mod tests {
             path: path.to_string(),
             badges: Badges::default(),
             children: vec![],
+            skip_reason: None,
+            test_symbol_count: None,
         }
     }
 
@@ -322,6 +324,8 @@ mod tests {
             path: path.to_string(),
             badges: Badges::default(),
             children,
+            skip_reason: None,
+            test_symbol_count: None,
         }
     }
 
@@ -331,6 +335,8 @@ mod tests {
             path: path.to_string(),
             badges: Badges::default(),
             children,
+            skip_reason: None,
+            test_symbol_count: None,
         }
     }
 

--- a/rinkaku-tui/src/order.rs
+++ b/rinkaku-tui/src/order.rs
@@ -1070,6 +1070,8 @@ mod tests {
             path: path.to_string(),
             badges: crate::tree::Badges::default(),
             children,
+            skip_reason: None,
+            test_symbol_count: None,
         }
     }
 
@@ -1079,6 +1081,8 @@ mod tests {
             path: path.to_string(),
             badges: crate::tree::Badges::default(),
             children: vec![],
+            skip_reason: None,
+            test_symbol_count: None,
         }
     }
 
@@ -1332,6 +1336,8 @@ mod tests {
             path: path.to_string(),
             badges: crate::tree::Badges::default(),
             children,
+            skip_reason: None,
+            test_symbol_count: None,
         }
     }
 

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -70,9 +70,17 @@ pub fn entry_row_line(
         }
         NodeKind::File => {
             spans.push(Span::raw(format!("{} ", expand_marker(row))));
-            spans.push(Span::raw(label.to_string()));
+            spans.push(Span::styled(label.to_string(), file_label_style(row.node)));
             spans.push(Span::raw(" "));
             spans.push(badges_span(&row.node.badges));
+            if let Some(reason) = row.node.skip_reason {
+                spans.push(Span::raw(" "));
+                spans.push(skip_reason_span(reason));
+            }
+            if let Some(count) = row.node.test_symbol_count {
+                spans.push(Span::raw(" "));
+                spans.push(test_badge_span(count));
+            }
         }
         NodeKind::Symbol(symbol_ref) => {
             spans.push(Span::raw("  "));
@@ -186,6 +194,52 @@ fn badges_span(badges: &Badges) -> Span<'static> {
     Span::styled(parts.join(" "), Style::default().fg(Color::Cyan))
 }
 
+/// A `File` row's label style: dimmed for a skipped file (nothing was
+/// extracted from it, so it reads visually as "less relevant" than an
+/// analyzed file, same intent as `symbol_name_style`'s dimming of a removed
+/// symbol), plain otherwise — including a whole-test-file row, which is
+/// still an ordinarily-styled label with its own `[test]` badge appended
+/// separately (see `test_badge_span`) rather than dimmed, since a test file
+/// is not "uninteresting", just excluded from the default symbol-level view
+/// (ADR 0009).
+fn file_label_style(node: &crate::tree::TreeNode) -> Style {
+    if node.skip_reason.is_some() {
+        Style::default().fg(Color::DarkGray)
+    } else {
+        Style::default()
+    }
+}
+
+/// The `(skipped: <reason>)` annotation for a skipped `File` row, reusing
+/// [`rinkaku_core::render::skip_reason_label`]'s exact wording so the TUI
+/// and Markdown output never describe the same `SkipReason` differently.
+fn skip_reason_span(reason: rinkaku_core::render::SkipReason) -> Span<'static> {
+    Span::styled(
+        format!(
+            "(skipped: {})",
+            rinkaku_core::render::skip_reason_label(reason)
+        ),
+        Style::default().fg(Color::DarkGray),
+    )
+}
+
+/// The `[test] (N symbols)` badge for a whole-test-file `File` row (a file
+/// with no `FileReport` in `report.files` at all, see
+/// `crate::tree::TreeNode::test_symbol_count`'s doc comment) — `N symbol`
+/// (singular) when there is exactly one, matching `render.rs`'s own
+/// singular/plural "Tests" section wording.
+fn test_badge_span(symbol_count: usize) -> Span<'static> {
+    let noun = if symbol_count == 1 {
+        "symbol"
+    } else {
+        "symbols"
+    };
+    Span::styled(
+        format!("[test] ({symbol_count} {noun})"),
+        Style::default().fg(Color::Magenta),
+    )
+}
+
 /// A symbol row's leading classification marker: `+` added, `~`
 /// signature-changed, ` ` (blank, one column) body-only or unclassified,
 /// `x` removed. Kept as its own single-character span (rather than folded
@@ -244,6 +298,8 @@ mod tests {
             path: path.to_string(),
             badges,
             children,
+            skip_reason: None,
+            test_symbol_count: None,
         }
     }
 
@@ -253,6 +309,30 @@ mod tests {
             path: path.to_string(),
             badges,
             children: vec![],
+            skip_reason: None,
+            test_symbol_count: None,
+        }
+    }
+
+    fn skipped_file_node(path: &str, reason: rinkaku_core::render::SkipReason) -> TreeNode {
+        TreeNode {
+            kind: NodeKind::File,
+            path: path.to_string(),
+            badges: Badges::default(),
+            children: vec![],
+            skip_reason: Some(reason),
+            test_symbol_count: None,
+        }
+    }
+
+    fn test_file_node(path: &str, symbol_count: usize) -> TreeNode {
+        TreeNode {
+            kind: NodeKind::File,
+            path: path.to_string(),
+            badges: Badges::default(),
+            children: vec![],
+            skip_reason: None,
+            test_symbol_count: Some(symbol_count),
         }
     }
 
@@ -262,6 +342,8 @@ mod tests {
             path: path.to_string(),
             badges,
             children: vec![],
+            skip_reason: None,
+            test_symbol_count: None,
         }
     }
 
@@ -330,6 +412,77 @@ mod tests {
         let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
 
         assert_eq!("  lib.rs ", line_text(&line));
+    }
+
+    #[test]
+    fn should_append_skip_reason_for_a_skipped_file_row() {
+        let node = skipped_file_node("assets/logo.png", rinkaku_core::render::SkipReason::Binary);
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "assets/logo.png", &HashMap::new(), false);
+
+        assert_eq!("  assets/logo.png  (skipped: binary)", line_text(&line));
+    }
+
+    #[test]
+    fn should_dim_label_for_a_skipped_file_row() {
+        let node = skipped_file_node("assets/logo.png", rinkaku_core::render::SkipReason::Binary);
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "assets/logo.png", &HashMap::new(), false);
+
+        // The label span is the third span: indent, expand marker, label.
+        assert_eq!(Some(Color::DarkGray), line.spans[2].style.fg);
+    }
+
+    #[test]
+    fn should_not_append_skip_reason_for_an_ordinary_file_row() {
+        let node = file_node("lib.rs", Badges::default());
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
+
+        assert!(!line_text(&line).contains("skipped"));
+    }
+
+    #[test]
+    fn should_append_test_badge_with_plural_symbols_noun_for_a_whole_test_file_row() {
+        let node = test_file_node("src/lib_test.go", 3);
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "src/lib_test.go", &HashMap::new(), false);
+
+        assert_eq!("  src/lib_test.go  [test] (3 symbols)", line_text(&line));
+    }
+
+    #[test]
+    fn should_append_test_badge_with_singular_symbol_noun_when_count_is_one() {
+        let node = test_file_node("src/lib_test.go", 1);
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "src/lib_test.go", &HashMap::new(), false);
+
+        assert_eq!("  src/lib_test.go  [test] (1 symbol)", line_text(&line));
     }
 
     #[test]

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -73,11 +73,19 @@ pub fn entry_row_line(
             spans.push(Span::styled(label.to_string(), file_label_style(row.node)));
             spans.push(Span::raw(" "));
             spans.push(badges_span(&row.node.badges));
+            // `skip_reason`/`test_symbol_count` are mutually exclusive by
+            // construction (`crate::tree::TreeNode`'s own doc comment, and
+            // `TreeBuilder::insert_file`'s `debug_assert` in `tree.rs`), so
+            // this `if`/`else if` never actually has to choose between the
+            // two badges — but the priority (skip reason first) is kept
+            // explicit and matches `crate::ui::file_detail_lines`'s own
+            // skip-reason-first early return, so the two panes never
+            // disagree about which explanation wins if that invariant were
+            // ever violated upstream.
             if let Some(reason) = row.node.skip_reason {
                 spans.push(Span::raw(" "));
                 spans.push(skip_reason_span(reason));
-            }
-            if let Some(count) = row.node.test_symbol_count {
+            } else if let Some(count) = row.node.test_symbol_count {
                 spans.push(Span::raw(" "));
                 spans.push(test_badge_span(count));
             }

--- a/rinkaku-tui/src/tree.rs
+++ b/rinkaku-tui/src/tree.rs
@@ -7,7 +7,7 @@
 //! separate concern, see `crate::order`).
 
 use rinkaku_core::extract::{Classification, SymbolKind};
-use rinkaku_core::render::Report;
+use rinkaku_core::render::{Report, SkipReason};
 use std::collections::{BTreeMap, HashMap};
 
 /// A symbol's identity, as carried by a [`NodeKind::Symbol`] leaf — enough
@@ -113,6 +113,28 @@ pub struct TreeNode {
     pub path: String,
     pub badges: Badges,
     pub children: Vec<TreeNode>,
+    /// `Some` only for a [`NodeKind::File`] node built from
+    /// `report.skipped` (a file rinkaku could not extract symbols from —
+    /// see `SkipReason`), `None` for every other node including an
+    /// ordinary analyzed `File`. Kept as a field on `TreeNode` rather than a
+    /// new `NodeKind` variant so `crate::app`/`crate::order`'s existing
+    /// exhaustive `match`es over `NodeKind` (dispatching detail/diff/pivot
+    /// panes and sibling ordering) keep treating a skipped file exactly
+    /// like any other file row — it already has the right shape (a
+    /// childless file with a path), it just additionally carries *why*
+    /// rinkaku skipped it, for `row_view`/the detail pane to surface.
+    pub skip_reason: Option<SkipReason>,
+    /// `Some(symbol_count)` only for a [`NodeKind::File`] node built from
+    /// `report.tests` (a file whose changed symbols were *all* test code,
+    /// ADR 0009 — such a file has no `FileReport` in `report.files` at all,
+    /// see `pipeline::partition_test_symbols`'s doc comment, so without
+    /// this it would be invisible in the tree the same way a skipped file
+    /// is). `None` for every other node, including an ordinary `File` node
+    /// whose *some* (not all) symbols were tests — those are filtered out
+    /// of `report.files` silently today and stay that way here too; only a
+    /// whole-file test exclusion has no other representation in the tree to
+    /// piggyback on.
+    pub test_symbol_count: Option<usize>,
 }
 
 /// The whole directory tree built from one [`Report`]. `roots` holds the
@@ -128,13 +150,31 @@ pub struct Tree {
 /// (`report.files`, including files with an empty `symbols` list — e.g. a
 /// pure rename, still shown as a `File` node with zero badges — and
 /// `report.removed`'s files, which may not otherwise appear in `files` at
-/// all if every symbol in that file was removed).
+/// all if every symbol in that file was removed), plus every whole-test
+/// file summarized in `report.tests` and every non-`Generated` entry in
+/// `report.skipped` (a file rinkaku could not extract symbols from at
+/// all) — both of which otherwise have no `TreeNode` of their own and so
+/// were previously invisible in the tree entirely (see `TreeNode`'s
+/// `skip_reason`/`test_symbol_count` doc comments).
+///
+/// `SkipReason::Generated` entries are dropped from the tree the same way
+/// `render_markdown` drops them from "Skipped files" — a `.gitattributes`
+/// declaration or linguist-compatible marker has already told the
+/// repository this file is uninteresting to diff-review (ADR 0010/0011),
+/// so surfacing it in the TUI would just be noise a reviewer has to
+/// scroll past, same reasoning as the Markdown renderer's own comment.
 ///
 /// Construction is a pure function of `report` alone and deterministic:
 /// files are visited in `report.files` order (already source order per
-/// `pipeline::analyze_diff`), then `report.removed` for any additional
-/// files/symbols not already covered, and directory chains are inserted in
-/// that same discovery order.
+/// `pipeline::analyze_diff`), then `report.removed`, then `report.tests`,
+/// then `report.skipped`, for any additional files/symbols not already
+/// covered, and directory chains are inserted in that same discovery
+/// order. A path present in more than one of these sources (not expected
+/// from `pipeline::analyze_diff`'s own invariants — a file is either kept
+/// in `files`, summarized in `tests`, or listed in `skipped`, never more
+/// than one) merges into one `TreeNode` the same way `insert_file`/
+/// `insert_removed` already merge on a shared path, rather than producing
+/// a duplicate row.
 ///
 /// **Single-child directory collapsing**: a directory whose only content is
 /// exactly one child directory (and nothing else — no files or symbols of
@@ -161,6 +201,14 @@ pub fn build_tree(report: &Report) -> Tree {
     }
     for removed in &report.removed {
         builder.insert_removed(&removed.path, removed);
+    }
+    for test_file in &report.tests {
+        builder.insert_test_file(&test_file.path, test_file.symbol_count);
+    }
+    for skipped in &report.skipped {
+        if !matches!(skipped.reason, SkipReason::Generated) {
+            builder.insert_skipped(&skipped.path, skipped.reason);
+        }
     }
 
     builder.finish()
@@ -195,6 +243,11 @@ struct DirBuilder {
 #[derive(Default)]
 struct FileBuilder {
     symbols: Vec<SymbolRef>,
+    /// Set by `insert_skipped` — see `TreeNode::skip_reason`'s doc comment.
+    skip_reason: Option<SkipReason>,
+    /// Set by `insert_test_file` — see `TreeNode::test_symbol_count`'s doc
+    /// comment.
+    test_symbol_count: Option<usize>,
 }
 
 impl<'a> TreeBuilder<'a> {
@@ -229,6 +282,24 @@ impl<'a> TreeBuilder<'a> {
             classification: None,
             removed: true,
         });
+    }
+
+    /// Inserts a whole-test-file summary (`report.tests`, see
+    /// `TreeNode::test_symbol_count`'s doc comment) as a childless `File`
+    /// node — there is no per-symbol data to nest under it, only the count
+    /// `pipeline::partition_test_symbols` kept.
+    fn insert_test_file(&mut self, path: &str, symbol_count: usize) {
+        let segments: Vec<&str> = path.split('/').collect();
+        let file_builder = self.root.file_at(&segments);
+        file_builder.test_symbol_count = Some(symbol_count);
+    }
+
+    /// Inserts a skipped-file entry (`report.skipped`, see
+    /// `TreeNode::skip_reason`'s doc comment) as a childless `File` node.
+    fn insert_skipped(&mut self, path: &str, reason: SkipReason) {
+        let segments: Vec<&str> = path.split('/').collect();
+        let file_builder = self.root.file_at(&segments);
+        file_builder.skip_reason = Some(reason);
     }
 
     fn finish(self) -> Tree {
@@ -347,6 +418,8 @@ fn build_dir_node(
         path,
         badges,
         children,
+        skip_reason: None,
+        test_symbol_count: None,
     }
 }
 
@@ -369,6 +442,8 @@ fn build_file_node(
                 path: path.clone(),
                 badges: symbol_badges,
                 children: Vec::new(),
+                skip_reason: None,
+                test_symbol_count: None,
             }
         })
         .collect();
@@ -378,6 +453,8 @@ fn build_file_node(
         path,
         badges,
         children,
+        skip_reason: file.skip_reason,
+        test_symbol_count: file.test_symbol_count,
     }
 }
 
@@ -418,7 +495,7 @@ mod tests {
     use rinkaku_core::diff::LineRange;
     use rinkaku_core::extract::{ExtractedSymbol, RemovedSymbol};
     use rinkaku_core::graph::{Hotspot, SymbolGraph};
-    use rinkaku_core::render::FileReport;
+    use rinkaku_core::render::{FileReport, SkippedFile, TestFileSummary};
 
     fn symbol(id: &str, name: &str, kind: SymbolKind) -> ExtractedSymbol {
         ExtractedSymbol {
@@ -498,7 +575,11 @@ mod tests {
                         fan_in: 0,
                     },
                     children: vec![],
+                    skip_reason: None,
+                    test_symbol_count: None,
                 }],
+                skip_reason: None,
+                test_symbol_count: None,
             }],
         };
         let actual = build_tree(&report);
@@ -529,7 +610,11 @@ mod tests {
                     path: "src/foo/bar/lib.rs".to_string(),
                     badges: Badges::default(),
                     children: vec![],
+                    skip_reason: None,
+                    test_symbol_count: None,
                 }],
+                skip_reason: None,
+                test_symbol_count: None,
             }],
         };
         let actual = build_tree(&report);
@@ -565,14 +650,20 @@ mod tests {
                         path: "src/a.rs".to_string(),
                         badges: Badges::default(),
                         children: vec![],
+                        skip_reason: None,
+                        test_symbol_count: None,
                     },
                     TreeNode {
                         kind: NodeKind::File,
                         path: "src/b.rs".to_string(),
                         badges: Badges::default(),
                         children: vec![],
+                        skip_reason: None,
+                        test_symbol_count: None,
                     },
                 ],
+                skip_reason: None,
+                test_symbol_count: None,
             }],
         };
         let actual = build_tree(&report);
@@ -611,6 +702,8 @@ mod tests {
                         path: "src/mod.rs".to_string(),
                         badges: Badges::default(),
                         children: vec![],
+                        skip_reason: None,
+                        test_symbol_count: None,
                     },
                     TreeNode {
                         kind: NodeKind::Dir,
@@ -621,9 +714,15 @@ mod tests {
                             path: "src/foo/bar.rs".to_string(),
                             badges: Badges::default(),
                             children: vec![],
+                            skip_reason: None,
+                            test_symbol_count: None,
                         }],
+                        skip_reason: None,
+                        test_symbol_count: None,
                     },
                 ],
+                skip_reason: None,
+                test_symbol_count: None,
             }],
         };
         let actual = build_tree(&report);
@@ -721,7 +820,11 @@ mod tests {
                         fan_in: 0,
                     },
                     children: vec![],
+                    skip_reason: None,
+                    test_symbol_count: None,
                 }],
+                skip_reason: None,
+                test_symbol_count: None,
             }],
         };
         let actual = build_tree(&report);
@@ -774,6 +877,8 @@ mod tests {
                             fan_in: 0,
                         },
                         children: vec![],
+                        skip_reason: None,
+                        test_symbol_count: None,
                     },
                     TreeNode {
                         kind: NodeKind::Symbol(SymbolRef {
@@ -790,8 +895,12 @@ mod tests {
                             fan_in: 0,
                         },
                         children: vec![],
+                        skip_reason: None,
+                        test_symbol_count: None,
                     },
                 ],
+                skip_reason: None,
+                test_symbol_count: None,
             }],
         };
         let actual = build_tree(&report);
@@ -863,7 +972,11 @@ mod tests {
                     path: "src/renamed.rs".to_string(),
                     badges: Badges::default(),
                     children: vec![],
+                    skip_reason: None,
+                    test_symbol_count: None,
                 }],
+                skip_reason: None,
+                test_symbol_count: None,
             }],
         };
         let actual = build_tree(&report);
@@ -942,5 +1055,201 @@ mod tests {
         let tree = build_tree(&report);
 
         assert_eq!(0, tree.roots[0].badges.fan_in);
+    }
+
+    // Skipped-file tests: a file rinkaku could not extract symbols from
+    // (unsupported language, binary, deleted) must still show up in the
+    // tree, since otherwise it is invisible to a reviewer relying on the
+    // TUI to see the whole PR (the user-reported gap this feature closes).
+
+    #[test]
+    fn should_add_skipped_file_as_childless_file_node_with_skip_reason() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            skipped: vec![SkippedFile {
+                path: "assets/logo.png".to_string(),
+                reason: rinkaku_core::render::SkipReason::Binary,
+            }],
+            ..empty_report()
+        };
+
+        let expected = Tree {
+            roots: vec![TreeNode {
+                kind: NodeKind::Dir,
+                path: "assets".to_string(),
+                badges: Badges::default(),
+                children: vec![TreeNode {
+                    kind: NodeKind::File,
+                    path: "assets/logo.png".to_string(),
+                    badges: Badges::default(),
+                    children: vec![],
+                    skip_reason: Some(rinkaku_core::render::SkipReason::Binary),
+                    test_symbol_count: None,
+                }],
+                skip_reason: None,
+                test_symbol_count: None,
+            }],
+        };
+        let actual = build_tree(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_omit_generated_skip_reason_from_tree_by_default() {
+        // Mirrors `render_markdown`'s own `SkipReason::Generated` filter
+        // (ADR 0010/0011): a `.gitattributes`-declared or content-marked
+        // generated file is already known-uninteresting, so it should not
+        // clutter the TUI tree either.
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            skipped: vec![SkippedFile {
+                path: "Cargo.lock".to_string(),
+                reason: rinkaku_core::render::SkipReason::Generated,
+            }],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        assert_eq!(Tree { roots: vec![] }, tree);
+    }
+
+    #[test]
+    fn should_keep_non_generated_skip_reasons_when_mixed_with_a_generated_entry() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            skipped: vec![
+                SkippedFile {
+                    path: "Cargo.lock".to_string(),
+                    reason: rinkaku_core::render::SkipReason::Generated,
+                },
+                SkippedFile {
+                    path: "assets/logo.png".to_string(),
+                    reason: rinkaku_core::render::SkipReason::Binary,
+                },
+            ],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        let paths: Vec<&str> = tree.roots.iter().map(|n| n.path.as_str()).collect();
+        assert_eq!(vec!["assets"], paths);
+    }
+
+    #[test]
+    fn should_merge_skipped_file_into_existing_dir_alongside_analyzed_files() {
+        // A skipped file sharing a directory with an already-analyzed file
+        // must land in the same `Dir` node, not create a second "src" root.
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![],
+            }],
+            skipped: vec![SkippedFile {
+                path: "src/generated.pb.go".to_string(),
+                reason: rinkaku_core::render::SkipReason::UnsupportedLanguage,
+            }],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        assert_eq!(1, tree.roots.len());
+        let src = &tree.roots[0];
+        assert_eq!("src", src.path);
+        assert_eq!(2, src.children.len());
+        // Source order: `report.files` is inserted before `report.skipped`
+        // (see `build_tree`'s own doc comment), so the analyzed file comes
+        // first even though "generated.pb.go" sorts first alphabetically.
+        let paths: Vec<&str> = src.children.iter().map(|n| n.path.as_str()).collect();
+        assert_eq!(vec!["src/lib.rs", "src/generated.pb.go"], paths);
+    }
+
+    // Whole-test-file tests: a file whose changed symbols were *all* test
+    // code has no `FileReport` in `report.files` at all
+    // (`pipeline::partition_test_symbols`'s doc comment) — only a
+    // `TestFileSummary` in `report.tests`. Without surfacing that summary
+    // into the tree, such a file is invisible to a reviewer, the same gap
+    // as a skipped file.
+
+    #[test]
+    fn should_add_whole_test_file_as_childless_file_node_with_symbol_count() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            tests: vec![TestFileSummary {
+                path: "src/lib_test.go".to_string(),
+                symbol_count: 3,
+            }],
+            ..empty_report()
+        };
+
+        let expected = Tree {
+            roots: vec![TreeNode {
+                kind: NodeKind::Dir,
+                path: "src".to_string(),
+                badges: Badges::default(),
+                children: vec![TreeNode {
+                    kind: NodeKind::File,
+                    path: "src/lib_test.go".to_string(),
+                    badges: Badges::default(),
+                    children: vec![],
+                    skip_reason: None,
+                    test_symbol_count: Some(3),
+                }],
+                skip_reason: None,
+                test_symbol_count: None,
+            }],
+        };
+        let actual = build_tree(&report);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_merge_test_file_into_existing_dir_alongside_analyzed_files() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol("src/lib.rs::foo", "foo", SymbolKind::Function)],
+            }],
+            tests: vec![TestFileSummary {
+                path: "src/lib_test.rs".to_string(),
+                symbol_count: 2,
+            }],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        assert_eq!(1, tree.roots.len());
+        let src = &tree.roots[0];
+        assert_eq!("src", src.path);
+        assert_eq!(2, src.children.len());
+        let paths: Vec<&str> = src.children.iter().map(|n| n.path.as_str()).collect();
+        assert_eq!(vec!["src/lib.rs", "src/lib_test.rs"], paths);
+    }
+
+    #[test]
+    fn should_not_set_test_symbol_count_or_skip_reason_on_an_ordinary_file() {
+        // Regression guard: an ordinary analyzed file must keep both new
+        // fields at `None`, not accidentally inherit a stale default from
+        // whatever `FileBuilder` construction path is taken.
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![],
+            }],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        assert_eq!(None, tree.roots[0].skip_reason);
+        assert_eq!(None, tree.roots[0].test_symbol_count);
     }
 }

--- a/rinkaku-tui/src/tree.rs
+++ b/rinkaku-tui/src/tree.rs
@@ -261,6 +261,25 @@ impl<'a> TreeBuilder<'a> {
     fn insert_file(&mut self, path: &str, symbols: &[rinkaku_core::extract::ExtractedSymbol]) {
         let segments: Vec<&str> = path.split('/').collect();
         let file_builder = self.root.file_at(&segments);
+        // `pipeline::analyze_diff`'s own invariant is that a path is either
+        // kept in `report.files`, summarized in `report.tests`, or listed
+        // in `report.skipped` — never more than one (see `build_tree`'s doc
+        // comment). This is unreachable from that pipeline today, but
+        // `build_tree` is a public, pure function any caller (e.g. a future
+        // non-`analyze_diff` JSON-input path) could feed a `Report` that
+        // violates it — silently the later insert would win, producing a
+        // `File` row that both lists symbols and claims to be
+        // skipped/test-only, a display contradiction (`row_view` would show
+        // a skip/test badge alongside real symbol children; the detail pane
+        // would drop the symbols entirely, see `file_detail_lines`'s
+        // mutually-exclusive branches). Debug-only since this is a caller
+        // contract violation, not a condition `build_tree` itself needs to
+        // handle gracefully in release builds.
+        debug_assert!(
+            file_builder.skip_reason.is_none() && file_builder.test_symbol_count.is_none(),
+            "path {path:?} has real symbols but was already marked skipped/test-only — \
+             report.files/report.tests/report.skipped must not overlap on the same path"
+        );
         for symbol in symbols {
             file_builder.symbols.push(SymbolRef {
                 id: symbol.id.clone(),
@@ -291,6 +310,16 @@ impl<'a> TreeBuilder<'a> {
     fn insert_test_file(&mut self, path: &str, symbol_count: usize) {
         let segments: Vec<&str> = path.split('/').collect();
         let file_builder = self.root.file_at(&segments);
+        // Same overlap contract as `insert_file`'s debug_assert, mirrored
+        // here: a path already carrying real symbols must not also be
+        // marked test-only, or `file_detail_lines`'s early-return on
+        // `test_symbol_count` would silently drop those symbols from the
+        // detail pane.
+        debug_assert!(
+            file_builder.symbols.is_empty(),
+            "path {path:?} already has real symbols but was also summarized in report.tests — \
+             report.files/report.tests must not overlap on the same path"
+        );
         file_builder.test_symbol_count = Some(symbol_count);
     }
 
@@ -299,6 +328,12 @@ impl<'a> TreeBuilder<'a> {
     fn insert_skipped(&mut self, path: &str, reason: SkipReason) {
         let segments: Vec<&str> = path.split('/').collect();
         let file_builder = self.root.file_at(&segments);
+        // Same overlap contract as `insert_file`'s debug_assert.
+        debug_assert!(
+            file_builder.symbols.is_empty(),
+            "path {path:?} already has real symbols but was also listed in report.skipped — \
+             report.files/report.skipped must not overlap on the same path"
+        );
         file_builder.skip_reason = Some(reason);
     }
 
@@ -1251,5 +1286,51 @@ mod tests {
 
         assert_eq!(None, tree.roots[0].skip_reason);
         assert_eq!(None, tree.roots[0].test_symbol_count);
+    }
+
+    // `pipeline::analyze_diff` never produces a `Report` where the same
+    // path appears in more than one of `files`/`tests`/`skipped` (see
+    // `build_tree`'s doc comment), so `#[cfg(debug_assertions)]` keeps this
+    // panic-path test out of release builds, matching the `debug_assert!`s
+    // themselves — this only guards a caller contract, not a condition
+    // `build_tree` needs to handle gracefully at runtime.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "report.files/report.skipped must not overlap")]
+    fn should_panic_when_the_same_path_appears_in_files_and_skipped() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo", SymbolKind::Function)],
+            }],
+            skipped: vec![SkippedFile {
+                path: "lib.rs".to_string(),
+                reason: rinkaku_core::render::SkipReason::Binary,
+            }],
+            ..empty_report()
+        };
+
+        build_tree(&report);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "report.files/report.tests must not overlap")]
+    fn should_panic_when_the_same_path_appears_in_files_and_tests() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo", SymbolKind::Function)],
+            }],
+            tests: vec![TestFileSummary {
+                path: "lib.rs".to_string(),
+                symbol_count: 1,
+            }],
+            ..empty_report()
+        };
+
+        build_tree(&report);
     }
 }

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -716,6 +716,17 @@ fn dir_detail_lines(detail: &DirDetail, origin: ReportOrigin) -> Vec<Line<'stati
 /// "Symbols (N)" label itself is already origin-neutral, unlike
 /// `dir_detail_lines`'s first badge line, so no `origin` parameter is
 /// needed here.
+/// Formats a [`FileDetail`] into displayable lines: a `File <path>` header,
+/// then either a skipped-file explanation, a whole-test-file explanation, or
+/// the ordinary "Symbols (N)" listing — the three are mutually exclusive by
+/// construction (`crate::tree::TreeNode`'s own doc comment on
+/// `skip_reason`/`test_symbol_count`: an ordinary analyzed file has neither
+/// set, a skipped file has no symbols to list, and a whole-test file has no
+/// per-symbol data at all, only the count `pipeline::partition_test_symbols`
+/// kept). Without this, a skipped or whole-test file's detail pane would
+/// show a bare "Symbols (0)" — indistinguishable from a file that genuinely
+/// changed nothing, which is exactly the gap this feature closes for the
+/// entry-tree row too (see `row_view::entry_row_line`).
 fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
@@ -724,6 +735,35 @@ fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
         Style::default().add_modifier(Modifier::BOLD),
     ));
     lines.push(Line::raw(""));
+
+    if let Some(reason) = detail.skip_reason {
+        lines.push(Line::styled(
+            format!(
+                "Skipped: {}",
+                rinkaku_core::render::skip_reason_label(reason)
+            ),
+            Style::default().fg(Color::DarkGray),
+        ));
+        lines.push(Line::raw("rinkaku did not extract symbols from this file."));
+        return lines;
+    }
+
+    if let Some(symbol_count) = detail.test_symbol_count {
+        let noun = if symbol_count == 1 {
+            "symbol"
+        } else {
+            "symbols"
+        };
+        lines.push(Line::styled(
+            format!("Test file: {symbol_count} changed test {noun}"),
+            Style::default().fg(Color::Magenta),
+        ));
+        lines.push(Line::raw(
+            "Every changed symbol in this file is test code, excluded from the default view (see --include-tests).",
+        ));
+        return lines;
+    }
+
     lines.push(Line::styled(
         format!("Symbols ({})", detail.symbols.len()),
         Style::default().add_modifier(Modifier::BOLD),
@@ -1152,6 +1192,106 @@ mod tests {
         assert!(!text.contains("changed symbols:"));
     }
 
+    /// A [`Report`] whose only entry is a skipped file (no `files`, no
+    /// `tests`) — pairs with `report_with_one_symbol` for the detail-pane
+    /// tests below.
+    fn report_with_one_skipped_file() -> Report {
+        Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![],
+            skipped: vec![rinkaku_core::render::SkippedFile {
+                path: "assets/logo.png".to_string(),
+                reason: rinkaku_core::render::SkipReason::Binary,
+            }],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    #[test]
+    fn should_draw_skip_reason_in_detail_pane_when_cursor_is_on_a_skipped_file_row() {
+        let report = report_with_one_skipped_file();
+        // Row 0 is the collapsing "assets" dir (single child, see
+        // `crate::tree::build_tree`'s collapsing rule); row 1 is the
+        // skipped "logo.png" file itself.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &[],
+                    &[],
+                    &PivotSelection::NotApplicable,
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("File assets/logo.png"));
+        assert!(text.contains("Skipped: binary"));
+        assert!(!text.contains("Symbols ("));
+    }
+
+    /// A [`Report`] whose only entry is a whole-test-file summary (no
+    /// `files`, no `skipped`).
+    fn report_with_one_test_file() -> Report {
+        Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![rinkaku_core::render::TestFileSummary {
+                path: "src/lib_test.go".to_string(),
+                symbol_count: 3,
+            }],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    #[test]
+    fn should_draw_test_symbol_count_in_detail_pane_when_cursor_is_on_a_whole_test_file_row() {
+        let report = report_with_one_test_file();
+        // Row 0 is the collapsing "src" dir; row 1 is the whole test file.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &[],
+                    &[],
+                    &PivotSelection::NotApplicable,
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("File src/lib_test.go"));
+        // "Test file: 3 changed test symbols" wraps across two rendered
+        // lines at this terminal's pane width, so assert on a substring
+        // that survives the wrap rather than the whole phrase.
+        assert!(text.contains("Test file: 3 changed test"));
+        assert!(!text.contains("Symbols ("));
+    }
+
     #[test]
     fn should_draw_diff_pane_with_hunk_lines_when_toggled_on_a_symbol_row() {
         let report = report_with_one_symbol();
@@ -1188,6 +1328,130 @@ index e69de29..4b825dc 100644
         let text = buffer_text(&terminal);
         assert!(text.contains("Diff"));
         assert!(text.contains("+fn foo() {}"));
+    }
+
+    // Dynamic-verification note (see CLAUDE.md's reviewing-changes
+    // section): this pins that a skipped file's diff pane still resolves
+    // real hunks from the raw diff text — `App::selected_diff_target`
+    // scopes a `NodeKind::File` row to `DiffTarget::File { path }`
+    // regardless of `skip_reason` (see the `app.rs` unit test
+    // `should_return_file_diff_target_when_cursor_is_on_a_skipped_file_row`),
+    // and `draw_diff_pane` looks hunks up by that path alone — so a
+    // skipped file (which has no `FileReport`/symbols to key off of) must
+    // not silently fall back to the "no diff hunks found" placeholder just
+    // because rinkaku didn't extract symbols from it.
+    #[test]
+    fn should_draw_diff_pane_with_hunk_lines_when_toggled_on_a_skipped_file_row() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            skipped: vec![rinkaku_core::render::SkippedFile {
+                path: "assets/logo.png".to_string(),
+                reason: rinkaku_core::render::SkipReason::Binary,
+            }],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+            files: vec![],
+        };
+        // Row 0 is the collapsing "assets" dir; row 1 is the skipped file.
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::ToggleDiff);
+        let diff_text = "\
+diff --git a/assets/logo.png b/assets/logo.png
+index e69de29..4b825dc 100644
+Binary files a/assets/logo.png and b/assets/logo.png differ
+";
+        let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+        let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &diff_files,
+                    &diff_highlights,
+                    &PivotSelection::NotApplicable,
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        // A binary file has no hunks at all in the diff text itself (git
+        // reports "Binary files ... differ" instead of `@@` hunks), so the
+        // correct, honest behavior is the pane's own "no diff hunks found"
+        // placeholder — this test's real assertion is that it names the
+        // right path, not a stale/mismatched one, confirming the lookup
+        // reached this row's `path` at all. Checked as two substrings
+        // rather than the whole phrase since it wraps across rendered
+        // lines at this terminal's pane width.
+        assert!(text.contains("no diff hunks found for"));
+        assert!(text.contains("assets/logo.png"));
+    }
+
+    /// Sibling of the binary-skip test above, using an unsupported-language
+    /// skip (a real text file with real hunks in the raw diff) to confirm
+    /// the diff pane actually renders content — not just the placeholder —
+    /// for a skipped-but-textual file.
+    #[test]
+    fn should_draw_diff_pane_with_hunk_lines_for_an_unsupported_language_skipped_file() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            skipped: vec![rinkaku_core::render::SkippedFile {
+                path: "vendor/lib.zig".to_string(),
+                reason: rinkaku_core::render::SkipReason::UnsupportedLanguage,
+            }],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+            files: vec![],
+        };
+        // Row 0 is the collapsing "vendor" dir; row 1 is the skipped file.
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::ToggleDiff);
+        let diff_text = "\
+diff --git a/vendor/lib.zig b/vendor/lib.zig
+index e69de29..4b825dc 100644
+--- a/vendor/lib.zig
++++ b/vendor/lib.zig
+@@ -1,1 +1,2 @@
+ const a = 1;
++const b = 2;
+";
+        let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+        let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &diff_files,
+                    &diff_highlights,
+                    &PivotSelection::NotApplicable,
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Diff"));
+        assert!(text.contains("+const b = 2;"));
     }
 
     #[test]

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -709,13 +709,6 @@ fn dir_detail_lines(detail: &DirDetail, origin: ReportOrigin) -> Vec<Line<'stati
     lines
 }
 
-/// Formats a [`FileDetail`] into displayable lines: every symbol in this
-/// file (changed symbols for a diff, every symbol for a whole-repo
-/// outline — ADR 0017), with the same classification marker convention
-/// `crate::row_view::entry_row_line` uses on symbol rows, plus fan-in. The
-/// "Symbols (N)" label itself is already origin-neutral, unlike
-/// `dir_detail_lines`'s first badge line, so no `origin` parameter is
-/// needed here.
 /// Formats a [`FileDetail`] into displayable lines: a `File <path>` header,
 /// then either a skipped-file explanation, a whole-test-file explanation, or
 /// the ordinary "Symbols (N)" listing — the three are mutually exclusive by

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -1225,6 +1225,7 @@ mod tests {
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1272,6 +1273,7 @@ mod tests {
                     &[],
                     &[],
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1373,6 +1375,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
                     &diff_files,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");
@@ -1438,6 +1441,7 @@ index e69de29..4b825dc 100644
                     &diff_files,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
+                    &test_repo_root(),
                 )
             })
             .expect("draw");


### PR DESCRIPTION
## Summary

- Both skipped files (unsupported language, binary, deleted) and
  whole-test files were previously invisible in the TUI entry tree.
  Investigation confirmed a whole-test file — one whose changed
  symbols are *all* test code — has no `FileReport` in `report.files`
  at all (`pipeline::partition_test_symbols` drops it entirely,
  keeping only a count-only `TestFileSummary` in `report.tests`), so
  it never got a `TreeNode` and a reviewer relying on the TUI to see
  the whole PR would miss it completely.
- `crate::tree::TreeNode` gains two optional fields (`skip_reason`,
  `test_symbol_count`) instead of a new `NodeKind` variant, so a
  skipped/test file stays an ordinary `NodeKind::File` row and every
  existing exhaustive match over `NodeKind` (detail/diff/pivot
  dispatch in `app.rs`, sibling ordering in `order.rs`) keeps working
  unchanged. `build_tree` now also walks `report.tests` and
  `report.skipped`, dropping `SkipReason::Generated` entries by
  default to match `render_markdown`'s existing Markdown behavior.
- The entry row shows a dimmed `(skipped: <reason>)` or `[test] (N
  symbols)` badge; the detail pane explains why a skipped/whole-test
  file has no symbols listed instead of a bare "Symbols (0)"; the diff
  pane needed no code change (`App::selected_diff_target` already
  scopes a `File` row to its path regardless of skip reason).
- Follow-up fixes from review: `debug_assert!` guards (plus
  `#[should_panic]` regression tests) on the three tree-insert paths
  pinning the "one path, one source" invariant between
  `report.files`/`report.tests`/`report.skipped`; a leftover duplicate
  doc comment removed; the entry-row badge priority aligned with the
  detail pane's own skip-reason-first priority.

## Review process

Reviewed with the two-pass protocol from
[`docs/experiments/0001-map-assisted-llm-review.md`](docs/experiments/0001-map-assisted-llm-review.md)
(round 9): a map-assisted pass routed by the diff's two hotspots
(`TreeNode`, `FileDetail`) into consumers (`nav`/`order`/`app`/
`detail`/`ui`/`row_view`), and an independent pass with mandatory
dynamic verification. Zero overlap between the two passes' findings —
map-assisted found a structural gap (the three tree-insert paths could
silently overwrite each other's fields on a colliding path), the
independent pass found a leftover doc comment and confirmed the whole
feature end-to-end by driving the real TUI binary. No blockers.

## Verification

- `make test && make lint` — all green (rinkaku 158, rinkaku-core 327,
  rinkaku-tui 265 tests).
- Live dogfood run: built a synthetic Go repository with a whole
  test-only file, a binary file, and an unsupported-language text
  file, then drove the actual `rinkaku --tui` binary end-to-end in
  tmux — navigation, the detail pane for both new row kinds, the diff
  pane for both (including the binary file's correct "no diff hunks
  found" fallback, since git itself reports no hunks for binaries),
  and confirmed no regression in whole-repo/non-TTY behavior.

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync
