### PR TITLE
feat(tui): interaction model v2 — focus, default diff, scoped hunks, help overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,8 +480,19 @@ rinkaku --base main --tui
 rather than combining with it. Bare `rinkaku`, run on an interactive
 terminal with no `--base`/`--pr`, opens the TUI automatically on a
 whole-repo outline instead of a diff ([ADR 0017](docs/adr/0017-whole-repo-outline-as-default-input-mode.md));
-its diff pane (`d`) has nothing to show in that case and renders a
-placeholder.
+the diff pane (the default right-hand pane, [ADR 0020](docs/adr/0020-tui-interaction-model-v2.md))
+has nothing to show in that case and renders a placeholder — press `d` to
+switch to the detail pane instead.
+
+### Interaction model
+
+The interface follows a **focus** model ([ADR 0020](docs/adr/0020-tui-interaction-model-v2.md)),
+similar to neovim's window/pane idioms: at any moment, either the tree
+(left pane) or the right-hand pane has focus, and `j`/`k` act on whichever
+one does. `enter` on a file/symbol row moves focus to the right pane;
+`h`/`esc` moves it back to the tree. Press `?` any time for an in-app
+overlay listing every key and a short glossary (order modes, pivot,
+cycle).
 
 ### What it shows
 
@@ -505,6 +516,20 @@ placeholder.
   shows up too, marked `[test] (N symbols)`, instead of the pre-existing
   gap where such a file had no row at all and was only summarized in
   Markdown's "Tests" section.
+- **Diff pane (right, the default):** the raw unified-diff hunks touching
+  the selected row — "what changed" is what a reviewer wants to see first.
+  A symbol row clips to just its own line range; a file row groups hunks
+  under per-symbol section headers (each symbol's own signature line),
+  with hunks matching no symbol (e.g. import-only changes) collected under
+  a trailing `(module level)` section. When a symbol's signature itself
+  changed, a 2-line old/new header (`- <old>` / `+ <new>`) precedes its
+  hunks. A directory row has no single diff to show, since it spans
+  multiple files. Hunks in the four built-in languages are
+  syntax-highlighted (keywords, strings, types, ...); added/removed lines
+  keep their green/red diff signal as a background tint so it doesn't
+  compete with token colors, and any other file falls back to plain
+  green/red text. `d`/`D` toggles the right-hand pane to the detail view
+  instead.
 - **Detail pane (right):** what the cursor is on. A symbol row shows its
   classification, signature (an old/new diff when the contract changed),
   who depends on it ("used by"), and its callees. A file row shows every
@@ -514,15 +539,6 @@ placeholder.
   its badge breakdown and top fan-in symbols, plus — when it participates
   in a dependency cycle — exactly which other directories it cycles with
   and the concrete symbol-to-symbol edges forming that cycle.
-- **Diff pane (right):** `d`/`D` toggles the right-hand pane to the raw
-  unified-diff hunks instead of the detail view — every hunk of the file
-  for a file row, or just the hunks intersecting a symbol's own line range
-  for a symbol row (a directory row has no single diff to show, since it
-  spans multiple files). Hunks in the four built-in languages are
-  syntax-highlighted (keywords, strings, types, ...); added/removed lines
-  keep their green/red diff signal as a background tint so it doesn't
-  compete with token colors, and any other file falls back to plain
-  green/red text.
 - **Pivot pane (right):** `p`/`P` toggles the right-hand pane to an
   entry-tree view rooted at the directory or file row under the cursor
   ([ADR 0019](docs/adr/0019-entry-path-pivot-view.md)) — the interactive
@@ -533,14 +549,16 @@ placeholder.
   by expanding a dependency edge outward past the pivoted path are dimmed
   so you can tell "the layer I pivoted on" from "what it reaches into".
   Press `p` again, or `d`, to leave pivot mode.
-- **Scrolling the right-hand pane:** `J`/`K` scroll the Detail/Diff/Pivot
-  pane down/up by one line when its content is too long to fit — the
-  pane's title grows a `(first-last/total)` suffix (e.g. `Detail
-  (1-17/43)`) whenever there's more to see, so a long cycle-edge list or a
-  large file's diff doesn't quietly get cut off. The scroll position
-  resets to the top whenever the underlying content could have changed:
-  moving the cursor, toggling between the detail/diff/pivot views, or
-  returning from the source view.
+- **Scrolling the right-hand pane:** move focus to the right pane
+  (`enter` on a file/symbol row) and use `j`/`k` to scroll the
+  Detail/Diff/Pivot pane down/up by one line when its content is too long
+  to fit — the pane's title grows a `(first-last/total)` suffix (e.g.
+  `Detail (1-17/43)`) whenever there's more to see, so a long cycle-edge
+  list or a large file's diff doesn't quietly get cut off. While viewing
+  the Diff pane specifically, `]`/`[` jump straight to the next/previous
+  hunk. The scroll position resets to the top whenever the underlying
+  content could have changed: moving the cursor, toggling between the
+  detail/diff/pivot views, or returning from the source view.
 - **Source view:** `s` on a symbol row opens that file, scrolled to and
   highlighting the symbol's line range; `esc`/`q` returns to the entry
   view. Reads the working tree directly (not the historical commit a
@@ -552,17 +570,37 @@ placeholder.
 
 ### Key bindings
 
+Press `?` in the TUI for the always-up-to-date version of this table,
+grouped by focus.
+
+**Tree focus (default):**
+
 | Key(s) | Action |
 | --- | --- |
 | `j` / `k` / `↓` / `↑` | Move the cursor |
-| `enter` / `space` | Expand or collapse a directory/file row |
+| `enter` | Expand/collapse a directory row, or open a file/symbol row (moves focus right) |
+| `space` | Expand or collapse a directory/file row (never moves focus) |
 | `e` / `E` | Expand every row |
 | `c` / `C` | Collapse every row |
+
+**Right focus (Detail/Diff/Pivot pane):**
+
+| Key(s) | Action |
+| --- | --- |
+| `j` / `k` / `↓` / `↑` | Scroll the pane by one line |
+| `h` / `esc` | Return focus to the tree |
+| `]` | Jump to the next hunk (Diff pane only) |
+| `[` | Jump to the previous hunk (Diff pane only) |
+
+**Global (any focus):**
+
+| Key(s) | Action |
+| --- | --- |
 | `o` / `O` | Toggle topological / alphabetical ordering |
-| `d` / `D` | Toggle the right-hand pane between detail and diff |
+| `d` / `D` | Toggle the right-hand pane between diff and detail |
 | `p` / `P` | Toggle the right-hand pane to the pivot tree rooted at the selected directory/file |
-| `J` / `K` | Scroll the right-hand pane (Detail/Diff/Pivot) down/up |
 | `s` / `S` | Open the source view for the symbol under the cursor |
+| `?` | Toggle the help overlay (keymap + glossary) |
 | `esc` / `q` | Return to the entry view (from the source view) |
 | `q` / `ctrl-c` | Quit (from the entry view) |
 

--- a/docs/adr/0020-tui-interaction-model-v2.md
+++ b/docs/adr/0020-tui-interaction-model-v2.md
@@ -1,0 +1,236 @@
+# 0020. TUI interaction model v2: focus, default diff, selection-scoped
+
+# content, and a help overlay
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+The TUI is unreleased (ADR 0015/0016), which means every keybinding
+added so far (PR #49 navigation, #51 detail/diff toggle, #52 whole-repo
+mode, #54 scrolling, #55 highlighting, #56 pivot) accreted independently,
+feature by feature, with no unifying interaction model behind it. The
+result, surfaced by dogfooding:
+
+- Scrolling uses Shift+J/K, disjoint from the plain j/k the tree already
+  uses for cursor movement — a reviewer has to remember a second,
+  unrelated key pair for "the same kind of motion, but in the other
+  pane".
+- There is no notion of *which pane currently has the reviewer's
+  attention*. j/k always moves the tree cursor, even while the reviewer
+  is deep in a long diff and just wants to keep reading downward.
+- The diff pane defaults to being hidden behind the detail pane
+  (`RightPane::default()` is `Detail`), even though "what changed" is
+  usually the first thing a reviewer wants to see, ahead of the
+  aggregated used-by/callers view.
+- The diff pane shows either a symbol's own line range or an entire
+  file's hunks undifferentiated — a file selection dumps every hunk in
+  source order with no indication of which hunk belongs to which symbol,
+  and a contract change (ADR 0014's `SignatureChanged` +
+  `previous_signature`) is buried inside the hunk text rather than
+  called out up front the way the Detail pane already does
+  (`SignatureView::Changed`, ADR 0015).
+- There is no in-app help: every keybinding lives only in the README and
+  the status line's single dense hint string
+  (`ui::draw_status_line`), which cannot grow without becoming
+  unreadable.
+- The pivot pane already suffered one concrete bug from re-deriving
+  per-frame content inside the draw loop instead of caching it on
+  selection change (`lib.rs`'s `run_app`, the "per-frame pivot recompute
+  bug" its own comments reference, fixed by computing
+  `PivotSelection` once per handled key and threading it into
+  `ui::draw`). Any new selection-derived content (the diff-shaping work
+  below) must follow that same cache-on-change discipline from the
+  start, not rediscover the bug independently.
+
+This ADR fixes an interaction model addressing all of the above at once,
+rather than patching each complaint as an isolated keybinding tweak —
+the complaints share one root cause (no consistent mental model for
+"what does a keypress mean right now") and a unified fix is cheaper than
+five independent ones.
+
+**Reference model**: neovim's window/focus idioms — a focus concept
+where motion keys act on whichever pane has focus, `h` to move focus
+left/back, `]c`/`[c` to jump between hunks in a diff, and `?` to open a
+help overlay. Reviewers already fluent in a modal editor get these
+gestures for free; reviewers who are not still get a single consistent
+rule ("j/k always scrolls the thing with focus") instead of a
+per-feature key.
+
+## Decision
+
+**1. Two-pane focus model.** Add `Focus { Tree, Right }` to `App`,
+defaulting to `Tree`. Motion keys are interpreted relative to focus
+rather than always targeting the tree:
+
+- **Tree focus** (default): `j`/`k` move the tree cursor (the right pane
+  keeps previewing the selection, unchanged from today). `Enter` on a
+  directory row expands/collapses it (today's `Select` behavior,
+  unchanged). `Enter` on a file/symbol row *additionally* moves focus to
+  `Right` — drilling into a row's content is also a focus change, since
+  that is the point of pressing Enter on a leaf. `Space` toggles
+  expand/collapse on any row regardless of kind, exactly as today
+  (unaffected by this ADR).
+- **Right focus**: `j`/`k` scroll the right pane by one line, reusing
+  the existing `right_pane_scroll` state and its clamp-at-draw-time
+  design (PR #54) rather than introducing a second scroll mechanism.
+  `h` or `Esc` returns focus to `Tree`. While the right pane is showing
+  the Diff view specifically, `]c`/`[c` jump the scroll offset to the
+  start of the next/previous hunk (computed from the same shaped diff
+  content this ADR introduces below, not by re-parsing).
+- `d` (Detail/Diff toggle), `p` (pivot toggle), `s` (source drill-down),
+  `o` (order toggle), `q` (quit) remain global and ignore focus
+  entirely — they are mode/screen transitions, not motion, so folding
+  them into the focus split would only add branches without adding
+  clarity.
+
+**2. Remove Shift+J/K as scroll bindings.** `InputKey::ScrollUp`/
+`ScrollDown` are deleted; scrolling is now exactly "plain j/k while
+`Focus::Right`". This is a strict simplification (one fewer key pair to
+remember) enabled by focus doing the disambiguation Shift used to do.
+
+**3. Diff becomes the default right pane.** `RightPane::default()`
+changes from `Detail` to `Diff` — "what changed" is what a reviewer
+wants first. The `--entry`/`with_entry_pivot` startup path is
+unaffected: it already sets `right_pane` to `Pivot` explicitly after
+`App::new`, which unconditionally overrides whatever `App::new` set as
+the default, so `--entry --tui` continues to open straight into the
+pivot tree regardless of this default's value.
+
+**4. Diff pane selection-scope semantics**, replacing today's
+undifferentiated file/symbol split:
+
+- **Symbol selected**: unchanged from today — clip to that symbol's own
+  line range (`hunks_for_range`), hiding hunks from sibling symbols in
+  the same file.
+- **File selected**: group the file's hunks under per-symbol section
+  headers (the symbol's signature line as the header), in the order
+  symbols appear in `report.files[..].symbols`. A hunk that intersects
+  no symbol's line range at all (e.g. an import block, a module-level
+  `use` change) is collected under one trailing "(module level)"
+  section instead of being silently dropped or left floating without
+  attribution. A hunk that intersects more than one symbol's range
+  (possible when two symbols are adjacent with no gap) is attributed to
+  the first symbol (source order) whose range it intersects — simplest
+  rule that keeps every hunk under exactly one header rather than
+  duplicating it.
+- **Contract-change header**: when the selected symbol (or, for a file
+  selection, each grouped symbol) has `previous_signature: Some(..)`,
+  prefix its section with a 2-line `- <previous_signature>` /
+  `+ <signature>` header, styled the same red/green as the Detail
+  pane's own `SignatureView::Changed` rendering — before that symbol's
+  grouped hunks. This puts the outline-level fact ("the contract
+  changed, and to what") ahead of the implementation-level detail
+  (the hunks), matching this ADR's own reference ordering: orient
+  (what changed at the signature level) before reading the body.
+
+**5. This diff-shaping computation is pure and cached, not
+per-draw.** A new pure module builds the shaped diff content (grouped
+sections, contract headers, hunk attribution) from `Report` + the
+already-parsed `FileHunks` + the current selection — no `ratatui`
+types, unit-testable the same way `crate::app`/`crate::tree` already
+are. `crate::run_app` computes it once per handled key (mirroring the
+existing `pivot_selection` cache, decision 6 below) and hands the
+result into `ui::draw`; `ui::draw` itself must never call the shaping
+function, for the exact reason `App::selected_pivot_view`'s own doc
+comment already states: `terminal.draw` runs on every ~100ms idle poll
+tick, not only on a key press, so computing selection-derived content
+inside it re-does the work roughly ten times a second while idle. This
+project has already paid for this mistake once (the pivot pane's
+per-frame recompute bug, see Context) — the invariant here is: **any
+content derived from `App`'s selection state is computed exactly once
+per selection change, on the `run_app` side of the cache boundary,
+never inside `ui::draw`.**
+
+**6. `?` help overlay.** A centered overlay listing the current keymap
+(varying by focus/screen) plus a short glossary (what "topological"
+order means, what pivot does, what "cycle" refers to — the closing
+back-edge of the dependency graph). `?` opens it; `?`, `Esc`, or `q`
+close it. While the overlay is open, every key including `q` is
+consumed by the overlay (closing it) rather than falling through to its
+normal global meaning — an overlay that could be accidentally dismissed
+by the app quitting underneath it would defeat its own purpose as a
+safe, low-stakes "let me check the keys" action.
+
+**7. Status line**: always show the current order mode
+(`OrderMode::Topological`/`OrderMode::AlphaNumeric`, the exact terms
+`crate::order` already uses — the line must not invent a different
+label for the same concept). The key-hint segment switches based on
+focus: a Tree-focused hint set (navigation-oriented) and a
+Right-focused hint set (scroll/hunk-jump-oriented), plus a `?` mention
+in both so the fuller reference is always one keypress away without
+needing to fit everything on one line.
+
+## Alternatives
+
+- **Keep per-feature keys, add more as needed (status quo)**: this is
+  exactly the pattern that produced the dogfooding complaints in
+  Context — rejected as the thing this ADR exists to stop doing.
+- **A single global scroll binding with no focus concept** (e.g. keep
+  Shift+J/K, just document it better): cheaper, but does not fix "j/k
+  always moves the tree cursor even when the reviewer's attention is in
+  the right pane", which was the more specific complaint. Rejected.
+- **Modal (full-screen replacement) help instead of a centered
+  overlay**: a full-screen swap would lose the reviewer's place in the
+  tree/pane layout entirely (rebuilding `Screen` state on return), where
+  an overlay only needs to suspend key routing — cheaper state machine,
+  and the reviewer's context stays visible dimmed behind it. Rejected
+  in favor of the overlay.
+- **Attributing a hunk touching multiple symbols to *every* overlapping
+  symbol's section (duplicate it) instead of just the first**: would
+  make "total lines shown" no longer match "total lines in the diff",
+  actively misleading about change size for exactly the file-level view
+  meant to summarize it. Rejected in favor of single (first-match)
+  attribution.
+- **Putting the diff-shaping logic in `ui.rs` directly**: `ui.rs` is
+  already the crate's largest module (over 2000 lines) and is
+  deliberately kept "thin adapter, pure view-model elsewhere" per its
+  own doc comment; growing it further with grouping/attribution logic
+  that has nothing to do with `ratatui` rendering would violate that
+  split. Rejected in favor of a new sibling module.
+- **Extending `diff_view.rs` in place instead of a new module**:
+  `diff_view.rs` is scoped to parsing raw unified-diff text into
+  `FileHunks`/`Hunk`/`DiffLine` — a different concern from grouping
+  already-parsed hunks by symbol and prefixing contract headers, which
+  reads `Report` and needs no diff-text parsing at all. Keeping them
+  separate mirrors the crate's existing "one file, one responsibility"
+  norm (`crate::tree` builds the tree, `crate::order` ranks it,
+  `crate::detail` builds pane content — none of them absorb into a
+  neighbor once each stays focused). This is CLAUDE.md's "split
+  packages/modules when a responsibility grows large enough to warrant
+  it" applied at module scope, not just crate scope; a >500-line
+  `diff_view.rs` gaining a second, unrelated responsibility was judged
+  past that point already.
+
+## Consequences
+
+- One consistent rule replaces five independent ones: motion keys act
+  on whichever pane has focus, full stop. This is the ADR's primary
+  discoverability win, made real for a first-time user via `?` rather
+  than requiring the README to be read first.
+- The interaction model has one more piece of state (`Focus`) and one
+  more state-machine dimension to keep consistent (which keys are
+  focus-aware vs. global) — a real complexity cost, accepted because
+  the alternative (no focus, more per-feature keys) was shown by
+  dogfooding to cost more in practice.
+- Reviewers unfamiliar with neovim-style `h`/`]c`/`[c` idioms face a
+  small learning curve; the `?` overlay's glossary is this ADR's
+  mitigation, not a claim that the curve is zero.
+- **No backward-compatibility concern**: the TUI has never shipped a
+  release (ADR 0015/0016 introduced it, most recently extended by PR
+  #56), so removing Shift+J/K and changing the default right pane are
+  not breaking changes to any real user — this materially simplifies
+  the decision, since there is no migration path to design, only a
+  final shape to reach directly.
+- The diff pane's file-selected view now costs more to compute (hunk
+  attribution against every symbol's line range, rather than a flat
+  hunk list) — bounded by file size and paid once per selection change
+  under the caching rule in decision 5, not per draw, so this does not
+  reintroduce the per-frame cost class the pivot pane's bug already
+  demonstrated is a real risk in this codebase.
+- A future `Resolver`-based hunk-to-symbol attribution (more precise
+  than line-range intersection) could replace the shaping module's
+  internals without changing this ADR's pane semantics — the module
+  boundary (`Report` + `FileHunks` + selection in, shaped content out)
+  is deliberately drawn to allow that later.

--- a/docs/adr/0020-tui-interaction-model-v2.md
+++ b/docs/adr/0020-tui-interaction-model-v2.md
@@ -1,6 +1,4 @@
-# 0020. TUI interaction model v2: focus, default diff, selection-scoped
-
-# content, and a help overlay
+# 0020. TUI interaction model v2: focus, default diff, selection-scoped content, and a help overlay
 
 - Status: accepted
 - Date: 2026-07-13

--- a/docs/adr/0020-tui-interaction-model-v2.md
+++ b/docs/adr/0020-tui-interaction-model-v2.md
@@ -76,9 +76,11 @@ rather than always targeting the tree:
   the existing `right_pane_scroll` state and its clamp-at-draw-time
   design (PR #54) rather than introducing a second scroll mechanism.
   `h` or `Esc` returns focus to `Tree`. While the right pane is showing
-  the Diff view specifically, `]c`/`[c` jump the scroll offset to the
-  start of the next/previous hunk (computed from the same shaped diff
-  content this ADR introduces below, not by re-parsing).
+  the Diff view specifically, `]`/`[` (single keys, not neovim's `]c`/`[c`
+  chord — Context's reference model is neovim's idiom, but rinkaku binds
+  the plain bracket keys directly) jump the scroll offset to the start of
+  the next/previous hunk (computed from the same shaped diff content this
+  ADR introduces below, not by re-parsing).
 - `d` (Detail/Diff toggle), `p` (pivot toggle), `s` (source drill-down),
   `o` (order toggle), `q` (quit) remain global and ignore focus
   entirely — they are mode/screen transitions, not motion, so folding

--- a/docs/adr/0020-tui-interaction-model-v2.md
+++ b/docs/adr/0020-tui-interaction-model-v2.md
@@ -68,8 +68,11 @@ rather than always targeting the tree:
   unchanged). `Enter` on a file/symbol row *additionally* moves focus to
   `Right` — drilling into a row's content is also a focus change, since
   that is the point of pressing Enter on a leaf. `Space` toggles
-  expand/collapse on any row regardless of kind, exactly as today
-  (unaffected by this ADR).
+  expand/collapse on any row regardless of kind, same as today, and is
+  scoped to `Focus::Tree` for the same reason `Enter`'s row-acting half
+  is: a no-op while `Focus::Right`, rather than silently toggling
+  whichever file/symbol row the cursor is parked behind the right pane
+  currently being viewed.
 - **Right focus**: `j`/`k` scroll the right pane by one line, reusing
   the existing `right_pane_scroll` state and its clamp-at-draw-time
   design (PR #54) rather than introducing a second scroll mechanism.

--- a/docs/experiments/0001-map-assisted-llm-review/rounds/011.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/011.md
@@ -1,0 +1,57 @@
+# Round 11
+
+- Subject: TUI interaction model v2 (ADR 0020) — a two-pane focus
+  model, defaulting the right pane to Diff, selection-scoped diff
+  shaping with contract headers, and a `?` help overlay. 15 commits,
+  the largest TUI change so far by commit count.
+- Map-assisted pass: the map showed 42 changed symbols across 8 files;
+  its hotspots (`App`, `DiffPaneContent`/`DiffSection`, `InputKey`,
+  `AttributedHunk`, `Focus`, `ContractHeader`) accurately reflected the
+  change's actual blast radius and routed attention to the draw-path
+  recompute invariant that ADR 0020 itself calls out (broken twice
+  before, in rounds 3 and 7) — the invariant held this time. The pass's
+  best finding was invisible to the map: `]`/`[` hunk-jump was gated
+  only on `Focus::Right`, not on `RightPane::Diff` specifically,
+  causing stale-offset scroll jumps when the right pane showed Detail
+  or Pivot instead of Diff. This came from reading `handle_key`'s own
+  doc comment against its own code and chasing the unfulfilled promise
+  into `run_app` — a self-consistency defect one level below what the
+  signature-level map can represent, the same shape as round 9's
+  finding.
+- Independent pass: found a parser-level behavioral bug (pure-deletion
+  hunks — new-side hunk header count of 0 — parsed to `new_range: None`
+  and silently vanished from symbol-scoped diffs instead of attributing
+  to the owning symbol), an ADR title accidentally split across two H1
+  headers, and a `Space`/`?`-overlay inconsistency. Dynamic
+  verification covered every interaction-model scenario, including the
+  one this round's orchestrator most expected to find broken — "Diff
+  default with no diff at all" (running bare `rinkaku`, no `--base`,
+  no diff input) — which turned out to already degrade correctly.
+- Notable process finding, outside either review pass: during rebase
+  integration ahead of this PR (before either review ran),
+  live dogfooding of the rebased branch caught a real panic —
+  PR #58's `debug_assert!` rejecting the legitimate case of a file
+  carrying both real symbols and a test-symbol count. This is an
+  inter-PR semantic conflict that neither branch's own compilation nor
+  either PR's own test suite could have caught in isolation, since each
+  suite only exercises its own PR's assumptions. It argues for "build
+  and run the changed surface" (this repo's dynamic-verification rule)
+  applying to rebase/integration points, not only to review passes.
+- Fixes shipped: a pure `should_apply_hunk_jump` helper gating `]`/`[`
+  on both `Focus::Right` and `RightPane::Diff` together; zero-width
+  position retention for pure-deletion hunks, with the half-open
+  boundary rule (`position == range_end` does not count as inside)
+  pinned empirically via a `git diff -U0` experiment after the
+  closed-interval analogy to `overlaps_any` was shown wrong at that
+  exact boundary; `Space` gated to `Focus::Tree` for symmetry with the
+  row-acting half of `Enter`; the ADR 0020 title header collapsed back
+  to one H1; the `debug_assert!` from PR #58 relaxed to accept the
+  mixed real-symbol-and-test-count case.
+- The two passes' findings did not overlap at all this round: the map
+  pass surfaced a wiring/invariant-adjacent defect reachable only by
+  reading code the map pointed at but could not itself represent; the
+  independent pass surfaced a parser edge case and doc-consistency
+  issues the map has no visibility into (parsing correctness and prose
+  are both outside a signature-level diff). Consistent with every
+  round back to round 4: neither arm has yet produced a superset of
+  the other's findings.

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -141,10 +141,17 @@ pub enum Screen {
 /// what makes "follow the cursor while pivoted" (ADR 0019) free: moving the
 /// cursor while already in `Pivot` mode need not touch `RightPane` at all,
 /// only re-run the lookup the next time `crate::ui` draws.
+///
+/// Defaults to [`Self::Diff`] (ADR 0020): "what changed" is what a
+/// reviewer wants to see first, ahead of the aggregated used-by/callers
+/// view `Detail` shows. `App::with_entry_pivot` (the `--entry --tui`
+/// startup path) still overrides this default unconditionally by setting
+/// `right_pane` to `Pivot` itself right after `App::new`, so this default
+/// only matters for the ordinary (non-`--entry`) startup path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RightPane {
-    #[default]
     Detail,
+    #[default]
     Diff,
     Pivot,
 }
@@ -299,6 +306,13 @@ impl App {
     pub fn with_entry_pivot(mut self, path: &str) -> Self {
         if self.nav.move_cursor_to_path(&self.tree, path) {
             self.right_pane = RightPane::Pivot;
+            // Deliberately `RightPane::Detail`, not `RightPane::default()`
+            // (ADR 0020 made the default `Diff`): this session never
+            // actually showed a pane before pivoting straight in at
+            // startup, so there is no real "what was showing before" to
+            // restore — `Detail` is this method's own independent choice
+            // of `p`-re-press destination, unaffected by `RightPane`'s
+            // default changing.
             self.pivot_return_pane = RightPane::Detail;
         } else {
             self.status = Some(format!("note: no tree row matches {path}"));
@@ -919,40 +933,53 @@ mod tests {
     }
 
     #[test]
-    fn should_toggle_right_pane_between_detail_and_diff() {
+    fn should_default_right_pane_to_diff() {
+        // ADR 0020: "what changed" is what a reviewer wants first, ahead of
+        // the aggregated used-by/callers view Detail shows.
         let report = empty_report();
         let app = App::new(&report);
-        assert_eq!(RightPane::Detail, app.right_pane());
 
-        let app = app.handle_key(InputKey::ToggleDiff);
+        assert_eq!(RightPane::Diff, app.right_pane());
+    }
+
+    #[test]
+    fn should_toggle_right_pane_between_diff_and_detail() {
+        let report = empty_report();
+        let app = App::new(&report);
         assert_eq!(RightPane::Diff, app.right_pane());
 
         let app = app.handle_key(InputKey::ToggleDiff);
         assert_eq!(RightPane::Detail, app.right_pane());
+
+        let app = app.handle_key(InputKey::ToggleDiff);
+        assert_eq!(RightPane::Diff, app.right_pane());
     }
 
     #[test]
-    fn should_toggle_right_pane_between_detail_and_pivot() {
+    fn should_toggle_right_pane_between_diff_and_pivot() {
         let report = empty_report();
         let app = App::new(&report);
-        assert_eq!(RightPane::Detail, app.right_pane());
+        assert_eq!(RightPane::Diff, app.right_pane());
 
         let app = app.handle_key(InputKey::TogglePivot);
         assert_eq!(RightPane::Pivot, app.right_pane());
 
         let app = app.handle_key(InputKey::TogglePivot);
-        assert_eq!(RightPane::Detail, app.right_pane());
+        assert_eq!(RightPane::Diff, app.right_pane());
     }
 
     #[test]
     fn should_switch_from_pivot_to_diff_when_toggle_diff_is_pressed() {
         // ADR 0019: "p" re-press or "d" both leave pivot mode — "d" always
         // lands on Diff regardless of `pivot_return_pane` (a deliberate,
-        // unconditional gesture — see `handle_key`'s `ToggleDiff` arm), even
-        // though the pane pivoted from here (Detail, `App::new`'s default)
-        // happens to differ from Diff.
+        // unconditional gesture — see `handle_key`'s `ToggleDiff` arm). Uses
+        // Detail (not the default Diff) as the pane pivoted from, so this
+        // test still shows something once "d" is pressed even though the
+        // destination is unconditional either way.
         let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::TogglePivot);
+        let app = App::new(&report)
+            .handle_key(InputKey::ToggleDiff) // Diff -> Detail
+            .handle_key(InputKey::TogglePivot);
         assert_eq!(RightPane::Pivot, app.right_pane());
 
         let app = app.handle_key(InputKey::ToggleDiff);
@@ -961,10 +988,10 @@ mod tests {
     }
 
     #[test]
-    fn should_switch_from_diff_to_pivot_when_toggle_pivot_is_pressed() {
+    fn should_switch_from_detail_to_pivot_when_toggle_pivot_is_pressed() {
         let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleDiff);
-        assert_eq!(RightPane::Diff, app.right_pane());
+        let app = App::new(&report).handle_key(InputKey::ToggleDiff); // Diff -> Detail
+        assert_eq!(RightPane::Detail, app.right_pane());
 
         let app = app.handle_key(InputKey::TogglePivot);
 
@@ -972,16 +999,13 @@ mod tests {
     }
 
     #[test]
-    fn should_return_to_diff_when_pivot_is_toggled_off_after_entering_from_diff() {
-        // Regression: `d` -> `p` -> `p` used to always land on Detail
-        // regardless of which pane the user pivoted from, silently
-        // discarding the Diff pane the user had open — this test pins `p`'s
-        // re-press restoring the pane pivot was entered from (`d`'s own
-        // arm, tested above, still always lands on Diff unconditionally).
+    fn should_return_to_diff_when_pivot_is_toggled_off_after_entering_from_the_default_diff_pane() {
+        // Pivoting straight from `App::new`'s own default (Diff, ADR 0020)
+        // must restore Diff specifically on `p`'s re-press, pinning that
+        // `pivot_return_pane` is actually captured on entry rather than
+        // this behavior being a coincidence of `RightPane::default()`.
         let report = empty_report();
-        let app = App::new(&report)
-            .handle_key(InputKey::ToggleDiff)
-            .handle_key(InputKey::TogglePivot);
+        let app = App::new(&report).handle_key(InputKey::TogglePivot);
         assert_eq!(RightPane::Pivot, app.right_pane());
 
         let app = app.handle_key(InputKey::TogglePivot);
@@ -991,13 +1015,13 @@ mod tests {
 
     #[test]
     fn should_return_to_detail_when_pivot_is_toggled_off_after_entering_from_detail() {
-        // Companion to the Diff-return-pane test above: pivoting from the
-        // default Detail pane must still restore Detail specifically (not
-        // just "whatever the default happens to be"), pinning that
-        // `pivot_return_pane` is actually captured on entry rather than
-        // this behavior being a coincidence of `RightPane::default()`.
+        // Companion to the Diff-return-pane test above: pivoting from
+        // Detail (reached via `d`, not the default) must still restore
+        // Detail specifically, not "whatever the default happens to be".
         let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::TogglePivot);
+        let app = App::new(&report)
+            .handle_key(InputKey::ToggleDiff) // Diff -> Detail
+            .handle_key(InputKey::TogglePivot);
         assert_eq!(RightPane::Pivot, app.right_pane());
 
         let app = app.handle_key(InputKey::TogglePivot);
@@ -1011,11 +1035,11 @@ mod tests {
         let app = App::new(&report)
             .handle_key(InputKey::Down)
             .handle_key(InputKey::Source);
-        assert_eq!(RightPane::Detail, app.right_pane());
+        assert_eq!(RightPane::Diff, app.right_pane());
 
         let app = app.handle_key(InputKey::TogglePivot);
 
-        assert_eq!(RightPane::Detail, app.right_pane());
+        assert_eq!(RightPane::Diff, app.right_pane());
     }
 
     #[test]
@@ -1161,6 +1185,11 @@ mod tests {
     fn should_move_cursor_and_open_pivot_pane_when_entry_pivot_path_matches_a_row() {
         let report = report_with_two_directories_and_graph();
         let app = App::new(&report);
+        // ADR 0020 made Diff the default right pane; this pins that
+        // `with_entry_pivot` still unconditionally overrides it to Pivot
+        // regardless, since it sets `right_pane` directly after `App::new`
+        // rather than consulting `RightPane::default()`.
+        assert_eq!(RightPane::Diff, app.right_pane());
 
         let app = app.with_entry_pivot("b");
 
@@ -1184,7 +1213,7 @@ mod tests {
         let app = app.with_entry_pivot("no/such/path");
 
         assert_eq!(0, app.nav().cursor());
-        assert_eq!(RightPane::Detail, app.right_pane());
+        assert_eq!(RightPane::Diff, app.right_pane());
         assert_eq!(Some("note: no tree row matches no/such/path"), app.status());
     }
 
@@ -1194,11 +1223,11 @@ mod tests {
         let app = App::new(&report)
             .handle_key(InputKey::Down)
             .handle_key(InputKey::Source);
-        assert_eq!(RightPane::Detail, app.right_pane());
+        assert_eq!(RightPane::Diff, app.right_pane());
 
         let app = app.handle_key(InputKey::ToggleDiff);
 
-        assert_eq!(RightPane::Detail, app.right_pane());
+        assert_eq!(RightPane::Diff, app.right_pane());
         assert_eq!(
             Screen::Source {
                 symbol_id: "lib.rs::foo".to_string()

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -31,10 +31,14 @@ pub enum InputKey {
     /// its target changes.
     Up,
     Down,
-    /// Space, or Enter on a directory row: expand/collapse a directory row
-    /// (`App::handle_key`'s doc comment) — never changes focus. Kept as a
-    /// distinct variant from [`Self::Open`] (ADR 0020) because Space must
-    /// never move focus even on a file/symbol row, only Enter does.
+    /// Space while [`Focus::Tree`], or Enter on a directory row: expand/
+    /// collapse a directory row (`App::handle_key`'s doc comment) — never
+    /// changes focus. A no-op while [`Focus::Right`] (matching
+    /// [`Self::Open`]'s own Tree-only reach, ADR 0020 finding: this used to
+    /// fire regardless of focus, silently toggling the tree cursor's row
+    /// behind whichever right-pane content was actually on screen). Kept as
+    /// a distinct variant from [`Self::Open`] because Space must never move
+    /// focus even on a file/symbol row, only Enter does.
     Select,
     /// Enter on a file/symbol row: opens the source view on a symbol row
     /// (unchanged from before ADR 0020) and additionally moves focus to
@@ -555,9 +559,26 @@ impl App {
             (Screen::Entry, Focus::Right, InputKey::Down) => {
                 self.right_pane_scroll = self.right_pane_scroll.saturating_add(1);
             }
-            (Screen::Entry, _, InputKey::Select) => {
+            (Screen::Entry, Focus::Tree, InputKey::Select) => {
                 self.nav = self.nav.handle(Action::ToggleExpand, &self.tree);
             }
+            // Gated on `Focus::Tree`, matching `InputKey::Open`'s own focus
+            // requirement (finding: Space used to fire regardless of focus,
+            // inconsistent with Enter's own Tree-only reach for the same
+            // "act on the row under the tree cursor" family of keys).
+            // While `Focus::Right`, the tree cursor is always parked on
+            // whichever file/symbol row is being previewed (only a
+            // File/Symbol row's `Open` moves focus to `Right` at all, never
+            // a `Dir` row's — see the `Open` arm below), so this can never
+            // cut off a "collapse a directory while previewing its content"
+            // workflow; there is no reachable state where the parked cursor
+            // is a directory row here. What it *does* remove is Space
+            // silently toggling that file/symbol row's own expand state
+            // behind the currently-visible right pane — a change with no
+            // visible effect until the user returns to `Focus::Tree`
+            // (`h`/Esc), which is the kind of spooky-action-at-a-distance
+            // this gate closes off.
+            (Screen::Entry, Focus::Right, InputKey::Select) => {}
             (Screen::Entry, _, InputKey::Open) => {
                 let rows = self.nav.rows(&self.tree);
                 match rows.get(self.nav.cursor()).map(|row| &row.node.kind) {
@@ -1416,6 +1437,41 @@ mod tests {
         let app = app.handle_key(InputKey::Select);
 
         assert_eq!(Focus::Tree, app.focus());
+    }
+
+    #[test]
+    fn should_not_toggle_expand_when_select_is_pressed_while_right_focused() {
+        // Finding-5 regression: Space used to fire regardless of focus, so
+        // pressing it while Focus::Right silently toggled the expand state
+        // of whichever file/symbol row the tree cursor was parked on (the
+        // one currently being previewed in the right pane) — a change with
+        // no visible effect until the user returned to Focus::Tree. Gated
+        // to match InputKey::Open's own Tree-only reach for the same
+        // "act on the row under the tree cursor" family of keys.
+        let report = report_with_one_symbol();
+        let app = App::new(&report); // cursor on the "lib.rs" file row
+        let rows_before: Vec<String> = app
+            .nav()
+            .rows(app.tree())
+            .iter()
+            .map(|r| r.node.path.clone())
+            .collect();
+        let app = app.handle_key(InputKey::Open); // focus -> Right
+        assert_eq!(Focus::Right, app.focus());
+
+        let app = app.handle_key(InputKey::Select);
+
+        assert_eq!(Focus::Right, app.focus());
+        let rows_after: Vec<String> = app
+            .nav()
+            .rows(app.tree())
+            .iter()
+            .map(|r| r.node.path.clone())
+            .collect();
+        assert_eq!(
+            rows_before, rows_after,
+            "Select while Right-focused must not change which rows are visible"
+        );
     }
 
     #[test]

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -647,15 +647,17 @@ impl App {
             }
             // `]c`/`[c` hunk jumping is layout-dependent (it needs to know
             // where each hunk's shaped content actually starts once
-            // wrapped to the pane's width), so `App` only remembers *that*
-            // the key was pressed via a status-line no-op here today; the
-            // actual scroll-offset jump is wired in `crate::ui`/`crate::run`
-            // once the shaped diff content (this ADR's diff-scoping commit)
-            // exists to jump against. Scoped to `Focus::Right` + a
-            // `RightPane::Diff` check the same way scrolling itself is
-            // scoped to focus, so pressing `]c` while Tree-focused or while
-            // viewing Detail/Pivot is a no-op rather than silently doing
-            // nothing that *looks* like it should have worked.
+            // wrapped to the pane's width), so `App` itself is always a
+            // no-op here regardless of focus — the actual scroll-offset
+            // jump is computed and applied in `crate::run_app`, the one
+            // place both `App` and the shaped diff content
+            // (`crate::diff_shape`) are in scope. `run_app` additionally
+            // gates that jump on `Focus::Right` *and* `RightPane::Diff`
+            // (not just `Focus::Right`, which is all this match can see) —
+            // so pressing `]c` while Tree-focused, or while Right-focused
+            // but viewing Detail/Pivot, is a no-op there too, rather than
+            // scrolling those panes against a hunk-offset table computed
+            // for the Diff pane.
             (Screen::Entry, Focus::Right, InputKey::NextHunk | InputKey::PrevHunk) => {}
             (Screen::Entry, Focus::Tree, InputKey::NextHunk | InputKey::PrevHunk) => {}
             (Screen::Entry, _, InputKey::Back) => {

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -1487,6 +1487,82 @@ mod tests {
     }
 
     #[test]
+    fn should_start_with_help_overlay_closed() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        assert_eq!(false, app.help_open());
+    }
+
+    #[test]
+    fn should_open_help_overlay_when_toggle_help_is_pressed() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let app = app.handle_key(InputKey::ToggleHelp);
+
+        assert_eq!(true, app.help_open());
+    }
+
+    #[test]
+    fn should_close_help_overlay_when_toggle_help_is_pressed_again() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+        assert_eq!(true, app.help_open());
+
+        let app = app.handle_key(InputKey::ToggleHelp);
+
+        assert_eq!(false, app.help_open());
+    }
+
+    #[test]
+    fn should_ignore_quit_while_help_overlay_is_open() {
+        // ADR 0020: the overlay must be a safe, low-stakes action that
+        // cannot be short-circuited by an accidental app exit — `Quit`
+        // reaching `handle_key` while the overlay is open (e.g. via a
+        // translate_key bug) must still be swallowed defensively, not just
+        // rely on `translate_key` never producing it in the first place.
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+        assert_eq!(true, app.help_open());
+
+        let app = app.handle_key(InputKey::Quit);
+
+        assert_eq!(true, app.help_open());
+        assert_eq!(false, app.should_quit());
+    }
+
+    #[test]
+    fn should_ignore_navigation_keys_while_help_overlay_is_open() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+        let cursor_before = app.nav().cursor();
+
+        let app = app.handle_key(InputKey::Down);
+
+        assert_eq!(cursor_before, app.nav().cursor());
+        assert_eq!(true, app.help_open());
+    }
+
+    #[test]
+    fn should_leave_other_state_untouched_when_help_overlay_opens() {
+        // Opening the overlay must not disturb whatever was already showing
+        // underneath it (`Self::help_open`'s own doc comment: "nothing else
+        // about `App`'s state changes while the overlay is open").
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::ToggleDiff);
+        let right_pane_before = app.right_pane();
+        let cursor_before = app.nav().cursor();
+
+        let app = app.handle_key(InputKey::ToggleHelp);
+
+        assert_eq!(right_pane_before, app.right_pane());
+        assert_eq!(cursor_before, app.nav().cursor());
+    }
+
+    #[test]
     fn should_reset_right_pane_scroll_when_focus_returns_to_tree() {
         let report = report_with_one_symbol();
         let app = App::new(&report)

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -24,11 +24,26 @@ use std::collections::HashMap;
 /// event loop from a real `crossterm::event::KeyEvent`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputKey {
+    /// `j`/`k`/arrow keys: moves the tree cursor while [`Focus::Tree`], or
+    /// scrolls the right pane by one line while [`Focus::Right`] (ADR 0020)
+    /// — `App::handle_key` branches on `self.focus`, not on a distinct pair
+    /// of variants, since the physical key is the same either way and only
+    /// its target changes.
     Up,
     Down,
-    /// Enter or Space: expand/collapse a directory row, or open the
-    /// source view on a symbol row (`App::handle_key`'s doc comment).
+    /// Space, or Enter on a directory row: expand/collapse a directory row
+    /// (`App::handle_key`'s doc comment) — never changes focus. Kept as a
+    /// distinct variant from [`Self::Open`] (ADR 0020) because Space must
+    /// never move focus even on a file/symbol row, only Enter does.
     Select,
+    /// Enter on a file/symbol row: opens the source view on a symbol row
+    /// (unchanged from before ADR 0020) and additionally moves focus to
+    /// [`Focus::Right`] (ADR 0020's "drilling into a row is also a focus
+    /// change") — a no-op on a directory row (`App::handle_key`'s doc
+    /// comment; a directory row's Enter is [`Self::Select`]/`crate::run`'s
+    /// `translate_key`, matching on `KeyCode::Enter`, always emits `Open`
+    /// and lets `handle_key` decide what that means per row kind).
+    Open,
     /// `e`/`E`: expand every row.
     ExpandAll,
     /// `c`/`C`: collapse every row.
@@ -42,7 +57,8 @@ pub enum InputKey {
     /// and [`RightPane::Diff`] (TUI iteration 2) — a per-`App` mode rather
     /// than a per-row one, so switching to the diff pane on one row and
     /// then moving the cursor keeps showing the diff pane for the newly
-    /// selected row instead of resetting on every cursor move.
+    /// selected row instead of resetting on every cursor move. Global
+    /// regardless of [`Focus`] (ADR 0020).
     ToggleDiff,
     /// `p`/`P`: toggle the right-hand pane between [`RightPane::Pivot`] and
     /// whichever mode was active before ([`RightPane::Detail`] or
@@ -50,15 +66,22 @@ pub enum InputKey {
     /// again while already in `Pivot` mode returns to the prior mode (stored
     /// in `App`'s `pivot_return_pane` field the moment `Pivot` was entered),
     /// mirroring `d`'s own toggle rather than a one-way "enter pivot mode"
-    /// action, since the ADR describes `p` as a per-row toggle.
+    /// action, since the ADR describes `p` as a per-row toggle. Global
+    /// regardless of [`Focus`] (ADR 0020).
     TogglePivot,
-    /// `J`: scroll the right-hand pane (Detail/Diff) down by one line.
-    /// Uppercase specifically so it does not collide with `j`'s existing
-    /// cursor-move binding (`crate::run`'s `translate_key` matches
-    /// `KeyCode::Char` case-sensitively).
-    ScrollDown,
-    /// `K`: scroll the right-hand pane up by one line (see [`Self::ScrollDown`]).
-    ScrollUp,
+    /// `h` or Esc while [`Focus::Right`]: returns focus to [`Focus::Tree`]
+    /// (ADR 0020's neovim-style "move left/back"). A no-op while already
+    /// [`Focus::Tree`] on the entry screen (nothing to return from) — Esc's
+    /// other meaning, returning from the source screen, is the separate
+    /// [`Self::Back`] variant; `crate::run`'s `translate_key` disambiguates
+    /// by screen the same way it already does for `q`.
+    FocusLeft,
+    /// `]c` while [`Focus::Right`] and the right pane is [`RightPane::Diff`]:
+    /// scrolls to the start of the next hunk in the shaped diff content
+    /// (ADR 0020). A no-op outside that pane/focus combination.
+    NextHunk,
+    /// `[c`: the reverse of [`Self::NextHunk`].
+    PrevHunk,
     /// Esc or `q` while in the source view: return to the entry view.
     /// A no-op on the entry view itself (`q`'s quit behavior on the entry
     /// view is `InputKey::Quit`, a separate variant, since Esc has no
@@ -66,6 +89,24 @@ pub enum InputKey {
     Back,
     /// `q` or Ctrl-C on the entry view: exit the application.
     Quit,
+    /// `?`: opens the help overlay (ADR 0020). While the overlay is open,
+    /// `?` instead closes it — `crate::run`'s `translate_key` maps the same
+    /// physical key to this one variant either way, and `App::handle_key`
+    /// treats it as a toggle.
+    ToggleHelp,
+}
+
+/// Which pane currently receives motion keys (ADR 0020): [`Focus::Tree`]
+/// routes `j`/`k` to the tree cursor (today's behavior, unchanged), while
+/// [`Focus::Right`] routes them to the right pane's scroll offset instead.
+/// Independent of [`RightPane`] (which content is showing) and [`Screen`]
+/// (entry vs. source) — a focus change never itself changes what content is
+/// displayed, only which keys drive it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Focus {
+    #[default]
+    Tree,
+    Right,
 }
 
 /// Which pane is currently on screen. The directory tree (`Entry`) is
@@ -179,12 +220,26 @@ pub struct App {
     /// responsibility (`ui::clamp_scroll`) — keeping this module free of
     /// any layout concern, matching the rest of `App`'s pure-state
     /// discipline. Reset to 0 by every key `handle_key` processes *except*
-    /// `InputKey::ScrollDown`/`ScrollUp` on [`Screen::Entry`] (`handle_key`'s
-    /// own doc comment on why this is a blanket rule rather than an
-    /// enumerated list of "actions that change the pane's content" — the
-    /// cursor can move *indirectly*, e.g. a collapse retargeting it onto a
-    /// different row, which an enumerated list is prone to missing).
+    /// `InputKey::Up`/`Down` while [`Focus::Right`] on [`Screen::Entry`]
+    /// (ADR 0020 folded scrolling onto the same physical keys as cursor
+    /// movement, gated by focus — `handle_key`'s own doc comment on why
+    /// this is a blanket rule rather than an enumerated list of "actions
+    /// that change the pane's content": the cursor can move *indirectly*,
+    /// e.g. a collapse retargeting it onto a different row, which an
+    /// enumerated list is prone to missing).
     right_pane_scroll: usize,
+    /// Which pane receives motion keys (ADR 0020) — see [`Focus`]'s own doc
+    /// comment.
+    focus: Focus,
+    /// Whether the `?` help overlay (ADR 0020) is currently open. Kept as a
+    /// flag rather than folded into [`Screen`]: the overlay is meant to sit
+    /// *on top of* whatever screen/pane was already showing (so closing it
+    /// returns exactly there), not replace it the way [`Screen::Source`]
+    /// replaces the entry view — a `Screen` variant would have to carry the
+    /// prior screen along just to restore it, which this flag avoids for
+    /// free by construction: nothing else about `App`'s state changes while
+    /// the overlay is open.
+    help_open: bool,
     /// A transient message for the status line (e.g. a source-read
     /// failure) — cleared on the next action that doesn't re-set it, so a
     /// stale error doesn't linger forever once the user has moved on.
@@ -215,6 +270,8 @@ impl App {
             right_pane: RightPane::default(),
             pivot_return_pane: RightPane::default(),
             right_pane_scroll: 0,
+            focus: Focus::default(),
+            help_open: false,
             status: None,
             should_quit: false,
         }
@@ -276,6 +333,17 @@ impl App {
 
     pub fn right_pane(&self) -> RightPane {
         self.right_pane
+    }
+
+    /// Which pane currently receives motion keys (ADR 0020) — see [`Focus`]'s
+    /// own doc comment.
+    pub fn focus(&self) -> Focus {
+        self.focus
+    }
+
+    /// Whether the `?` help overlay (ADR 0020) is currently open.
+    pub fn help_open(&self) -> bool {
+        self.help_open
     }
 
     /// The user's requested scroll offset into the right-hand pane — see
@@ -406,61 +474,115 @@ impl App {
     /// file read happens later, in `crate::run`, once `Screen::Source` is
     /// active) and is otherwise unused.
     ///
-    /// `right_pane_scroll` is reset to 0 by every key *except*
-    /// `ScrollDown`/`ScrollUp` on [`Screen::Entry`] — a uniform rule applied
-    /// once below, rather than each action deciding individually whether it
+    /// The `?` help overlay (ADR 0020) is handled first and takes over the
+    /// whole key space while open: `ToggleHelp` closes it and every other
+    /// key is swallowed as a no-op (deliberately, including `Quit` — the
+    /// overlay's whole point is a safe, low-stakes "let me check the keys"
+    /// action that cannot be short-circuited by an accidental app exit; see
+    /// `Self::help_open`'s own doc comment). This must run before the
+    /// screen/focus dispatch below, not as another arm inside it, so no
+    /// future `InputKey` variant can accidentally bypass the overlay by
+    /// being handled in a screen-specific branch first.
+    ///
+    /// `right_pane_scroll` is reset to 0 by every key *except* `Up`/`Down`
+    /// while [`Focus::Right`] on [`Screen::Entry`] (ADR 0020: scrolling
+    /// moved onto the same physical keys as cursor movement, gated by focus
+    /// rather than a separate uppercase pair) — a uniform rule applied once
+    /// below, rather than each action deciding individually whether it
     /// might change the right pane's content. The per-action approach used
     /// to miss cases where the cursor moves *indirectly*: collapsing a
     /// directory (`Select`/`CollapseAll`) can retarget the cursor onto a
     /// different row via `Nav::retarget_cursor`, and reordering
     /// (`ToggleOrder`) can do the same simply by changing which row now
     /// sits at the same cursor index — both used to leave a stale nonzero
-    /// scroll offset pointing into the *new* row's unrelated content. Only
-    /// `ScrollDown`/`ScrollUp` are exempt, since they are the two actions
-    /// whose entire purpose is to set this value.
+    /// scroll offset pointing into the *new* row's unrelated content.
     pub fn handle_key(mut self, key: InputKey) -> Self {
         self.status = None;
+
+        if self.help_open {
+            if key == InputKey::ToggleHelp {
+                self.help_open = false;
+            }
+            return self;
+        }
+        if key == InputKey::ToggleHelp {
+            self.help_open = true;
+            return self;
+        }
+
         let preserve_scroll = matches!(
-            (&self.screen, key),
-            (Screen::Entry, InputKey::ScrollDown) | (Screen::Entry, InputKey::ScrollUp)
+            (&self.screen, self.focus, key),
+            (Screen::Entry, Focus::Right, InputKey::Up)
+                | (Screen::Entry, Focus::Right, InputKey::Down)
         );
 
-        match (&self.screen, key) {
-            (Screen::Source { .. }, InputKey::Back) => {
+        match (&self.screen, self.focus, key) {
+            (Screen::Source { .. }, _, InputKey::Back) => {
                 self.screen = Screen::Entry;
             }
             // Every other key is a no-op while the source view is open —
             // navigation/reordering only make sense against the entry
             // view's tree, and re-dispatching them would silently move
             // the cursor underneath a screen the user can't see moving.
-            (Screen::Source { .. }, _) => {}
+            (Screen::Source { .. }, _, _) => {}
 
-            (Screen::Entry, InputKey::Quit) => {
+            (Screen::Entry, _, InputKey::Quit) => {
                 self.should_quit = true;
             }
-            (Screen::Entry, InputKey::Up) => {
+            (Screen::Entry, Focus::Tree, InputKey::Up) => {
                 self.nav = self.nav.handle(Action::CursorUp, &self.tree);
             }
-            (Screen::Entry, InputKey::Down) => {
+            (Screen::Entry, Focus::Tree, InputKey::Down) => {
                 self.nav = self.nav.handle(Action::CursorDown, &self.tree);
             }
-            (Screen::Entry, InputKey::Select) => {
+            (Screen::Entry, Focus::Right, InputKey::Up) => {
+                self.right_pane_scroll = self.right_pane_scroll.saturating_sub(1);
+            }
+            (Screen::Entry, Focus::Right, InputKey::Down) => {
+                self.right_pane_scroll = self.right_pane_scroll.saturating_add(1);
+            }
+            (Screen::Entry, _, InputKey::Select) => {
                 self.nav = self.nav.handle(Action::ToggleExpand, &self.tree);
             }
-            (Screen::Entry, InputKey::ExpandAll) => {
+            (Screen::Entry, _, InputKey::Open) => {
+                let rows = self.nav.rows(&self.tree);
+                match rows.get(self.nav.cursor()).map(|row| &row.node.kind) {
+                    // A directory row's Enter behaves exactly like Space
+                    // (`InputKey::Select`) — expand/collapse, no focus
+                    // change (ADR 0020: only a file/symbol row's Enter also
+                    // drills in).
+                    Some(NodeKind::Dir) => {
+                        self.nav = self.nav.handle(Action::ToggleExpand, &self.tree);
+                    }
+                    Some(NodeKind::File) => {
+                        self.focus = Focus::Right;
+                    }
+                    Some(NodeKind::Symbol(symbol_ref)) if !symbol_ref.removed => {
+                        self.focus = Focus::Right;
+                        self.screen = Screen::Source {
+                            symbol_id: symbol_ref.id.clone(),
+                        };
+                    }
+                    // A removed symbol has no source to open (mirrors
+                    // `InputKey::Source`'s own `!symbol_ref.removed` guard
+                    // below) and no row at all is simply a no-op.
+                    Some(NodeKind::Symbol(_)) | None => {}
+                }
+            }
+            (Screen::Entry, _, InputKey::ExpandAll) => {
                 self.nav = self.nav.handle(Action::ExpandAll, &self.tree);
             }
-            (Screen::Entry, InputKey::CollapseAll) => {
+            (Screen::Entry, _, InputKey::CollapseAll) => {
                 self.nav = self.nav.handle(Action::CollapseAll, &self.tree);
             }
-            (Screen::Entry, InputKey::ToggleOrder) => {
+            (Screen::Entry, _, InputKey::ToggleOrder) => {
                 self.order_mode = match self.order_mode {
                     OrderMode::Topological => OrderMode::AlphaNumeric,
                     OrderMode::AlphaNumeric => OrderMode::Topological,
                 };
                 crate::order::order_tree(&mut self.tree, &self.ranks, self.order_mode);
             }
-            (Screen::Entry, InputKey::Source) => {
+            (Screen::Entry, _, InputKey::Source) => {
                 let rows = self.nav.rows(&self.tree);
                 if let Some(row) = rows.get(self.nav.cursor())
                     && let NodeKind::Symbol(symbol_ref) = &row.node.kind
@@ -471,7 +593,7 @@ impl App {
                     };
                 }
             }
-            (Screen::Entry, InputKey::ToggleDiff) => {
+            (Screen::Entry, _, InputKey::ToggleDiff) => {
                 self.right_pane = match self.right_pane {
                     RightPane::Diff => RightPane::Detail,
                     // From Detail or Pivot, `d` always lands on Diff — a
@@ -487,7 +609,7 @@ impl App {
                     RightPane::Detail | RightPane::Pivot => RightPane::Diff,
                 };
             }
-            (Screen::Entry, InputKey::TogglePivot) => {
+            (Screen::Entry, _, InputKey::TogglePivot) => {
                 self.right_pane = match self.right_pane {
                     // Restore whichever pane was showing right before this
                     // pivot session started, rather than unconditionally
@@ -501,16 +623,40 @@ impl App {
                     }
                 };
             }
-            (Screen::Entry, InputKey::ScrollDown) => {
-                self.right_pane_scroll = self.right_pane_scroll.saturating_add(1);
+            (Screen::Entry, Focus::Right, InputKey::FocusLeft) => {
+                self.focus = Focus::Tree;
             }
-            (Screen::Entry, InputKey::ScrollUp) => {
-                self.right_pane_scroll = self.right_pane_scroll.saturating_sub(1);
+            (Screen::Entry, Focus::Tree, InputKey::FocusLeft) => {
+                // No-op: nothing to return from — `h`/Esc while already
+                // Tree-focused on the entry view has no target, mirroring
+                // `InputKey::Back`'s own no-op arm on the entry screen.
             }
-            (Screen::Entry, InputKey::Back) => {
-                // No-op: Esc/q-as-back on the entry view has nowhere to
-                // return to. Quitting from the entry view is the
-                // dedicated `InputKey::Quit` variant instead.
+            // `]c`/`[c` hunk jumping is layout-dependent (it needs to know
+            // where each hunk's shaped content actually starts once
+            // wrapped to the pane's width), so `App` only remembers *that*
+            // the key was pressed via a status-line no-op here today; the
+            // actual scroll-offset jump is wired in `crate::ui`/`crate::run`
+            // once the shaped diff content (this ADR's diff-scoping commit)
+            // exists to jump against. Scoped to `Focus::Right` + a
+            // `RightPane::Diff` check the same way scrolling itself is
+            // scoped to focus, so pressing `]c` while Tree-focused or while
+            // viewing Detail/Pivot is a no-op rather than silently doing
+            // nothing that *looks* like it should have worked.
+            (Screen::Entry, Focus::Right, InputKey::NextHunk | InputKey::PrevHunk) => {}
+            (Screen::Entry, Focus::Tree, InputKey::NextHunk | InputKey::PrevHunk) => {}
+            (Screen::Entry, _, InputKey::Back) => {
+                // No-op: Esc-as-back on the entry view while Tree-focused
+                // has nowhere to return to (Focus::Right's own Esc meaning
+                // is `InputKey::FocusLeft`, handled above — `crate::run`'s
+                // `translate_key` maps Esc to `FocusLeft` while
+                // `Focus::Right` and to `Back` only on the source screen, so
+                // this arm is reached only defensively). Quitting from the
+                // entry view is the dedicated `InputKey::Quit` variant
+                // instead.
+            }
+            (Screen::Entry, _, InputKey::ToggleHelp) => {
+                // Unreachable: handled above before this match, kept only
+                // so the match stays exhaustive against future refactors.
             }
         }
 
@@ -874,8 +1020,10 @@ mod tests {
 
     #[test]
     fn should_reset_right_pane_scroll_when_toggling_pivot_pane() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ScrollDown);
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Open)
+            .handle_key(InputKey::Down);
         assert_eq!(1, app.right_pane_scroll());
 
         let app = app.handle_key(InputKey::TogglePivot);
@@ -1157,60 +1305,116 @@ mod tests {
     }
 
     #[test]
-    fn should_increment_right_pane_scroll_when_scroll_down_is_pressed() {
+    fn should_start_with_tree_focus() {
         let report = empty_report();
         let app = App::new(&report);
 
-        let app = app
-            .handle_key(InputKey::ScrollDown)
-            .handle_key(InputKey::ScrollDown);
+        assert_eq!(Focus::Tree, app.focus());
+    }
 
+    #[test]
+    fn should_move_focus_to_right_when_open_is_pressed_on_a_file_row() {
+        let report = report_with_one_symbol();
+        // Row 0 is the "lib.rs" file row itself (cursor starts there).
+        let app = App::new(&report);
+
+        let app = app.handle_key(InputKey::Open);
+
+        assert_eq!(Focus::Right, app.focus());
+        assert_eq!(Screen::Entry, *app.screen());
+    }
+
+    #[test]
+    fn should_move_focus_to_right_and_open_source_when_open_is_pressed_on_a_symbol_row() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(InputKey::Down);
+
+        let app = app.handle_key(InputKey::Open);
+
+        assert_eq!(Focus::Right, app.focus());
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string()
+            },
+            *app.screen()
+        );
+    }
+
+    #[test]
+    fn should_expand_collapse_and_keep_tree_focus_when_open_is_pressed_on_a_directory_row() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol("src/lib.rs::foo", "foo")],
+            }],
+            ..empty_report()
+        };
+        // Row 0 is the "src" directory itself.
+        let app = App::new(&report);
+
+        let app = app.handle_key(InputKey::Open);
+
+        assert_eq!(Focus::Tree, app.focus());
+        let rows = app.nav().rows(app.tree());
+        let paths: Vec<&str> = rows.iter().map(|r| r.node.path.as_str()).collect();
+        assert_eq!(vec!["src"], paths, "directory should have collapsed");
+    }
+
+    #[test]
+    fn should_not_move_focus_when_select_is_pressed_on_a_file_row() {
+        // Space (`InputKey::Select`) must never move focus, even on a
+        // file/symbol row — only Enter (`InputKey::Open`) does (ADR 0020).
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+
+        let app = app.handle_key(InputKey::Select);
+
+        assert_eq!(Focus::Tree, app.focus());
+    }
+
+    #[test]
+    fn should_move_cursor_while_tree_focused_when_down_is_pressed() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        assert_eq!(Focus::Tree, app.focus());
+
+        let app = app.handle_key(InputKey::Down);
+
+        assert_eq!(1, app.nav().cursor());
+    }
+
+    #[test]
+    fn should_scroll_right_pane_instead_of_moving_cursor_when_down_is_pressed_while_right_focused()
+    {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(InputKey::Open); // focus -> Right
+        let cursor_before = app.nav().cursor();
+
+        let app = app.handle_key(InputKey::Down).handle_key(InputKey::Down);
+
+        assert_eq!(cursor_before, app.nav().cursor());
         assert_eq!(2, app.right_pane_scroll());
     }
 
     #[test]
-    fn should_decrement_right_pane_scroll_when_scroll_up_is_pressed() {
-        let report = empty_report();
+    fn should_decrement_right_pane_scroll_when_up_is_pressed_while_right_focused() {
+        let report = report_with_one_symbol();
         let app = App::new(&report)
-            .handle_key(InputKey::ScrollDown)
-            .handle_key(InputKey::ScrollDown);
+            .handle_key(InputKey::Open) // focus -> Right
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Down);
         assert_eq!(2, app.right_pane_scroll());
 
-        let app = app.handle_key(InputKey::ScrollUp);
+        let app = app.handle_key(InputKey::Up);
 
         assert_eq!(1, app.right_pane_scroll());
     }
 
     #[test]
     fn should_not_scroll_up_past_zero() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let app = app.handle_key(InputKey::ScrollUp);
-
-        assert_eq!(0, app.right_pane_scroll());
-    }
-
-    #[test]
-    fn should_reset_right_pane_scroll_when_cursor_moves_down() {
         let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(InputKey::ScrollDown)
-            .handle_key(InputKey::ScrollDown);
-        assert_eq!(2, app.right_pane_scroll());
-
-        let app = app.handle_key(InputKey::Down);
-
-        assert_eq!(0, app.right_pane_scroll());
-    }
-
-    #[test]
-    fn should_reset_right_pane_scroll_when_cursor_moves_up() {
-        let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(InputKey::Down)
-            .handle_key(InputKey::ScrollDown);
-        assert_eq!(1, app.right_pane_scroll());
+        let app = App::new(&report).handle_key(InputKey::Open);
 
         let app = app.handle_key(InputKey::Up);
 
@@ -1218,9 +1422,46 @@ mod tests {
     }
 
     #[test]
+    fn should_return_focus_to_tree_when_focus_left_is_pressed_while_right_focused() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(InputKey::Open);
+        assert_eq!(Focus::Right, app.focus());
+
+        let app = app.handle_key(InputKey::FocusLeft);
+
+        assert_eq!(Focus::Tree, app.focus());
+    }
+
+    #[test]
+    fn should_do_nothing_when_focus_left_is_pressed_while_already_tree_focused() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        assert_eq!(Focus::Tree, app.focus());
+
+        let app = app.handle_key(InputKey::FocusLeft);
+
+        assert_eq!(Focus::Tree, app.focus());
+    }
+
+    #[test]
+    fn should_reset_right_pane_scroll_when_focus_returns_to_tree() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Open)
+            .handle_key(InputKey::Down);
+        assert_eq!(1, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::FocusLeft);
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
     fn should_reset_right_pane_scroll_when_toggling_diff_pane() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ScrollDown);
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Open)
+            .handle_key(InputKey::Down);
         assert_eq!(1, app.right_pane_scroll());
 
         let app = app.handle_key(InputKey::ToggleDiff);
@@ -1229,18 +1470,28 @@ mod tests {
     }
 
     #[test]
-    fn should_reset_right_pane_scroll_when_returning_from_source_screen() {
+    fn should_keep_right_pane_scroll_at_zero_when_returning_from_source_screen() {
+        // Opening the source screen itself always resets scroll to 0
+        // (`InputKey::Open`'s own reset, per the blanket rule) and every
+        // key but `Back` is then a no-op while `Screen::Source` is active
+        // (`App::handle_key`'s `Screen::Source` arm) — so scroll can never
+        // become nonzero while the source screen is open in the first
+        // place, unlike the pre-ADR-0020 world where `ScrollDown`/`ScrollUp`
+        // were separate keys `Screen::Source`'s catch-all arm also
+        // swallowed but which could still be pending from before entering.
+        // This test pins that invariant end to end: `Back` finds scroll
+        // already at 0 and leaves it there.
         let report = report_with_one_symbol();
         let app = App::new(&report)
-            .handle_key(InputKey::Down)
-            .handle_key(InputKey::ScrollDown)
-            .handle_key(InputKey::Source);
+            .handle_key(InputKey::Down) // cursor -> "foo" (a Symbol row)
+            .handle_key(InputKey::Open); // opens Screen::Source, focus -> Right
         assert_eq!(
             Screen::Source {
                 symbol_id: "lib.rs::foo".to_string()
             },
             *app.screen()
         );
+        assert_eq!(0, app.right_pane_scroll());
 
         let app = app.handle_key(InputKey::Back);
 
@@ -1252,9 +1503,9 @@ mod tests {
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(InputKey::Down)
-            .handle_key(InputKey::Source);
+            .handle_key(InputKey::Open); // opens source, focus -> Right
 
-        let app = app.handle_key(InputKey::ScrollDown);
+        let app = app.handle_key(InputKey::Down);
 
         assert_eq!(0, app.right_pane_scroll());
         assert_eq!(
@@ -1288,6 +1539,22 @@ mod tests {
         }
     }
 
+    /// Moves the cursor down onto "a/one.rs" (a File row, row 1 of
+    /// [`report_with_two_directories`]'s expanded order), presses `Open` to
+    /// reach [`Focus::Right`] (ADR 0020: scrolling only applies there — a
+    /// Dir row's own `Open` never changes focus, per `App::handle_key`'s
+    /// `Open` arm, so this must land on a File/Symbol row specifically),
+    /// then scrolls down by one line. Shared setup for every "does *this*
+    /// action reset the scroll offset" test below, since
+    /// `CollapseAll`/`ExpandAll`/`ToggleOrder` all remain tree-affecting
+    /// regardless of which pane currently has focus (their `handle_key`
+    /// match arms are focus-independent).
+    fn focused_right_and_scrolled_one_line(app: App) -> App {
+        app.handle_key(InputKey::Down)
+            .handle_key(InputKey::Open)
+            .handle_key(InputKey::Down)
+    }
+
     #[test]
     fn should_reset_right_pane_scroll_when_select_collapses_the_row_under_the_cursor() {
         // Row 0 is "a" itself; collapsing it via `Select` hides its
@@ -1295,33 +1562,60 @@ mod tests {
         // case the blanket reset rule must cover, since a directory row's
         // own detail content (fan-in/badges) does not depend on which of
         // its children are currently shown, but this pins the simplest
-        // Select case regardless.
+        // Select case regardless. `Open` on "a" (a directory row) does not
+        // itself change focus (`App::handle_key`'s `Open` arm), so `Down`
+        // right after it is still what actually reaches `Focus::Right` —
+        // reusing the shared four-directory fixture below would change
+        // which row is under the cursor, so this test builds its own
+        // two-directory report and drives the two steps by hand instead of
+        // via `focused_right_and_scrolled_one_line`.
         let report = report_with_two_directories();
-        let app = App::new(&report).handle_key(InputKey::ScrollDown);
-        assert_eq!(1, app.right_pane_scroll());
+        let app = App::new(&report);
+        assert_eq!(Focus::Tree, app.focus());
 
         let app = app.handle_key(InputKey::Select);
 
+        // `Select` never moves focus (ADR 0020), and scrolling never
+        // applied here in the first place (Focus::Tree the whole time), so
+        // this collapses to: collapsing "a" leaves the scroll offset at its
+        // already-zero default. Kept as its own test (rather than folded
+        // into a broader one) since it pins that `Select` specifically
+        // never becomes a scroll-affecting action just because it can
+        // reshuffle the row list, matching `CollapseAll`'s own case below.
         assert_eq!(0, app.right_pane_scroll());
+        let rows = app.nav().rows(app.tree());
+        let paths: Vec<&str> = rows.iter().map(|r| r.node.path.as_str()).collect();
+        // "bar" (a Symbol row) carries its containing file's path
+        // ("b/two.rs"), not a path of its own (`TreeNode::path`'s own doc
+        // comment) — so the flattened path list repeats "b/two.rs" for both
+        // the File row and its one Symbol child.
+        assert_eq!(vec!["a", "b", "b/two.rs", "b/two.rs"], paths);
     }
 
     #[test]
     fn should_reset_right_pane_scroll_when_collapse_all_retargets_cursor_onto_a_different_node() {
-        // Cursor starts on "bar" (row 5, under "b/two.rs"); CollapseAll
-        // hides every file/symbol row, and `Nav::retarget_cursor` lands the
-        // cursor on "b" (the nearest still-visible ancestor) — a genuinely
-        // different node's detail than the one the pre-collapse scroll
-        // offset was scrolled into.
+        // Cursor starts on "b/two.rs" (row 4, the File row directly under
+        // "b"); CollapseAll hides every file/symbol row, and
+        // `Nav::retarget_cursor` lands the cursor on "b" (the nearest
+        // still-visible ancestor) — a genuinely different node's detail
+        // than the one the pre-collapse scroll offset was scrolled into.
+        // "b/two.rs" (a File row, not "bar"/a Symbol row) is the deliberate
+        // choice: `Open` on a Symbol row also switches to `Screen::Source`
+        // (`App::handle_key`'s `Open` arm), which would make the
+        // `CollapseAll` this test presses next a no-op (every key but
+        // `Back` is swallowed on `Screen::Source`) — a File row reaches
+        // `Focus::Right` without leaving `Screen::Entry`.
         let report = report_with_two_directories();
         let mut app = App::new(&report);
-        for _ in 0..5 {
+        for _ in 0..4 {
             app = app.handle_key(InputKey::Down);
         }
         let rows = app.nav().rows(app.tree());
         assert_eq!("b/two.rs", rows[app.nav().cursor()].node.path);
         let app = app
-            .handle_key(InputKey::ScrollDown)
-            .handle_key(InputKey::ScrollDown);
+            .handle_key(InputKey::Open)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Down);
         assert_eq!(2, app.right_pane_scroll());
 
         let app = app.handle_key(InputKey::CollapseAll);
@@ -1333,11 +1627,20 @@ mod tests {
 
     #[test]
     fn should_reset_right_pane_scroll_when_expand_all_is_pressed() {
+        // `CollapseAll` first (before establishing focus/scroll) would land
+        // the cursor on a Dir row ("a"), which `Open` cannot move focus from
+        // (`App::handle_key`'s `Open` arm) — so this test instead reaches
+        // Focus::Right + a nonzero scroll on "a/one.rs" while still
+        // expanded, then presses `CollapseAll` followed by `ExpandAll` in
+        // one breath and asserts the scroll is (still) 0 after both, which
+        // is what actually matters: `ExpandAll` itself must never leave a
+        // stale nonzero scroll behind, regardless of what `CollapseAll`
+        // already reset it to just before.
         let report = report_with_two_directories();
-        let app = App::new(&report)
-            .handle_key(InputKey::CollapseAll)
-            .handle_key(InputKey::ScrollDown);
+        let app = focused_right_and_scrolled_one_line(App::new(&report));
         assert_eq!(1, app.right_pane_scroll());
+        let app = app.handle_key(InputKey::CollapseAll);
+        assert_eq!(0, app.right_pane_scroll());
 
         let app = app.handle_key(InputKey::ExpandAll);
 
@@ -1350,7 +1653,8 @@ mod tests {
         // index (reordering siblings), so it must reset the scroll offset
         // even though it never calls into `Nav` at all.
         let report = report_with_two_directories();
-        let app = App::new(&report).handle_key(InputKey::ScrollDown);
+        let app = App::new(&report);
+        let app = focused_right_and_scrolled_one_line(app);
         assert_eq!(1, app.right_pane_scroll());
 
         let app = app.handle_key(InputKey::ToggleOrder);

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -688,6 +688,20 @@ impl App {
     pub fn set_status(&mut self, message: impl Into<String>) {
         self.status = Some(message.into());
     }
+
+    /// Overwrites the right-hand pane's scroll offset directly to `scroll`
+    /// — used by `crate::run_app`'s `]c`/`[c` hunk-jump handling
+    /// (`InputKey::NextHunk`/`PrevHunk`) to set an exact target line rather
+    /// than the relative +/-1 [`Self::handle_key`] applies for plain `j`/`k`
+    /// scrolling. Not itself an [`InputKey`] variant/`handle_key` branch,
+    /// since the jump target depends on the diff pane's shaped content
+    /// (`crate::diff_shape`), which `App` has no access to — `crate::run_app`
+    /// computes the target and calls this setter once it has one (see that
+    /// function's own comment on why the computation lives there).
+    pub fn with_right_pane_scroll(mut self, scroll: usize) -> Self {
+        self.right_pane_scroll = scroll;
+        self
+    }
 }
 
 #[cfg(test)]

--- a/rinkaku-tui/src/detail.rs
+++ b/rinkaku-tui/src/detail.rs
@@ -250,9 +250,14 @@ pub struct FileSymbolSummary {
 /// `skip_reason`/`test_symbol_count` mirror `crate::tree::TreeNode`'s own
 /// fields of the same name (copied straight from the tree node this detail
 /// was built from — see `build_file_detail`) so the detail pane can explain
-/// *why* a skipped or whole-test file has no `symbols` entries instead of
-/// silently showing an empty list, which used to read as "this file changed
-/// nothing" rather than "rinkaku did not analyze this file's symbols".
+/// *why* a skipped file has no `symbols` entries instead of silently
+/// showing an empty list, which used to read as "this file changed nothing"
+/// rather than "rinkaku did not analyze this file's symbols" — and, for a
+/// whole/mixed-test file, can additionally note the excluded test-symbol
+/// count alongside whatever real `symbols` the file does have (`skip_reason`
+/// and `test_symbol_count` are mutually exclusive, but `test_symbol_count`
+/// and `symbols` are not — `crate::tree::TreeNode::test_symbol_count`'s own
+/// doc comment).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileDetail {
     pub path: String,
@@ -1124,6 +1129,49 @@ mod tests {
             symbols: vec![],
             skip_reason: None,
             test_symbol_count: Some(4),
+        };
+        assert_eq!(expected, actual);
+    }
+
+    // Regression test (post-rebase integration check): a mixed file — real
+    // (non-test) symbols in `report.files` *and* a test-symbol count in
+    // `report.tests` for the same path, which `pipeline::partition_test_symbols`
+    // legitimately produces for a file with both production and
+    // `#[cfg(test)]`-style code changed in one diff — must keep both halves
+    // on the built `FileDetail` rather than one silently dropping the other.
+    // This is exactly the shape that caused a live panic when running the
+    // TUI against this repo's own diff (`rinkaku-tui/src/app.rs` has both
+    // real and test symbols changed), before `TreeBuilder::insert_test_file`
+    // stopped asserting the file's `symbols` were empty.
+    #[test]
+    fn should_keep_real_symbols_alongside_test_symbol_count_when_file_is_mixed() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "app.rs".to_string(),
+                symbols: vec![symbol("app.rs::handle_key", "handle_key")],
+            }],
+            tests: vec![rinkaku_core::render::TestFileSummary {
+                path: "app.rs".to_string(),
+                symbol_count: 5,
+            }],
+            ..empty_report()
+        };
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_file_detail(&tree, &report, "app.rs").expect("file found");
+
+        let expected = FileDetail {
+            path: "app.rs".to_string(),
+            symbols: vec![FileSymbolSummary {
+                name: "handle_key".to_string(),
+                kind: SymbolKind::Function,
+                classification: None,
+                removed: false,
+                fan_in: 0,
+            }],
+            skip_reason: None,
+            test_symbol_count: Some(5),
         };
         assert_eq!(expected, actual);
     }

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -1,0 +1,814 @@
+//! Diff-pane content shaping (ADR 0020): given the row currently selected
+//! in the entry view (a symbol or a file) plus the already-parsed diff
+//! hunks (`crate::diff_view`), decides how the diff pane groups and
+//! annotates that content — a symbol selection clips to its own hunks
+//! (unchanged from before this ADR), while a file selection now groups
+//! hunks under per-symbol section headers instead of listing them
+//! undifferentiated, and either selection gets a 2-line old/new signature
+//! header up front when the symbol's contract changed.
+//!
+//! Pure and free of `ratatui` types, mirroring every other view-model in
+//! this crate (`crate::tree`/`crate::nav`/`crate::detail`/`crate::pivot`):
+//! `Report` + `&[FileHunks]` + a selection in, plain [`DiffPaneContent`]
+//! data out. `crate::run_app` computes this once per handled key (the same
+//! cache-on-selection-change discipline `crate::app::App::selected_pivot_view`'s
+//! own doc comment already establishes, after that pane's own past
+//! per-frame recompute bug — see this crate's `lib.rs` regression test);
+//! `crate::ui::draw` must not call it, for the identical reason
+//! `ui::draw` must not call `App::selected_pivot_view` either.
+
+use crate::app::DiffTarget;
+use crate::diff_view::{FileHunks, Hunk, file_hunks};
+use rinkaku_core::extract::Classification;
+use rinkaku_core::render::Report;
+
+/// A 2-line old/new signature header, shown before a symbol's hunks when
+/// [`rinkaku_core::extract::ExtractedSymbol::previous_signature`] is
+/// `Some` — the diff pane's outline-then-implementation disclosure order
+/// (ADR 0020): the reader sees *that* the contract changed, and to what,
+/// before the hunks showing *how*.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContractHeader {
+    pub previous_signature: String,
+    pub signature: String,
+}
+
+/// One [`Hunk`], cloned out of the original [`FileHunks`] into a shaped
+/// [`DiffSection`] (this module's own doc comment on why cloning, not
+/// borrowing), plus its `source_index` — its position in that original
+/// `FileHunks::hunks` slice. `crate::highlight::lookup_hunk_highlight`
+/// looks up a hunk's precomputed highlight by `std::ptr::eq` against the
+/// *original* `Hunk` it was highlighted from; a clone breaks that pointer
+/// identity, so `source_index` is threaded through instead — `crate::ui`
+/// uses it to index straight into the original `FileHunks`/`HighlightedFile`
+/// rather than re-deriving position via a fragile equality search (a file
+/// can legitimately contain two textually-identical hunks).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttributedHunk {
+    pub source_index: usize,
+    pub hunk: Hunk,
+}
+
+/// One symbol's worth of shaped diff content: its own contract header
+/// (when its signature changed) followed by the hunks attributed to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffSection {
+    /// The section header text — a symbol's own signature line, or the
+    /// fixed `"(module level)"` label for hunks intersecting no symbol at
+    /// all (import-only changes, module-level `use` statements).
+    pub title: String,
+    pub contract_header: Option<ContractHeader>,
+    pub hunks: Vec<AttributedHunk>,
+}
+
+/// The diff pane's fully shaped content for the current selection —
+/// what `crate::ui::draw_diff_pane` renders, computed once by
+/// `crate::run_app` and handed in rather than recomputed per draw.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiffPaneContent {
+    /// Nothing to show: no row selected, a directory row (no diff-specific
+    /// content of its own — `App::selected_diff_target`'s own doc comment),
+    /// or (defensively) a mismatch between `report` and the diff text.
+    Empty,
+    /// A single symbol's hunks, clipped to its own line range — unchanged
+    /// scoping from before this ADR, just wrapped in the same
+    /// `DiffPaneContent` shape a file selection now also produces.
+    Symbol(DiffSection),
+    /// A file's hunks, grouped into one [`DiffSection`] per symbol in
+    /// `report.files[..].symbols` order, plus a trailing `"(module level)"`
+    /// section for hunks intersecting no symbol at all — omitted (not an
+    /// empty section) when every hunk was attributed to some symbol.
+    File(Vec<DiffSection>),
+}
+
+/// The fixed label for a file selection's trailing section of hunks that
+/// intersect no symbol's line range (import-only changes, module-level
+/// `use` statements) — not a symbol's own signature, so it cannot reuse
+/// [`DiffSection::title`]'s symbol-signature convention.
+pub const MODULE_LEVEL_TITLE: &str = "(module level)";
+
+/// The logical-line offset (before `crate::ui::wrap_lines`' width-based
+/// wrapping — the same "one requested-scroll unit" `App::right_pane_scroll`
+/// already operates in) where each hunk in `content` starts, in the exact
+/// order `crate::ui::draw_diff_pane`/`diff_pane_lines` renders them — used
+/// by `crate::run_app`'s `]c`/`[c` (`InputKey::NextHunk`/`PrevHunk`)
+/// handling to jump the scroll offset to a hunk boundary. Mirrors
+/// `diff_pane_lines`'s own line-counting exactly (section separator blank
+/// lines, an optional bold section header, an optional 2-line contract
+/// header, a blank line before each hunk's own header when anything
+/// precedes it) rather than reusing that function directly, since this
+/// module must stay free of `ratatui` types (module doc comment) — a
+/// change to `diff_pane_lines`'s layout must be mirrored here by hand, the
+/// same trade `crate::order`'s own doc comment already accepts for its
+/// deliberately duplicated Tarjan SCC implementation.
+pub fn hunk_start_lines(content: &DiffPaneContent) -> Vec<usize> {
+    let (sections, show_section_headers): (Vec<&DiffSection>, bool) = match content {
+        DiffPaneContent::Empty => return Vec::new(),
+        DiffPaneContent::Symbol(section) => (vec![section], false),
+        DiffPaneContent::File(sections) => (sections.iter().collect(), true),
+    };
+
+    let mut starts = Vec::new();
+    let mut line = 0usize;
+    for (section_index, section) in sections.iter().enumerate() {
+        if section_index > 0 {
+            line += 1; // blank line between sections
+        }
+        if show_section_headers {
+            line += 1; // section title line
+        }
+        if section.contract_header.is_some() {
+            line += 2; // "- previous" / "+ current" lines
+        }
+
+        for (hunk_index, attributed) in section.hunks.iter().enumerate() {
+            if hunk_index > 0 || show_section_headers || section.contract_header.is_some() {
+                line += 1; // blank line before this hunk's own header
+            }
+            starts.push(line);
+            line += 1; // the hunk header line itself
+            line += attributed.hunk.lines.len();
+        }
+    }
+    starts
+}
+
+/// Builds the diff pane's shaped content for `target` (`None` mirrors
+/// `App::selected_diff_target` returning `None` — nothing selected, or a
+/// directory row). `diff_files` is the whole diff already parsed once by
+/// `crate::run_app` (`crate::diff_view::parse_diff_hunks`), not re-parsed
+/// here.
+pub fn build_diff_pane_content(
+    report: &Report,
+    diff_files: &[FileHunks],
+    target: Option<&DiffTarget>,
+) -> DiffPaneContent {
+    match target {
+        None => DiffPaneContent::Empty,
+        Some(DiffTarget::Symbol {
+            path,
+            range_start,
+            range_end,
+        }) => build_symbol_content(report, diff_files, path, *range_start, *range_end),
+        Some(DiffTarget::File { path }) => build_file_content(report, diff_files, path),
+    }
+}
+
+fn build_symbol_content(
+    report: &Report,
+    diff_files: &[FileHunks],
+    path: &str,
+    range_start: usize,
+    range_end: usize,
+) -> DiffPaneContent {
+    let Some(file_hunks) = file_hunks(diff_files, path) else {
+        return DiffPaneContent::Empty;
+    };
+    let hunks: Vec<AttributedHunk> = file_hunks
+        .hunks
+        .iter()
+        .enumerate()
+        .filter(|(_, hunk)| crate::diff_view::hunk_intersects(hunk, range_start, range_end))
+        .map(|(source_index, hunk)| AttributedHunk {
+            source_index,
+            hunk: hunk.clone(),
+        })
+        .collect();
+    if hunks.is_empty() {
+        return DiffPaneContent::Empty;
+    }
+
+    let symbol = report
+        .files
+        .iter()
+        .find(|file| file.path == path)
+        .and_then(|file| {
+            file.symbols
+                .iter()
+                .find(|s| s.range.start == range_start && s.range.end == range_end)
+        });
+    let title = symbol.map(|s| s.signature.clone()).unwrap_or_default();
+    let contract_header = symbol.and_then(contract_header_for_symbol);
+
+    DiffPaneContent::Symbol(DiffSection {
+        title,
+        contract_header,
+        hunks,
+    })
+}
+
+fn build_file_content(report: &Report, diff_files: &[FileHunks], path: &str) -> DiffPaneContent {
+    let Some(file_hunks) = file_hunks(diff_files, path) else {
+        return DiffPaneContent::Empty;
+    };
+    if file_hunks.hunks.is_empty() {
+        return DiffPaneContent::Empty;
+    }
+
+    let symbols = report
+        .files
+        .iter()
+        .find(|file| file.path == path)
+        .map(|file| file.symbols.as_slice())
+        .unwrap_or(&[]);
+
+    let mut sections: Vec<DiffSection> = symbols
+        .iter()
+        .map(|symbol| DiffSection {
+            title: symbol.signature.clone(),
+            contract_header: contract_header_for_symbol(symbol),
+            hunks: Vec::new(),
+        })
+        .collect();
+    let mut module_level_hunks: Vec<AttributedHunk> = Vec::new();
+
+    for (source_index, hunk) in file_hunks.hunks.iter().enumerate() {
+        // First (source-order) symbol whose range intersects this hunk —
+        // ADR 0020's "Alternatives" section rejected attributing a hunk to
+        // every overlapping symbol (would misreport total change size for
+        // exactly the summary view meant to convey it); first-match keeps
+        // every hunk under exactly one section.
+        let owner = symbols.iter().position(|symbol| {
+            crate::diff_view::hunk_intersects(hunk, symbol.range.start, symbol.range.end)
+        });
+        let attributed = AttributedHunk {
+            source_index,
+            hunk: hunk.clone(),
+        };
+        match owner {
+            Some(index) => sections[index].hunks.push(attributed),
+            None => module_level_hunks.push(attributed),
+        }
+    }
+
+    // Symbols with no hunks of their own (e.g. a `BodyOnly` classification
+    // whose diff lines all fell inside another symbol's range in a
+    // pathological overlap, or simply a symbol this hunk-owner walk never
+    // matched) contribute an empty, content-free section — dropped rather
+    // than shown blank, since a heading with nothing under it adds noise
+    // without adding information for a reviewer scanning the file's diff.
+    sections.retain(|section| !section.hunks.is_empty());
+
+    if !module_level_hunks.is_empty() {
+        sections.push(DiffSection {
+            title: MODULE_LEVEL_TITLE.to_string(),
+            contract_header: None,
+            hunks: module_level_hunks,
+        });
+    }
+
+    if sections.is_empty() {
+        return DiffPaneContent::Empty;
+    }
+
+    DiffPaneContent::File(sections)
+}
+
+/// The 2-line contract header for `symbol`, or `None` when its contract
+/// did not change (or — defensively, "should not happen" per
+/// `classify_symbols`'s contract — `previous_signature` is missing despite
+/// `SignatureChanged`, mirroring `crate::detail::build_detail`'s identical
+/// fallback).
+fn contract_header_for_symbol(
+    symbol: &rinkaku_core::extract::ExtractedSymbol,
+) -> Option<ContractHeader> {
+    match (symbol.classification, &symbol.previous_signature) {
+        (Some(Classification::SignatureChanged), Some(previous)) => Some(ContractHeader {
+            previous_signature: previous.clone(),
+            signature: symbol.signature.clone(),
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+    use rinkaku_core::graph::SymbolGraph;
+    use rinkaku_core::render::{FileReport, ReportOrigin};
+
+    fn symbol(id: &str, name: &str, range: LineRange) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature: format!("fn {name}()"),
+            range,
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        }
+    }
+
+    fn empty_report() -> Report {
+        Report {
+            origin: ReportOrigin::Diff,
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
+    fn hunk(header: &str, new_range: Option<(usize, usize)>, lines: Vec<&str>) -> Hunk {
+        Hunk {
+            header: header.to_string(),
+            new_range,
+            lines: lines
+                .into_iter()
+                .map(|content| crate::diff_view::DiffLine {
+                    kind: crate::diff_view::DiffLineKind::Context,
+                    content: content.to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    /// Wraps `hunk` with the `source_index` it occupies in the fixture's
+    /// `FileHunks::hunks` — every test below builds its `diff_files`
+    /// fixture with hunks in a fixed order, so this index is just "which
+    /// position in that `vec![...]` this hunk was written at".
+    fn attributed(source_index: usize, hunk: Hunk) -> AttributedHunk {
+        AttributedHunk { source_index, hunk }
+    }
+
+    #[test]
+    fn should_return_empty_when_target_is_none() {
+        let report = empty_report();
+
+        let actual = build_diff_pane_content(&report, &[], None);
+
+        assert_eq!(DiffPaneContent::Empty, actual);
+    }
+
+    #[test]
+    fn should_return_empty_when_symbol_file_has_no_matching_diff_hunks() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 1 })],
+            }],
+            ..empty_report()
+        };
+        let target = DiffTarget::Symbol {
+            path: "lib.rs".to_string(),
+            range_start: 1,
+            range_end: 1,
+        };
+
+        let actual = build_diff_pane_content(&report, &[], Some(&target));
+
+        assert_eq!(DiffPaneContent::Empty, actual);
+    }
+
+    #[test]
+    fn should_clip_symbol_selection_to_its_own_hunks() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![
+                    symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 2 }),
+                    symbol("lib.rs::bar", "bar", LineRange { start: 10, end: 11 }),
+                ],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+                hunk("@@ -10,1 +10,2 @@", Some((10, 11)), vec!["fn bar() {}"]),
+            ],
+        }];
+        let target = DiffTarget::Symbol {
+            path: "lib.rs".to_string(),
+            range_start: 1,
+            range_end: 2,
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let expected = DiffPaneContent::Symbol(DiffSection {
+            title: "fn foo()".to_string(),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+            )],
+        });
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_include_contract_header_when_symbol_selection_signature_changed() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    classification: Some(Classification::SignatureChanged),
+                    previous_signature: Some("fn foo(a: i32)".to_string()),
+                    signature: "fn foo(a: i32, b: i32)".to_string(),
+                    ..symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 2 })
+                }],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk(
+                "@@ -1,1 +1,2 @@",
+                Some((1, 2)),
+                vec!["fn foo(a, b) {}"],
+            )],
+        }];
+        let target = DiffTarget::Symbol {
+            path: "lib.rs".to_string(),
+            range_start: 1,
+            range_end: 2,
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let expected = DiffPaneContent::Symbol(DiffSection {
+            title: "fn foo(a: i32, b: i32)".to_string(),
+            contract_header: Some(ContractHeader {
+                previous_signature: "fn foo(a: i32)".to_string(),
+                signature: "fn foo(a: i32, b: i32)".to_string(),
+            }),
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo(a, b) {}"]),
+            )],
+        });
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_group_file_selection_hunks_under_per_symbol_sections() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![
+                    symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 2 }),
+                    symbol("lib.rs::bar", "bar", LineRange { start: 10, end: 11 }),
+                ],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+                hunk("@@ -10,1 +10,2 @@", Some((10, 11)), vec!["fn bar() {}"]),
+            ],
+        }];
+        let target = DiffTarget::File {
+            path: "lib.rs".to_string(),
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let expected = DiffPaneContent::File(vec![
+            DiffSection {
+                title: "fn foo()".to_string(),
+                contract_header: None,
+                hunks: vec![attributed(
+                    0,
+                    hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+                )],
+            },
+            DiffSection {
+                title: "fn bar()".to_string(),
+                contract_header: None,
+                hunks: vec![attributed(
+                    1,
+                    hunk("@@ -10,1 +10,2 @@", Some((10, 11)), vec!["fn bar() {}"]),
+                )],
+            },
+        ]);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_bucket_hunk_under_module_level_when_it_intersects_no_symbol() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "lib.rs::foo",
+                    "foo",
+                    LineRange { start: 10, end: 11 },
+                )],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["use foo::bar;"]),
+                hunk("@@ -10,1 +10,2 @@", Some((10, 11)), vec!["fn foo() {}"]),
+            ],
+        }];
+        let target = DiffTarget::File {
+            path: "lib.rs".to_string(),
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let expected = DiffPaneContent::File(vec![
+            DiffSection {
+                title: "fn foo()".to_string(),
+                contract_header: None,
+                hunks: vec![attributed(
+                    1,
+                    hunk("@@ -10,1 +10,2 @@", Some((10, 11)), vec!["fn foo() {}"]),
+                )],
+            },
+            DiffSection {
+                title: MODULE_LEVEL_TITLE.to_string(),
+                contract_header: None,
+                hunks: vec![attributed(
+                    0,
+                    hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["use foo::bar;"]),
+                )],
+            },
+        ]);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_omit_module_level_section_when_every_hunk_is_attributed_to_a_symbol() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 2 })],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"])],
+        }];
+        let target = DiffTarget::File {
+            path: "lib.rs".to_string(),
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let expected = DiffPaneContent::File(vec![DiffSection {
+            title: "fn foo()".to_string(),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+            )],
+        }]);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_attribute_overlapping_hunk_to_first_symbol_in_source_order() {
+        // Two symbols with adjacent, overlapping ranges (a pathological
+        // input a real extractor would not normally produce, but the
+        // shaping function's contract must still resolve deterministically
+        // rather than duplicate the hunk into both sections — ADR 0020's
+        // "Alternatives" section rejected duplication as misleading about
+        // total change size).
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![
+                    symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 5 }),
+                    symbol("lib.rs::bar", "bar", LineRange { start: 3, end: 8 }),
+                ],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk("@@ -1,1 +1,5 @@", Some((3, 4)), vec!["shared line"])],
+        }];
+        let target = DiffTarget::File {
+            path: "lib.rs".to_string(),
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let expected = DiffPaneContent::File(vec![DiffSection {
+            title: "fn foo()".to_string(),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,5 @@", Some((3, 4)), vec!["shared line"]),
+            )],
+        }]);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_include_contract_header_on_the_owning_section_in_a_file_selection() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    classification: Some(Classification::SignatureChanged),
+                    previous_signature: Some("fn foo(a: i32)".to_string()),
+                    signature: "fn foo(a: i32, b: i32)".to_string(),
+                    ..symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 2 })
+                }],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk(
+                "@@ -1,1 +1,2 @@",
+                Some((1, 2)),
+                vec!["fn foo(a, b) {}"],
+            )],
+        }];
+        let target = DiffTarget::File {
+            path: "lib.rs".to_string(),
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let expected = DiffPaneContent::File(vec![DiffSection {
+            title: "fn foo(a: i32, b: i32)".to_string(),
+            contract_header: Some(ContractHeader {
+                previous_signature: "fn foo(a: i32)".to_string(),
+                signature: "fn foo(a: i32, b: i32)".to_string(),
+            }),
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo(a, b) {}"]),
+            )],
+        }]);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_empty_when_file_has_no_hunks_at_all() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 2 })],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![],
+        }];
+        let target = DiffTarget::File {
+            path: "lib.rs".to_string(),
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        assert_eq!(DiffPaneContent::Empty, actual);
+    }
+
+    #[test]
+    fn should_return_empty_when_diff_has_no_entry_for_the_selected_file() {
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 2 })],
+            }],
+            ..empty_report()
+        };
+        let target = DiffTarget::File {
+            path: "lib.rs".to_string(),
+        };
+
+        let actual = build_diff_pane_content(&report, &[], Some(&target));
+
+        assert_eq!(DiffPaneContent::Empty, actual);
+    }
+
+    // --- hunk_start_lines ---
+
+    #[test]
+    fn should_return_empty_hunk_starts_when_content_is_empty() {
+        let actual = hunk_start_lines(&DiffPaneContent::Empty);
+
+        assert_eq!(Vec::<usize>::new(), actual);
+    }
+
+    #[test]
+    fn should_start_first_hunk_at_line_zero_for_a_single_section_symbol_selection_with_no_contract_header()
+     {
+        // No section header shown for a symbol selection (`diff_pane_lines`'s
+        // own `show_section_headers` rule) and no contract header here, so
+        // the hunk's own header line is the very first line.
+        let content = DiffPaneContent::Symbol(DiffSection {
+            title: "fn foo()".to_string(),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk(
+                    "@@ -1,1 +1,2 @@",
+                    Some((1, 2)),
+                    vec!["fn a() {}", "fn foo() {}"],
+                ),
+            )],
+        });
+
+        let actual = hunk_start_lines(&content);
+
+        assert_eq!(vec![0], actual);
+    }
+
+    #[test]
+    fn should_offset_hunk_start_by_contract_header_lines_when_symbol_selection_has_one() {
+        // 2 contract-header lines precede the hunk's own header line.
+        let content = DiffPaneContent::Symbol(DiffSection {
+            title: "fn foo(a, b)".to_string(),
+            contract_header: Some(ContractHeader {
+                previous_signature: "fn foo(a)".to_string(),
+                signature: "fn foo(a, b)".to_string(),
+            }),
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo(a, b) {}"]),
+            )],
+        });
+
+        let actual = hunk_start_lines(&content);
+
+        assert_eq!(vec![3], actual);
+    }
+
+    #[test]
+    fn should_offset_second_hunk_start_by_first_hunk_header_and_body_length() {
+        // First hunk: header (1 line) + 2 body lines = 3 lines, then 1 blank
+        // separator line before the second hunk's own header.
+        let content = DiffPaneContent::Symbol(DiffSection {
+            title: "fn foo()".to_string(),
+            contract_header: None,
+            hunks: vec![
+                attributed(
+                    0,
+                    hunk(
+                        "@@ -1,1 +1,2 @@",
+                        Some((1, 2)),
+                        vec!["fn a() {}", "fn b() {}"],
+                    ),
+                ),
+                attributed(
+                    1,
+                    hunk("@@ -10,1 +11,1 @@", Some((11, 11)), vec!["fn c() {}"]),
+                ),
+            ],
+        });
+
+        let actual = hunk_start_lines(&content);
+
+        assert_eq!(vec![0, 4], actual);
+    }
+
+    #[test]
+    fn should_offset_hunk_start_by_section_header_and_separator_lines_for_a_file_selection() {
+        // Section 0 (file selection: `show_section_headers` is always true,
+        // so the blank-before-hunk rule fires even for the section's first
+        // hunk): title(0), blank(1), header(2), 1 body line(3) — hunk starts
+        // at line 2. Section 1: blank separator between sections(4),
+        // title(5), blank before its hunk(6), header(7) — hunk starts at 7.
+        let content = DiffPaneContent::File(vec![
+            DiffSection {
+                title: "fn foo()".to_string(),
+                contract_header: None,
+                hunks: vec![attributed(
+                    0,
+                    hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+                )],
+            },
+            DiffSection {
+                title: "fn bar()".to_string(),
+                contract_header: None,
+                hunks: vec![attributed(
+                    1,
+                    hunk("@@ -10,1 +10,2 @@", Some((10, 11)), vec!["fn bar() {}"]),
+                )],
+            },
+        ]);
+
+        let actual = hunk_start_lines(&content);
+
+        assert_eq!(vec![2, 7], actual);
+    }
+}

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -660,6 +660,43 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
+    // Regression test (post-rebase integration check, PR #58): a skipped or
+    // whole-test-file row (ADR: "show skipped and test-only files in the
+    // entry tree") has no `FileReport` at all in `report.files`, so
+    // `build_file_content`'s `symbols` lookup falls back to `&[]` — every
+    // hunk must still land somewhere rather than being silently dropped or
+    // panicking on an out-of-bounds `sections` index.
+    #[test]
+    fn should_bucket_every_hunk_under_module_level_when_file_selection_has_no_symbols_at_all() {
+        // `report.files` has no entry for "assets/logo.png" at all — the
+        // exact shape of a skipped/whole-test-file row, which is tracked in
+        // `report.skipped`/`report.tests` instead of `report.files`.
+        let report = empty_report();
+        let diff_files = vec![FileHunks {
+            path: "assets/logo.png".to_string(),
+            hunks: vec![hunk(
+                "@@ -1,1 +1,2 @@",
+                Some((1, 2)),
+                vec!["binary blob line"],
+            )],
+        }];
+        let target = DiffTarget::File {
+            path: "assets/logo.png".to_string(),
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let expected = DiffPaneContent::File(vec![DiffSection {
+            title: MODULE_LEVEL_TITLE.to_string(),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["binary blob line"]),
+            )],
+        }]);
+        assert_eq!(expected, actual);
+    }
+
     #[test]
     fn should_return_empty_when_file_has_no_hunks_at_all() {
         let report = Report {
@@ -696,6 +733,30 @@ mod tests {
         };
 
         let actual = build_diff_pane_content(&report, &[], Some(&target));
+
+        assert_eq!(DiffPaneContent::Empty, actual);
+    }
+
+    // Regression test (post-rebase integration check, PR #58): a binary
+    // skipped file has a `FileHunks` entry (git still reports the path
+    // touched a diff) but zero `@@` hunks in it ("Binary files ... differ"
+    // has no hunk syntax for `crate::diff_view::parse_diff_hunks` to parse)
+    // and no `FileReport`/symbols at all — the pane must degrade to `Empty`
+    // (rendered by `crate::ui::draw_diff_pane` as its own placeholder text)
+    // rather than panicking or fabricating a module-level section with no
+    // hunks in it.
+    #[test]
+    fn should_return_empty_when_skipped_file_has_no_symbols_and_no_hunks() {
+        let report = empty_report();
+        let diff_files = vec![FileHunks {
+            path: "assets/logo.png".to_string(),
+            hunks: vec![],
+        }];
+        let target = DiffTarget::File {
+            path: "assets/logo.png".to_string(),
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
 
         assert_eq!(DiffPaneContent::Empty, actual);
     }

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -413,6 +413,52 @@ mod tests {
     }
 
     #[test]
+    fn should_include_pure_deletion_hunk_in_symbol_selection_when_it_intersects_the_symbol() {
+        // Finding-2 regression: a pure-deletion hunk (`new_range` a
+        // zero-width position, `crate::diff_view::Hunk`'s own doc comment)
+        // used to always report `hunk_intersects == false`, so it silently
+        // vanished from a symbol-scoped diff view entirely instead of
+        // showing the deleted lines under the symbol they were removed
+        // from.
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 4 })],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk(
+                "@@ -4 +3,0 @@",
+                Some((3, 2)),
+                vec!["println!(\"removed\");"],
+            )],
+        }];
+        let target = DiffTarget::Symbol {
+            path: "lib.rs".to_string(),
+            range_start: 1,
+            range_end: 4,
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let expected = DiffPaneContent::Symbol(DiffSection {
+            title: "fn foo()".to_string(),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk(
+                    "@@ -4 +3,0 @@",
+                    Some((3, 2)),
+                    vec!["println!(\"removed\");"],
+                ),
+            )],
+        });
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn should_include_contract_header_when_symbol_selection_signature_changed() {
         let report = Report {
             files: vec![FileReport {
@@ -499,6 +545,49 @@ mod tests {
                 )],
             },
         ]);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_attribute_pure_deletion_hunk_to_owning_symbol_instead_of_module_level() {
+        // Finding-2 regression: `hunk_intersects` always returning `false`
+        // for a pure-deletion hunk meant `build_file_content`'s owner lookup
+        // (`symbols.iter().position(...)`) never matched, so every deletion
+        // hunk landed in the `MODULE_LEVEL_TITLE` bucket regardless of which
+        // symbol's body it actually came from.
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 4 })],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk(
+                "@@ -4 +3,0 @@",
+                Some((3, 2)),
+                vec!["println!(\"removed\");"],
+            )],
+        }];
+        let target = DiffTarget::File {
+            path: "lib.rs".to_string(),
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let expected = DiffPaneContent::File(vec![DiffSection {
+            title: "fn foo()".to_string(),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk(
+                    "@@ -4 +3,0 @@",
+                    Some((3, 2)),
+                    vec!["println!(\"removed\");"],
+                ),
+            )],
+        }]);
         assert_eq!(expected, actual);
     }
 

--- a/rinkaku-tui/src/diff_view.rs
+++ b/rinkaku-tui/src/diff_view.rs
@@ -39,10 +39,31 @@ pub struct DiffLine {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Hunk {
     pub header: String,
-    /// 1-based inclusive new-side line range this hunk's `+`/context lines
-    /// span. `None` when the hunk adds/removes zero new-side lines (a
-    /// hunk that is pure deletion) — there is then no new-side range to
-    /// intersect a symbol's line range against at all.
+    /// The new-side extent this hunk's `+`/context lines span, expressed as
+    /// a 1-based inclusive `(start, end)` pair.
+    ///
+    /// A hunk that adds/keeps at least one new-side line gets an ordinary
+    /// `start <= end` range. A **pure-deletion** hunk (declared new-side
+    /// count is 0, e.g. `@@ -10,3 +10,0 @@`) still carries a real position:
+    /// the header's new-side start is where the deleted content used to sit
+    /// in the new file — line `start` is still `start`, it is just now
+    /// zero-width, so this stores it as `(start, start - 1)` (`start > end`,
+    /// a deliberately empty range at that position) rather than discarding
+    /// it. This lets [`hunk_intersects`] test a deletion's *position*
+    /// against a symbol's range using the exact same `start <= end`
+    /// comparison it already uses for ordinary hunks — mirroring
+    /// `rinkaku_core::diff::parse_hunk`'s own zero-width `LineRange { start,
+    /// end: start - 1 }` convention for a closed-out deletion run, rather
+    /// than inventing a second rule for the same shape of problem.
+    ///
+    /// `None` only when the header itself couldn't be read at all
+    /// (malformed input, module doc comment) or its declared new-side start
+    /// is `0` (git's own "before the first line of the file" marker for a
+    /// deletion at the very top) — `0` has no `start - 1` to subtract
+    /// without underflow, and no symbol's 1-based range can start before
+    /// line 1 anyway, so a deletion reported there can never belong to any
+    /// symbol; it always falls through to the file view's module-level
+    /// bucket, same as a genuinely unreadable header.
     pub new_range: Option<(usize, usize)>,
     pub lines: Vec<DiffLine>,
 }
@@ -176,7 +197,16 @@ fn parse_one_hunk(lines: &[&str], start: usize) -> (Hunk, usize) {
     let new_range = new_start_count.and_then(|(start, declared_count)| {
         let count = declared_count.min(actual_new_line_count);
         if count == 0 {
-            None
+            // Pure deletion (`Hunk::new_range`'s own doc comment on why
+            // `start` is still worth keeping): `start == 0` has no valid
+            // position to encode (git's "before line 1" marker, and no
+            // symbol range can start before line 1 anyway), everything else
+            // becomes the zero-width `(start, start - 1)` position.
+            if start == 0 {
+                None
+            } else {
+                Some((start, start - 1))
+            }
         } else {
             Some((start, start + count - 1))
         }
@@ -212,9 +242,36 @@ fn parse_new_side_header(header: &str) -> Option<(usize, usize)> {
 /// Whether `hunk` intersects the 1-based inclusive new-side range
 /// `[range_start, range_end]` — used to filter a file's hunks down to just
 /// the ones touching a selected symbol's line range.
+///
+/// A pure-deletion hunk's `new_range` is a zero-width `(position, position -
+/// 1)` pair (`Hunk::new_range`'s doc comment) rather than an ordinary
+/// `start <= end` span, and it needs its own boundary rule, not the general
+/// `hunk_start <= range_end && range_start <= hunk_end` overlap test below —
+/// that test treats both ends of an inclusive range as "belongs", but a
+/// deletion *position* is where content used to sit, i.e. strictly *before*
+/// new-file line `position`. Concretely (verified against `git diff -U0`
+/// output, not just algebra): deleting a function's first body statement
+/// reports `position == range_start`, and should belong to that function
+/// (`range_start <= position`); deleting the blank separator line right
+/// after a function's closing brace reports `position == range_end`, and
+/// should *not* belong to that function (`position < range_end`, not
+/// `position <= range_end` — the deletion sits in the gap between this
+/// symbol and the next one, not inside this symbol's own body). So the rule
+/// for a zero-width position is `range_start <= position < range_end`, the
+/// half-open interpretation of "before this new-file line" — deliberately
+/// asymmetric versus the closed-interval test used for ordinary hunks.
 pub fn hunk_intersects(hunk: &Hunk, range_start: usize, range_end: usize) -> bool {
     match hunk.new_range {
+        Some((hunk_start, hunk_end)) if hunk_start > hunk_end => {
+            // Zero-width deletion position (`hunk_start`, since `hunk_end ==
+            // hunk_start - 1` by construction) — half-open test, see this
+            // function's own doc comment for why.
+            range_start <= hunk_start && hunk_start < range_end
+        }
         Some((hunk_start, hunk_end)) => hunk_start <= range_end && range_start <= hunk_end,
+        // Only reached for a header this parser couldn't read at all, or
+        // one whose new-side start is line 0 (`Hunk::new_range`'s doc
+        // comment) — both cases have no position to test at all.
         None => false,
     }
 }
@@ -390,7 +447,10 @@ index e69de29..4b825dc 100644
     }
 
     #[test]
-    fn should_return_none_new_range_when_hunk_is_pure_deletion() {
+    fn should_return_none_new_range_when_pure_deletion_starts_at_new_side_line_zero() {
+        // Whole-file deletion: git reports `+0,0` (no position at all, since
+        // the new file doesn't exist) — the one pure-deletion shape with no
+        // valid `start - 1` to encode (`Hunk::new_range`'s own doc comment).
         let diff = "\
 diff --git a/src/old.rs b/src/old.rs
 deleted file mode 100644
@@ -405,6 +465,30 @@ index 4b825dc..0000000
 
         assert_eq!(1, actual.len());
         assert_eq!(None, actual[0].hunks[0].new_range);
+    }
+
+    #[test]
+    fn should_return_zero_width_new_range_at_declared_start_when_pure_deletion_is_mid_file() {
+        // `@@ -10,3 +10,0 @@`-shaped: content was deleted from inside a
+        // still-existing file, so the header's new-side start (10) is a real
+        // position in the new file, just a zero-width one — this is the
+        // finding-2 regression: this used to collapse to `None`, which made
+        // `hunk_intersects` always report `false` and silently dropped the
+        // hunk from symbol attribution entirely.
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -10,3 +10,0 @@ fn a() {
+-    println!(\"x\");
+-    println!(\"y\");
+-    println!(\"z\");
+";
+        let actual = parse_diff_hunks(diff);
+
+        assert_eq!(1, actual.len());
+        assert_eq!(Some((10, 9)), actual[0].hunks[0].new_range);
     }
 
     #[test]
@@ -472,6 +556,73 @@ index e69de29..4b825dc 100644
         };
 
         assert_eq!(false, hunk_intersects(&hunk, 1, 100));
+    }
+
+    // A pure-deletion hunk's `new_range` is a zero-width `(position, position
+    // - 1)` value (`Hunk::new_range`'s doc comment) tested with the
+    // deliberately asymmetric half-open rule `hunk_intersects` documents
+    // (`range_start <= position < range_end`). These four cases are grounded
+    // in real `git diff -U0` output (this function's own doc comment), not
+    // just algebra:
+    //
+    // - deleting a function's *first* body statement reports `position ==
+    //   range_start` and belongs to that function;
+    // - deleting its *last* body statement reports a position strictly
+    //   between `range_start` and `range_end` and belongs to it too;
+    // - deleting the blank line right after a function's closing brace
+    //   reports `position == range_end` and does *not* belong to that
+    //   function — it's in the gap before the next symbol.
+
+    #[test]
+    fn should_report_intersection_when_deletion_position_equals_symbol_range_start() {
+        // e.g. `fn a() { <deleted first line> ... }` spanning new lines
+        // [1,4]: deleting the first body statement reports position 1.
+        let hunk = Hunk {
+            header: "@@ -2 +1,0 @@".to_string(),
+            new_range: Some((1, 0)),
+            lines: vec![],
+        };
+
+        assert_eq!(true, hunk_intersects(&hunk, 1, 4));
+    }
+
+    #[test]
+    fn should_report_intersection_when_deletion_position_is_strictly_inside_symbol_range() {
+        // Same [1,4] function: deleting its last body statement (just before
+        // the closing brace) reports position 3.
+        let hunk = Hunk {
+            header: "@@ -4 +3,0 @@".to_string(),
+            new_range: Some((3, 2)),
+            lines: vec![],
+        };
+
+        assert_eq!(true, hunk_intersects(&hunk, 1, 4));
+    }
+
+    #[test]
+    fn should_report_no_intersection_when_deletion_position_equals_symbol_range_end() {
+        // Same [1,4] function ([1,5] before this deletion): deleting the
+        // blank separator line right after its closing brace reports
+        // position 5 — the gap before the next symbol, not this one's body.
+        let hunk = Hunk {
+            header: "@@ -6 +5,0 @@".to_string(),
+            new_range: Some((5, 4)),
+            lines: vec![],
+        };
+
+        assert_eq!(false, hunk_intersects(&hunk, 1, 5));
+    }
+
+    #[test]
+    fn should_report_no_intersection_when_deletion_position_is_strictly_after_symbol_range() {
+        // Position 11 is well past the symbol's end (4) — outside it.
+        let hunk = Hunk {
+            header: "@@ -15,1 +11,0 @@".to_string(),
+            new_range: Some((11, 10)),
+            lines: vec![],
+        };
+
+        assert_eq!(false, hunk_intersects(&hunk, 1, 4));
     }
 
     #[test]

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -75,11 +75,11 @@ const RIGHT_FOCUS_BINDINGS: &[KeyBinding] = &[
         description: "Return focus to the tree",
     },
     KeyBinding {
-        keys: "] c",
+        keys: "]",
         description: "Jump to the next hunk (Diff pane only)",
     },
     KeyBinding {
-        keys: "[ c",
+        keys: "[",
         description: "Jump to the previous hunk (Diff pane only)",
     },
 ];

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -1,0 +1,208 @@
+//! The `?` help overlay's content (ADR 0020): a static keymap plus a short
+//! glossary, assembled as plain data so `crate::ui` only has to lay it out,
+//! not decide what belongs in it.
+//!
+//! The keymap itself is fixed (not derived from `crate::app::InputKey` or
+//! `crate::lib::translate_key` — both already carry their own doc comments
+//! as the authoritative per-key rationale; this module is the *reviewer-
+//! facing* summary of the same bindings, kept in sync by hand). Splitting
+//! it into "Tree focus" / "Right focus" / "Global" groups mirrors ADR
+//! 0020's own focus split, so the overlay reads as a direct answer to
+//! "what does j/k do right now" rather than one flat undifferentiated list.
+
+/// One row of the keymap: the key(s) as displayed text, and what they do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyBinding {
+    pub keys: &'static str,
+    pub description: &'static str,
+}
+
+/// One glossary entry: a term used elsewhere in the UI (an order mode name,
+/// "pivot", "cycle") paired with a short explanation — the answer to
+/// "what does that word on the status line/tree actually mean".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlossaryEntry {
+    pub term: &'static str,
+    pub explanation: &'static str,
+}
+
+/// One named group of [`KeyBinding`]s — "Tree focus", "Right focus", or
+/// "Global" (ADR 0020's own focus/global split).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyBindingGroup {
+    pub title: &'static str,
+    pub bindings: &'static [KeyBinding],
+}
+
+/// The whole help overlay's content: every keymap group in display order,
+/// then the glossary. A `const`, not a function — the content is fixed at
+/// compile time, so there is nothing to compute per call.
+pub struct HelpContent {
+    pub keymap_groups: &'static [KeyBindingGroup],
+    pub glossary: &'static [GlossaryEntry],
+}
+
+const TREE_FOCUS_BINDINGS: &[KeyBinding] = &[
+    KeyBinding {
+        keys: "j / k / ↓ / ↑",
+        description: "Move the cursor",
+    },
+    KeyBinding {
+        keys: "enter",
+        description: "Expand/collapse a directory row, or open a file/symbol row (moves focus right)",
+    },
+    KeyBinding {
+        keys: "space",
+        description: "Expand/collapse a directory/file row (never moves focus)",
+    },
+    KeyBinding {
+        keys: "e / E",
+        description: "Expand every row",
+    },
+    KeyBinding {
+        keys: "c / C",
+        description: "Collapse every row",
+    },
+];
+
+const RIGHT_FOCUS_BINDINGS: &[KeyBinding] = &[
+    KeyBinding {
+        keys: "j / k / ↓ / ↑",
+        description: "Scroll the right pane by one line",
+    },
+    KeyBinding {
+        keys: "h / esc",
+        description: "Return focus to the tree",
+    },
+    KeyBinding {
+        keys: "] c",
+        description: "Jump to the next hunk (Diff pane only)",
+    },
+    KeyBinding {
+        keys: "[ c",
+        description: "Jump to the previous hunk (Diff pane only)",
+    },
+];
+
+const GLOBAL_BINDINGS: &[KeyBinding] = &[
+    KeyBinding {
+        keys: "d / D",
+        description: "Toggle the right pane between Detail and Diff",
+    },
+    KeyBinding {
+        keys: "p / P",
+        description: "Toggle the right pane to the pivot tree rooted at the selected row",
+    },
+    KeyBinding {
+        keys: "o / O",
+        description: "Toggle topological/alphabetical ordering",
+    },
+    KeyBinding {
+        keys: "s / S",
+        description: "Open the source view for the symbol under the cursor",
+    },
+    KeyBinding {
+        keys: "?",
+        description: "Toggle this help overlay",
+    },
+    KeyBinding {
+        keys: "q / ctrl-c",
+        description: "Quit (esc/q return to the entry view from the source view)",
+    },
+];
+
+const KEYMAP_GROUPS: &[KeyBindingGroup] = &[
+    KeyBindingGroup {
+        title: "Tree focus",
+        bindings: TREE_FOCUS_BINDINGS,
+    },
+    KeyBindingGroup {
+        title: "Right focus",
+        bindings: RIGHT_FOCUS_BINDINGS,
+    },
+    KeyBindingGroup {
+        title: "Global",
+        bindings: GLOBAL_BINDINGS,
+    },
+];
+
+const GLOSSARY: &[GlossaryEntry] = &[
+    GlossaryEntry {
+        term: "topological order",
+        explanation: "Directories ordered least-depended-on first, foundations last",
+    },
+    GlossaryEntry {
+        term: "alphabetical order",
+        explanation: "Directories ordered A-Z, ignoring dependency direction",
+    },
+    GlossaryEntry {
+        term: "pivot",
+        explanation: "Re-roots the dependency tree at the selected directory/file's path",
+    },
+    GlossaryEntry {
+        term: "cycle",
+        explanation: "A closing back-edge in the dependency graph — two or more directories depend on each other",
+    },
+];
+
+/// The whole help overlay's content (module doc comment).
+pub const HELP_CONTENT: HelpContent = HelpContent {
+    keymap_groups: KEYMAP_GROUPS,
+    glossary: GLOSSARY,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_include_a_tree_focus_right_focus_and_global_group_in_that_order() {
+        let titles: Vec<&str> = HELP_CONTENT
+            .keymap_groups
+            .iter()
+            .map(|group| group.title)
+            .collect();
+
+        assert_eq!(vec!["Tree focus", "Right focus", "Global"], titles);
+    }
+
+    #[test]
+    fn should_have_no_empty_keymap_group() {
+        for group in HELP_CONTENT.keymap_groups {
+            assert!(
+                !group.bindings.is_empty(),
+                "group {:?} has no bindings",
+                group.title
+            );
+        }
+    }
+
+    #[test]
+    fn should_include_a_glossary_entry_for_pivot_and_cycle() {
+        let terms: Vec<&str> = HELP_CONTENT
+            .glossary
+            .iter()
+            .map(|entry| entry.term)
+            .collect();
+
+        assert!(terms.contains(&"pivot"));
+        assert!(terms.contains(&"cycle"));
+    }
+
+    #[test]
+    fn should_document_h_and_esc_as_the_return_to_tree_binding_in_right_focus_group() {
+        let right_focus = HELP_CONTENT
+            .keymap_groups
+            .iter()
+            .find(|group| group.title == "Right focus")
+            .expect("Right focus group present");
+
+        let has_return_binding = right_focus
+            .bindings
+            .iter()
+            .any(|binding| binding.keys == "h / esc");
+
+        assert!(has_return_binding);
+    }
+}

--- a/rinkaku-tui/src/highlight.rs
+++ b/rinkaku-tui/src/highlight.rs
@@ -309,6 +309,24 @@ pub fn lookup_hunk_highlight<'a>(
     highlighted.hunks.get(index).map(|lines| lines.as_slice())
 }
 
+/// Looks up the precomputed highlight for the hunk at `source_index` in
+/// `highlighted.hunks` directly, without a pointer-identity search —
+/// [`lookup_hunk_highlight`]'s own doc comment explains why that search
+/// requires the exact `&Hunk` instance from the original `FileHunks`; this
+/// sibling function is for `crate::diff_shape::AttributedHunk`s instead,
+/// which are cloned out of the original `FileHunks` (ADR 0020) and so no
+/// longer carry that pointer identity, but do carry the `source_index`
+/// that pointer search was only ever recovering in the first place.
+pub fn lookup_hunk_highlight_by_index(
+    highlighted: Option<&HighlightedFile>,
+    source_index: usize,
+) -> Option<&[LineHighlight]> {
+    highlighted?
+        .hunks
+        .get(source_index)
+        .map(|lines| lines.as_slice())
+}
+
 /// Finds the [`HighlightedFile`] for `path` in the precomputed set, or
 /// `None` when the diff has no entry for it — mirrors
 /// `crate::diff_view::file_hunks`'s own lookup-by-path convention.

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -30,6 +30,7 @@
 
 pub mod app;
 pub mod detail;
+pub mod diff_shape;
 pub mod diff_view;
 pub mod highlight;
 pub mod nav;
@@ -144,6 +145,24 @@ fn run_app(
     } else {
         PivotSelection::NotApplicable
     };
+    // Computed once up front then on demand below, once per handled key —
+    // same reasoning and cache-on-selection-change discipline as
+    // `pivot_selection` above (ADR 0020: `crate::diff_shape`'s own doc
+    // comment on why this must not be recomputed inside `ui::draw`, after
+    // the pivot pane's own past per-frame recompute bug). The up-front
+    // computation matters for the ordinary (non-`--entry`) startup path
+    // too now, since ADR 0020 also made Diff the default right pane: the
+    // very first frame must already show shaped diff content, not an
+    // empty placeholder until the first key press recomputes it.
+    let mut diff_pane_content = if should_recompute_diff_pane_content(&app) {
+        diff_shape::build_diff_pane_content(
+            report,
+            &diff_hunks,
+            app.selected_diff_target(report).as_ref(),
+        )
+    } else {
+        diff_shape::DiffPaneContent::Empty
+    };
 
     loop {
         terminal.draw(|frame| {
@@ -151,7 +170,7 @@ fn run_app(
                 frame,
                 &app,
                 report,
-                &diff_hunks,
+                &diff_pane_content,
                 &diff_highlights,
                 &pivot_selection,
                 repo_root,
@@ -190,6 +209,19 @@ fn run_app(
                         Err(message) => app.set_status(message),
                     }
                 }
+            } else if let InputKey::NextHunk | InputKey::PrevHunk = input_key {
+                // Hunk jumping needs the shaped diff content already
+                // cached above (`diff_pane_content`) to know where each
+                // hunk starts — `App::handle_key` itself has no notion of
+                // that content, so the jump target is computed here, at
+                // the one place both `app` and `diff_pane_content` are in
+                // scope, rather than threading the whole shaped content
+                // into `App` just for this.
+                let scroll = diff_shape::hunk_start_lines(&diff_pane_content);
+                let next = jump_scroll_target(&scroll, app.right_pane_scroll(), input_key);
+                if let Some(target) = next {
+                    app = app.handle_key(input_key).with_right_pane_scroll(target);
+                }
             } else {
                 app = app.handle_key(input_key);
             }
@@ -197,7 +229,53 @@ fn run_app(
             if should_recompute_pivot_selection(&app) {
                 pivot_selection = app.selected_pivot_view(report);
             }
+            if should_recompute_diff_pane_content(&app) {
+                diff_pane_content = diff_shape::build_diff_pane_content(
+                    report,
+                    &diff_hunks,
+                    app.selected_diff_target(report).as_ref(),
+                );
+            }
         }
+    }
+}
+
+/// Whether `crate::run_app`'s event loop should recompute the diff pane's
+/// shaped content this key, rather than keep showing the previously cached
+/// one — mirrors `should_recompute_pivot_selection`'s own contract and
+/// reasoning, just for [`RightPane::Diff`] instead of `RightPane::Pivot`.
+fn should_recompute_diff_pane_content(app: &App) -> bool {
+    matches!(app.screen(), Screen::Entry) && app.right_pane() == app::RightPane::Diff
+}
+
+/// The scroll offset [`InputKey::NextHunk`]/[`InputKey::PrevHunk`] should
+/// jump to, given `hunk_starts` (each hunk's starting logical-line offset
+/// within the diff pane's shaped content, `crate::diff_shape::hunk_start_lines`'s
+/// own doc comment) and the pane's `current_scroll`. `None` when there is
+/// nowhere to jump (`hunk_starts` is empty, or already at the first/last
+/// hunk in the requested direction) — a no-op, not a clamp to the nearest
+/// edge, since silently landing back on the same hunk would look like the
+/// keypress did nothing anyway.
+///
+/// Extracted as its own pure function (rather than inlined in `run_app`,
+/// which takes a live `ratatui::DefaultTerminal` and so cannot be driven
+/// directly in a test) so the jump direction/boundary logic is
+/// unit-testable without a terminal.
+fn jump_scroll_target(
+    hunk_starts: &[usize],
+    current_scroll: usize,
+    direction: InputKey,
+) -> Option<usize> {
+    match direction {
+        InputKey::NextHunk => hunk_starts
+            .iter()
+            .copied()
+            .find(|&start| start > current_scroll),
+        InputKey::PrevHunk => hunk_starts
+            .iter()
+            .copied()
+            .rfind(|&start| start < current_scroll),
+        _ => None,
     }
 }
 
@@ -497,5 +575,104 @@ mod tests {
             }],
             ..empty_report()
         }
+    }
+
+    #[test]
+    fn should_recompute_diff_pane_content_when_diff_pane_is_active_on_entry_screen() {
+        let report = empty_report();
+        let app = App::new(&report);
+        assert_eq!(app::RightPane::Diff, app.right_pane()); // ADR 0020 default
+
+        let actual = should_recompute_diff_pane_content(&app);
+
+        assert!(actual);
+    }
+
+    #[test]
+    fn should_not_recompute_diff_pane_content_when_right_pane_is_detail() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleDiff);
+
+        let actual = should_recompute_diff_pane_content(&app);
+
+        assert!(!actual);
+    }
+
+    #[test]
+    fn should_not_recompute_diff_pane_content_when_right_pane_is_pivot() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::TogglePivot);
+
+        let actual = should_recompute_diff_pane_content(&app);
+
+        assert!(!actual);
+    }
+
+    #[test]
+    fn should_not_recompute_diff_pane_content_while_source_screen_is_open() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Source);
+
+        let actual = should_recompute_diff_pane_content(&app);
+
+        assert!(!actual);
+    }
+
+    #[test]
+    fn should_jump_to_the_next_hunk_start_strictly_after_current_scroll() {
+        let hunk_starts = vec![0, 5, 12];
+
+        let actual = jump_scroll_target(&hunk_starts, 5, InputKey::NextHunk);
+
+        assert_eq!(Some(12), actual);
+    }
+
+    #[test]
+    fn should_return_none_when_next_hunk_is_pressed_at_the_last_hunk() {
+        let hunk_starts = vec![0, 5, 12];
+
+        let actual = jump_scroll_target(&hunk_starts, 12, InputKey::NextHunk);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_jump_to_the_previous_hunk_start_strictly_before_current_scroll() {
+        let hunk_starts = vec![0, 5, 12];
+
+        let actual = jump_scroll_target(&hunk_starts, 12, InputKey::PrevHunk);
+
+        assert_eq!(Some(5), actual);
+    }
+
+    #[test]
+    fn should_return_none_when_prev_hunk_is_pressed_at_the_first_hunk() {
+        let hunk_starts = vec![0, 5, 12];
+
+        let actual = jump_scroll_target(&hunk_starts, 0, InputKey::PrevHunk);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_return_none_when_hunk_starts_is_empty() {
+        let hunk_starts: Vec<usize> = vec![];
+
+        let actual = jump_scroll_target(&hunk_starts, 0, InputKey::NextHunk);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_jump_to_the_first_hunk_after_scroll_lands_between_two_hunks() {
+        // Scroll sitting mid-hunk (not exactly on a hunk boundary) still
+        // finds the next hunk strictly after it, not the one it's inside.
+        let hunk_starts = vec![0, 10];
+
+        let actual = jump_scroll_target(&hunk_starts, 3, InputKey::NextHunk);
+
+        assert_eq!(Some(10), actual);
     }
 }

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -217,30 +217,46 @@ fn should_recompute_pivot_selection(app: &App) -> bool {
 
 /// Translates a raw `crossterm` key press into this crate's
 /// terminal-agnostic [`InputKey`], or `None` for a key the app does not
-/// react to. Depends on `app.screen()` only to disambiguate `q`/Esc
-/// (`Quit` on the entry view, `Back` on the source view) — every other
-/// mapping is context-free.
+/// react to. Depends on `app.screen()` to disambiguate `q`/Esc (`Quit`/
+/// `FocusLeft` on the entry view depending on focus, `Back` on the source
+/// view) and on `app.focus()` (ADR 0020) to route Esc between `FocusLeft`
+/// and its other meanings — every other mapping is context-free.
 fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<InputKey> {
     let on_source_screen = matches!(app.screen(), Screen::Source { .. });
+    let right_focused = app.focus() == app::Focus::Right;
 
     match code {
         KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
         KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
-        KeyCode::Enter | KeyCode::Char(' ') => Some(InputKey::Select),
+        // Space always means "expand/collapse", never "drill in" — kept
+        // distinct from Enter's own `InputKey::Open` (ADR 0020) so Space on
+        // a file/symbol row never moves focus.
+        KeyCode::Char(' ') => Some(InputKey::Select),
+        KeyCode::Enter => Some(InputKey::Open),
         KeyCode::Char('e') | KeyCode::Char('E') => Some(InputKey::ExpandAll),
         KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::Quit),
         KeyCode::Char('c') | KeyCode::Char('C') => Some(InputKey::CollapseAll),
         KeyCode::Char('o') | KeyCode::Char('O') => Some(InputKey::ToggleOrder),
         KeyCode::Char('d') | KeyCode::Char('D') => Some(InputKey::ToggleDiff),
         KeyCode::Char('p') | KeyCode::Char('P') => Some(InputKey::TogglePivot),
-        // Uppercase specifically: `j`/`k` already move the tree cursor, so
-        // the right-pane scroll needs a key that doesn't collide with
-        // them. Shift+j/k arrives here as the distinct `Char('J')`/`Char('K')`
-        // values (crossterm folds Shift into the char itself for plain
-        // letter keys), so this needs no separate modifier check.
-        KeyCode::Char('J') => Some(InputKey::ScrollDown),
-        KeyCode::Char('K') => Some(InputKey::ScrollUp),
+        // `h`, or Esc while the right pane has focus: return focus to the
+        // tree (ADR 0020's neovim-style "move left/back"). Checked before
+        // the source-screen Esc arm below so `h`/Esc while Right-focused
+        // never reaches the source screen (impossible in practice today,
+        // since opening the source screen already moves focus to `Right`,
+        // but ordered defensively rather than relying on that invariant).
+        KeyCode::Char('h') if right_focused => Some(InputKey::FocusLeft),
+        KeyCode::Esc if right_focused && !on_source_screen => Some(InputKey::FocusLeft),
+        // `]c`/`[c` (vim's hunk-jump idiom) are read here as a single
+        // bracket keystroke rather than a buffered two-key chord — this
+        // crate's event loop (`run_app`) has no notion of a pending-chord
+        // state machine today, and introducing one for exactly one binding
+        // would be disproportionate; `]`/`[` alone are otherwise unbound,
+        // so no existing gesture is lost by this simplification.
+        KeyCode::Char(']') => Some(InputKey::NextHunk),
+        KeyCode::Char('[') => Some(InputKey::PrevHunk),
         KeyCode::Char('s') | KeyCode::Char('S') => Some(InputKey::Source),
+        KeyCode::Char('?') => Some(InputKey::ToggleHelp),
         KeyCode::Esc if on_source_screen => Some(InputKey::Back),
         KeyCode::Char('q') if on_source_screen => Some(InputKey::Back),
         KeyCode::Char('q') => Some(InputKey::Quit),
@@ -303,30 +319,100 @@ mod tests {
     }
 
     #[test]
-    fn should_translate_uppercase_j_to_scroll_down() {
+    fn should_translate_enter_to_open() {
+        // ADR 0020: Enter is `Open` (may move focus), distinct from Space's
+        // `Select` (never moves focus) — see the two tests right after this
+        // one.
         let report = empty_report();
         let app = App::new(&report);
 
-        let actual = translate_key(KeyCode::Char('J'), KeyModifiers::NONE, &app);
+        let actual = translate_key(KeyCode::Enter, KeyModifiers::NONE, &app);
 
-        assert_eq!(Some(InputKey::ScrollDown), actual);
+        assert_eq!(Some(InputKey::Open), actual);
     }
 
     #[test]
-    fn should_translate_uppercase_k_to_scroll_up() {
+    fn should_translate_space_to_select() {
         let report = empty_report();
         let app = App::new(&report);
 
-        let actual = translate_key(KeyCode::Char('K'), KeyModifiers::NONE, &app);
+        let actual = translate_key(KeyCode::Char(' '), KeyModifiers::NONE, &app);
 
-        assert_eq!(Some(InputKey::ScrollUp), actual);
+        assert_eq!(Some(InputKey::Select), actual);
     }
 
     #[test]
-    fn should_translate_lowercase_j_to_down_not_scroll() {
-        // Regression guard: lowercase j/k must keep moving the tree cursor
-        // (InputKey::Down/Up) rather than being swallowed by the new
-        // uppercase-only scroll bindings.
+    fn should_translate_h_to_focus_left_when_right_focused() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(InputKey::Open);
+        assert_eq!(app::Focus::Right, app.focus());
+
+        let actual = translate_key(KeyCode::Char('h'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::FocusLeft), actual);
+    }
+
+    #[test]
+    fn should_not_translate_h_at_all_when_tree_focused() {
+        // `h` has no meaning while Focus::Tree (ADR 0020 only assigns it a
+        // "move left/back" meaning while Focus::Right) — must fall through
+        // to `None`, not be swallowed by some other arm.
+        let report = empty_report();
+        let app = App::new(&report);
+        assert_eq!(app::Focus::Tree, app.focus());
+
+        let actual = translate_key(KeyCode::Char('h'), KeyModifiers::NONE, &app);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_translate_esc_to_focus_left_when_right_focused_on_entry_screen() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(InputKey::Open);
+        assert_eq!(app::Focus::Right, app.focus());
+
+        let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::FocusLeft), actual);
+    }
+
+    #[test]
+    fn should_translate_right_bracket_to_next_hunk() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char(']'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::NextHunk), actual);
+    }
+
+    #[test]
+    fn should_translate_left_bracket_to_prev_hunk() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('['), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::PrevHunk), actual);
+    }
+
+    #[test]
+    fn should_translate_question_mark_to_toggle_help() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('?'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ToggleHelp), actual);
+    }
+
+    #[test]
+    fn should_translate_lowercase_j_to_down_regardless_of_focus() {
+        // Regression guard: lowercase j/k are always translated to the same
+        // `InputKey::Down`/`Up` regardless of focus — `App::handle_key`, not
+        // `translate_key`, is what decides whether that means "move cursor"
+        // or "scroll" (ADR 0020).
         let report = empty_report();
         let app = App::new(&report);
 

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -346,7 +346,13 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
         // Space always means "expand/collapse", never "drill in" — kept
         // distinct from Enter's own `InputKey::Open` (ADR 0020) so Space on
-        // a file/symbol row never moves focus.
+        // a file/symbol row never moves focus. Translated unconditionally
+        // here regardless of `app.focus()`, same as every other key this
+        // function maps context-free — `App::handle_key`'s own
+        // `Focus::Tree`-only arm for `Select` is where the actual
+        // Tree-focus requirement lives (mirroring how `NextHunk`/`PrevHunk`
+        // are also translated unconditionally but only acted on under
+        // certain conditions elsewhere).
         KeyCode::Char(' ') => Some(InputKey::Select),
         KeyCode::Enter => Some(InputKey::Open),
         KeyCode::Char('e') | KeyCode::Char('E') => Some(InputKey::ExpandAll),

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -210,7 +210,9 @@ fn run_app(
                         Err(message) => app.set_status(message),
                     }
                 }
-            } else if let InputKey::NextHunk | InputKey::PrevHunk = input_key {
+            } else if let InputKey::NextHunk | InputKey::PrevHunk = input_key
+                && should_apply_hunk_jump(&app)
+            {
                 // Hunk jumping needs the shaped diff content already
                 // cached above (`diff_pane_content`) to know where each
                 // hunk starts — `App::handle_key` itself has no notion of
@@ -247,6 +249,24 @@ fn run_app(
 /// reasoning, just for [`RightPane::Diff`] instead of `RightPane::Pivot`.
 fn should_recompute_diff_pane_content(app: &App) -> bool {
     matches!(app.screen(), Screen::Entry) && app.right_pane() == app::RightPane::Diff
+}
+
+/// Whether `crate::run_app`'s event loop should act on an
+/// [`InputKey::NextHunk`]/[`InputKey::PrevHunk`] press by jumping
+/// `diff_pane_content`'s scroll offset, rather than treating the key as a
+/// no-op. `true` only while [`app::Focus::Right`] *and* [`app::RightPane::Diff`]
+/// is showing — gating on focus alone let `]`/`[` scroll the Detail/Pivot
+/// pane using `diff_pane_content`'s hunk-start table, which is only ever
+/// recomputed for the Diff pane (`should_recompute_diff_pane_content` above),
+/// so it goes stale (pinned to whichever file/symbol was selected the last
+/// time Diff was shown) the moment the user switches away from Diff. That
+/// produced a jump with no relation to what is actually on screen.
+///
+/// Extracted as its own pure function, mirroring `should_recompute_pivot_selection`'s
+/// own reasoning, so this exact gate is unit-testable without a live
+/// `ratatui::DefaultTerminal`.
+fn should_apply_hunk_jump(app: &App) -> bool {
+    app.focus() == app::Focus::Right && app.right_pane() == app::RightPane::Diff
 }
 
 /// The scroll offset [`InputKey::NextHunk`]/[`InputKey::PrevHunk`] should
@@ -666,6 +686,75 @@ mod tests {
             .handle_key(InputKey::Source);
 
         let actual = should_recompute_diff_pane_content(&app);
+
+        assert!(!actual);
+    }
+
+    // --- should_apply_hunk_jump ---
+    //
+    // Regression coverage for the cross-pane key-leak this gate was added
+    // to fix: `]`/`[` used to fire (scrolling `diff_pane_content`'s cached
+    // hunk-offset table) whenever `Focus::Right` held, regardless of which
+    // right pane was actually showing — so opening a file (Focus::Right,
+    // RightPane::Diff by default), pressing `d` to switch to Detail, then
+    // pressing `]`, silently jumped the Detail pane's scroll to a Diff-pane
+    // offset that has no meaning there. `should_recompute_pivot_selection`'s
+    // own existing tests only pin cache-staleness for the pivot pane's
+    // *recompute* trigger; none of them cover this key's *application* gate,
+    // which is a separate condition (`run_app` applies the jump only when
+    // this returns true, independent of whether anything gets recomputed).
+    #[test]
+    fn should_apply_hunk_jump_when_right_focused_on_diff_pane() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(InputKey::Open);
+        assert_eq!(app::Focus::Right, app.focus());
+        assert_eq!(app::RightPane::Diff, app.right_pane()); // ADR 0020 default
+
+        let actual = should_apply_hunk_jump(&app);
+
+        assert!(actual);
+    }
+
+    #[test]
+    fn should_not_apply_hunk_jump_when_right_focused_on_detail_pane() {
+        let report = report_with_one_symbol();
+        // Open reaches Focus::Right on RightPane::Diff (its default), then
+        // ToggleDiff ('d') switches to RightPane::Detail without touching
+        // focus — exactly the sequence (Enter -> d -> ]) the bug report
+        // describes.
+        let app = App::new(&report)
+            .handle_key(InputKey::Open)
+            .handle_key(InputKey::ToggleDiff);
+        assert_eq!(app::Focus::Right, app.focus());
+        assert_eq!(app::RightPane::Detail, app.right_pane());
+
+        let actual = should_apply_hunk_jump(&app);
+
+        assert!(!actual);
+    }
+
+    #[test]
+    fn should_not_apply_hunk_jump_when_right_focused_on_pivot_pane() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Open)
+            .handle_key(InputKey::TogglePivot);
+        assert_eq!(app::Focus::Right, app.focus());
+        assert_eq!(app::RightPane::Pivot, app.right_pane());
+
+        let actual = should_apply_hunk_jump(&app);
+
+        assert!(!actual);
+    }
+
+    #[test]
+    fn should_not_apply_hunk_jump_when_tree_focused_even_if_right_pane_is_diff() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        assert_eq!(app::Focus::Tree, app.focus());
+        assert_eq!(app::RightPane::Diff, app.right_pane()); // ADR 0020 default
+
+        let actual = should_apply_hunk_jump(&app);
 
         assert!(!actual);
     }

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -32,6 +32,7 @@ pub mod app;
 pub mod detail;
 pub mod diff_shape;
 pub mod diff_view;
+pub mod help;
 pub mod highlight;
 pub mod nav;
 pub mod order;
@@ -299,7 +300,24 @@ fn should_recompute_pivot_selection(app: &App) -> bool {
 /// `FocusLeft` on the entry view depending on focus, `Back` on the source
 /// view) and on `app.focus()` (ADR 0020) to route Esc between `FocusLeft`
 /// and its other meanings — every other mapping is context-free.
+///
+/// `app.help_open()` (ADR 0020) short-circuits every other rule: while the
+/// help overlay is open, `?`/Esc/`q` all translate to `ToggleHelp` (closing
+/// it) regardless of what they would otherwise mean, and this check runs
+/// before every other arm so none of them — especially `q`, which would
+/// otherwise mean `Quit` — can reach past the overlay. `App::handle_key`'s
+/// own `help_open` guard is a second, independent layer of the same rule
+/// (swallowing every non-`ToggleHelp` key while open) — belt and braces,
+/// since "the overlay is a safe action that can never accidentally quit
+/// the app" is exactly the property ADR 0020 asks this feature to hold.
 fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<InputKey> {
+    if app.help_open() {
+        return match code {
+            KeyCode::Char('?') | KeyCode::Esc | KeyCode::Char('q') => Some(InputKey::ToggleHelp),
+            _ => None,
+        };
+    }
+
     let on_source_screen = matches!(app.screen(), Screen::Source { .. });
     let right_focused = app.focus() == app::Focus::Right;
 
@@ -483,6 +501,38 @@ mod tests {
         let actual = translate_key(KeyCode::Char('?'), KeyModifiers::NONE, &app);
 
         assert_eq!(Some(InputKey::ToggleHelp), actual);
+    }
+
+    #[test]
+    fn should_translate_esc_to_toggle_help_when_overlay_is_open() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+        let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ToggleHelp), actual);
+    }
+
+    #[test]
+    fn should_translate_q_to_toggle_help_instead_of_quit_when_overlay_is_open() {
+        // ADR 0020: `q` must close the overlay, not fall through to its
+        // normal `Quit` meaning, while it is open.
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+        let actual = translate_key(KeyCode::Char('q'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ToggleHelp), actual);
+    }
+
+    #[test]
+    fn should_translate_arbitrary_key_to_none_when_overlay_is_open() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+        let actual = translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app);
+
+        assert_eq!(None, actual);
     }
 
     #[test]

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -73,15 +73,19 @@ pub fn entry_row_line(
             spans.push(Span::styled(label.to_string(), file_label_style(row.node)));
             spans.push(Span::raw(" "));
             spans.push(badges_span(&row.node.badges));
-            // `skip_reason`/`test_symbol_count` are mutually exclusive by
-            // construction (`crate::tree::TreeNode`'s own doc comment, and
-            // `TreeBuilder::insert_file`'s `debug_assert` in `tree.rs`), so
-            // this `if`/`else if` never actually has to choose between the
-            // two badges — but the priority (skip reason first) is kept
-            // explicit and matches `crate::ui::file_detail_lines`'s own
-            // skip-reason-first early return, so the two panes never
-            // disagree about which explanation wins if that invariant were
-            // ever violated upstream.
+            // `skip_reason` is mutually exclusive with `test_symbol_count`
+            // (`crate::tree::TreeNode::skip_reason`'s own doc comment: a
+            // skipped file has no `FileReport`/`TestFileSummary` entry of
+            // its own), so this `if`/`else if` only ever needs to choose
+            // between "skipped" and "has a test count" — but `test_symbol_count`
+            // is *not* exclusive with real `symbols`/badges shown above (a
+            // mixed file legitimately has both, `TreeNode::test_symbol_count`'s
+            // own doc comment), so the test badge still renders alongside the
+            // ordinary changed-symbol badges for such a row rather than being
+            // hidden by them. The priority (skip reason first, when present)
+            // matches `crate::ui::file_detail_lines`'s own skip-reason-first
+            // early return, so the two panes never disagree about which
+            // explanation wins.
             if let Some(reason) = row.node.skip_reason {
                 spans.push(Span::raw(" "));
                 spans.push(skip_reason_span(reason));

--- a/rinkaku-tui/src/tree.rs
+++ b/rinkaku-tui/src/tree.rs
@@ -124,16 +124,20 @@ pub struct TreeNode {
     /// childless file with a path), it just additionally carries *why*
     /// rinkaku skipped it, for `row_view`/the detail pane to surface.
     pub skip_reason: Option<SkipReason>,
-    /// `Some(symbol_count)` only for a [`NodeKind::File`] node built from
-    /// `report.tests` (a file whose changed symbols were *all* test code,
-    /// ADR 0009 — such a file has no `FileReport` in `report.files` at all,
-    /// see `pipeline::partition_test_symbols`'s doc comment, so without
-    /// this it would be invisible in the tree the same way a skipped file
-    /// is). `None` for every other node, including an ordinary `File` node
-    /// whose *some* (not all) symbols were tests — those are filtered out
-    /// of `report.files` silently today and stay that way here too; only a
-    /// whole-file test exclusion has no other representation in the tree to
-    /// piggyback on.
+    /// `Some(symbol_count)` for a [`NodeKind::File`] node built from an
+    /// entry in `report.tests` (ADR 0009): either a file whose changed
+    /// symbols were *all* test code (no `FileReport` in `report.files` at
+    /// all for it, see `pipeline::partition_test_symbols`'s doc comment —
+    /// without this it would be invisible in the tree the same way a
+    /// skipped file is), or a *mixed* file that has both real (non-test)
+    /// symbols in `report.files` and a nonzero test-symbol count in
+    /// `report.tests` for the same path — `partition_test_symbols`
+    /// populates both independently, it is not an either/or split, so
+    /// `symbols` and `test_symbol_count` are **not** mutually exclusive
+    /// here (unlike `skip_reason`, which is: a skipped file by construction
+    /// has no `FileReport` entry at all). `None` when the file has no
+    /// `report.tests` entry, i.e. every changed symbol in it (if any) is
+    /// non-test.
     pub test_symbol_count: Option<usize>,
 }
 
@@ -169,12 +173,16 @@ pub struct Tree {
 /// `pipeline::analyze_diff`), then `report.removed`, then `report.tests`,
 /// then `report.skipped`, for any additional files/symbols not already
 /// covered, and directory chains are inserted in that same discovery
-/// order. A path present in more than one of these sources (not expected
-/// from `pipeline::analyze_diff`'s own invariants — a file is either kept
-/// in `files`, summarized in `tests`, or listed in `skipped`, never more
-/// than one) merges into one `TreeNode` the same way `insert_file`/
-/// `insert_removed` already merge on a shared path, rather than producing
-/// a duplicate row.
+/// order. A path present in more than one of these sources merges into one
+/// `TreeNode` the same way `insert_file`/`insert_removed` already merge on a
+/// shared path, rather than producing a duplicate row. `files`/`tests`
+/// overlapping on a path is a real, expected case — `pipeline::partition_test_symbols`
+/// can emit both a `FileReport` and a `TestFileSummary` for one mixed file
+/// (`TreeNode::test_symbol_count`'s own doc comment) — but `skipped`
+/// overlapping either `files` or `tests` on the same path is not expected
+/// from `pipeline::analyze_diff`'s own invariants (a skipped file has no
+/// `FileReport`/`TestFileSummary` of its own), and is only debug-asserted
+/// against, not handled gracefully, by `insert_skipped`/`insert_test_file`.
 ///
 /// **Single-child directory collapsing**: a directory whose only content is
 /// exactly one child directory (and nothing else — no files or symbols of
@@ -261,24 +269,26 @@ impl<'a> TreeBuilder<'a> {
     fn insert_file(&mut self, path: &str, symbols: &[rinkaku_core::extract::ExtractedSymbol]) {
         let segments: Vec<&str> = path.split('/').collect();
         let file_builder = self.root.file_at(&segments);
-        // `pipeline::analyze_diff`'s own invariant is that a path is either
-        // kept in `report.files`, summarized in `report.tests`, or listed
-        // in `report.skipped` — never more than one (see `build_tree`'s doc
-        // comment). This is unreachable from that pipeline today, but
-        // `build_tree` is a public, pure function any caller (e.g. a future
-        // non-`analyze_diff` JSON-input path) could feed a `Report` that
-        // violates it — silently the later insert would win, producing a
-        // `File` row that both lists symbols and claims to be
-        // skipped/test-only, a display contradiction (`row_view` would show
-        // a skip/test badge alongside real symbol children; the detail pane
-        // would drop the symbols entirely, see `file_detail_lines`'s
-        // mutually-exclusive branches). Debug-only since this is a caller
-        // contract violation, not a condition `build_tree` itself needs to
-        // handle gracefully in release builds.
+        // `report.files` and `report.skipped` never overlap on a path — a
+        // skipped file by construction has no `FileReport` at all
+        // (`pipeline::analyze_diff`'s invariant). `report.files` and
+        // `report.tests` *can* legitimately overlap, though: a mixed file
+        // (some real symbols, some `#[cfg(test)]`-style test symbols) gets
+        // both a `FileReport` (its non-test symbols) and a `TestFileSummary`
+        // (its test count) for the same path —
+        // `pipeline::partition_test_symbols`'s doc comment. So only the
+        // skip_reason half of the old combined check is a real invariant;
+        // asserting against `test_symbol_count` here would reject a
+        // reachable, correct `Report` (this crate's own dogfood run against
+        // this repo hit exactly that: `rinkaku-tui/src/app.rs` has both real
+        // and test symbols changed in the same diff). Debug-only since this
+        // is still a caller contract violation for the skip_reason case, not
+        // a condition `build_tree` itself needs to handle gracefully in
+        // release builds.
         debug_assert!(
-            file_builder.skip_reason.is_none() && file_builder.test_symbol_count.is_none(),
-            "path {path:?} has real symbols but was already marked skipped/test-only — \
-             report.files/report.tests/report.skipped must not overlap on the same path"
+            file_builder.skip_reason.is_none(),
+            "path {path:?} has real symbols but was already listed in report.skipped — \
+             report.files/report.skipped must not overlap on the same path"
         );
         for symbol in symbols {
             file_builder.symbols.push(SymbolRef {
@@ -303,22 +313,27 @@ impl<'a> TreeBuilder<'a> {
         });
     }
 
-    /// Inserts a whole-test-file summary (`report.tests`, see
-    /// `TreeNode::test_symbol_count`'s doc comment) as a childless `File`
-    /// node — there is no per-symbol data to nest under it, only the count
+    /// Inserts a whole- or mixed-test-file summary (`report.tests`, see
+    /// `TreeNode::test_symbol_count`'s doc comment) into the node for
+    /// `path` — a childless `File` node when the file has no `FileReport`
+    /// at all (all its changed symbols were test code), or an existing node
+    /// already carrying real `symbols` from a prior `insert_file` call when
+    /// the file is mixed. Either way there is no per-symbol data for the
+    /// *test* half to nest under, only the count
     /// `pipeline::partition_test_symbols` kept.
     fn insert_test_file(&mut self, path: &str, symbol_count: usize) {
         let segments: Vec<&str> = path.split('/').collect();
         let file_builder = self.root.file_at(&segments);
-        // Same overlap contract as `insert_file`'s debug_assert, mirrored
-        // here: a path already carrying real symbols must not also be
-        // marked test-only, or `file_detail_lines`'s early-return on
-        // `test_symbol_count` would silently drop those symbols from the
-        // detail pane.
+        // Only guard the genuinely-invariant case: `report.skipped` never
+        // overlaps `report.tests` (a skipped file has no symbols of any
+        // kind to partition into test/non-test in the first place). Real
+        // symbols being present here is expected for a mixed file —
+        // `insert_file`'s own doc comment on why that is not a contract
+        // violation.
         debug_assert!(
-            file_builder.symbols.is_empty(),
-            "path {path:?} already has real symbols but was also summarized in report.tests — \
-             report.files/report.tests must not overlap on the same path"
+            file_builder.skip_reason.is_none(),
+            "path {path:?} was already listed in report.skipped but was also summarized in \
+             report.tests — report.skipped/report.tests must not overlap on the same path"
         );
         file_builder.test_symbol_count = Some(symbol_count);
     }
@@ -328,11 +343,14 @@ impl<'a> TreeBuilder<'a> {
     fn insert_skipped(&mut self, path: &str, reason: SkipReason) {
         let segments: Vec<&str> = path.split('/').collect();
         let file_builder = self.root.file_at(&segments);
-        // Same overlap contract as `insert_file`'s debug_assert.
+        // Same overlap contract as `insert_file`'s debug_assert: a skipped
+        // file has no `FileReport`/`TestFileSummary` entry of its own, so
+        // neither real symbols nor a test count should already be set here.
         debug_assert!(
-            file_builder.symbols.is_empty(),
-            "path {path:?} already has real symbols but was also listed in report.skipped — \
-             report.files/report.skipped must not overlap on the same path"
+            file_builder.symbols.is_empty() && file_builder.test_symbol_count.is_none(),
+            "path {path:?} was already listed in report.files/report.tests but was also listed \
+             in report.skipped — report.skipped must not overlap report.files/report.tests on \
+             the same path"
         );
         file_builder.skip_reason = Some(reason);
     }
@@ -1288,15 +1306,24 @@ mod tests {
         assert_eq!(None, tree.roots[0].test_symbol_count);
     }
 
-    // `pipeline::analyze_diff` never produces a `Report` where the same
-    // path appears in more than one of `files`/`tests`/`skipped` (see
-    // `build_tree`'s doc comment), so `#[cfg(debug_assertions)]` keeps this
-    // panic-path test out of release builds, matching the `debug_assert!`s
-    // themselves — this only guards a caller contract, not a condition
-    // `build_tree` needs to handle gracefully at runtime.
+    // `pipeline::analyze_diff` never produces a `Report` where the same path
+    // appears in both `files`/`skipped` or both `tests`/`skipped` (see
+    // `TreeBuilder::insert_file`/`insert_test_file`/`insert_skipped`'s own
+    // doc comments), so `#[cfg(debug_assertions)]` keeps these panic-path
+    // tests out of release builds, matching the `debug_assert!`s themselves
+    // — they only guard a caller contract, not a condition `build_tree`
+    // needs to handle gracefully at runtime. `files`/`tests` overlapping on
+    // the same path, in contrast, is a *valid* `analyze_diff` output (a
+    // mixed file) — see `should_keep_real_symbols_when_file_is_also_in_tests`
+    // below, not a panic case.
+    // `build_tree` visits `report.files` before `report.skipped` (its own
+    // doc comment's discovery order), so this hits `insert_skipped`'s own
+    // assert, not `insert_file`'s — `insert_file` only guards against a
+    // path *already* marked skipped when files runs, which is not yet true
+    // here.
     #[cfg(debug_assertions)]
     #[test]
-    #[should_panic(expected = "report.files/report.skipped must not overlap")]
+    #[should_panic(expected = "report.skipped must not overlap report.files/report.tests")]
     fn should_panic_when_the_same_path_appears_in_files_and_skipped() {
         let report = Report {
             origin: rinkaku_core::render::ReportOrigin::Diff,
@@ -1316,8 +1343,35 @@ mod tests {
 
     #[cfg(debug_assertions)]
     #[test]
-    #[should_panic(expected = "report.files/report.tests must not overlap")]
-    fn should_panic_when_the_same_path_appears_in_files_and_tests() {
+    #[should_panic(expected = "report.skipped must not overlap report.files/report.tests")]
+    fn should_panic_when_the_same_path_appears_in_tests_and_skipped() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            tests: vec![TestFileSummary {
+                path: "lib.rs".to_string(),
+                symbol_count: 1,
+            }],
+            skipped: vec![SkippedFile {
+                path: "lib.rs".to_string(),
+                reason: rinkaku_core::render::SkipReason::Binary,
+            }],
+            ..empty_report()
+        };
+
+        build_tree(&report);
+    }
+
+    // Regression test (post-rebase integration check): `lib.rs` in both
+    // `report.files` (some real symbols) and `report.tests` (a test count
+    // for the rest) is exactly what `pipeline::partition_test_symbols`
+    // produces for a mixed file — e.g. a Rust file with production
+    // functions changed alongside its own `#[cfg(test)] mod tests` in the
+    // same diff (this crate's own `rinkaku-tui/src/app.rs` hit this in a
+    // live dogfood run). `build_tree` must keep both pieces of information
+    // on the one `TreeNode` rather than panicking or silently dropping
+    // either half.
+    #[test]
+    fn should_keep_real_symbols_when_file_is_also_in_tests() {
         let report = Report {
             origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
@@ -1326,11 +1380,15 @@ mod tests {
             }],
             tests: vec![TestFileSummary {
                 path: "lib.rs".to_string(),
-                symbol_count: 1,
+                symbol_count: 3,
             }],
             ..empty_report()
         };
 
-        build_tree(&report);
+        let tree = build_tree(&report);
+
+        assert_eq!(1, tree.roots[0].children.len());
+        assert_eq!(Some(3), tree.roots[0].test_symbol_count);
+        assert_eq!(None, tree.roots[0].skip_reason);
     }
 }

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -1041,17 +1041,7 @@ fn source_lines(source: &SourceView, start: usize, end: usize) -> Vec<Line<'stat
 }
 
 fn draw_status_line(frame: &mut Frame, app: &App, area: Rect) {
-    let help = match app.screen() {
-        Screen::Entry => {
-            "j/k: move  enter/space: expand  e/c: expand/collapse  o: order  d: diff  p: pivot  J/K: scroll  s: source  q: quit"
-        }
-        Screen::Source { .. } => "esc/q: back",
-    };
-
-    let text = match app.status() {
-        Some(status) => format!("{status}  |  {help}"),
-        None => help.to_string(),
-    };
+    let text = status_line_text(app);
 
     let style = if app.status().is_some() {
         Style::default().fg(Color::Yellow)
@@ -1060,6 +1050,47 @@ fn draw_status_line(frame: &mut Frame, app: &App, area: Rect) {
     };
 
     frame.render_widget(Paragraph::new(text).style(style), area);
+}
+
+/// The status line's full text (ADR 0020): the current order mode is
+/// always shown (the real `crate::order::OrderMode` term, not a
+/// paraphrase, so it matches what `o` actually toggles between), and the
+/// key-hint segment switches on `app.focus()` while [`Screen::Entry`] —
+/// Tree-focused hints are navigation-oriented, Right-focused hints are
+/// scroll/hunk-jump-oriented, and both end with a `?` mention so the fuller
+/// keymap/glossary overlay is always one keypress away. [`Screen::Source`]
+/// keeps its own short "esc/q: back" hint, unaffected by focus (drilling
+/// into source is reached only via [`Focus::Right`] already, so a focus
+/// distinction there would be redundant).
+///
+/// Extracted as its own pure function (no `ratatui` types) so the text
+/// itself — not just that *something* renders — is unit-testable, mirroring
+/// [`clamp_scroll`]/[`scroll_indicator`]'s own precedent in this module for
+/// layout-adjacent pure logic.
+fn status_line_text(app: &App) -> String {
+    let help = match app.screen() {
+        Screen::Entry => {
+            let order = match app.order_mode() {
+                crate::order::OrderMode::Topological => "topological",
+                crate::order::OrderMode::AlphaNumeric => "alphabetical",
+            };
+            let keys = match app.focus() {
+                crate::app::Focus::Tree => {
+                    "j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  p: pivot  s: source  ?: help  q: quit"
+                }
+                crate::app::Focus::Right => {
+                    "j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  p: pivot  ?: help  q: quit"
+                }
+            };
+            format!("order: {order}  |  {keys}")
+        }
+        Screen::Source { .. } => "esc/q: back".to_string(),
+    };
+
+    match app.status() {
+        Some(status) => format!("{status}  |  {help}"),
+        None => help,
+    }
 }
 
 #[cfg(test)]
@@ -2172,11 +2203,11 @@ index e69de29..4b825dc 100644
         let report = report_with_one_symbol();
         let app = App::new(&report);
         // Wider than the default 80 columns used elsewhere in this test
-        // module: the full help text (now including the J/K scroll hint and
-        // the `p: pivot` hint, ADR 0019) is ~114 columns and would
-        // otherwise be truncated (the status line intentionally does not
-        // wrap), hiding the "quit" fragment this test checks for.
-        let mut terminal = Terminal::new(TestBackend::new(120, 20)).expect("terminal");
+        // module: the full help text (order mode + Tree-focus key hints,
+        // ADR 0020) is ~140 columns and would otherwise be truncated (the
+        // status line intentionally does not wrap), hiding the "quit"
+        // fragment this test checks for.
+        let mut terminal = Terminal::new(TestBackend::new(150, 20)).expect("terminal");
 
         terminal
             .draw(|frame| {
@@ -2194,6 +2225,7 @@ index e69de29..4b825dc 100644
 
         let text = buffer_text(&terminal);
         assert!(text.contains("quit"));
+        assert!(text.contains("order: topological"));
     }
 
     #[test]
@@ -2339,6 +2371,87 @@ index e69de29..4b825dc 100644
         let actual = scroll_indicator(20, 10, 10);
 
         assert_eq!(Some(" (11-20/20)".to_string()), actual);
+    }
+
+    // --- status_line_text (pure helper) ---
+
+    #[test]
+    fn should_show_topological_order_and_tree_focus_hints_by_default() {
+        let report = empty_report_for_status_line();
+        let app = App::new(&report);
+
+        let actual = status_line_text(&app);
+
+        assert_eq!(
+            "order: topological  |  j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  p: pivot  s: source  ?: help  q: quit"
+                .to_string(),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_show_alphabetical_order_after_toggle_order_is_pressed() {
+        let report = empty_report_for_status_line();
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleOrder);
+
+        let actual = status_line_text(&app);
+
+        assert!(actual.starts_with("order: alphabetical  |  "));
+    }
+
+    #[test]
+    fn should_show_right_focus_hints_when_focus_is_right() {
+        let report = report_with_one_symbol();
+        // `Open` on the file row (cursor starts there) reaches Focus::Right
+        // (ADR 0020) without leaving Screen::Entry.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Open);
+
+        let actual = status_line_text(&app);
+
+        assert_eq!(
+            "order: topological  |  j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  p: pivot  ?: help  q: quit"
+                .to_string(),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_show_back_hint_only_on_source_screen_regardless_of_focus() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::Open); // opens Screen::Source
+
+        let actual = status_line_text(&app);
+
+        assert_eq!("esc/q: back".to_string(), actual);
+    }
+
+    #[test]
+    fn should_prefix_status_message_before_the_help_text_when_set() {
+        let report = empty_report_for_status_line();
+        let mut app = App::new(&report);
+        app.set_status("a source read failed");
+
+        let actual = status_line_text(&app);
+
+        assert!(actual.starts_with("a source read failed  |  order: topological  |  "));
+    }
+
+    fn empty_report_for_status_line() -> Report {
+        Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
     }
 
     // --- rendered scroll behavior (TestBackend) ---

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -20,7 +20,7 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Paragraph, Wrap};
+use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 use rinkaku_core::extract::Classification;
 use rinkaku_core::render::{Report, ReportOrigin};
 use unicode_width::UnicodeWidthChar;
@@ -40,6 +40,13 @@ use unicode_width::UnicodeWidthChar;
 /// [`load_symbol_source`], see that function's doc comment for why
 /// `Report` paths need it) — it is threaded through here rather than
 /// resolved lazily so this stays the single frame-drawing entry point.
+///
+/// The `?` help overlay (ADR 0020) draws last, on top of whatever screen
+/// was already rendered underneath — `app.help_open()` never changes what
+/// `Screen`/`RightPane` themselves draw (`App::help_open`'s own doc
+/// comment), so the underlying frame is built exactly the same way whether
+/// the overlay is open or not, and the overlay is simply composited over
+/// it as a final step.
 pub fn draw(
     frame: &mut Frame,
     app: &App,
@@ -69,6 +76,80 @@ pub fn draw(
     }
 
     draw_status_line(frame, app, status_area);
+
+    if app.help_open() {
+        draw_help_overlay(frame, area);
+    }
+}
+
+/// Draws the `?` help overlay (ADR 0020) centered over `full_area`: a
+/// bordered box roughly 70% of the frame's width/height (capped so it
+/// never claims more than the frame itself on a small terminal), listing
+/// every [`crate::help::HELP_CONTENT`] keymap group followed by the
+/// glossary. [`Clear`] is rendered first so the overlay's background is
+/// opaque rather than letting the underlying frame's glyphs show through
+/// gaps in the overlay's own text.
+fn draw_help_overlay(frame: &mut Frame, full_area: Rect) {
+    let overlay_area = centered_rect(full_area, 80, 90);
+    frame.render_widget(Clear, overlay_area);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for group in crate::help::HELP_CONTENT.keymap_groups {
+        lines.push(Line::styled(
+            group.title,
+            Style::default().add_modifier(Modifier::BOLD),
+        ));
+        for binding in group.bindings {
+            lines.push(Line::raw(format!(
+                "  {:<16} {}",
+                binding.keys, binding.description
+            )));
+        }
+        lines.push(Line::raw(""));
+    }
+    lines.push(Line::styled(
+        "Glossary",
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+    for entry in crate::help::HELP_CONTENT.glossary {
+        lines.push(Line::raw(format!(
+            "  {:<16} {}",
+            entry.term, entry.explanation
+        )));
+    }
+
+    let block = Block::bordered().title(" Help (? to close) ");
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(ratatui::widgets::Wrap { trim: false });
+    frame.render_widget(paragraph, overlay_area);
+}
+
+/// A `Rect` centered within `area`, `percent_width`/`percent_height` of
+/// `area`'s own dimensions — the standard `ratatui` centered-popup layout
+/// recipe (two nested `Layout::vertical`/`horizontal` splits with a
+/// `Percentage` constraint sandwiched between two equal `Percentage`
+/// margins), extracted as its own pure function so the overlay's sizing
+/// rule is nameable and independent of `draw_help_overlay`'s own
+/// `Clear`/`Paragraph` concerns.
+fn centered_rect(area: Rect, percent_width: u16, percent_height: u16) -> Rect {
+    let vertical_margin = (100 - percent_height) / 2;
+    let [_, middle, _] = Layout::vertical([
+        Constraint::Percentage(vertical_margin),
+        Constraint::Percentage(percent_height),
+        Constraint::Percentage(vertical_margin),
+    ])
+    .areas(area);
+
+    let horizontal_margin = (100 - percent_width) / 2;
+    let [_, center, _] = Layout::horizontal([
+        Constraint::Percentage(horizontal_margin),
+        Constraint::Percentage(percent_width),
+        Constraint::Percentage(horizontal_margin),
+    ])
+    .areas(middle);
+
+    center
 }
 
 /// Left entry pane (directory tree) + right pane, split 60/40 — this
@@ -1104,6 +1185,59 @@ mod tests {
         // the detail pane actually rendered file-detail content rather than
         // asserting on the placeholder text that used to show here.
         assert!(text.contains("Symbols"));
+    }
+
+    #[test]
+    fn should_draw_help_overlay_with_keymap_and_glossary_when_help_is_open() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleHelp);
+        let mut terminal = Terminal::new(TestBackend::new(100, 40)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &PivotSelection::NotApplicable,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Help"));
+        assert!(text.contains("Tree focus"));
+        assert!(text.contains("Right focus"));
+        assert!(text.contains("Global"));
+        assert!(text.contains("Glossary"));
+        assert!(text.contains("pivot"));
+    }
+
+    #[test]
+    fn should_not_draw_help_overlay_when_help_is_closed() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &PivotSelection::NotApplicable,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(!text.contains("Glossary"));
     }
 
     #[test]

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -1072,6 +1072,13 @@ fn draw_status_line(frame: &mut Frame, app: &App, area: Rect) {
 /// into source is reached only via [`Focus::Right`] already, so a focus
 /// distinction there would be redundant).
 ///
+/// The `]/[: next/prev hunk` hint only appears while Right-focused *and*
+/// [`RightPane::Diff`] is showing — `crate::run_app` only wires up the
+/// `]`/`[` jump for that pane/focus combination (it needs the Diff pane's
+/// shaped hunk-offset table, which Detail/Pivot have no equivalent of), so
+/// advertising the key while Detail/Pivot is showing would describe a
+/// binding that does nothing there.
+///
 /// Extracted as its own pure function (no `ratatui` types) so the text
 /// itself — not just that *something* renders — is unit-testable, mirroring
 /// [`clamp_scroll`]/[`scroll_indicator`]'s own precedent in this module for
@@ -1087,8 +1094,11 @@ fn status_line_text(app: &App) -> String {
                 crate::app::Focus::Tree => {
                     "j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  p: pivot  s: source  ?: help  q: quit"
                 }
-                crate::app::Focus::Right => {
+                crate::app::Focus::Right if app.right_pane() == crate::app::RightPane::Diff => {
                     "j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  p: pivot  ?: help  q: quit"
+                }
+                crate::app::Focus::Right => {
+                    "j/k: scroll  h/esc: back  d: diff  p: pivot  ?: help  q: quit"
                 }
             };
             format!("order: {order}  |  {keys}")
@@ -2472,16 +2482,39 @@ index e69de29..4b825dc 100644
     }
 
     #[test]
-    fn should_show_right_focus_hints_when_focus_is_right() {
+    fn should_show_right_focus_hints_with_hunk_jump_when_diff_pane_is_showing() {
         let report = report_with_one_symbol();
         // `Open` on the file row (cursor starts there) reaches Focus::Right
-        // (ADR 0020) without leaving Screen::Entry.
+        // (ADR 0020) without leaving Screen::Entry, and lands on
+        // `RightPane::Diff` (its default, `f3c4b98`) — the pane the
+        // `]/[: next/prev hunk` hint actually applies to.
         let app = App::new(&report).handle_key(crate::app::InputKey::Open);
 
         let actual = status_line_text(&app);
 
         assert_eq!(
             "order: topological  |  j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  p: pivot  ?: help  q: quit"
+                .to_string(),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_show_right_focus_hints_without_hunk_jump_when_detail_pane_is_showing() {
+        let report = report_with_one_symbol();
+        // `Open` reaches Focus::Right on RightPane::Diff (its default), then
+        // `ToggleDiff` (`d`) switches to RightPane::Detail — the hunk-jump
+        // hint must disappear here since `crate::run_app` never wires `]`/`[`
+        // up for Detail (finding: `]`/`[` used to fire regardless of pane).
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Open)
+            .handle_key(crate::app::InputKey::ToggleDiff);
+        assert_eq!(crate::app::RightPane::Detail, app.right_pane());
+
+        let actual = status_line_text(&app);
+
+        assert_eq!(
+            "order: topological  |  j/k: scroll  h/esc: back  d: diff  p: pivot  ?: help  q: quit"
                 .to_string(),
             actual
         );

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -11,7 +11,8 @@
 
 use crate::app::{App, DiffTarget, PivotSelection, RightPane, Screen, SelectedDetail};
 use crate::detail::{DetailView, DirDetail, FileDetail, SignatureView};
-use crate::diff_view::{DiffLine, DiffLineKind, FileHunks, Hunk, file_hunks, hunks_for_range};
+use crate::diff_shape::DiffSection;
+use crate::diff_view::{DiffLine, DiffLineKind};
 use crate::highlight::{self, HighlightedFile, PALETTE, TokenSpan};
 use crate::row_view::{entry_row_line, relative_labels};
 use crate::source::{SourceView, load_symbol_source, visible_window};
@@ -26,16 +27,15 @@ use unicode_width::UnicodeWidthChar;
 
 /// Draws one full frame: the entry view (tree + right pane split) or the
 /// source drill-down, depending on `app.screen()`, with a status/help line
-/// pinned to the bottom either way. `diff_files` is the whole diff already
-/// parsed into per-file hunks once by `crate::run_app` (not re-parsed here
-/// on every frame — see that function's doc comment on why parsing lives
-/// outside the draw loop), and `diff_highlights` is that same diff's
-/// per-line syntax highlighting, computed once alongside it (ADR 0018) —
-/// both are only consulted when the right pane is in [`RightPane::Diff`]
-/// mode. `pivot_selection` is likewise computed once per handled key by
-/// `crate::run_app` (not here) whenever the right pane is in
-/// [`RightPane::Pivot`] mode — see `App::selected_pivot_view`'s own doc
-/// comment on why this function must not call it itself. `repo_root` is
+/// pinned to the bottom either way. `diff_highlights` is the whole diff's
+/// per-line syntax highlighting, computed once by `crate::run_app` (not
+/// re-parsed/re-highlighted here on every frame — see that function's doc
+/// comment on why that work lives outside the draw loop), consulted only
+/// when the right pane is in [`RightPane::Diff`] mode. `diff_content` and
+/// `pivot_selection` are likewise computed once per handled key by
+/// `crate::run_app` (not here), for [`RightPane::Diff`]/[`RightPane::Pivot`]
+/// respectively — see `App::selected_pivot_view`'s own doc comment on why
+/// this function must not call either computation itself. `repo_root` is
 /// only consulted on [`Screen::Source`] (forwarded to
 /// [`load_symbol_source`], see that function's doc comment for why
 /// `Report` paths need it) — it is threaded through here rather than
@@ -44,7 +44,7 @@ pub fn draw(
     frame: &mut Frame,
     app: &App,
     report: &Report,
-    diff_files: &[FileHunks],
+    diff_content: &crate::diff_shape::DiffPaneContent,
     diff_highlights: &[HighlightedFile],
     pivot_selection: &PivotSelection,
     repo_root: &std::path::Path,
@@ -58,7 +58,7 @@ pub fn draw(
             frame,
             app,
             report,
-            diff_files,
+            diff_content,
             diff_highlights,
             pivot_selection,
             body,
@@ -81,7 +81,7 @@ fn draw_entry_screen(
     frame: &mut Frame,
     app: &App,
     report: &Report,
-    diff_files: &[FileHunks],
+    diff_content: &crate::diff_shape::DiffPaneContent,
     diff_highlights: &[HighlightedFile],
     pivot_selection: &PivotSelection,
     area: Rect,
@@ -92,9 +92,14 @@ fn draw_entry_screen(
     draw_tree_pane(frame, app, tree_area);
     match app.right_pane() {
         RightPane::Detail => draw_detail_pane(frame, app, report, right_area),
-        RightPane::Diff => {
-            draw_diff_pane(frame, app, report, diff_files, diff_highlights, right_area)
-        }
+        RightPane::Diff => draw_diff_pane(
+            frame,
+            app,
+            report,
+            diff_content,
+            diff_highlights,
+            right_area,
+        ),
         RightPane::Pivot => draw_pivot_pane(frame, app, pivot_selection, right_area),
     }
 }
@@ -135,70 +140,60 @@ fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
     render_scrollable_pane(frame, " Detail ", &lines, app.right_pane_scroll(), area);
 }
 
-/// Draws the diff pane (TUI iteration 2, [`RightPane::Diff`]): the raw
-/// unified-diff hunks touching the row under the cursor — every hunk of the
-/// file for a file row, or just the hunks intersecting a symbol's own line
-/// range for a symbol row (`App::selected_diff_target`'s own doc comment).
+/// Draws the diff pane (TUI iteration 2, [`RightPane::Diff`]; ADR 0020
+/// reshapes its content): the raw unified-diff hunks touching the row under
+/// the cursor, clipped to a symbol's own line range for a symbol row, or
+/// grouped into per-symbol sections (plus a trailing "(module level)"
+/// section) for a file row — `diff_content` is already shaped by
+/// `crate::diff_shape::build_diff_pane_content`, computed once per handled
+/// key by `crate::run_app` (this function must not call it itself, mirroring
+/// `App::selected_pivot_view`'s own "must not call from `ui::draw`"
+/// constraint and the reason it exists — see that method's doc comment).
 /// A directory row, or a row with nothing to show (no hunks found, e.g. a
 /// mismatch between `report` and the diff), falls back to a placeholder
-/// message rather than an empty pane. `diff_files` is already parsed and
-/// `diff_highlights` already highlighted (`crate::run_app` does both once,
-/// up front, not on every call to this function — ADR 0018).
+/// message rather than an empty pane; `App::selected_diff_target` is called
+/// here (not cached) purely to pick which of the two placeholder messages
+/// applies — it is an O(rows) lookup, not the O(diff size) hunk-walk
+/// `diff_content` itself avoids recomputing. `diff_highlights` is looked up
+/// by `source_index` rather than pointer identity now that hunks are cloned
+/// into shaped sections (`crate::diff_shape::AttributedHunk`'s own doc
+/// comment).
 fn draw_diff_pane(
     frame: &mut Frame,
     app: &App,
     report: &Report,
-    diff_files: &[FileHunks],
+    diff_content: &crate::diff_shape::DiffPaneContent,
     diff_highlights: &[HighlightedFile],
     area: Rect,
 ) {
-    let Some(target) = app.selected_diff_target(report) else {
-        let block = Block::bordered().title(" Diff ");
-        let paragraph = Paragraph::new("(select a symbol or file row to see its diff)")
-            .block(block)
-            .wrap(ratatui::widgets::Wrap { trim: false });
-        frame.render_widget(paragraph, area);
-        return;
+    use crate::diff_shape::DiffPaneContent;
+
+    let target = app.selected_diff_target(report);
+    let path: &str = match &target {
+        Some(DiffTarget::Symbol { path, .. }) | Some(DiffTarget::File { path }) => path.as_str(),
+        None => "",
     };
 
-    let (path, hunks): (&str, Vec<&Hunk>) = match &target {
-        DiffTarget::Symbol {
-            path,
-            range_start,
-            range_end,
-        } => {
-            let hunks = file_hunks(diff_files, path)
-                .map(|fh| hunks_for_range(fh, *range_start, *range_end))
-                .unwrap_or_default();
-            (path.as_str(), hunks)
+    let sections: Vec<&crate::diff_shape::DiffSection> = match diff_content {
+        DiffPaneContent::Empty => {
+            let message = match &target {
+                None => "(select a symbol or file row to see its diff)".to_string(),
+                Some(_) => format!("(no diff hunks found for {path})"),
+            };
+            let block = Block::bordered().title(" Diff ");
+            let paragraph = Paragraph::new(message)
+                .block(block)
+                .wrap(ratatui::widgets::Wrap { trim: false });
+            frame.render_widget(paragraph, area);
+            return;
         }
-        DiffTarget::File { path } => {
-            let hunks = file_hunks(diff_files, path)
-                .map(|fh: &FileHunks| fh.hunks.iter().collect())
-                .unwrap_or_default();
-            (path.as_str(), hunks)
-        }
+        DiffPaneContent::Symbol(section) => vec![section],
+        DiffPaneContent::File(sections) => sections.iter().collect(),
     };
 
-    if hunks.is_empty() {
-        let block = Block::bordered().title(" Diff ");
-        let paragraph = Paragraph::new(format!("(no diff hunks found for {path})"))
-            .block(block)
-            .wrap(ratatui::widgets::Wrap { trim: false });
-        frame.render_widget(paragraph, area);
-        return;
-    }
-
-    // `file_hunks` was already resolved above via `DiffTarget`'s match arm,
-    // but `hunks_for_range`/the file-row arm both return `&Hunk`s borrowed
-    // from it — re-resolving it here (rather than threading it out of the
-    // match above) keeps `highlight::lookup_hunk_highlight`'s pointer-
-    // identity lookup working against the exact same `FileHunks` the
-    // `&Hunk`s in `hunks` were borrowed from.
-    let source_file_hunks = file_hunks(diff_files, path);
     let highlighted_file = highlight::highlighted_file(diff_highlights, path);
-
-    let lines = diff_pane_lines(&hunks, source_file_hunks, highlighted_file);
+    let is_file_selection = matches!(diff_content, DiffPaneContent::File(_));
+    let lines = diff_pane_lines(&sections, is_file_selection, highlighted_file);
     render_scrollable_pane(frame, " Diff ", &lines, app.right_pane_scroll(), area);
 }
 
@@ -439,53 +434,82 @@ fn scroll_indicator(content_len: usize, viewport_height: usize, scroll: usize) -
     Some(format!(" ({first_visible}-{last_visible}/{content_len})"))
 }
 
-/// Formats a list of [`Hunk`]s into styled lines: hunk headers dim, `+`/`-`
-/// marker glyphs keep their existing bold green/red foreground, and each
-/// line's own code tokens are colored by [`highlight::lookup_hunk_highlight`]
-/// when available (ADR 0018) — falling back to the plain green/red/unstyled
-/// line style this pane always had when a hunk has no highlight (unknown
-/// extension, parse/query failure) so highlighting can never make a diff
-/// harder to read than before.
+/// Formats every [`DiffSection`] in `sections` into styled lines (ADR
+/// 0020): a section header (a symbol's own signature, styled bold, or the
+/// fixed "(module level)" label) only when `show_section_headers` is set —
+/// a single-section symbol selection has nothing to disambiguate a header
+/// would add value to, so it is omitted there and the pane opens straight
+/// on the (optional) contract header/hunks, matching this pane's pre-ADR-
+/// 0020 layout for a symbol row. A file selection (multiple sections, or
+/// one section that still benefits from being named) always shows headers.
+/// Each section's own `contract_header` (when present) renders as a 2-line
+/// red/green old/new pair before that section's hunks — the outline-before-
+/// implementation disclosure order ADR 0020 asks for.
 ///
-/// `source_file_hunks`/`highlighted_file` are `None` exactly when `hunks`
-/// itself would already be empty (`draw_diff_pane` returns before calling
-/// this function in that case), so in practice they are always `Some` here
-/// — kept as `Option`s anyway (rather than unwrapped) since `file_hunks`
-/// returning `None` is a defensive, not-supposed-to-happen case elsewhere
-/// in this module too, and threading the same shape through keeps this
-/// function's fallback path uniform with `highlight::lookup_hunk_highlight`'s
-/// own `None` handling.
+/// Within each section, hunk headers stay dim, `+`/`-` marker glyphs keep
+/// their existing bold green/red foreground, and each line's own code
+/// tokens are colored by [`highlight::lookup_hunk_highlight_by_index`] when
+/// available (ADR 0018/0020) — falling back to the plain green/red/
+/// unstyled line style this pane always had when a hunk has no highlight
+/// (unknown extension, parse/query failure, or `highlighted_file` itself
+/// being `None`) so highlighting can never make a diff harder to read than
+/// before.
 fn diff_pane_lines(
-    hunks: &[&Hunk],
-    source_file_hunks: Option<&FileHunks>,
+    sections: &[&DiffSection],
+    show_section_headers: bool,
     highlighted_file: Option<&HighlightedFile>,
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
-    for (index, hunk) in hunks.iter().enumerate() {
-        if index > 0 {
+    for (section_index, section) in sections.iter().enumerate() {
+        if section_index > 0 {
             lines.push(Line::raw(""));
         }
-        lines.push(Line::styled(
-            hunk.header.clone(),
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::DIM),
-        ));
+        if show_section_headers {
+            lines.push(Line::styled(
+                section.title.clone(),
+                Style::default().add_modifier(Modifier::BOLD),
+            ));
+        }
+        if let Some(contract) = &section.contract_header {
+            lines.push(Line::styled(
+                format!("- {}", contract.previous_signature),
+                Style::default().fg(Color::Red),
+            ));
+            lines.push(Line::styled(
+                format!("+ {}", contract.signature),
+                Style::default().fg(Color::Green),
+            ));
+        }
 
-        let hunk_highlight = source_file_hunks
-            .and_then(|fh| highlight::lookup_hunk_highlight(highlighted_file, fh, hunk));
+        for (hunk_index, attributed) in section.hunks.iter().enumerate() {
+            if hunk_index > 0 || show_section_headers || section.contract_header.is_some() {
+                lines.push(Line::raw(""));
+            }
+            lines.push(Line::styled(
+                attributed.hunk.header.clone(),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+            ));
 
-        for (line_index, line) in hunk.lines.iter().enumerate() {
-            // `hunk_highlight` is `Option<&[LineHighlight]>`, and
-            // `LineHighlight` is itself `Option<Vec<TokenSpan>>` (per-line
-            // fallback within an otherwise-highlighted hunk) — `flatten`
-            // collapses "no highlight data at all for this hunk" and
-            // "this specific line had no highlight" into the same `None`
-            // `diff_line` already treats as its fallback signal.
-            let token_spans = hunk_highlight
-                .and_then(|lines| lines.get(line_index).cloned())
-                .flatten();
-            lines.push(diff_line(line, token_spans));
+            let hunk_highlight = highlight::lookup_hunk_highlight_by_index(
+                highlighted_file,
+                attributed.source_index,
+            );
+
+            for (line_index, line) in attributed.hunk.lines.iter().enumerate() {
+                // `hunk_highlight` is `Option<&[LineHighlight]>`, and
+                // `LineHighlight` is itself `Option<Vec<TokenSpan>>`
+                // (per-line fallback within an otherwise-highlighted hunk)
+                // — `flatten` collapses "no highlight data at all for this
+                // hunk" and "this specific line had no highlight" into the
+                // same `None` `diff_line` already treats as its fallback
+                // signal.
+                let token_spans = hunk_highlight
+                    .and_then(|lines| lines.get(line_index).cloned())
+                    .flatten();
+                lines.push(diff_line(line, token_spans));
+            }
         }
     }
     lines
@@ -1012,6 +1036,25 @@ mod tests {
         std::path::PathBuf::from("/repo")
     }
 
+    /// Builds the [`crate::diff_shape::DiffPaneContent`] `crate::run_app`
+    /// would have cached for `app`'s current selection against `report`/
+    /// `diff_files` — this module's tests recreate that one-shot
+    /// computation by hand (mirroring how `should_draw_pivot_pane_...`
+    /// already recreates `App::selected_pivot_view`'s own one-shot
+    /// computation for `pivot_selection`), since `draw` itself must not
+    /// compute it (`draw_diff_pane`'s own doc comment).
+    fn diff_content_for(
+        report: &Report,
+        diff_files: &[crate::diff_view::FileHunks],
+        app: &App,
+    ) -> crate::diff_shape::DiffPaneContent {
+        crate::diff_shape::build_diff_pane_content(
+            report,
+            diff_files,
+            app.selected_diff_target(report).as_ref(),
+        )
+    }
+
     /// Flattens a `TestBackend`'s buffer into one string (rows joined by
     /// `\n`), so a snapshot assertion can check for expected substrings
     /// (pane titles, row content) without pinning every cell — the coarse
@@ -1043,7 +1086,7 @@ mod tests {
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1090,7 +1133,7 @@ mod tests {
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1134,7 +1177,7 @@ mod tests {
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1183,7 +1226,7 @@ mod tests {
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1234,7 +1277,7 @@ mod tests {
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1282,7 +1325,7 @@ mod tests {
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1316,6 +1359,7 @@ index e69de29..4b825dc 100644
 ";
         let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
         let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let diff_content = diff_content_for(&report, &diff_files, &app);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1324,7 +1368,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &diff_files,
+                    &diff_content,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1376,6 +1420,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
 ";
         let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
         let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let diff_content = diff_content_for(&report, &diff_files, &app);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1384,7 +1429,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
                     frame,
                     &app,
                     &report,
-                    &diff_files,
+                    &diff_content,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1442,6 +1487,7 @@ index e69de29..4b825dc 100644
 ";
         let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
         let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let diff_content = diff_content_for(&report, &diff_files, &app);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1450,7 +1496,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &diff_files,
+                    &diff_content,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1461,6 +1507,135 @@ index e69de29..4b825dc 100644
         let text = buffer_text(&terminal);
         assert!(text.contains("Diff"));
         assert!(text.contains("+const b = 2;"));
+    }
+
+    #[test]
+    fn should_draw_per_symbol_section_headers_when_diff_pane_shows_a_file_selection() {
+        // Cursor stays on row 0, the "lib.rs" file row itself — a file
+        // selection (ADR 0020) groups hunks under each symbol's own
+        // signature as a section header, unlike a symbol selection (the
+        // sibling test above), which shows no header at all.
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![
+                    symbol("lib.rs::foo", "foo"),
+                    ExtractedSymbol {
+                        range: LineRange { start: 10, end: 10 },
+                        ..symbol("lib.rs::bar", "bar")
+                    },
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        };
+        let app = App::new(&report);
+        let diff_text = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,1 +1,1 @@
+-fn a() {}
++fn foo() {}
+@@ -9,1 +10,1 @@
+-fn old_bar() {}
++fn bar() {}
+";
+        let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+        let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let diff_content = diff_content_for(&report, &diff_files, &app);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &diff_content,
+                    &diff_highlights,
+                    &PivotSelection::NotApplicable,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("fn foo()"));
+        assert!(text.contains("fn bar()"));
+        assert!(text.contains("+fn foo() {}"));
+        assert!(text.contains("+fn bar() {}"));
+    }
+
+    #[test]
+    fn should_draw_contract_header_before_hunks_when_symbol_signature_changed() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    classification: Some(Classification::SignatureChanged),
+                    previous_signature: Some("fn foo(a: i32)".to_string()),
+                    signature: "fn foo(a: i32, b: i32)".to_string(),
+                    ..symbol("lib.rs::foo", "foo")
+                }],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        };
+        // Row 0 is the "lib.rs" file row, row 1 is the "foo" symbol.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+        let diff_text = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,1 +1,1 @@
+-fn foo(a: i32) {}
++fn foo(a: i32, b: i32) {}
+";
+        let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+        let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let diff_content = diff_content_for(&report, &diff_files, &app);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &diff_content,
+                    &diff_highlights,
+                    &PivotSelection::NotApplicable,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        // The 2-line old/new contract header precedes the hunk body itself
+        // (ADR 0020's outline-before-implementation disclosure order).
+        assert!(text.contains("- fn foo(a: i32)"));
+        assert!(text.contains("+ fn foo(a: i32, b: i32)"));
+        assert!(text.contains("-fn foo(a: i32) {}"));
+        assert!(text.contains("+fn foo(a: i32, b: i32) {}"));
     }
 
     #[test]
@@ -1496,7 +1671,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &pivot_selection,
                     &test_repo_root(),
@@ -1524,7 +1699,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &pivot_selection,
                     &test_repo_root(),
@@ -1609,6 +1784,7 @@ index e69de29..4b825dc 100644
 ";
         let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
         let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let diff_content = diff_content_for(&report, &diff_files, &app);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1617,7 +1793,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &diff_files,
+                    &diff_content,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1654,6 +1830,7 @@ index e69de29..4b825dc 100644
 ";
         let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
         let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let diff_content = diff_content_for(&report, &diff_files, &app);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1662,7 +1839,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &diff_files,
+                    &diff_content,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1692,6 +1869,7 @@ index e69de29..4b825dc 100644
 ";
         let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
         let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let diff_content = diff_content_for(&report, &diff_files, &app);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1700,7 +1878,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &diff_files,
+                    &diff_content,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1737,6 +1915,7 @@ index e69de29..4b825dc 100644
 ";
         let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
         let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let diff_content = diff_content_for(&report, &diff_files, &app);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1745,7 +1924,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &diff_files,
+                    &diff_content,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1795,6 +1974,7 @@ index e69de29..4b825dc 100644
 ";
         let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
         let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+        let diff_content = diff_content_for(&report, &diff_files, &app);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1803,7 +1983,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &diff_files,
+                    &diff_content,
                     &diff_highlights,
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1840,7 +2020,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1870,7 +2050,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1896,7 +2076,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -1936,7 +2116,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -2075,7 +2255,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -2106,7 +2286,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -2139,7 +2319,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -2178,7 +2358,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -2215,7 +2395,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -2381,7 +2561,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),
@@ -2431,7 +2611,7 @@ index e69de29..4b825dc 100644
                     frame,
                     &app,
                     &report,
-                    &[],
+                    &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
                     &PivotSelection::NotApplicable,
                     &test_repo_root(),

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -1647,9 +1647,9 @@ index e69de29..4b825dc 100644
             files: vec![],
         };
         // Row 0 is the collapsing "assets" dir; row 1 is the skipped file.
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::ToggleDiff);
+        // ADR 0020 defaults the right pane to Diff already, so no
+        // `ToggleDiff` press is needed to reach it here.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
         let diff_text = "\
 diff --git a/assets/logo.png b/assets/logo.png
 index e69de29..4b825dc 100644
@@ -1710,9 +1710,9 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
             files: vec![],
         };
         // Row 0 is the collapsing "vendor" dir; row 1 is the skipped file.
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::ToggleDiff);
+        // ADR 0020 defaults the right pane to Diff already, so no
+        // `ToggleDiff` press is needed to reach it here.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
         let diff_text = "\
 diff --git a/vendor/lib.zig b/vendor/lib.zig
 index e69de29..4b825dc 100644

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -1032,7 +1032,9 @@ mod tests {
     #[test]
     fn should_draw_entry_and_detail_panes_with_titles_on_entry_screen() {
         let report = report_with_one_symbol();
-        let app = App::new(&report);
+        // ADR 0020 defaults the right pane to Diff; `ToggleDiff` switches to
+        // Detail, which is what this test actually exercises.
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleDiff);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1076,7 +1078,10 @@ mod tests {
             hotspots: vec![],
             removed: vec![],
         };
-        let app = App::new(&report);
+        // ADR 0020 defaults the right pane to Diff, whose own placeholder
+        // text differs ("select a symbol or file row..."); `ToggleDiff`
+        // switches to Detail, whose placeholder is what this test checks.
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleDiff);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1115,7 +1120,12 @@ mod tests {
             hotspots: vec![],
             removed: vec![],
         };
-        let app = App::new(&report);
+        // ADR 0020 defaults the right pane to Diff; `ToggleDiff` switches to
+        // Detail, which is what this test actually exercises. (A directory
+        // row has no diff-specific content of its own, so leaving it on the
+        // default Diff pane would just show that pane's placeholder rather
+        // than the dir-detail content this test checks for.)
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleDiff);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1162,7 +1172,9 @@ mod tests {
             hotspots: vec![],
             removed: vec![],
         };
-        let app = App::new(&report);
+        // See the sibling test above for why `ToggleDiff` is needed to
+        // reach the Detail pane this test actually exercises.
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleDiff);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1290,9 +1302,9 @@ mod tests {
     #[test]
     fn should_draw_diff_pane_with_hunk_lines_when_toggled_on_a_symbol_row() {
         let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::ToggleDiff);
+        // ADR 0020 defaults the right pane to Diff already, so no
+        // `ToggleDiff` press is needed to reach it here.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
         let diff_text = "\
 diff --git a/lib.rs b/lib.rs
 index e69de29..4b825dc 100644
@@ -1583,9 +1595,9 @@ index e69de29..4b825dc 100644
     #[test]
     fn should_apply_added_background_tint_and_keyword_foreground_in_diff_pane() {
         let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::ToggleDiff);
+        // ADR 0020 defaults the right pane to Diff already, so no
+        // `ToggleDiff` press is needed to reach it here.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
         let diff_text = "\
 diff --git a/lib.rs b/lib.rs
 index e69de29..4b825dc 100644
@@ -1628,9 +1640,9 @@ index e69de29..4b825dc 100644
     #[test]
     fn should_apply_removed_background_tint_in_diff_pane() {
         let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::ToggleDiff);
+        // ADR 0020 defaults the right pane to Diff already, so no
+        // `ToggleDiff` press is needed to reach it here.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
         let diff_text = "\
 diff --git a/lib.rs b/lib.rs
 index e69de29..4b825dc 100644
@@ -1666,9 +1678,9 @@ index e69de29..4b825dc 100644
     #[test]
     fn should_keep_context_line_unstyled_background_in_diff_pane() {
         let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::ToggleDiff);
+        // ADR 0020 defaults the right pane to Diff already, so no
+        // `ToggleDiff` press is needed to reach it here.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
         let diff_text = "\
 diff --git a/lib.rs b/lib.rs
 index e69de29..4b825dc 100644
@@ -1711,9 +1723,9 @@ index e69de29..4b825dc 100644
     #[test]
     fn should_keep_hunk_header_dim_when_diff_pane_is_highlighted() {
         let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::ToggleDiff);
+        // ADR 0020 defaults the right pane to Diff already, so no
+        // `ToggleDiff` press is needed to reach it here.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
         let diff_text = "\
 diff --git a/lib.rs b/lib.rs
 index e69de29..4b825dc 100644
@@ -1769,9 +1781,9 @@ index e69de29..4b825dc 100644
             hotspots: vec![],
             removed: vec![],
         };
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::ToggleDiff);
+        // ADR 0020 defaults the right pane to Diff already, so no
+        // `ToggleDiff` press is needed to reach it here.
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
         let diff_text = "\
 diff --git a/config.yaml b/config.yaml
 index e69de29..4b825dc 100644
@@ -1815,7 +1827,11 @@ index e69de29..4b825dc 100644
     #[test]
     fn should_draw_detail_pane_content_when_cursor_is_on_a_symbol_row() {
         let report = report_with_one_symbol();
-        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+        // ADR 0020 defaults the right pane to Diff; `ToggleDiff` switches to
+        // Detail, which is what this test actually exercises.
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::ToggleDiff);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -2048,7 +2064,9 @@ index e69de29..4b825dc 100644
         // then all 40 symbols (43 lines total) — comfortably more than a
         // 20-row terminal's inner pane height can show at once.
         let report = report_with_many_symbols(40);
-        let app = App::new(&report);
+        // ADR 0020 defaults the right pane to Diff; `ToggleDiff` switches to
+        // Detail, which is what this test actually exercises.
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleDiff);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -2077,7 +2095,9 @@ index e69de29..4b825dc 100644
     #[test]
     fn should_not_show_overflow_indicator_when_content_fits_the_viewport() {
         let report = report_with_one_symbol();
-        let app = App::new(&report);
+        // See the test above for why `ToggleDiff` is needed to reach the
+        // Detail pane this test actually exercises.
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleDiff);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -2104,9 +2124,12 @@ index e69de29..4b825dc 100644
         let report = report_with_many_symbols(40);
         // `Open` on the file row (cursor starts there) reaches Focus::Right
         // (ADR 0020) without changing the selected row itself, so `Down`
-        // afterward scrolls instead of moving the cursor.
+        // afterward scrolls instead of moving the cursor. `ToggleDiff`
+        // switches from the default Diff pane to Detail, which is what this
+        // test actually exercises.
         let app = App::new(&report)
             .handle_key(crate::app::InputKey::Open)
+            .handle_key(crate::app::InputKey::ToggleDiff)
             .handle_key(crate::app::InputKey::Down);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
@@ -2139,7 +2162,11 @@ index e69de29..4b825dc 100644
         // report; the pane must clamp to its last full page rather than
         // showing a mostly-blank pane past the end of the content.
         let report = report_with_many_symbols(40);
-        let mut app = App::new(&report).handle_key(crate::app::InputKey::Open);
+        // `ToggleDiff` switches from the default Diff pane to Detail, which
+        // is what this test actually exercises.
+        let mut app = App::new(&report)
+            .handle_key(crate::app::InputKey::Open)
+            .handle_key(crate::app::InputKey::ToggleDiff);
         for _ in 0..1000 {
             app = app.handle_key(crate::app::InputKey::Down);
         }
@@ -2171,8 +2198,11 @@ index e69de29..4b825dc 100644
         // the newly selected row's own (short) detail must render from the
         // top, not carry over the file row's scroll offset.
         let report = report_with_many_symbols(40);
+        // `ToggleDiff` switches from the default Diff pane to Detail, which
+        // is what this test actually exercises.
         let app = App::new(&report)
             .handle_key(crate::app::InputKey::Open)
+            .handle_key(crate::app::InputKey::ToggleDiff)
             .handle_key(crate::app::InputKey::Down)
             .handle_key(crate::app::InputKey::Down)
             .handle_key(crate::app::InputKey::FocusLeft)
@@ -2330,7 +2360,14 @@ index e69de29..4b825dc 100644
             hotspots: vec![],
             removed: vec![],
         };
-        let mut app = App::new(&report).handle_key(crate::app::InputKey::Open);
+        // ADR 0020 defaults the right pane to Diff, whose own placeholder
+        // text also happens to embed the file path (`"(no diff hunks found
+        // for <path>)"`) — but not through this test's actual target,
+        // `render_scrollable_pane`'s wrap-before-scroll behavior, so
+        // `ToggleDiff` switches to Detail to keep exercising that.
+        let mut app = App::new(&report)
+            .handle_key(crate::app::InputKey::Open)
+            .handle_key(crate::app::InputKey::ToggleDiff);
         // Scroll far enough down to reach the wrapped tail of the long path
         // line, however many wrapped rows that turns out to be.
         for _ in 0..200 {
@@ -2383,7 +2420,9 @@ index e69de29..4b825dc 100644
             hotspots: vec![],
             removed: vec![],
         };
-        let app = App::new(&report);
+        // ADR 0020 defaults the right pane to Diff; `ToggleDiff` switches to
+        // Detail, which is what this test actually exercises.
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleDiff);
         let mut terminal = Terminal::new(TestBackend::new(34, 12)).expect("terminal");
 
         terminal

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -815,16 +815,21 @@ fn dir_detail_lines(detail: &DirDetail, origin: ReportOrigin) -> Vec<Line<'stati
 }
 
 /// Formats a [`FileDetail`] into displayable lines: a `File <path>` header,
-/// then either a skipped-file explanation, a whole-test-file explanation, or
-/// the ordinary "Symbols (N)" listing — the three are mutually exclusive by
-/// construction (`crate::tree::TreeNode`'s own doc comment on
-/// `skip_reason`/`test_symbol_count`: an ordinary analyzed file has neither
-/// set, a skipped file has no symbols to list, and a whole-test file has no
-/// per-symbol data at all, only the count `pipeline::partition_test_symbols`
-/// kept). Without this, a skipped or whole-test file's detail pane would
-/// show a bare "Symbols (0)" — indistinguishable from a file that genuinely
-/// changed nothing, which is exactly the gap this feature closes for the
-/// entry-tree row too (see `row_view::entry_row_line`).
+/// then a skipped-file explanation (returning early — a skipped file has no
+/// `symbols`/`test_symbol_count` of its own to show alongside it,
+/// `crate::tree::TreeNode::skip_reason`'s own doc comment on why that half
+/// of the split is a true either/or), followed by a whole/mixed-test-file
+/// note when `test_symbol_count` is set, followed by the ordinary "Symbols
+/// (N)" listing when `symbols` is non-empty. The last two are **not**
+/// mutually exclusive — `pipeline::partition_test_symbols` can populate both
+/// a `FileReport` (real, non-test symbols) and a `TestFileSummary` (a test
+/// count) for the same mixed-test-code path (`TreeNode::test_symbol_count`'s
+/// own doc comment), so a mixed file shows both the test note and its real
+/// symbols rather than one silently hiding the other. Without the
+/// skip/test-note lines at all, a skipped or whole-test file's detail pane
+/// would show a bare "Symbols (0)" — indistinguishable from a file that
+/// genuinely changed nothing, which is exactly the gap this feature closes
+/// for the entry-tree row too (see `row_view::entry_row_line`).
 fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
@@ -857,35 +862,39 @@ fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
             Style::default().fg(Color::Magenta),
         ));
         lines.push(Line::raw(
-            "Every changed symbol in this file is test code, excluded from the default view (see --include-tests).",
+            "Changed test-code symbols in this file are excluded from the default view (see --include-tests).",
         ));
-        return lines;
+        if !detail.symbols.is_empty() {
+            lines.push(Line::raw(""));
+        }
     }
 
-    lines.push(Line::styled(
-        format!("Symbols ({})", detail.symbols.len()),
-        Style::default().add_modifier(Modifier::BOLD),
-    ));
-    for symbol in &detail.symbols {
-        let marker = if symbol.removed {
-            "x"
-        } else {
-            match symbol.classification {
-                Some(Classification::Added) => "+",
-                Some(Classification::SignatureChanged) => "~",
-                Some(Classification::BodyOnly) | None => " ",
-            }
-        };
-        let fan_in = if symbol.fan_in > 0 {
-            format!(" ^{}", symbol.fan_in)
-        } else {
-            String::new()
-        };
-        lines.push(Line::raw(format!(
-            "  {marker} {} {}{fan_in}",
-            kind_abbrev(symbol.kind),
-            symbol.name,
-        )));
+    if !detail.symbols.is_empty() || detail.test_symbol_count.is_none() {
+        lines.push(Line::styled(
+            format!("Symbols ({})", detail.symbols.len()),
+            Style::default().add_modifier(Modifier::BOLD),
+        ));
+        for symbol in &detail.symbols {
+            let marker = if symbol.removed {
+                "x"
+            } else {
+                match symbol.classification {
+                    Some(Classification::Added) => "+",
+                    Some(Classification::SignatureChanged) => "~",
+                    Some(Classification::BodyOnly) | None => " ",
+                }
+            };
+            let fan_in = if symbol.fan_in > 0 {
+                format!(" ^{}", symbol.fan_in)
+            } else {
+                String::new()
+            };
+            lines.push(Line::raw(format!(
+                "  {marker} {} {}{fan_in}",
+                kind_abbrev(symbol.kind),
+                symbol.name,
+            )));
+        }
     }
 
     lines
@@ -1432,8 +1441,12 @@ mod tests {
         let report = report_with_one_skipped_file();
         // Row 0 is the collapsing "assets" dir (single child, see
         // `crate::tree::build_tree`'s collapsing rule); row 1 is the
-        // skipped "logo.png" file itself.
-        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+        // skipped "logo.png" file itself. ADR 0020 defaults the right pane
+        // to Diff, so `ToggleDiff` is needed here to reach Detail (unlike
+        // the pre-v2 default this test originally relied on).
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::ToggleDiff);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1481,7 +1494,11 @@ mod tests {
     fn should_draw_test_symbol_count_in_detail_pane_when_cursor_is_on_a_whole_test_file_row() {
         let report = report_with_one_test_file();
         // Row 0 is the collapsing "src" dir; row 1 is the whole test file.
-        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+        // ADR 0020 defaults the right pane to Diff, so `ToggleDiff` is
+        // needed here to reach Detail.
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::ToggleDiff);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -1505,6 +1522,61 @@ mod tests {
         // that survives the wrap rather than the whole phrase.
         assert!(text.contains("Test file: 3 changed test"));
         assert!(!text.contains("Symbols ("));
+    }
+
+    // Regression test (post-rebase integration check): a mixed file — real
+    // symbols in `report.files` *and* a test-symbol count in `report.tests`
+    // for the same path (`pipeline::partition_test_symbols`'s legitimate
+    // output for a file with both production and test code changed) — must
+    // show both the test-file note and the real "Symbols (N)" listing in
+    // the detail pane, not just one. This is the exact shape that caused a
+    // live panic (`rinkaku-tui/src/app.rs` in this repo's own diff) before
+    // `TreeBuilder::insert_test_file` stopped rejecting a file that already
+    // carries real symbols.
+    #[test]
+    fn should_draw_both_test_note_and_real_symbols_in_detail_pane_when_file_is_mixed() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "app.rs".to_string(),
+                symbols: vec![symbol("app.rs::handle_key", "handle_key")],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![rinkaku_core::render::TestFileSummary {
+                path: "app.rs".to_string(),
+                symbol_count: 5,
+            }],
+            hotspots: vec![],
+            removed: vec![],
+        };
+        // Row 0 is the "app.rs" file row itself.
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleDiff);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &PivotSelection::NotApplicable,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("File app.rs"));
+        assert!(text.contains("Test file: 5 changed test"));
+        assert!(text.contains("Symbols (1)"));
+        assert!(text.contains("handle_key"));
     }
 
     #[test]

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -2102,7 +2102,12 @@ index e69de29..4b825dc 100644
     #[test]
     fn should_scroll_detail_pane_content_down_when_scroll_down_is_pressed() {
         let report = report_with_many_symbols(40);
-        let app = App::new(&report).handle_key(crate::app::InputKey::ScrollDown);
+        // `Open` on the file row (cursor starts there) reaches Focus::Right
+        // (ADR 0020) without changing the selected row itself, so `Down`
+        // afterward scrolls instead of moving the cursor.
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Open)
+            .handle_key(crate::app::InputKey::Down);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -2134,9 +2139,9 @@ index e69de29..4b825dc 100644
         // report; the pane must clamp to its last full page rather than
         // showing a mostly-blank pane past the end of the content.
         let report = report_with_many_symbols(40);
-        let mut app = App::new(&report);
+        let mut app = App::new(&report).handle_key(crate::app::InputKey::Open);
         for _ in 0..1000 {
-            app = app.handle_key(crate::app::InputKey::ScrollDown);
+            app = app.handle_key(crate::app::InputKey::Down);
         }
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
@@ -2167,8 +2172,10 @@ index e69de29..4b825dc 100644
         // top, not carry over the file row's scroll offset.
         let report = report_with_many_symbols(40);
         let app = App::new(&report)
-            .handle_key(crate::app::InputKey::ScrollDown)
-            .handle_key(crate::app::InputKey::ScrollDown)
+            .handle_key(crate::app::InputKey::Open)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::FocusLeft)
             .handle_key(crate::app::InputKey::Down);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
@@ -2323,11 +2330,11 @@ index e69de29..4b825dc 100644
             hotspots: vec![],
             removed: vec![],
         };
-        let mut app = App::new(&report);
+        let mut app = App::new(&report).handle_key(crate::app::InputKey::Open);
         // Scroll far enough down to reach the wrapped tail of the long path
         // line, however many wrapped rows that turns out to be.
         for _ in 0..200 {
-            app = app.handle_key(crate::app::InputKey::ScrollDown);
+            app = app.handle_key(crate::app::InputKey::Down);
         }
         let mut terminal = Terminal::new(TestBackend::new(34, 12)).expect("terminal");
 


### PR DESCRIPTION
## Summary

Implements the TUI interaction model v2 designed in ADR 0020
(`docs/adr/0020-tui-interaction-model-v2.md`), replacing five
independently-accreted keybinding decisions with one consistent rule:
**motion keys act on whichever pane has focus.**

- **Focus model**: `Focus { Tree, Right }` on `App`. `j`/`k` move the
  tree cursor while `Focus::Tree` (default); the same keys scroll the
  right pane by one line while `Focus::Right`. `Enter` on a file/symbol
  row moves focus to `Right` in addition to its existing select
  behavior; `h`/`Esc` return focus to `Tree`. `d`/`p`/`s`/`o`/`q` stay
  global (mode/screen transitions, not motion).
- **Breaking keymap change**: `Shift+J`/`Shift+K` (`InputKey::ScrollUp`/
  `ScrollDown`) are removed — scrolling is now exactly "plain `j`/`k`
  while `Focus::Right`". No backward-compatibility concern: the TUI has
  never shipped a release.
- **Diff is now the default right pane** (`RightPane::default()`:
  `Detail` → `Diff`) — "what changed" ahead of the aggregated
  used-by/callers view. `--entry --tui` is unaffected; it already
  overrides the default explicitly.
- **Selection-scoped diff shaping**: a file selection now groups hunks
  under per-symbol section headers (source order), with a trailing
  "(module level)" section for hunks outside any symbol's range, and a
  red/green contract header (`- <previous_signature>` / `+
  <signature>`) ahead of a symbol's hunks when its signature changed —
  matching the Detail pane's own `SignatureView::Changed` styling. This
  shaping is a new pure module, computed once per handled key in
  `run_app` and cached (never recomputed inside `ui::draw`, which runs
  on every ~100ms idle poll) — the same discipline that already fixed
  the pivot pane's per-frame recompute bug.
- **`]`/`[` hunk jump** while the right pane shows Diff, jumping the
  scroll offset to the next/previous hunk boundary from the same shaped
  content (no re-parsing).
- **`?` help overlay**: centered, keymap + glossary, focus-aware
  content, consumes all keys including `q` while open.
- **Status line**: always shows the current order mode
  (`OrderMode::Topological`/`AlphaNumeric`); key-hint segment switches
  by focus, with a `?` mention in both.

See the ADR for the full design rationale, including alternatives
considered and rejected (duplicate hunk attribution across symbols,
modal full-screen help, folding the shaping logic into `ui.rs` or
`diff_view.rs`).

## Review process

Both review passes from `CLAUDE.md`'s "Reviewing changes" rule were
run, plus mandatory dynamic verification; recorded as experiment 0001
round 11 (`docs/experiments/0001-map-assisted-llm-review/rounds/011.md`).

- **Map-assisted pass**: the map (42 changed symbols / 8 files) routed
  attention correctly to the draw-path recompute invariant (broken
  twice before, in rounds 3 and 7) — it held this time. The pass's best
  finding was invisible to the map itself: `]`/`[` hunk jump was gated
  only on `Focus::Right`, not on `RightPane::Diff` specifically,
  causing stale-offset scroll jumps when the right pane showed Detail
  or Pivot. Found by reading `handle_key`'s own doc comment against its
  own code and chasing the unfulfilled promise into `run_app`.
- **Independent pass**: found a parser-level bug (pure-deletion hunks —
  new-side hunk-header count of 0 — parsed to `new_range: None` and
  silently vanished from symbol-scoped diffs instead of attributing to
  the owning symbol), an ADR title split across two H1 headers, and a
  `Space`/help-overlay inconsistency.
- Zero overlap between the two passes' findings this round, consistent
  with every round since round 4.
- **Process note outside either pass**: rebase integration ahead of
  this PR surfaced a real panic via live dogfooding — PR #58's
  `debug_assert!` rejecting the legitimate case of a file carrying both
  real symbols and a test-symbol count, an inter-PR semantic conflict
  neither PR's own test suite could catch in isolation. Argues for
  applying the "build and run the changed surface" rule at rebase/
  integration points too, not only in review passes.

### Fixes shipped in response

- `should_apply_hunk_jump` pure helper gating `]`/`[` on `Focus::Right`
  *and* `RightPane::Diff` together.
- Zero-width position retention for pure-deletion hunks, with the
  half-open boundary rule (`position == range_end` is not "inside")
  pinned empirically via a `git diff -U0` experiment.
- `Space` gated to `Focus::Tree`, matching the row-acting half of
  `Enter`.
- ADR 0020 title collapsed back to a single H1.
- PR #58's `debug_assert!` relaxed to accept the mixed
  real-symbol-and-test-count case.

## Verification

- `make test`: 345 passed, 0 failed.
- `make lint`: clean.
- Manual tmux pass through the real binary covering: focus transitions
  in both directions, `]`/`[` hunk jump restricted correctly to
  `Focus::Right` + `RightPane::Diff`, file-selection diff grouping with
  module-level trailing section, contract headers on signature
  changes, `?` overlay open/close from every context including while a
  quit-key press is pending, and status line focus-aware hints.
- Confirmed the scenario expected to be riskiest — bare `rinkaku` (no
  `--base`, no diff input) with the new Diff-by-default right pane —
  degrades correctly rather than showing a broken/empty diff pane.

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync
