### PR TITLE
feat: mermaid output format and PR report GitHub Action

### DIFF
--- a/.github/workflows/rinkaku-report.yaml
+++ b/.github/workflows/rinkaku-report.yaml
@@ -67,7 +67,28 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
+      # Bootstrap guard: the very PR that *introduces* this workflow (and
+      # action.yaml) is, by definition, the one case where the trusted
+      # base checkout above cannot contain either — they don't exist on
+      # `main` yet. Trying to run them anyway would mean falling back to
+      # the PR-head copy, exactly the trust-boundary violation this
+      # workflow exists to prevent. Skip cleanly instead: every step from
+      # here on is gated on this check, and the job still succeeds (the
+      # skip is expected and self-explanatory via the notice), rather
+      # than failing with a confusing "can't find action.yaml" error the
+      # way an unguarded `uses: ./` does.
+      - name: Check whether the trusted base checkout has this action
+        id: check-action
+        run: |
+          if [ -f action.yaml ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::action.yaml does not exist on the PR base ref yet (this is expected on the PR that introduces it) — skipping the report step rather than running untrusted PR-head code"
+          fi
+
       - name: Checkout PR head into a subdirectory (data only)
+        if: steps.check-action.outputs.present == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -75,19 +96,23 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch base branch into the head checkout
+        if: steps.check-action.outputs.present == 'true'
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         working-directory: rinkaku-pr-head
         run: git fetch origin "${BASE_REF}"
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        if: steps.check-action.outputs.present == 'true'
         with:
           key: rinkaku-report-build
 
       - name: Build rinkaku from the base ref
+        if: steps.check-action.outputs.present == 'true'
         run: cargo build --release -p rinkaku
 
       - name: Run rinkaku report action
+        if: steps.check-action.outputs.present == 'true'
         uses: ./
         with:
           binary: ${{ github.workspace }}/target/release/rinkaku

--- a/.github/workflows/rinkaku-report.yaml
+++ b/.github/workflows/rinkaku-report.yaml
@@ -1,6 +1,6 @@
 name: rinkaku PR report
 
-# Dogfoods this repository's own action (ADR 0020): posts a mermaid
+# Dogfoods this repository's own action (ADR 0021): posts a mermaid
 # call/dependency graph plus a collapsed Markdown outline as a sticky PR
 # comment.
 #

--- a/.github/workflows/rinkaku-report.yaml
+++ b/.github/workflows/rinkaku-report.yaml
@@ -1,0 +1,66 @@
+name: rinkaku PR report
+
+# Dogfoods this repository's own action (ADR 0020): posts a mermaid
+# call/dependency graph plus a collapsed Markdown outline as a sticky PR
+# comment.
+#
+# Trust boundary: rinkaku is built from the PR's *base* ref, not the PR
+# head and not a downloaded release binary, then run against the PR head
+# checkout's diff. A PR is exactly the input an attacker controls, so the
+# tool doing the inspecting must never be built from it — same rule this
+# repository's own README documents for the "map-assisted LLM review"
+# recipe (docs/experiments/0001-map-assisted-llm-review.md): "built from a
+# trusted `main` checkout, never from the branch under review."
+#
+# The PR head is checked out at the job's default workspace root (no
+# `path:`) so `uses: ./` below — the action definition committed on the PR
+# branch itself — runs its composite steps with that checkout as the
+# working directory, which is what lets `rinkaku --base` resolve the diff
+# via plain `git diff`/`git show` without any extra `working-directory`
+# plumbing. The base build lives in a subdirectory instead.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: rinkaku-report-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      - name: Checkout PR base into a subdirectory (trusted build source)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: rinkaku-base-build
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          workspaces: rinkaku-base-build
+          key: rinkaku-report-build
+
+      - name: Build rinkaku from the base ref
+        working-directory: rinkaku-base-build
+        run: cargo build --release -p rinkaku
+
+      - name: Run rinkaku report action
+        uses: ./
+        with:
+          binary: ${{ github.workspace }}/rinkaku-base-build/target/release/rinkaku
+          base: ${{ github.event.pull_request.base.ref }}
+          github-token: ${{ github.token }}

--- a/.github/workflows/rinkaku-report.yaml
+++ b/.github/workflows/rinkaku-report.yaml
@@ -48,14 +48,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Explicit `ref:` on BOTH checkouts below, not the trigger's default —
+      # `actions/checkout` on a `pull_request` event defaults to
+      # `refs/remotes/pull/<N>/merge`, GitHub's ephemeral merge-of-head-
+      # into-base commit, whichever `ref:` is omitted. Omitting it here
+      # would silently defeat the whole trust-boundary point of this
+      # workflow: a "base" checkout with no explicit `ref:` still contains
+      # every change from the PR head (merged in), so the "trusted" binary
+      # and orchestration code would actually be built from a tree that
+      # includes the PR's own — unreviewed — changes. This was found by
+      # actually running this workflow (see PR #59's dogfooding comment,
+      # which posted a full mermaid section despite `main` not having
+      # `--format mermaid` yet — proof the base checkout was not really
+      # base).
       - name: Checkout PR base (trusted build source and orchestration code)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
       - name: Checkout PR head into a subdirectory (data only)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           path: rinkaku-pr-head
           fetch-depth: 0
 

--- a/.github/workflows/rinkaku-report.yaml
+++ b/.github/workflows/rinkaku-report.yaml
@@ -4,20 +4,33 @@ name: rinkaku PR report
 # call/dependency graph plus a collapsed Markdown outline as a sticky PR
 # comment.
 #
-# Trust boundary: rinkaku is built from the PR's *base* ref, not the PR
-# head and not a downloaded release binary, then run against the PR head
-# checkout's diff. A PR is exactly the input an attacker controls, so the
-# tool doing the inspecting must never be built from it — same rule this
-# repository's own README documents for the "map-assisted LLM review"
-# recipe (docs/experiments/0001-map-assisted-llm-review.md): "built from a
-# trusted `main` checkout, never from the branch under review."
+# Trust boundary — TWO rules, not one: a PR is exactly the input an
+# attacker controls, so nothing that inspects it may itself come from it.
+# That applies to BOTH:
+#   1. the rinkaku BINARY (built from the PR's base ref, never the head
+#      or a downloaded release binary), and
+#   2. the ORCHESTRATION CODE running that binary — action.yaml and
+#      compose_and_post_comment.sh. This job runs with `pull-requests:
+#      write`, so if that code were the version committed on the PR
+#      branch, a malicious PR could rewrite its own comment-posting logic
+#      (or anything else in the composite steps) and have it execute with
+#      a write token before any human reviews it — on a same-repo (non-
+#      fork) PR, `pull_request` grants the real repo token, not a
+#      restricted one, so this is not merely theoretical.
+# Same rule this repository's own README documents for the "map-assisted
+# LLM review" recipe (docs/experiments/0001-map-assisted-llm-review.md):
+# "built from a trusted `main` checkout, never from the branch under
+# review" — extended here to cover the script that runs the tool, not
+# just the tool itself.
 #
-# The PR head is checked out at the job's default workspace root (no
-# `path:`) so `uses: ./` below — the action definition committed on the PR
-# branch itself — runs its composite steps with that checkout as the
-# working directory, which is what lets `rinkaku --base` resolve the diff
-# via plain `git diff`/`git show` without any extra `working-directory`
-# plumbing. The base build lives in a subdirectory instead.
+# Concretely: the PR's BASE ref is checked out at the job's default
+# workspace root (no `path:`), so `uses: ./` below resolves action.yaml
+# (and, transitively, compose_and_post_comment.sh via
+# $GITHUB_ACTION_PATH) from that trusted checkout. The PR HEAD is
+# checked out into a subdirectory instead and treated purely as DATA —
+# rinkaku's `repo-path` input points at it so `--base`'s `git diff`/
+# `git show` resolve the actual PR diff, but no code from that checkout
+# is ever `source`d, `uses:`d, or executed directly.
 on:
   pull_request:
     branches: [main]
@@ -35,32 +48,34 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Checkout PR head
+      - name: Checkout PR base (trusted build source and orchestration code)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}
-
-      - name: Checkout PR base into a subdirectory (trusted build source)
+      - name: Checkout PR head into a subdirectory (data only)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path: rinkaku-base-build
-          ref: ${{ github.event.pull_request.base.sha }}
+          path: rinkaku-pr-head
+          fetch-depth: 0
+
+      - name: Fetch base branch into the head checkout
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        working-directory: rinkaku-pr-head
+        run: git fetch origin "${BASE_REF}"
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
-          workspaces: rinkaku-base-build
           key: rinkaku-report-build
 
       - name: Build rinkaku from the base ref
-        working-directory: rinkaku-base-build
         run: cargo build --release -p rinkaku
 
       - name: Run rinkaku report action
         uses: ./
         with:
-          binary: ${{ github.workspace }}/rinkaku-base-build/target/release/rinkaku
+          binary: ${{ github.workspace }}/target/release/rinkaku
+          repo-path: ${{ github.workspace }}/rinkaku-pr-head
           base: ${{ github.event.pull_request.base.ref }}
           github-token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ rinkaku --base main
 rinkaku --base main --format json
 
 # A human-oriented call/dependency graph as a mermaid flowchart (ADR
-# 0020) — opt-in, meant for pasting into a GitHub PR comment/description
+# 0021) — opt-in, meant for pasting into a GitHub PR comment/description
 # where mermaid renders natively, not for piping into an LLM
 rinkaku --base main --format mermaid
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ rinkaku --base main
 # JSON output for feeding into another tool or LLM
 rinkaku --base main --format json
 
+# A human-oriented call/dependency graph as a mermaid flowchart (ADR
+# 0020) — opt-in, meant for pasting into a GitHub PR comment/description
+# where mermaid renders natively, not for piping into an LLM
+rinkaku --base main --format mermaid
+
 # Skip dependency resolution (faster, no repo-wide index — see below)
 rinkaku --base main --deps 0
 ```
@@ -594,6 +599,51 @@ instead of reconstructing the change's structure itself.
    Behavioral bugs don't show up on the signature surface the map draws
    from, and the experiment's own rounds found real defects (a non-TTY
    panic) only by running the binary.
+
+## GitHub Action
+
+This repository ships a composite [`action.yaml`](action.yaml) that runs
+rinkaku against a pull request's diff and posts (or updates) a sticky PR
+comment: a [`--format mermaid`](#usage) call/dependency graph up front —
+rendered natively by GitHub in the comment — with the full Markdown
+outline collapsed underneath for anyone who wants signature-level detail.
+
+```yaml
+name: rinkaku PR report
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      - uses: hiro-o918/rinkaku@main
+        with:
+          github-token: ${{ github.token }}
+```
+
+Inputs: `version` (a release tag to download, default `latest`), `binary`
+(path to an already-built rinkaku binary, skipping the download entirely —
+see this repository's own [dogfooding workflow](.github/workflows/rinkaku-report.yaml),
+which builds rinkaku from the PR's *base* ref rather than trusting a
+downloaded binary, for the same reason the LLM-review recipe above always
+builds its map from a trusted checkout), `base` (defaults to the PR's base
+ref), `github-token` (defaults to `github.token`), and `comment` (set
+`false` to skip posting and just get the `mermaid-path`/`markdown-path`
+outputs).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -636,14 +636,30 @@ jobs:
 ```
 
 Inputs: `version` (a release tag to download, default `latest`), `binary`
-(path to an already-built rinkaku binary, skipping the download entirely —
-see this repository's own [dogfooding workflow](.github/workflows/rinkaku-report.yaml),
-which builds rinkaku from the PR's *base* ref rather than trusting a
-downloaded binary, for the same reason the LLM-review recipe above always
-builds its map from a trusted checkout), `base` (defaults to the PR's base
-ref), `github-token` (defaults to `github.token`), and `comment` (set
-`false` to skip posting and just get the `mermaid-path`/`markdown-path`
-outputs).
+(path to an already-built rinkaku binary, skipping the download entirely),
+`repo-path` (the checkout rinkaku should analyze; defaults to the current
+directory), `base` (defaults to the PR's base ref), `github-token`
+(defaults to `github.token`), and `comment` (set `false` to skip posting
+and just get the `mermaid-path`/`markdown-path` outputs).
+
+**Trusted-base posture**: the snippet above is the simple case (a pinned
+release binary, `permissions: pull-requests: write` scoped to only what
+posting a comment needs). If you build rinkaku yourself instead of using a
+release binary, build it from the PR's **base** ref, not the PR head —
+same rule this repository's own [dogfooding
+workflow](.github/workflows/rinkaku-report.yaml) follows, and for the
+same reason the [LLM-review recipe](#using-rinkaku-with-llm-reviewers)
+above always builds its map from a trusted checkout: a PR is exactly the
+input an attacker controls, and this job runs with a write token before
+anyone has reviewed it. That workflow checks out the PR's base ref at the
+job's default location (so `uses: ./` resolves *its own action code* —
+not just the binary — from the trusted checkout too) and checks out the
+PR head into a subdirectory purely as data, passed to this action via
+`repo-path`. **Fork PRs** get a read-only token from the `pull_request`
+trigger regardless of `permissions:` — this action detects that and falls
+back to writing the report into the job's step summary instead of
+posting a comment, so a fork PR's run still succeeds (exit 0) rather than
+failing on a 403.
 
 ## Development
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,135 @@
+name: "rinkaku PR report"
+description: >-
+  Runs rinkaku against a pull request's diff and posts (or updates) a
+  sticky PR comment: a mermaid call/dependency graph up front, with the
+  full Markdown outline collapsed underneath for anyone who wants the
+  signature-level detail.
+branding:
+  icon: "git-pull-request"
+  color: "blue"
+
+inputs:
+  version:
+    description: >-
+      rinkaku release tag to download from GitHub Releases, e.g. "v0.4.1".
+      Defaults to the latest release. Ignored when `binary` is set.
+    required: false
+    default: "latest"
+  binary:
+    description: >-
+      Path to an already-built rinkaku binary to use instead of downloading
+      a release asset. Set this when the caller already built rinkaku
+      itself (e.g. the dogfooding workflow in this repository, which builds
+      rinkaku from the PR's base ref rather than trusting a release binary
+      built from who-knows-where) — leaving `version`'s download step
+      skipped entirely rather than duplicating the compose/post logic in
+      two places.
+    required: false
+    default: ""
+  base:
+    description: >-
+      Base ref to diff against, passed through to `rinkaku --base`.
+      Defaults to the pull request's base ref.
+    required: false
+    default: ${{ github.event.pull_request.base.ref }}
+  github-token:
+    description: Token used to read/write the PR comment via `gh`/`gh api`.
+    required: false
+    default: ${{ github.token }}
+  comment:
+    description: >-
+      Whether to post/update a sticky PR comment. When `false`, this action
+      only produces the report files referenced by this action's outputs —
+      useful for callers that want to compose their own comment or use the
+      report some other way.
+    required: false
+    default: "true"
+
+outputs:
+  mermaid-path:
+    description: Path to the generated mermaid report file.
+    value: ${{ steps.run-rinkaku.outputs.mermaid-path }}
+  markdown-path:
+    description: Path to the generated Markdown report file.
+    value: ${{ steps.run-rinkaku.outputs.markdown-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve rinkaku binary
+      id: resolve-binary
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        BINARY: ${{ inputs.binary }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "${BINARY}" ]; then
+          echo "using caller-provided binary: ${BINARY}"
+          echo "path=${BINARY}" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Asset naming matches .github/workflows/build-and-publish.yaml's
+        # `build` job: "rinkaku-<target>.tar.gz", containing the `rinkaku`
+        # binary at its archive root.
+        case "$(uname -s)-$(uname -m)" in
+          Linux-x86_64) target="x86_64-unknown-linux-gnu" ;;
+          Linux-aarch64) target="aarch64-unknown-linux-gnu" ;;
+          Darwin-x86_64) target="x86_64-apple-darwin" ;;
+          Darwin-arm64) target="aarch64-apple-darwin" ;;
+          *)
+            echo "::error::unsupported runner platform: $(uname -s)-$(uname -m)"
+            exit 1
+            ;;
+        esac
+
+        asset="rinkaku-${target}.tar.gz"
+        mkdir -p "${RUNNER_TEMP}/rinkaku-dist"
+
+        if [ "${VERSION}" = "latest" ]; then
+          gh release download --repo hiro-o918/rinkaku --pattern "${asset}" \
+            --dir "${RUNNER_TEMP}/rinkaku-dist" --clobber
+        else
+          gh release download "${VERSION}" --repo hiro-o918/rinkaku --pattern "${asset}" \
+            --dir "${RUNNER_TEMP}/rinkaku-dist" --clobber
+        fi
+
+        tar xzf "${RUNNER_TEMP}/rinkaku-dist/${asset}" -C "${RUNNER_TEMP}/rinkaku-dist"
+        binary_path=$(find "${RUNNER_TEMP}/rinkaku-dist" -type f -name rinkaku)
+        chmod +x "${binary_path}"
+        echo "path=${binary_path}" >> "$GITHUB_OUTPUT"
+
+    - name: Run rinkaku
+      id: run-rinkaku
+      shell: bash
+      env:
+        RINKAKU_BIN: ${{ steps.resolve-binary.outputs.path }}
+        BASE_REF: ${{ inputs.base }}
+      run: |
+        set -euo pipefail
+
+        mkdir -p "${RUNNER_TEMP}/rinkaku-report"
+        mermaid_path="${RUNNER_TEMP}/rinkaku-report/report.mmd"
+        markdown_path="${RUNNER_TEMP}/rinkaku-report/report.md"
+
+        "${RINKAKU_BIN}" --base "origin/${BASE_REF}" --format mermaid > "${mermaid_path}"
+        "${RINKAKU_BIN}" --base "origin/${BASE_REF}" --format md > "${markdown_path}"
+
+        echo "mermaid-path=${mermaid_path}" >> "$GITHUB_OUTPUT"
+        echo "markdown-path=${markdown_path}" >> "$GITHUB_OUTPUT"
+
+    - name: Compose and post sticky PR comment
+      if: inputs.comment == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        MERMAID_PATH: ${{ steps.run-rinkaku.outputs.mermaid-path }}
+        MARKDOWN_PATH: ${{ steps.run-rinkaku.outputs.markdown-path }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+        "${GITHUB_ACTION_PATH}/compose_and_post_comment.sh"

--- a/action.yaml
+++ b/action.yaml
@@ -3,7 +3,11 @@ description: >-
   Runs rinkaku against a pull request's diff and posts (or updates) a
   sticky PR comment: a mermaid call/dependency graph up front, with the
   full Markdown outline collapsed underneath for anyone who wants the
-  signature-level detail.
+  signature-level detail. Falls back to $GITHUB_STEP_SUMMARY when posting
+  a comment isn't possible (fork PRs get a read-only token from
+  `pull_request`; see the `comment`/`github-token` inputs below), and to a
+  Markdown-only report when the resolved rinkaku binary predates
+  `--format mermaid`.
 branding:
   icon: "git-pull-request"
   color: "blue"
@@ -26,6 +30,20 @@ inputs:
       two places.
     required: false
     default: ""
+  repo-path:
+    description: >-
+      Path to the git checkout rinkaku should analyze (i.e. the one
+      `--base`'s `git diff`/`git show` resolve against). Defaults to the
+      current directory, which is only correct when this action's own
+      steps run inside that checkout — the dogfooding workflow in this
+      repository instead points this at a separate PR-head checkout,
+      since the checkout this action itself is invoked *from* must stay
+      the trusted base copy (see that workflow's top-of-file comment for
+      the full trust-boundary rationale: both the rinkaku binary AND the
+      orchestration code executing it must come from base, never from
+      the PR head).
+    required: false
+    default: "."
   base:
     description: >-
       Base ref to diff against, passed through to `rinkaku --base`.
@@ -33,7 +51,11 @@ inputs:
     required: false
     default: ${{ github.event.pull_request.base.ref }}
   github-token:
-    description: Token used to read/write the PR comment via `gh`/`gh api`.
+    description: >-
+      Token used to read/write the PR comment via `gh`/`gh api`. On a
+      fork PR, the token `pull_request` events receive is read-only
+      regardless of the workflow's `permissions:` block — see `comment`
+      below for how this action degrades when posting fails.
     required: false
     default: ${{ github.token }}
   comment:
@@ -41,17 +63,30 @@ inputs:
       Whether to post/update a sticky PR comment. When `false`, this action
       only produces the report files referenced by this action's outputs —
       useful for callers that want to compose their own comment or use the
-      report some other way.
+      report some other way. Also downgrades automatically (rather than
+      failing the job) when posting isn't possible at all: a fork PR's
+      `pull_request` token is read-only regardless of this input or the
+      workflow's `permissions:` block, so `compose_and_post_comment.sh`
+      treats a 403 from the comment-post API call as "write to
+      $GITHUB_STEP_SUMMARY instead" and still exits 0.
     required: false
     default: "true"
 
 outputs:
   mermaid-path:
-    description: Path to the generated mermaid report file.
+    description: >-
+      Path to the generated mermaid report file. Empty when the resolved
+      rinkaku binary doesn't support `--format mermaid` (see
+      `markdown-only` below).
     value: ${{ steps.run-rinkaku.outputs.mermaid-path }}
   markdown-path:
     description: Path to the generated Markdown report file.
     value: ${{ steps.run-rinkaku.outputs.markdown-path }}
+  markdown-only:
+    description: >-
+      "true" when the resolved rinkaku binary predates `--format mermaid`
+      and this run fell back to a Markdown-only report.
+    value: ${{ steps.run-rinkaku.outputs.markdown-only }}
 
 runs:
   using: composite
@@ -73,8 +108,11 @@ runs:
         fi
 
         # Asset naming matches .github/workflows/build-and-publish.yaml's
-        # `build` job: "rinkaku-<target>.tar.gz", containing the `rinkaku`
-        # binary at its archive root.
+        # `build` job: "rinkaku-<target>.tar.gz", whose archive root
+        # contains a "rinkaku-<target>/" directory holding the `rinkaku`
+        # binary (not the binary directly at the archive root) — the
+        # `find` below locates it either way rather than assuming the
+        # exact nesting.
         case "$(uname -s)-$(uname -m)" in
           Linux-x86_64) target="x86_64-unknown-linux-gnu" ;;
           Linux-aarch64) target="aarch64-unknown-linux-gnu" ;;
@@ -108,6 +146,7 @@ runs:
       env:
         RINKAKU_BIN: ${{ steps.resolve-binary.outputs.path }}
         BASE_REF: ${{ inputs.base }}
+        REPO_PATH: ${{ inputs.repo-path }}
       run: |
         set -euo pipefail
 
@@ -115,11 +154,42 @@ runs:
         mermaid_path="${RUNNER_TEMP}/rinkaku-report/report.mmd"
         markdown_path="${RUNNER_TEMP}/rinkaku-report/report.md"
 
-        "${RINKAKU_BIN}" --base "origin/${BASE_REF}" --format mermaid > "${mermaid_path}"
-        "${RINKAKU_BIN}" --base "origin/${BASE_REF}" --format md > "${markdown_path}"
+        run_rinkaku() {
+          (cd "${REPO_PATH}" && "${RINKAKU_BIN}" --base "origin/${BASE_REF}" "$@")
+        }
 
-        echo "mermaid-path=${mermaid_path}" >> "$GITHUB_OUTPUT"
+        run_rinkaku --format md > "${markdown_path}"
         echo "markdown-path=${markdown_path}" >> "$GITHUB_OUTPUT"
+
+        # Bootstrap-safety (this repository's own introducing PR is the
+        # concrete case): the base ref a caller builds rinkaku from may
+        # predate `--format mermaid` entirely — including on the very PR
+        # that adds the flag, whose base is the pre-flag `main`. `--format`
+        # itself predates this action (md/json already existed), so the
+        # probe must grep for the literal value "mermaid" in clap's long
+        # `--help` output (which lists `--format`'s "Possible values:"),
+        # not just for the flag name — a binary with --format but no
+        # mermaid support is exactly the bootstrap case this guards
+        # against, and `grep -q -- '--format'` alone would never catch it.
+        # Probing `--help` rather than just letting the mermaid invocation
+        # fail also avoids relying on clap's exact unrecognized-value exit
+        # code/message staying stable across versions, and skips a doomed
+        # invocation entirely instead of treating "flag understood but the
+        # run itself failed" the same as "flag not understood at all".
+        if "${RINKAKU_BIN}" --help 2>&1 | grep -q -- 'mermaid'; then
+          if run_rinkaku --format mermaid > "${mermaid_path}" 2>/dev/null; then
+            echo "mermaid-path=${mermaid_path}" >> "$GITHUB_OUTPUT"
+            echo "markdown-only=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::rinkaku --format mermaid failed even though --help mentions --format; falling back to a Markdown-only report"
+            echo "mermaid-path=" >> "$GITHUB_OUTPUT"
+            echo "markdown-only=true" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          echo "::warning::resolved rinkaku binary predates --format mermaid; falling back to a Markdown-only report"
+          echo "mermaid-path=" >> "$GITHUB_OUTPUT"
+          echo "markdown-only=true" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Compose and post sticky PR comment
       if: inputs.comment == 'true'
@@ -130,6 +200,7 @@ runs:
         MARKDOWN_PATH: ${{ steps.run-rinkaku.outputs.markdown-path }}
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        IS_FORK_PR: ${{ github.event.pull_request.head.repo.fork }}
       run: |
         set -euo pipefail
         "${GITHUB_ACTION_PATH}/compose_and_post_comment.sh"

--- a/compose_and_post_comment.sh
+++ b/compose_and_post_comment.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # Composes rinkaku's mermaid + Markdown output into a single PR comment body
 # and posts it as a sticky comment (identified by MARKER below), updating an
-# existing one instead of piling up duplicates on every push.
+# existing one instead of piling up duplicates on every push. Falls back to
+# $GITHUB_STEP_SUMMARY when posting isn't possible at all (a fork PR's
+# `pull_request` token is read-only regardless of the workflow's
+# `permissions:` block).
 #
 # Pulled out of action.yaml's inline `run:` block so it has a path a human
 # (or this repository's own dogfooding workflow) can execute directly for
@@ -9,39 +12,118 @@
 # composite step.
 #
 # Required environment:
-#   MERMAID_PATH   path to the generated mermaid report
 #   MARKDOWN_PATH  path to the generated Markdown report
-#   REPO           "owner/repo", passed to `gh api`/`gh pr comment`
-#   PR_NUMBER      pull request number to comment on
-#   GH_TOKEN       token `gh` uses for authentication
 #
 # Optional environment:
+#   MERMAID_PATH   path to the generated mermaid report. Empty/unset when
+#                  the resolved rinkaku binary doesn't support
+#                  `--format mermaid` (action.yaml's bootstrap-safety
+#                  fallback) — the comment then omits the mermaid section
+#                  entirely instead of embedding an empty fence.
+#   REPO           "owner/repo", passed to `gh api`. Required unless
+#                  DRY_RUN=1.
+#   PR_NUMBER      pull request number to comment on. Required unless
+#                  DRY_RUN=1.
+#   GH_TOKEN       token `gh` uses for authentication. Required unless
+#                  DRY_RUN=1.
+#   IS_FORK_PR     "true" when the PR head repo is a fork (GitHub Actions'
+#                  `github.event.pull_request.head.repo.fork`) — skips the
+#                  comment-post attempt entirely and writes to
+#                  $GITHUB_STEP_SUMMARY instead, since a fork PR's
+#                  `pull_request`-event token is read-only regardless of
+#                  the workflow's `permissions:` block and would just 403.
+#   GITHUB_STEP_SUMMARY  path GitHub Actions exposes for step-summary
+#                  markdown; written to on the fork/403 fallback path.
+#                  When unset (e.g. local dynamic verification), the
+#                  fallback path prints to stdout instead.
 #   DRY_RUN        when set to "1", prints the composed body to stdout
-#                   instead of calling `gh api` — used for local dynamic
-#                   verification without a real PR to post to.
+#                   instead of calling `gh api`/writing the step summary —
+#                   used for local dynamic verification without a real PR
+#                   to post to.
 set -euo pipefail
+
+# Byte-, not character-, semantics for every `${#var}`/`${var:0:n}` use
+# below: under the default UTF-8 locale, bash's own string-length and
+# substring operators count *characters*, which can silently overshoot
+# GitHub's byte-based comment-size cap and — worse — split a multi-byte
+# character in half mid-sequence (rinkaku's own output contains multi-byte
+# glyphs like the cycle-warning ⚠️). `LC_ALL=C` makes both operators
+# byte-exact; `truncate_utf8_safe` below additionally guards the boundary
+# itself by backing off up to 3 bytes (the longest possible UTF-8
+# continuation run) until the result decodes cleanly.
+export LC_ALL=C
 
 MARKER="<!-- rinkaku-report -->"
 
-# GitHub's PR/issue comment body limit. Truncating the collapsed Markdown
-# section (rather than the mermaid graph, which must stay intact — a
-# truncated mermaid document fails to render at all) keeps the comment
-# postable even for a very large diff.
+# GitHub's PR/issue comment body limit.
 MAX_BODY_LENGTH=65536
 
-: "${MERMAID_PATH:?MERMAID_PATH is required}"
+# A mermaid document this large wouldn't render as a useful diagram on
+# GitHub anyway (ADR 0021's node budget already keeps a healthy graph well
+# under this), so past this size the section is replaced with a short note
+# rather than spending the whole comment budget on an unrenderable-in-
+# practice diagram and leaving nothing for the Markdown details.
+MAX_MERMAID_LENGTH=32768
+
 : "${MARKDOWN_PATH:?MARKDOWN_PATH is required}"
 
-mermaid_content=$(cat "${MERMAID_PATH}")
+# Truncates `text` to at most `budget` bytes, then backs off up to 3 more
+# bytes (bounded: the longest a single UTF-8 character's continuation-byte
+# run can be) until the result is valid UTF-8 on its own — a byte-count
+# truncation can otherwise land inside a multi-byte character and emit a
+# malformed tail byte sequence. Never called with a negative budget (both
+# call sites below clamp their budget to >= 0 first).
+truncate_utf8_safe() {
+  local text="$1"
+  local budget="$2"
+  local truncated="${text:0:budget}"
+  local attempt=0
+  while [ "${attempt}" -lt 4 ] && ! printf '%s' "${truncated}" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1; do
+    truncated="${truncated:0:$((${#truncated} - 1))}"
+    attempt=$((attempt + 1))
+  done
+  printf '%s' "${truncated}"
+}
+
 markdown_content=$(cat "${MARKDOWN_PATH}")
 
-body_prefix="${MARKER}
-## rinkaku PR report
+# `MERMAID_PATH` is empty (not just unset) on the markdown-only fallback
+# path (action.yaml's bootstrap-safety check) — `${MERMAID_PATH:-}` reads
+# as empty either way, so both "input never set" and "set to empty by the
+# caller" collapse to the same "omit the mermaid section" branch below.
+#
+# `mermaid_oversized` is tracked separately from "no mermaid content at
+# all" so the oversized case renders its explanatory note as plain text
+# instead of nesting it inside a ```mermaid fence — a fence around prose
+# is misleading (it reads as "here is the mermaid source," when the whole
+# point of the note is that there isn't one) and mermaid itself would
+# just fail to parse the note as a diagram anyway.
+mermaid_content=""
+mermaid_oversized=0
+if [ -n "${MERMAID_PATH:-}" ]; then
+  mermaid_content=$(cat "${MERMAID_PATH}")
+  if [ "${#mermaid_content}" -gt "${MAX_MERMAID_LENGTH}" ]; then
+    mermaid_content="*(mermaid graph omitted: it would exceed ${MAX_MERMAID_LENGTH} bytes, past the point a diagram this size renders usefully on GitHub anyway)*"
+    mermaid_oversized=1
+  fi
+fi
 
+mermaid_section=""
+if [ -n "${mermaid_content}" ] && [ "${mermaid_oversized}" -eq 1 ]; then
+  mermaid_section="
+${mermaid_content}
+"
+elif [ -n "${mermaid_content}" ]; then
+  mermaid_section="
 \`\`\`mermaid
 ${mermaid_content}
 \`\`\`
+"
+fi
 
+body_prefix="${MARKER}
+## rinkaku PR report
+${mermaid_section}
 <details>
 <summary>Details (full signature outline)</summary>
 
@@ -66,7 +148,8 @@ if [ "${budget}" -lt 0 ]; then
 fi
 
 if [ "${#markdown_content}" -gt "${budget}" ]; then
-  markdown_content="${markdown_content:0:budget}${truncation_note}"
+  markdown_content=$(truncate_utf8_safe "${markdown_content}" "${budget}")
+  markdown_content="${markdown_content}${truncation_note}"
 fi
 
 body="${body_prefix}${markdown_content}${body_suffix}"
@@ -76,22 +159,55 @@ if [ "${DRY_RUN:-0}" = "1" ]; then
   exit 0
 fi
 
+# Fork PRs (`github.event.pull_request.head.repo.fork == true`) get a
+# read-only GITHUB_TOKEN from the `pull_request` trigger no matter what
+# the workflow's own `permissions:` block declares — posting would just
+# 403. Detecting this ahead of time (rather than only reacting to a 403
+# after the fact) keeps the job green and gives a clear, deliberate
+# fallback surface instead of a caught-error one.
+if [ "${IS_FORK_PR:-false}" = "true" ]; then
+  echo "::notice::PR head is a fork; skipping comment post (read-only token) and writing the report to the step summary instead"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "${body}" >>"${GITHUB_STEP_SUMMARY}"
+  else
+    printf '%s\n' "${body}"
+  fi
+  exit 0
+fi
+
 : "${REPO:?REPO is required}"
 : "${PR_NUMBER:?PR_NUMBER is required}"
 
-# Find an existing sticky comment by marker (first match; a PR should only
-# ever accumulate one, since every run either updates it or creates the
-# first one) so repeated pushes update in place instead of spamming the PR
-# with a new comment each time.
-existing_comment_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-  --jq "[.[] | select(.body | startswith(\"${MARKER}\"))][0].id // empty")
-
 payload=$(jq -n --arg body "${body}" '{body: $body}')
 
-if [ -n "${existing_comment_id}" ]; then
-  gh api "repos/${REPO}/issues/comments/${existing_comment_id}" \
-    --method PATCH --input - <<<"${payload}" >/dev/null
-else
-  gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    --method POST --input - <<<"${payload}" >/dev/null
+# Finds an existing sticky comment by marker (first match; a PR should only
+# ever accumulate one, since every run either updates it or creates the
+# first one) and posts/updates it. A same-repo (non-fork) PR can still hit
+# a 403 in less common setups (org policy restricting `GITHUB_TOKEN`
+# further, branch protection quirks, etc.) — `IS_FORK_PR` above is the
+# expected/deliberate case this function's caller falls back for; this
+# function's own non-zero return covers every other `gh api` failure the
+# same way, including the *lookup* call below (not just the final
+# post/patch), since a read-only token 403s on that GET just as readily.
+post_comment() {
+  local existing_comment_id
+  existing_comment_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+    --jq "[.[] | select(.body | startswith(\"${MARKER}\"))][0].id // empty") || return 1
+
+  if [ -n "${existing_comment_id}" ]; then
+    gh api "repos/${REPO}/issues/comments/${existing_comment_id}" \
+      --method PATCH --input - <<<"${payload}" >/dev/null
+  else
+    gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+      --method POST --input - <<<"${payload}" >/dev/null
+  fi
+}
+
+if ! post_comment; then
+  echo "::notice::posting the PR comment failed (likely a read-only token); writing the report to the step summary instead"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "${body}" >>"${GITHUB_STEP_SUMMARY}"
+  else
+    printf '%s\n' "${body}"
+  fi
 fi

--- a/compose_and_post_comment.sh
+++ b/compose_and_post_comment.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Composes rinkaku's mermaid + Markdown output into a single PR comment body
+# and posts it as a sticky comment (identified by MARKER below), updating an
+# existing one instead of piling up duplicates on every push.
+#
+# Pulled out of action.yaml's inline `run:` block so it has a path a human
+# (or this repository's own dogfooding workflow) can execute directly for
+# dynamic verification, rather than only ever running inside a GitHub Actions
+# composite step.
+#
+# Required environment:
+#   MERMAID_PATH   path to the generated mermaid report
+#   MARKDOWN_PATH  path to the generated Markdown report
+#   REPO           "owner/repo", passed to `gh api`/`gh pr comment`
+#   PR_NUMBER      pull request number to comment on
+#   GH_TOKEN       token `gh` uses for authentication
+#
+# Optional environment:
+#   DRY_RUN        when set to "1", prints the composed body to stdout
+#                   instead of calling `gh api` — used for local dynamic
+#                   verification without a real PR to post to.
+set -euo pipefail
+
+MARKER="<!-- rinkaku-report -->"
+
+# GitHub's PR/issue comment body limit. Truncating the collapsed Markdown
+# section (rather than the mermaid graph, which must stay intact — a
+# truncated mermaid document fails to render at all) keeps the comment
+# postable even for a very large diff.
+MAX_BODY_LENGTH=65536
+
+: "${MERMAID_PATH:?MERMAID_PATH is required}"
+: "${MARKDOWN_PATH:?MARKDOWN_PATH is required}"
+
+mermaid_content=$(cat "${MERMAID_PATH}")
+markdown_content=$(cat "${MARKDOWN_PATH}")
+
+body_prefix="${MARKER}
+## rinkaku PR report
+
+\`\`\`mermaid
+${mermaid_content}
+\`\`\`
+
+<details>
+<summary>Details (full signature outline)</summary>
+
+"
+
+body_suffix="
+</details>
+"
+
+# Reserve space for everything except the Markdown details section itself,
+# then truncate that section to what's left — this is what keeps the
+# mermaid graph (the human-first part of the comment) intact even under the
+# size cap.
+truncation_note="
+
+*(details truncated: diff too large for a single PR comment)*"
+reserved=$((${#body_prefix} + ${#body_suffix} + ${#truncation_note}))
+budget=$((MAX_BODY_LENGTH - reserved))
+
+if [ "${budget}" -lt 0 ]; then
+  budget=0
+fi
+
+if [ "${#markdown_content}" -gt "${budget}" ]; then
+  markdown_content="${markdown_content:0:budget}${truncation_note}"
+fi
+
+body="${body_prefix}${markdown_content}${body_suffix}"
+
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  printf '%s' "${body}"
+  exit 0
+fi
+
+: "${REPO:?REPO is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+
+# Find an existing sticky comment by marker (first match; a PR should only
+# ever accumulate one, since every run either updates it or creates the
+# first one) so repeated pushes update in place instead of spamming the PR
+# with a new comment each time.
+existing_comment_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+  --jq "[.[] | select(.body | startswith(\"${MARKER}\"))][0].id // empty")
+
+payload=$(jq -n --arg body "${body}" '{body: $body}')
+
+if [ -n "${existing_comment_id}" ]; then
+  gh api "repos/${REPO}/issues/comments/${existing_comment_id}" \
+    --method PATCH --input - <<<"${payload}" >/dev/null
+else
+  gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    --method POST --input - <<<"${payload}" >/dev/null
+fi

--- a/docs/adr/0020-mermaid-output-format.md
+++ b/docs/adr/0020-mermaid-output-format.md
@@ -1,0 +1,142 @@
+# 0020. `--format mermaid`: an opt-in, GitHub-native graph output
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+ADR 0013 rejected a "mermaid flowchart of the symbol graph" as a
+Markdown addition: it "renders fine for a handful of nodes but becomes
+a hairball at 10-15, which is precisely the size of PR where blast-
+radius help matters most." ADR 0015 went further and drew a hard line:
+Markdown/JSON are for machine consumers and stay stable; all future
+human-facing visual work routes to the TUI, explicitly ruling out
+"mermaid diagrams... in Markdown."
+
+Both rejections are about mermaid *inside the default Markdown output*
+— an addition every existing consumer (LLMs piping `rinkaku`'s stdout,
+CI diffing the text) would receive whether they wanted it or not, and
+sized however large the change graph happens to be.
+
+This ADR is a different shape of request: a reviewer skimming a PR on
+github.com, in the one place that already renders mermaid natively
+inline — a PR comment or the PR description. Nothing today gives that
+audience a call/dependency graph at a glance; the TUI (ADR 0015) is
+terminal-only and unavailable to someone just reading the PR page. The
+audience is new (PR-page reviewers, not stdout/LLM consumers or
+terminal users), the surface is opt-in (`--format mermaid`, mutually
+exclusive with `--format md`/`--format json` the same way those already
+are with each other), and it is meant to be produced by a bot (the
+GitHub Action added alongside this ADR) and posted as its own comment,
+not blended into the Markdown a human or LLM already reads.
+
+The hairball objection is still real and is addressed head-on below,
+not argued away.
+
+## Decision
+
+Add `OutputFormat::Mermaid` and `render_mermaid(&Report) ->
+Result<String, RenderError>` to `rinkaku-core`, plus a `--format
+mermaid` CLI value. This does not touch `render_markdown` or the JSON
+path at all — every existing consumer's output is byte-for-byte
+unchanged.
+
+- **Direction: `flowchart LR`.** A call/dependency chain reads
+  caller-to-callee left-to-right the same way `render_markdown`'s tree
+  reads top-to-bottom (parent-then-child); `LR` keeps that same mental
+  model instead of introducing `TD`'s top-down convention for what is
+  the same underlying edge direction the tree already uses.
+- **Nodes: name only.** No kind prefix (`fn`/`struct`/...), no
+  signature — the design goal (from the user) is coarse and readable,
+  legible at a glance, not a second copy of "Definitions". A reviewer
+  wanting the signature already has the Markdown/TUI output; this
+  format answers "what talks to what," nothing more.
+- **Grouping: one `subgraph` per file**, titled with the path — this is
+  what lets a glance answer "how many files, how concentrated" the same
+  way `change_graph_summary`'s "most in ..." line does for Markdown,
+  but visually instead of as a sentence.
+- **Styling via `classDef`**: `added` (green-tinted), `changed`
+  (orange-tinted), `hotspot` (red-tinted, heavier stroke). A node that
+  is both `changed` and a hotspot gets the `hotspot` class — precedence
+  documented at the call site in `render.rs` — since "this is a wide
+  blast radius" is the more actionable fact for a glance-level view than
+  "this signature changed," and the node's own subgraph/label already
+  shows it changed via the Definitions/Markdown companion output.
+  Colors are chosen with explicit dark-on-light text so they hold up
+  under both GitHub's light and dark themes (mermaid's own theming
+  otherwise only flips background, not a fixed text color).
+- **Cycle edges** render as `-.->` (dashed) instead of `-->`, mirroring
+  the ⚠️ warning line `render_markdown` already gives a cycle edge —
+  visually distinct without needing a label.
+- **Hairball fallback: a node budget.** When `graph.nodes.len()` exceeds
+  a constant (30 — large enough that a real single-PR change graph
+  almost always fits under it per dogfooding so far, small enough that
+  a flowchart at that size is still readable in a PR comment's
+  viewport), rendering falls back to a **file-level graph**: one node
+  per file (no subgraphs, nothing to nest), edges aggregated between
+  files and deduplicated with a count label (`-- 3 -->`), changed files
+  (any file containing an `Added`/`SignatureChanged` symbol) styled via
+  the same `changed` class. This directly answers ADR 0013's objection:
+  past the size where a symbol-level flowchart degrades into a
+  hairball, the format demotes itself to the granularity mermaid can
+  still render legibly, rather than rendering the hairball anyway. A
+  leading `%% aggregated to file level (N symbols > budget)` comment
+  marks that the fallback fired, so a reader isn't left wondering why
+  symbol names disappeared.
+- **Determinism**: node/edge order follows the existing `graph.nodes`/
+  `graph.edges` vec order (already diff-derived and stable, per
+  `graph.rs`'s doc comments); aggregated file-level edges dedupe
+  first-seen-order, same convention `render_markdown` already uses
+  elsewhere (e.g. `change_graph_summary`'s path tie-break).
+- **Empty graph**: still emit a minimal valid document (`flowchart LR`
+  plus a `%% no symbols` comment) rather than an empty string or a
+  panic — unlike `render_markdown` (which returns `""` for a fully
+  empty report), a mermaid code fence with no `flowchart` header is not
+  valid mermaid, and the GitHub Action always wants *something* it can
+  post.
+- **Label escaping**: node ids are regenerated sequentially (`n0`,
+  `n1`, ...) rather than reusing `NodeId` strings — mermaid node ids
+  cannot contain many characters a path or symbol name might (`.`,
+  `/`, `::`, `@`). Labels are quoted (`n0["name"]`) with embedded `"`
+  escaped as `&quot;` and `[`/`]` escaped the same way, since an
+  unescaped bracket would prematurely close the label.
+
+## Alternatives
+
+- **Add mermaid to default Markdown output**: exactly what ADR 0013 and
+  ADR 0015 rejected, for the reasons restated in Context. Not
+  reconsidered here — this decision does not touch that output at all.
+- **Render every node individually regardless of graph size**: true to
+  "just show the graph," but reproduces ADR 0013's hairball at the
+  exact size where the format would matter most for a real PR.
+  Rejected in favor of the file-level fallback.
+- **Fallback: truncate to the top-N hotspot nodes instead of
+  aggregating to file level**: keeps symbol-level detail but silently
+  drops nodes, which misrepresents the graph's shape (missing edges to
+  the dropped nodes look like "nothing depends on this" rather than
+  "not shown"). Aggregating to file level keeps every symbol
+  represented, just at coarser granularity, and says so explicitly via
+  the leading comment.
+- **`flowchart TD`**: considered for consistency with mermaid's
+  "flowchart" example default, but a wide, shallow call graph (a common
+  shape — see `change_graph_summary`'s multi-root case) reads
+  awkwardly top-down in a narrow PR-comment viewport; `LR` fits a wide
+  shallow tree more naturally in that context.
+
+## Consequences
+
+- A new format value joins `md`/`json`, each mutually exclusive with
+  the others and with `--tui` — no change to that exclusivity
+  machinery beyond adding the third value.
+- The node budget (30) is a judgment call, not derived from data;
+  revisit if dogfooding a real PR's mermaid output shows the threshold
+  reads as a hairball before it's reached, or feels overly conservative
+  after it.
+- This format is additive and consumed primarily by the GitHub Action
+  (see the accompanying `action.yaml`/workflow), not by
+  `gh pr diff | rinkaku` piped into an LLM — that path stays on
+  Markdown/JSON per ADR 0015.
+- File-level aggregation means a very large diff's mermaid output
+  cannot be pivoted back to symbol level from this format alone; a
+  reader who wants that detail follows the Markdown/TUI companion
+  output the Action also posts (in a collapsed `<details>` section).

--- a/docs/adr/0021-mermaid-output-format.md
+++ b/docs/adr/0021-mermaid-output-format.md
@@ -1,4 +1,4 @@
-# 0020. `--format mermaid`: an opt-in, GitHub-native graph output
+# 0021. `--format mermaid`: an opt-in, GitHub-native graph output
 
 - Status: accepted
 - Date: 2026-07-13

--- a/docs/experiments/0001-map-assisted-llm-review.md
+++ b/docs/experiments/0001-map-assisted-llm-review.md
@@ -482,6 +482,158 @@ that in mind.
   stops being an independent signal. Seed when correctness matters
   more than the experiment (it usually does), but record it.
 
+## Results (round 8)
+
+Same two-pass method, eighth subject: this PR's own fix for the TUI
+source view's path resolution (2 commits — repo-root-relative reads for
+`load_symbol_source`, then a follow-up addressing review feedback on
+that first commit).
+
+| Metric               | A (map)     | B (control) |
+| -------------------- | ----------- | ----------- |
+| Blocker findings      | 1           | 1           |
+| Should-fix findings   | —           | 1           |
+
+- **Both arms independently converged on the same blocker**: `--pr`'s
+  resolved workdir (a ghq/cache clone that can live anywhere on disk,
+  `resolve_pr_workdir`) never reached `resolve_repo_root`, which was
+  called unconditionally with `None`. If the process's own current
+  directory happened to be a *different* git repository, the source
+  view would silently resolve *that* repository's root and, for any
+  relative path that happens to exist in both, show an unrelated
+  file — no error, just wrong content. Neither arm found this via the
+  map: `main`'s signature did not change, and "does the right variable
+  reach the right call" is not a relationship the map draws at all. It
+  came from actively cross-checking the README's description of `--pr`
+  against the new `resolve_repo_root(None)` call site — the same
+  doc-versus-implementation reading strategy that produced round 7's
+  four findings, applied here to code rather than a doc comment.
+- **Only the independent pass's live tmux verification** caught a
+  second, narrower defect: the read-failure error message this PR adds
+  (explaining that a missing file may simply not be checked out
+  locally, e.g. a PR/historical diff) was not wrapped, so `Paragraph`
+  silently truncated it in anything narrower than a very wide pane —
+  the very case the message exists to explain became unreadable in the
+  layout it was written for. A static read of the string literal gives
+  no signal that it will be cut off; only watching the rendered pane
+  does.
+- Dynamic verification also surfaced a defect entirely outside this
+  PR's scope: launching the TUI on stdin-piped diff input
+  (`git diff | rinkaku`) fails to start, because crossterm's raw-mode
+  input reader errors ("Failed to initialize input reader") when stdin
+  has already been consumed reading the diff. Not fixed here — recorded
+  as a backlog item, since stdin-diff mode piping straight into `--tui`
+  is a legitimate ADR 0016/0017 use case that currently cannot reach
+  the TUI at all.
+- Fixes shipped in response: the workdir-propagation blocker (with a
+  regression test constructing two independent repositories to prove
+  the fix resolves the passed-in workdir, not the process's own cwd
+  repository), the message-wrapping should-fix (with a regression test
+  in a 40-column `TestBackend` pane, confirmed to fail without
+  `.wrap(...)`), and a `debug_assert!` plus `#[should_panic]` test
+  pinning `resolve_source_path`'s pre-existing assumption that `Report`
+  paths stay relative (`PathBuf::join` silently discards the root
+  otherwise).
+
+## Conclusions (after 8 rounds)
+
+- Round 8 sharpens round 7's finding rather than adding a new one: the
+  map shows that a wire exists (`main` → `resolve_repo_root` →
+  `rinkaku_tui::run` → ... → `load_symbol_source`), not whether it
+  carries the *correct* value. A caller-side data-flow defect — the
+  right function called with the wrong variable — sits in exactly the
+  blind spot both round 7 and round 8 needed doc-versus-code
+  cross-checking, not the map, to see.
+- The narrow-pane wrapping bug is the same class experiment rounds 3–7
+  keep surfacing: a behavioral defect with zero footprint on any
+  signature, found only by watching the thing render. Reinforces (not
+  extends) round 6's standing conclusion that dynamic verification is
+  the review angle that does not get replaced by better static
+  tooling.
+- Unlike rounds 1–7, this round's map-assisted and independent passes
+  fully converged on the round's most important finding (the blocker)
+  rather than splitting territory — welcome as confidence, but a
+  reminder per round 5's caveat that convergence on an easy-to-spot
+  defect says less about the two passes' complementary value than
+  divergence does.
+
+## Results (round 9)
+
+Same two-pass method, ninth subject: showing skipped and whole-test
+files in the TUI entry tree (2 commits — the feature itself, then a
+follow-up addressing review feedback).
+
+| Metric               | A (map)     | B (control) |
+| --------------------- | ----------- | ----------- |
+| Blocker findings      | 0           | 0           |
+| Should-fix findings   | 1           | 1           |
+
+- The map for this diff was small: 15 changed symbols across 5 files,
+  with `TreeNode` and `FileDetail` (a `signature changed` node) as its
+  two hotspots. Allocating attention by hotspot and walking outward to
+  consumers (`nav`, `order`, `app`, `detail`, `ui`, `row_view`) worked
+  as intended — A's one should-fix came from actually reading the
+  `TreeNode` the map pointed at: the same file path can be inserted
+  from `report.files`, `report.tests`, and `report.skipped`
+  independently, and nothing stopped a later insert from silently
+  overwriting an earlier one's fields, producing a row that both lists
+  real symbols and claims to be skipped/test-only. What the map could
+  not show is the root cause underneath that finding — the three
+  insert paths share a private `file_at` get-or-insert helper, a
+  structural fact invisible to a signature-level diff.
+- B's finding was unrelated and came from plain reading, not
+  execution: a leftover duplicate doc comment above `file_detail_lines`
+  (an old block describing the pre-change behavior, superseded by a
+  new block but never deleted, left the two concatenated and
+  self-contradictory).
+- B also carried this round's dynamic-verification step: a synthetic
+  Go repository (a whole test-only file, a binary file, and an
+  unsupported-language text file) driven end-to-end through the real
+  TUI binary in tmux — every navigation key, the detail pane for both
+  new row kinds, the diff pane for both (including the binary file's
+  correct "no diff hunks found" fallback, since git itself reports no
+  hunks for binaries), and a check that whole-repo/non-TTY paths
+  weren't regressed. No behavioral defect turned up; this pass's value
+  here was confirming the feature, not finding a bug.
+- Zero overlap between the two passes' findings, and neither
+  finding was the kind the other pass's method could realistically
+  have produced: the map routed A to a structural risk sitting one
+  level of indirection below the diff's own signatures; B's finding
+  was a textual leftover a signature-level map has no reason to flag
+  at all, plus a clean bill of health from actually running the thing.
+- Fixes shipped in response: `debug_assert!` guards (plus two
+  `#[should_panic]` regression tests) on the three insert paths
+  pinning the "one path, one source" invariant explicitly rather than
+  leaving it as an unstated assumption of the shared `file_at` helper;
+  the duplicate doc comment removed; and, as a related consistency fix
+  neither pass explicitly flagged but both findings motivated once
+  looked at together, the entry-row badge's skip-reason-vs-test-badge
+  priority was aligned with the detail pane's own priority (`if`/`else
+  if` instead of two independent `if let`s).
+
+## Conclusions (after 9 rounds)
+
+- Round 9 adds a variant to round 8's "the map shows a wire exists,
+  not whether it's correct" lesson: here the map correctly pointed at
+  the *node* where the defect lived (`TreeNode`), but the defect's
+  cause was a shared private helper one layer beneath anything the
+  map's symbol-level view represents. A hotspot is still a good place
+  to look; it is not a guarantee the map has shown you everything
+  worth seeing at that location.
+- This is the first round with **zero overlap and no shared theme**
+  between the two passes' findings — a sharper case of round 8's
+  point that convergence is not itself evidence of complementary
+  value, restated from the other side: divergence this clean (a
+  structural-invariant gap vs. a leftover comment, found by
+  fundamentally different means) is closer to what "two
+  complementary angles" was supposed to produce than any prior round.
+- Dynamic verification's role keeps shifting round to round — round 8
+  used it to *find* a defect (unwrapped text truncated in a narrow
+  pane); here it *confirmed the absence* of one across every new
+  interactive surface. Both outcomes are the step earning its keep:
+  the point is that someone actually drove the binary, not that doing
+  so must always turn up a bug.
+
 ## Next
 
 - Consider a map feature flagging cross-crate duplicate-domain
@@ -493,3 +645,14 @@ that in mind.
   it has now appeared three times (rounds 3, 7, and PR #55's spec
   guarding against it), which is enough recurrence to justify
   mechanizing it.
+- Fix the stdin-diff + `--tui` startup failure found in round 8
+  (crossterm's input reader fails to initialize because stdin was
+  already consumed reading the diff) — a pre-existing gap in a
+  documented use case (ADR 0016/0017), not a regression of this PR.
+- Round 9's near-miss (a shared private helper causing a display bug
+  invisible to a symbol-level map) suggests a possible map feature:
+  flag when two or more independent top-level `Report` fields
+  (`files`/`tests`/`skipped`/`removed`) feed into the same
+  downstream construction function, since that shape recurs whenever
+  a `Report` consumer merges several "list of things about a path"
+  fields back into one per-path structure.

--- a/docs/experiments/0001-map-assisted-llm-review.md
+++ b/docs/experiments/0001-map-assisted-llm-review.md
@@ -634,6 +634,127 @@ follow-up addressing review feedback).
   the point is that someone actually drove the binary, not that doing
   so must always turn up a bug.
 
+## Results (round 10)
+
+Same two-pass method, tenth subject: this PR's own diff (dogfooding) —
+the `--format mermaid` renderer plus the composite GitHub Action/
+dogfooding workflow that posts it as a PR comment. Unlike every prior
+subject, most of the surface under review is YAML/shell, not Rust; the
+map has zero visibility into it beyond listing it as skipped
+(unsupported language). One protocol note: **dynamic verification was
+assigned to arm B only** this round (per the current CLAUDE.md split),
+so the arm-to-arm finding counts below are not a pure map/no-map
+comparison the way rounds 3–9's mandatory-both-arms protocol gave —
+recorded as a caveat, not folded silently into the numbers.
+
+| Metric               | A (map, no execution) | B (control + mandatory execution) |
+| --------------------- | ---------------------- | ---------------------------------- |
+| Output tokens         | 134.5k                  | 128.4k                              |
+| Tool calls            | 21                      | 71                                  |
+| Wall clock            | ~120s                   | ~499s                               |
+| Major findings        | 1                       | 2                                   |
+| Minor findings        | 1                       | 3                                   |
+| Nit findings          | 1                       | 2                                   |
+
+- **A's most useful signal from the map was what it *couldn't* cover**:
+  the "Skipped files (unsupported language)" list flagged that the
+  entire `action.yaml`/workflow/shell surface had zero map coverage,
+  telling A up front that this portion needed full manual reading
+  rather than hotspot-guided sampling — the map redirecting attention
+  by naming its own blind spot, not by pointing into it. For the Rust
+  portion it did cover, the hotspot list (5 of 7 changed symbols
+  concentrated in `render.rs`) let A verify the core renderer quickly
+  and spend the saved budget on the Action files instead.
+- **A's major finding** (trust boundary: the dogfooding workflow ran
+  `action.yaml`/`compose_and_post_comment.sh` from the PR *head*
+  checkout with `pull-requests: write`, so on a non-fork PR a
+  malicious change could rewrite its own comment-posting logic and
+  have it execute with a write token before any review) was reasoned
+  out from reading the workflow's checkout/`uses:` structure, not
+  executed — the class of defect a careful static read of trust
+  boundaries can catch without running anything.
+- **B's two majors were both found by running things**, not reading
+  them: (1) the fork-PR 403 (`pull_request`'s read-only token on fork
+  PRs, verified by checking `github.event.pull_request.head.repo.fork`
+  semantics against how the token scoping actually works) and (2) the
+  oversized-mermaid cap violation, reproduced concretely with a 70,220-
+  byte synthetic mermaid fixture that pushed the composed comment body
+  past GitHub's 65,536-byte limit — a violation the code path could not
+  have been shown broken any other way than constructing the input and
+  running the compose script against it.
+- **B's minor findings were also proven, not asserted**: the
+  `added`-can't-overlap-`hotspot` comment was shown factually wrong by
+  building a live repro (a new symbol referenced by two other changed
+  symbols, confirming `compute_hotspots` counts fan-in independent of
+  classification); the "binary at archive root" comment was shown stale
+  by reproducing the actual release-packaging layout (nested
+  `rinkaku-<target>/rinkaku`, not flat). B additionally validated the
+  mermaid output itself via real `mmdc` SVG rendering, including
+  escaping edge cases, rather than eyeballing the fenced text.
+- **Neither arm caught the bootstrap bug**: on this very PR, the
+  workflow builds rinkaku from base = `main`, which does not yet have
+  `--format mermaid` — the run would fail on its own introducing PR.
+  The orchestrator caught it, not either review arm. Worth recording
+  as a conclusion in its own right: a first-PR-for-a-feature is a
+  structural blind spot for *both* review strategies, since the defect
+  only exists in the relationship between "what this PR adds" and
+  "what the base ref the workflow builds from lacks" — a relationship
+  neither the map (which describes the diff) nor a control read
+  focused on the diff's own content has a reason to check without
+  being told to look for it specifically.
+- Fixes shipped in response to all findings: the workflow restructured
+  so the PR base (not head) provides both the built binary *and* the
+  orchestration code (`uses: ./` resolves from the base checkout; the
+  head checkout is data-only, referenced via a new `repo-path` input);
+  fork-PR and generic-403 detection with a `$GITHUB_STEP_SUMMARY`
+  fallback so a fork PR's run still exits 0; a `--help`-probe fallback
+  to a Markdown-only report when the resolved binary predates
+  `--format mermaid` (fixing the bootstrap bug the orchestrator found);
+  a mermaid-specific size budget in the compose script, replacing an
+  oversized graph with a short note rather than letting it blow the
+  total comment cap; byte-safe (`LC_ALL=C`) truncation with a
+  UTF-8-boundary backoff loop, verified against a fixture with the
+  cycle-warning glyph (⚠️) straddling the cut point; the wrong
+  hotspot/added-precedence rationale rewritten to the true one, with a
+  new test proving an `Added` symbol can be a hotspot; the stale
+  archive-layout comment corrected; embedded newlines in mermaid labels
+  now normalized to spaces; an exact-budget (30-node) boundary test
+  added alongside the existing over-budget one; unrouted `${{ }}`
+  interpolation in the workflow moved into `env:`; and a
+  `permissions:`/trusted-base/fork-behavior paragraph added to the
+  README's Action example.
+
+## Conclusions (after 10 rounds)
+
+- This round's subject shape — mostly non-Rust orchestration code —
+  produced a new instance of round 8/9's "the map shows what exists,
+  not whether it's correct/safe" lesson, from the opposite direction:
+  here the map couldn't even show *what exists*, and its most useful
+  contribution was making that gap visible (the skipped-files list) so
+  attention routed to full manual reading instead of false confidence
+  from partial coverage. A map's blind spots are worth surfacing
+  explicitly, not just silently narrowing what it can vouch for.
+- The asymmetry caveat matters this round more than most: with dynamic
+  execution assigned only to B, B's finding-count lead is expected by
+  construction, not evidence that unassisted review is stronger in
+  general — rounds 3–9's mandatory-both-arms protocol remains the
+  fairer comparison for that question. What this round *does* add
+  cleanly: A's static trust-boundary reasoning and B's dynamic
+  reproductions were different in kind (a structural read vs. a built
+  fixture), not just different in count, and both were real, useful,
+  non-overlapping findings.
+- **New failure mode identified**: neither review arm caught a defect
+  that only exists in the relationship between the PR's own diff and
+  the state of its own base ref (the bootstrap flag-availability gap).
+  Both review strategies in this experiment are framed around "read/
+  execute the diff" — neither is set up to ask "does this diff's own
+  premise hold against the ref it will actually run against on its own
+  introducing PR," which is a first-PR-only question by definition.
+  This is a genuinely new category, distinct from rounds 1–9's
+  recurring "map draws no edge to unchanged code" gap: it is not about
+  what the map can see, but about a question neither arm's prompt
+  currently asks at all.
+
 ## Next
 
 - Consider a map feature flagging cross-crate duplicate-domain
@@ -656,3 +777,19 @@ follow-up addressing review feedback).
   downstream construction function, since that shape recurs whenever
   a `Report` consumer merges several "list of things about a path"
   fields back into one per-path structure.
+- Round 10's new failure mode (neither arm checks whether a PR's own
+  premise holds against its own base ref) suggests adding an explicit
+  "bootstrap consistency" check to the review-prompt template for any
+  PR introducing a CLI flag/feature that a CI/Action step in the same
+  PR builds-and-uses from a base checkout: does the base ref actually
+  have the capability the new workflow step assumes? Neither the map
+  nor a diff-focused control read is positioned to ask this
+  unprompted, so it likely needs to be an explicit instruction rather
+  than something either strategy discovers on its own.
+- Round 10 also flags an experiment-design gap worth fixing before the
+  next non-Rust-heavy subject: consider giving arm A a lightweight
+  non-map "what does the map NOT cover" summary (e.g. the skipped-
+  files list alone, without the rest of the report) as a control, to
+  isolate whether the attention-routing benefit this round attributes
+  to the map specifically requires the full report or would come from
+  just knowing the coverage boundary.

--- a/docs/experiments/0001-map-assisted-llm-review.md
+++ b/docs/experiments/0001-map-assisted-llm-review.md
@@ -645,7 +645,10 @@ map has zero visibility into it beyond listing it as skipped
 assigned to arm B only** this round (per the current CLAUDE.md split),
 so the arm-to-arm finding counts below are not a pure map/no-map
 comparison the way rounds 3–9's mandatory-both-arms protocol gave —
-recorded as a caveat, not folded silently into the numbers.
+recorded as a caveat, not folded silently into the numbers. Metrics are
+the orchestrating session's harness-reported usage accounting for the
+two review subagent runs (output tokens, tool calls, wall clock), the
+same provenance every prior round's numbers share.
 
 | Metric               | A (map, no execution) | B (control + mandatory execution) |
 | --------------------- | ---------------------- | ---------------------------------- |

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -1013,14 +1013,20 @@ fn render_mermaid(report: &Report) -> String {
         writeln!(out, "  {from} {arrow} {to}").expect("writing to a String cannot fail");
     }
 
-    // Class assignment: a node that is both `changed` (SignatureChanged)
-    // and a hotspot gets `hotspot` styling, not `changed` — see this
-    // function's doc comment / ADR 0021's Decision on precedence. `added`
-    // never overlaps with `hotspot` in practice (a hotspot is referenced by
-    // >= 2 other changed symbols, which requires base-side symbols to
-    // compare against, the same data `Added` vs `SignatureChanged`
-    // classification depends on) but is checked after `changed` regardless,
-    // so the precedence order is explicit rather than incidental.
+    // Class assignment: a node that is both classified (`added` or
+    // `changed`) and a hotspot gets `hotspot` styling, checked first —
+    // see this function's doc comment / ADR 0021's Decision on
+    // precedence. This overlap is real, not just theoretical: fan-in
+    // (`hotspot_ids`, from `compute_hotspots`) counts referrers among
+    // *changed* symbols regardless of the target's own classification, so
+    // a brand-new (`Added`) symbol referenced by two or more other
+    // changed symbols is a perfectly ordinary hotspot too — e.g. a new
+    // helper function two other new/changed call sites both use in the
+    // same diff. `hotspot` wins because fan-in ("how many other changed
+    // symbols depend on this") is the more decision-relevant signal for a
+    // reviewer skimming the graph than "this particular node is new" —
+    // the node's own classification is still visible in the companion
+    // Markdown/JSON output's Definitions section either way.
     for n in &report.graph.nodes {
         let safe_id = &safe_id_by_node[n.id.as_str()];
         let class = if hotspot_ids.contains(n.id.as_str()) {
@@ -1158,12 +1164,19 @@ const MERMAID_CLASS_DEFS: &str = concat!(
 /// Escapes text embedded in a quoted mermaid node/subgraph label
 /// (`id["text"]`): `&` first (so the escape sequences below aren't
 /// themselves re-escaped), then `"` and `[`/`]`, any of which would
-/// otherwise prematurely close or corrupt the quoted label.
+/// otherwise prematurely close or corrupt the quoted label. Embedded
+/// newlines are replaced with a space rather than escaped — a path or
+/// symbol name is not expected to legitimately contain one, but a literal
+/// `\n` inside a quoted label would break the single-line label syntax
+/// (and, worse, could start a new line mermaid tries to parse as its own
+/// statement), so this is a defensive normalization rather than a
+/// meaning-preserving escape the way the others are.
 fn escape_mermaid_label(text: &str) -> String {
     text.replace('&', "&amp;")
         .replace('"', "&quot;")
         .replace('[', "&#91;")
         .replace(']', "&#93;")
+        .replace('\n', " ")
 }
 
 #[cfg(test)]
@@ -4559,6 +4572,37 @@ flowchart LR
     }
 
     #[test]
+    fn should_replace_embedded_newline_with_space_when_path_contains_one() {
+        // A path/name is not expected to legitimately contain a newline,
+        // but nothing upstream guarantees it can't — an unescaped `\n`
+        // inside a quoted mermaid label would break the single-line label
+        // syntax, so it is normalized to a space defensively rather than
+        // left as-is or escaped like the other special characters.
+        let report = empty_report(
+            SymbolGraph {
+                nodes: vec![node("src/lib.rs::weird", "src/li\nb.rs", "weird")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::weird".to_string()],
+            },
+            vec![],
+        );
+
+        let expected = "\
+flowchart LR
+  subgraph sub0[\"src/li b.rs\"]
+    n0[\"weird\"]
+  end
+  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
+  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
+  classDef hotspot fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn should_prefer_hotspot_class_over_changed_class_when_node_is_both() {
         // "shared" is SignatureChanged *and* referenced by two other
         // symbols (fan-in >= 2, so it's also a hotspot) — precedence goes
@@ -4601,6 +4645,98 @@ flowchart LR
   classDef hotspot fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
 "
         .to_string();
+        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_prefer_hotspot_class_over_added_class_when_a_new_symbol_is_also_a_hotspot() {
+        // Fan-in (`compute_hotspots`) counts referrers among *changed*
+        // symbols regardless of the referenced node's own classification —
+        // a brand-new ("added") symbol referenced by two or more other
+        // changed symbols in the same diff (e.g. a new helper two other
+        // new/changed call sites both use) is a perfectly ordinary
+        // hotspot too, not a case that can't occur. Same precedence as
+        // the SignatureChanged sibling test above: `hotspot` wins.
+        let report = Report {
+            origin: ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/lib.rs::new_helper",
+                    "new_helper",
+                    SymbolKind::Function,
+                    Some(Classification::Added),
+                )],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::new_helper", "src/lib.rs", "new_helper")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::new_helper".to_string()],
+            },
+            tests: vec![],
+            hotspots: vec![Hotspot {
+                id: "src/lib.rs::new_helper".to_string(),
+                path: "src/lib.rs".to_string(),
+                name: "new_helper".to_string(),
+                used_by: vec!["a".to_string(), "b".to_string()],
+            }],
+            removed: vec![],
+        };
+
+        let expected = "\
+flowchart LR
+  subgraph sub0[\"src/lib.rs\"]
+    n0[\"new_helper\"]
+  end
+  class n0 hotspot
+  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
+  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
+  classDef hotspot fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_stay_symbol_level_when_node_count_equals_budget_exactly() {
+        // Exactly MERMAID_NODE_BUDGET (30) nodes: the fallback condition
+        // is `> budget`, so this boundary case must still render one
+        // subgraph/node per symbol, not the file-level aggregation — pins
+        // the off-by-one the sibling over-budget test alone can't rule
+        // out (that test only proves 31 falls back, not that 30 doesn't).
+        let mut nodes = Vec::new();
+        let mut symbols = Vec::new();
+        for i in 0..30 {
+            let id = format!("src/lib.rs::s{i}");
+            nodes.push(node(&id, "src/lib.rs", &format!("s{i}")));
+            symbols.push(symbol(&id, &format!("s{i}"), SymbolKind::Function, None));
+        }
+        assert_eq!(30, nodes.len());
+
+        let report = empty_report(
+            SymbolGraph {
+                nodes,
+                edges: vec![],
+                roots: vec!["src/lib.rs::s0".to_string()],
+            },
+            vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols,
+            }],
+        );
+
+        let mut expected = String::from("flowchart LR\n  subgraph sub0[\"src/lib.rs\"]\n");
+        for i in 0..30 {
+            expected.push_str(&format!("    n{i}[\"s{i}\"]\n"));
+        }
+        expected.push_str("  end\n");
+        expected.push_str(MERMAID_CLASS_DEFS);
+
         let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
 
         assert_eq!(expected, actual);

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -168,6 +168,11 @@ pub enum SkipReason {
 pub enum OutputFormat {
     Markdown,
     Json,
+    /// A human-oriented call/dependency graph rendered as a mermaid
+    /// `flowchart` document (ADR 0020) — opt-in, aimed at GitHub's native
+    /// mermaid rendering (PR comments/descriptions), not the default
+    /// Markdown output ADR 0013/0015 keep machine-facing.
+    Mermaid,
 }
 
 /// Errors that can occur while rendering a [`Report`].
@@ -189,6 +194,7 @@ pub fn render(report: &Report, format: OutputFormat) -> Result<String, RenderErr
     match format {
         OutputFormat::Markdown => render_markdown(report),
         OutputFormat::Json => Ok(serde_json::to_string_pretty(report)?),
+        OutputFormat::Mermaid => Ok(render_mermaid(report)),
     }
 }
 
@@ -920,6 +926,244 @@ fn skip_reason_label(reason: SkipReason) -> &'static str {
         SkipReason::Deleted => "deleted",
         SkipReason::Generated => "generated",
     }
+}
+
+/// Node count above which [`render_mermaid`] falls back to a file-level
+/// graph (ADR 0020) instead of one node per symbol. Chosen as a size a
+/// `flowchart` still renders legibly in a PR comment's viewport; see the
+/// ADR's Consequences for the judgment-call caveat.
+const MERMAID_NODE_BUDGET: usize = 30;
+
+/// Renders a [`Report`] as a mermaid `flowchart LR` document (ADR 0020): a
+/// human-oriented call/dependency graph, opt-in via `--format mermaid`,
+/// separate from the machine-facing Markdown/JSON paths (`render_markdown`
+/// is untouched by this function).
+///
+/// Falls back to [`render_mermaid_file_level`] when `graph.nodes.len()`
+/// exceeds [`MERMAID_NODE_BUDGET`] — the hairball concern ADR 0013 raised
+/// against a symbol-level flowchart, addressed by demoting to file
+/// granularity rather than rendering every node anyway.
+///
+/// Infallible (`Result` in [`render`]'s signature is uniform across
+/// formats, not because this can fail): unlike `render_markdown`'s
+/// `std::fmt::Write` calls, building a `String` via `push_str`/`write!`
+/// into an owned buffer that is only ever handed back to the caller cannot
+/// error the way a fallible `io::Write` sink could.
+fn render_mermaid(report: &Report) -> String {
+    if report.graph.nodes.len() > MERMAID_NODE_BUDGET {
+        return render_mermaid_file_level(report);
+    }
+
+    let mut out = String::new();
+    out.push_str("flowchart LR\n");
+
+    if report.graph.nodes.is_empty() {
+        out.push_str("%% no symbols\n");
+        return out;
+    }
+
+    let lookup = SymbolLookup::build(&report.files);
+    let hotspot_ids: HashSet<&str> = report.hotspots.iter().map(|h| h.id.as_str()).collect();
+
+    // Sequential, mermaid-safe node ids (`n0`, `n1`, ...), mapped from the
+    // original `NodeId` — a `NodeId` like `src/lib.rs::foo@10` contains
+    // characters (`/`, `:`, `@`, `.`) mermaid does not accept in a bare
+    // node id.
+    let mut safe_id_by_node: HashMap<&str, String> = HashMap::new();
+    for (i, n) in report.graph.nodes.iter().enumerate() {
+        safe_id_by_node.insert(n.id.as_str(), format!("n{i}"));
+    }
+
+    // Group nodes by path, preserving first-seen order (same convention as
+    // `change_graph_summary`'s path tie-break) — this is what produces one
+    // `subgraph` per file, in source order.
+    let mut path_order: Vec<&str> = Vec::new();
+    let mut nodes_by_path: HashMap<&str, Vec<&Node>> = HashMap::new();
+    for n in &report.graph.nodes {
+        let path = n.path.as_str();
+        if !nodes_by_path.contains_key(path) {
+            path_order.push(path);
+        }
+        nodes_by_path.entry(path).or_default().push(n);
+    }
+
+    for (subgraph_i, path) in path_order.iter().enumerate() {
+        writeln!(
+            out,
+            "  subgraph sub{subgraph_i}[\"{}\"]",
+            escape_mermaid_label(path)
+        )
+        .expect("writing to a String cannot fail");
+        for n in &nodes_by_path[path] {
+            let safe_id = &safe_id_by_node[n.id.as_str()];
+            writeln!(out, "    {safe_id}[\"{}\"]", escape_mermaid_label(&n.name))
+                .expect("writing to a String cannot fail");
+        }
+        out.push_str("  end\n");
+    }
+
+    for edge in &report.graph.edges {
+        let (Some(from), Some(to)) = (
+            safe_id_by_node.get(edge.from.as_str()),
+            safe_id_by_node.get(edge.to.as_str()),
+        ) else {
+            continue;
+        };
+        let arrow = if edge.is_cycle { "-.->" } else { "-->" };
+        writeln!(out, "  {from} {arrow} {to}").expect("writing to a String cannot fail");
+    }
+
+    // Class assignment: a node that is both `changed` (SignatureChanged)
+    // and a hotspot gets `hotspot` styling, not `changed` — see this
+    // function's doc comment / ADR 0020's Decision on precedence. `added`
+    // never overlaps with `hotspot` in practice (a hotspot is referenced by
+    // >= 2 other changed symbols, which requires base-side symbols to
+    // compare against, the same data `Added` vs `SignatureChanged`
+    // classification depends on) but is checked after `changed` regardless,
+    // so the precedence order is explicit rather than incidental.
+    for n in &report.graph.nodes {
+        let safe_id = &safe_id_by_node[n.id.as_str()];
+        let class = if hotspot_ids.contains(n.id.as_str()) {
+            Some("hotspot")
+        } else {
+            match lookup.get(&n.id).and_then(|(_, s)| s.classification) {
+                Some(Classification::Added) => Some("added"),
+                Some(Classification::SignatureChanged) => Some("changed"),
+                _ => None,
+            }
+        };
+        if let Some(class) = class {
+            writeln!(out, "  class {safe_id} {class}").expect("writing to a String cannot fail");
+        }
+    }
+
+    out.push_str(MERMAID_CLASS_DEFS);
+    out
+}
+
+/// [`render_mermaid`]'s fallback for a graph over [`MERMAID_NODE_BUDGET`]
+/// nodes (ADR 0020): one node per file rather than per symbol, edges
+/// aggregated between files and deduplicated with a count label, so the
+/// output stays legible instead of degrading into a hairball. A leading
+/// `%% aggregated to file level` comment marks that this fallback fired.
+fn render_mermaid_file_level(report: &Report) -> String {
+    let mut out = String::new();
+    out.push_str("flowchart LR\n");
+    writeln!(
+        out,
+        "%% aggregated to file level ({} symbols > budget)",
+        report.graph.nodes.len()
+    )
+    .expect("writing to a String cannot fail");
+
+    let path_by_node: HashMap<&str, &str> = report
+        .graph
+        .nodes
+        .iter()
+        .map(|n| (n.id.as_str(), n.path.as_str()))
+        .collect();
+
+    // First-seen path order, matching `render_mermaid`'s subgraph order
+    // convention.
+    let mut path_order: Vec<&str> = Vec::new();
+    let mut seen_paths: HashSet<&str> = HashSet::new();
+    for n in &report.graph.nodes {
+        if seen_paths.insert(n.path.as_str()) {
+            path_order.push(n.path.as_str());
+        }
+    }
+
+    let mut safe_id_by_path: HashMap<&str, String> = HashMap::new();
+    for (i, path) in path_order.iter().enumerate() {
+        safe_id_by_path.insert(path, format!("n{i}"));
+    }
+
+    let changed_paths: HashSet<&str> = report
+        .files
+        .iter()
+        .filter(|f| {
+            f.symbols.iter().any(|s| {
+                matches!(
+                    s.classification,
+                    Some(Classification::Added) | Some(Classification::SignatureChanged)
+                )
+            })
+        })
+        .map(|f| f.path.as_str())
+        .collect();
+
+    for path in &path_order {
+        let safe_id = &safe_id_by_path[path];
+        writeln!(out, "  {safe_id}[\"{}\"]", escape_mermaid_label(path))
+            .expect("writing to a String cannot fail");
+    }
+
+    // Aggregate edges by (from_path, to_path), deduped/counted, first-seen
+    // order — an intra-file edge (from_path == to_path) is dropped, since a
+    // self-loop at file granularity carries no information a reader can act
+    // on (unlike a symbol-level cycle edge, which pinpoints a real
+    // dependency cycle).
+    let mut pair_order: Vec<(&str, &str)> = Vec::new();
+    let mut counts: HashMap<(&str, &str), usize> = HashMap::new();
+    for edge in &report.graph.edges {
+        let (Some(&from_path), Some(&to_path)) = (
+            path_by_node.get(edge.from.as_str()),
+            path_by_node.get(edge.to.as_str()),
+        ) else {
+            continue;
+        };
+        if from_path == to_path {
+            continue;
+        }
+        let key = (from_path, to_path);
+        if !counts.contains_key(&key) {
+            pair_order.push(key);
+        }
+        *counts.entry(key).or_insert(0) += 1;
+    }
+
+    for (from_path, to_path) in &pair_order {
+        let from = &safe_id_by_path[from_path];
+        let to = &safe_id_by_path[to_path];
+        let count = counts[&(*from_path, *to_path)];
+        writeln!(out, "  {from} -- {count} --> {to}").expect("writing to a String cannot fail");
+    }
+
+    for path in &path_order {
+        if changed_paths.contains(path) {
+            let safe_id = &safe_id_by_path[path];
+            writeln!(out, "  class {safe_id} changed").expect("writing to a String cannot fail");
+        }
+    }
+
+    out.push_str(MERMAID_CLASS_DEFS);
+    out
+}
+
+/// `classDef` lines shared by [`render_mermaid`] and
+/// [`render_mermaid_file_level`]. Colors are chosen with explicit
+/// dark-on-light text (rather than relying on mermaid's theme defaults) so
+/// they stay legible under both GitHub's light and dark PR-comment themes
+/// (ADR 0020) — `stroke-width` on `hotspot` gives it a heavier outline on
+/// top of its own fill, in addition to `changed`'s (SignatureChanged)
+/// styling, since `hotspot` styling takes precedence over `changed` for a
+/// node that qualifies as both (see `render_mermaid`'s class-assignment
+/// comment).
+const MERMAID_CLASS_DEFS: &str = concat!(
+    "  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;\n",
+    "  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;\n",
+    "  classDef hotspot fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;\n",
+);
+
+/// Escapes text embedded in a quoted mermaid node/subgraph label
+/// (`id["text"]`): `&` first (so the escape sequences below aren't
+/// themselves re-escaped), then `"` and `[`/`]`, any of which would
+/// otherwise prematurely close or corrupt the quoted label.
+fn escape_mermaid_label(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('[', "&#91;")
+        .replace(']', "&#93;")
 }
 
 #[cfg(test)]
@@ -4087,5 +4331,364 @@ fn foo()
 
             assert_eq!(expected, actual);
         }
+    }
+}
+
+#[cfg(test)]
+mod mermaid_tests {
+    use super::*;
+    use crate::diff::LineRange;
+    use crate::extract::{Classification, SymbolKind};
+    use crate::graph::{Edge, Hotspot, Node, SymbolGraph};
+    use pretty_assertions::assert_eq;
+
+    /// Same shape as the sibling `tests::symbol` helper, plus a
+    /// `classification` parameter these tests need to exercise
+    /// added/changed/hotspot styling.
+    fn symbol(
+        id: &str,
+        name: &str,
+        kind: SymbolKind,
+        classification: Option<Classification>,
+    ) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind,
+            signature: format!("{name}()"),
+            range: LineRange { start: 1, end: 1 },
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification,
+            previous_signature: None,
+        }
+    }
+
+    fn node(id: &str, path: &str, name: &str) -> Node {
+        Node {
+            id: id.to_string(),
+            path: path.to_string(),
+            name: name.to_string(),
+        }
+    }
+
+    fn empty_report(graph: SymbolGraph, files: Vec<FileReport>) -> Report {
+        Report {
+            origin: ReportOrigin::Diff,
+            files,
+            skipped: vec![],
+            graph,
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    #[test]
+    fn should_render_minimal_valid_document_when_graph_is_empty() {
+        let report = empty_report(
+            SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            vec![],
+        );
+
+        let expected = "\
+flowchart LR
+%% no symbols
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_subgraph_per_file_with_class_assignments_when_report_has_classified_symbols() {
+        // "foo" is Added, "bar" is SignatureChanged, both in src/lib.rs;
+        // "baz" (unclassified/body-only) lives in src/other.rs and depends
+        // on "foo" — pins subgraph grouping, node labels (name only, no
+        // kind prefix), the edge, and the `added`/`changed` class
+        // assignments together in one full-string comparison.
+        let report = empty_report(
+            SymbolGraph {
+                nodes: vec![
+                    node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                    node("src/lib.rs::bar", "src/lib.rs", "bar"),
+                    node("src/other.rs::baz", "src/other.rs", "baz"),
+                ],
+                edges: vec![Edge {
+                    from: "src/other.rs::baz".to_string(),
+                    to: "src/lib.rs::foo".to_string(),
+                    is_cycle: false,
+                }],
+                roots: vec![
+                    "src/lib.rs::foo".to_string(),
+                    "src/lib.rs::bar".to_string(),
+                    "src/other.rs::baz".to_string(),
+                ],
+            },
+            vec![
+                FileReport {
+                    path: "src/lib.rs".to_string(),
+                    symbols: vec![
+                        symbol(
+                            "src/lib.rs::foo",
+                            "foo",
+                            SymbolKind::Function,
+                            Some(Classification::Added),
+                        ),
+                        symbol(
+                            "src/lib.rs::bar",
+                            "bar",
+                            SymbolKind::Function,
+                            Some(Classification::SignatureChanged),
+                        ),
+                    ],
+                },
+                FileReport {
+                    path: "src/other.rs".to_string(),
+                    symbols: vec![symbol(
+                        "src/other.rs::baz",
+                        "baz",
+                        SymbolKind::Function,
+                        Some(Classification::BodyOnly),
+                    )],
+                },
+            ],
+        );
+
+        let expected = "\
+flowchart LR
+  subgraph sub0[\"src/lib.rs\"]
+    n0[\"foo\"]
+    n1[\"bar\"]
+  end
+  subgraph sub1[\"src/other.rs\"]
+    n2[\"baz\"]
+  end
+  n2 --> n0
+  class n0 added
+  class n1 changed
+  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
+  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
+  classDef hotspot fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_dashed_arrow_when_edge_is_a_cycle() {
+        let report = empty_report(
+            SymbolGraph {
+                nodes: vec![
+                    node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                    node("src/lib.rs::bar", "src/lib.rs", "bar"),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "src/lib.rs::foo".to_string(),
+                        to: "src/lib.rs::bar".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "src/lib.rs::bar".to_string(),
+                        to: "src/lib.rs::foo".to_string(),
+                        is_cycle: true,
+                    },
+                ],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
+            vec![],
+        );
+
+        let expected = "\
+flowchart LR
+  subgraph sub0[\"src/lib.rs\"]
+    n0[\"foo\"]
+    n1[\"bar\"]
+  end
+  n0 --> n1
+  n1 -.-> n0
+  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
+  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
+  classDef hotspot fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_escape_label_when_name_contains_quote_and_bracket() {
+        let report = empty_report(
+            SymbolGraph {
+                nodes: vec![node(
+                    "src/lib.rs::weird",
+                    "src/lib.rs",
+                    "weird\"name[with]brackets",
+                )],
+                edges: vec![],
+                roots: vec!["src/lib.rs::weird".to_string()],
+            },
+            vec![],
+        );
+
+        let expected = "\
+flowchart LR
+  subgraph sub0[\"src/lib.rs\"]
+    n0[\"weird&quot;name&#91;with&#93;brackets\"]
+  end
+  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
+  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
+  classDef hotspot fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_prefer_hotspot_class_over_changed_class_when_node_is_both() {
+        // "shared" is SignatureChanged *and* referenced by two other
+        // symbols (fan-in >= 2, so it's also a hotspot) — precedence goes
+        // to `hotspot` styling per this module's documented choice.
+        let report = Report {
+            origin: ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/lib.rs::shared",
+                    "shared",
+                    SymbolKind::Function,
+                    Some(Classification::SignatureChanged),
+                )],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::shared", "src/lib.rs", "shared")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::shared".to_string()],
+            },
+            tests: vec![],
+            hotspots: vec![Hotspot {
+                id: "src/lib.rs::shared".to_string(),
+                path: "src/lib.rs".to_string(),
+                name: "shared".to_string(),
+                used_by: vec!["a".to_string(), "b".to_string()],
+            }],
+            removed: vec![],
+        };
+
+        let expected = "\
+flowchart LR
+  subgraph sub0[\"src/lib.rs\"]
+    n0[\"shared\"]
+  end
+  class n0 hotspot
+  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
+  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
+  classDef hotspot fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_fall_back_to_file_level_graph_when_node_count_exceeds_budget() {
+        // 31 nodes (one over MERMAID_NODE_BUDGET's 30) across two files:
+        // 16 in src/a.rs (one classified Added, so a.rs is "changed"), 15
+        // in src/b.rs. Two edges cross from a.rs to b.rs (aggregated with
+        // count 2); one edge stays within a.rs (dropped: an intra-file
+        // edge carries no file-level signal).
+        let mut nodes = Vec::new();
+        let mut files_a_symbols = Vec::new();
+        for i in 0..16 {
+            let id = format!("src/a.rs::a{i}");
+            nodes.push(node(&id, "src/a.rs", &format!("a{i}")));
+            let classification = if i == 0 {
+                Some(Classification::Added)
+            } else {
+                None
+            };
+            files_a_symbols.push(symbol(
+                &id,
+                &format!("a{i}"),
+                SymbolKind::Function,
+                classification,
+            ));
+        }
+        let mut files_b_symbols = Vec::new();
+        for i in 0..15 {
+            let id = format!("src/b.rs::b{i}");
+            nodes.push(node(&id, "src/b.rs", &format!("b{i}")));
+            files_b_symbols.push(symbol(&id, &format!("b{i}"), SymbolKind::Function, None));
+        }
+        assert_eq!(31, nodes.len());
+
+        let edges = vec![
+            Edge {
+                from: "src/a.rs::a0".to_string(),
+                to: "src/b.rs::b0".to_string(),
+                is_cycle: false,
+            },
+            Edge {
+                from: "src/a.rs::a1".to_string(),
+                to: "src/b.rs::b1".to_string(),
+                is_cycle: false,
+            },
+            Edge {
+                from: "src/a.rs::a0".to_string(),
+                to: "src/a.rs::a1".to_string(),
+                is_cycle: false,
+            },
+        ];
+        let roots = vec!["src/a.rs::a0".to_string(), "src/b.rs::b0".to_string()];
+
+        let report = empty_report(
+            SymbolGraph {
+                nodes,
+                edges,
+                roots,
+            },
+            vec![
+                FileReport {
+                    path: "src/a.rs".to_string(),
+                    symbols: files_a_symbols,
+                },
+                FileReport {
+                    path: "src/b.rs".to_string(),
+                    symbols: files_b_symbols,
+                },
+            ],
+        );
+
+        let expected = "\
+flowchart LR
+%% aggregated to file level (31 symbols > budget)
+  n0[\"src/a.rs\"]
+  n1[\"src/b.rs\"]
+  n0 -- 2 --> n1
+  class n0 changed
+  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
+  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
+  classDef hotspot fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+        assert_eq!(expected, actual);
     }
 }

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -169,7 +169,7 @@ pub enum OutputFormat {
     Markdown,
     Json,
     /// A human-oriented call/dependency graph rendered as a mermaid
-    /// `flowchart` document (ADR 0020) — opt-in, aimed at GitHub's native
+    /// `flowchart` document (ADR 0021) — opt-in, aimed at GitHub's native
     /// mermaid rendering (PR comments/descriptions), not the default
     /// Markdown output ADR 0013/0015 keep machine-facing.
     Mermaid,
@@ -929,12 +929,12 @@ fn skip_reason_label(reason: SkipReason) -> &'static str {
 }
 
 /// Node count above which [`render_mermaid`] falls back to a file-level
-/// graph (ADR 0020) instead of one node per symbol. Chosen as a size a
+/// graph (ADR 0021) instead of one node per symbol. Chosen as a size a
 /// `flowchart` still renders legibly in a PR comment's viewport; see the
 /// ADR's Consequences for the judgment-call caveat.
 const MERMAID_NODE_BUDGET: usize = 30;
 
-/// Renders a [`Report`] as a mermaid `flowchart LR` document (ADR 0020): a
+/// Renders a [`Report`] as a mermaid `flowchart LR` document (ADR 0021): a
 /// human-oriented call/dependency graph, opt-in via `--format mermaid`,
 /// separate from the machine-facing Markdown/JSON paths (`render_markdown`
 /// is untouched by this function).
@@ -1015,7 +1015,7 @@ fn render_mermaid(report: &Report) -> String {
 
     // Class assignment: a node that is both `changed` (SignatureChanged)
     // and a hotspot gets `hotspot` styling, not `changed` — see this
-    // function's doc comment / ADR 0020's Decision on precedence. `added`
+    // function's doc comment / ADR 0021's Decision on precedence. `added`
     // never overlaps with `hotspot` in practice (a hotspot is referenced by
     // >= 2 other changed symbols, which requires base-side symbols to
     // compare against, the same data `Added` vs `SignatureChanged`
@@ -1042,7 +1042,7 @@ fn render_mermaid(report: &Report) -> String {
 }
 
 /// [`render_mermaid`]'s fallback for a graph over [`MERMAID_NODE_BUDGET`]
-/// nodes (ADR 0020): one node per file rather than per symbol, edges
+/// nodes (ADR 0021): one node per file rather than per symbol, edges
 /// aggregated between files and deduplicated with a count label, so the
 /// output stays legible instead of degrading into a hairball. A leading
 /// `%% aggregated to file level` comment marks that this fallback fired.
@@ -1144,7 +1144,7 @@ fn render_mermaid_file_level(report: &Report) -> String {
 /// [`render_mermaid_file_level`]. Colors are chosen with explicit
 /// dark-on-light text (rather than relying on mermaid's theme defaults) so
 /// they stay legible under both GitHub's light and dark PR-comment themes
-/// (ADR 0020) — `stroke-width` on `hotspot` gives it a heavier outline on
+/// (ADR 0021) — `stroke-width` on `hotspot` gives it a heavier outline on
 /// top of its own fill, in addition to `changed`'s (SignatureChanged)
 /// styling, since `hotspot` styling takes precedence over `changed` for a
 /// node that qualifies as both (see `render_mermaid`'s class-assignment

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -166,7 +166,7 @@ enum Format {
     Md,
     Json,
     /// A human-oriented call/dependency graph as a mermaid `flowchart`
-    /// document (ADR 0020) — opt-in, aimed at GitHub's native mermaid
+    /// document (ADR 0021) — opt-in, aimed at GitHub's native mermaid
     /// rendering in PR comments/descriptions, not the default Markdown
     /// output.
     Mermaid,

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -165,6 +165,11 @@ enum Command {
 enum Format {
     Md,
     Json,
+    /// A human-oriented call/dependency graph as a mermaid `flowchart`
+    /// document (ADR 0020) — opt-in, aimed at GitHub's native mermaid
+    /// rendering in PR comments/descriptions, not the default Markdown
+    /// output.
+    Mermaid,
 }
 
 impl From<Format> for OutputFormat {
@@ -172,6 +177,7 @@ impl From<Format> for OutputFormat {
         match format {
             Format::Md => OutputFormat::Markdown,
             Format::Json => OutputFormat::Json,
+            Format::Mermaid => OutputFormat::Mermaid,
         }
     }
 }


### PR DESCRIPTION
## Summary

Two related features, plus a full round of review-driven hardening:

1. **`--format mermaid`** (rinkaku-core, ADR 0021): renders the changed-symbol
   graph as a mermaid `flowchart LR` document — one subgraph per file, node
   labels are symbol names only, `classDef` styling for added/changed/hotspot
   symbols, dashed edges for dependency cycles. This is opt-in and separate
   from the default Markdown/JSON paths (ADR 0013 and ADR 0015 rejected
   mermaid *inside* default Markdown output for hairball/audience reasons —
   ADR 0021 explains why this is compatible: a new audience, GitHub's native
   mermaid rendering in PR comments, with a 30-node budget and automatic
   file-level aggregation fallback so the hairball concern doesn't reappear).

2. **A composite GitHub Action + dogfooding workflow** (`action.yaml`,
   `compose_and_post_comment.sh`, `.github/workflows/rinkaku-report.yaml`):
   runs rinkaku against a PR's diff and posts (or updates) a sticky PR
   comment — the mermaid graph up front, the full Markdown outline collapsed
   underneath.

### Sample: this PR's own mermaid graph

```mermaid
flowchart LR
  subgraph sub0["rinkaku-core/src/render.rs"]
    n0["OutputFormat"]
    n1["render"]
    n2["render_mermaid"]
    n3["render_mermaid_file_level"]
    n4["escape_mermaid_label"]
  end
  subgraph sub1["rinkaku/src/main.rs"]
    n5["Format"]
    n6["from"]
  end
  n1 --> n0
  n1 --> n2
  n2 --> n3
  n6 --> n5
  class n0 changed
  class n2 added
  class n3 added
  class n4 added
  class n5 changed
  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
  classDef hotspot fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
```

(Generated with `rinkaku --base main --format mermaid` from this branch;
should render as an actual diagram on the PR page.)

## ADR

[docs/adr/0021-mermaid-output-format.md](docs/adr/0021-mermaid-output-format.md)
— originally drafted as ADR 0020, renumbered to 0021 mid-branch after a
collision with another in-flight branch's ADR 0020.

## Review process

This PR went through the repo's two-arm review protocol (map-assisted +
independent/dynamic-verification), recorded as **Round 10** in
[`docs/experiments/0001-map-assisted-llm-review.md`](docs/experiments/0001-map-assisted-llm-review.md).
Note: this branch's copy of that file was behind `main` (rounds 8-9 landed
there after this branch was cut), so the PR also carries a same-file sync
of those two rounds alongside the new Round 10 entry — those lines aren't
authored by this branch's work, just picked up to avoid silently
regressing the doc on merge.

Findings from that review, all fixed in this PR:

- **[MAJOR] Trust boundary**: the dogfooding workflow originally ran the
  action/compose script *from the PR head* with `pull-requests: write`.
  Restructured so both the built binary and the orchestration code
  (`action.yaml`, `compose_and_post_comment.sh`) come from the PR's
  **base** ref; the head checkout is now data-only (a `repo-path` input),
  never executed.
- **[MAJOR] Fork PRs**: `pull_request` events from forks get a read-only
  token regardless of `permissions:`. The action now detects this
  (`github.event.pull_request.head.repo.fork`, plus a generic 403
  fallback) and degrades to writing the report into
  `$GITHUB_STEP_SUMMARY` instead of failing the job.
- **[MAJOR] Bootstrap bug**: on this PR's own introducing run, the
  workflow builds rinkaku from `main`, which doesn't have `--format
  mermaid` yet. The action now probes `--help` for literal `mermaid`
  support and falls back to a Markdown-only report with a warning
  otherwise — protecting future flag additions the same way.
- **[MAJOR] Oversized mermaid**: `compose_and_post_comment.sh` only
  budgeted the Markdown section; an oversized mermaid graph alone could
  still blow GitHub's 65536-byte comment cap (reproduced with a 70KB
  fixture). Added a mermaid-specific size budget with a short fallback
  note.
- **[MINOR] UTF-8-unsafe truncation**: bash's default character-counting
  `${#var}`/`${var:0:n}` could split a multi-byte character (e.g.
  rinkaku's own `⚠️` cycle-warning glyph) at the truncation boundary.
  Fixed with `LC_ALL=C` byte-exact semantics plus an `iconv`-validated
  backoff loop.
- **[MINOR]** Corrected a factually-wrong code comment (an `Added` symbol
  *can* be a hotspot — fan-in counts referrers regardless of the target's
  own classification) and the stale "binary at archive root" comment
  (actually nested `rinkaku-<target>/rinkaku`).
- **[NIT]** Routed remaining shell interpolation through `env:`;
  `escape_mermaid_label` now also neutralizes embedded newlines; added an
  exact-30-node boundary test; added `permissions:`/trusted-base/fork
  guidance to the README's Action example.

## Test plan

- [x] `make lint && make test` green throughout (336 rinkaku-core tests,
      239 rinkaku-tui tests, 155 rinkaku tests)
- [x] `actionlint` clean on the workflow; `shellcheck` clean on
      `compose_and_post_comment.sh` and `action.yaml`'s embedded scripts
- [x] Dynamic verification: `--format mermaid`/`--format mermaid --tui`
      conflict, empty/non-TTY stdin, unsupported-file-only diff, old- vs
      new-binary bootstrap paths, oversized-mermaid/both-oversized/
      multi-byte-boundary/markdown-only compose scenarios, fork-PR and
      generic-403 degrade-to-step-summary paths (all exit 0)

https://claude.ai/code/session_015ZgswoKpDpBmxb93g7KnGd
