### PR TITLE
feat(tui): jump to callers/callees with gd/gr and a jumplist

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,9 +490,13 @@ The interface follows a **focus** model ([ADR 0020](docs/adr/0020-tui-interactio
 similar to neovim's window/pane idioms: at any moment, either the tree
 (left pane) or the right-hand pane has focus, and `j`/`k` act on whichever
 one does. `enter` on a file/symbol row moves focus to the right pane;
-`h`/`esc` moves it back to the tree. Press `?` any time for an in-app
-overlay listing every key and a short glossary (order modes, pivot,
-cycle).
+`h`/`esc` moves it back to the tree. `gd`/`gr` jump to a callee/caller of
+the selected symbol and `ctrl-o`/`ctrl-i` move back/forward through a
+jumplist of those jumps, both borrowed from neovim too
+([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md), see
+[Jump navigation](#jump-navigation-gd--gr) below). Press `?` any time for
+an in-app overlay listing every key and a short glossary (order modes,
+pivot, cycle, jumplist).
 
 ### What it shows
 
@@ -600,6 +604,10 @@ grouped by focus.
 | `d` / `D` | Toggle the right-hand pane between diff and detail |
 | `p` / `P` | Toggle the right-hand pane to the pivot tree rooted at the selected directory/file |
 | `s` / `S` | Open the source view for the symbol under the cursor |
+| `gd` | Jump to a callee of the symbol under the cursor ([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md)) |
+| `gr` | Jump to a caller of the symbol under the cursor |
+| `ctrl-o` | Jump back to the previous jumplist location |
+| `ctrl-i` | Jump forward to the next jumplist location |
 | `?` | Toggle the help overlay (keymap + glossary) |
 | `esc` / `q` | Return to the entry view (from the source view) |
 | `q` / `ctrl-c` | Quit (from the entry view) |
@@ -607,6 +615,27 @@ grouped by focus.
 Glyphs are plain ASCII (`~`/`!`/`^`/`+`/`x`, `v`/`>` for expand state)
 rather than Unicode/emoji, for compatibility with plainer terminal
 configurations.
+
+### Jump navigation (`gd` / `gr`)
+
+While reading a diff or its detail, `gd` jumps toward a callee of the
+symbol under the cursor and `gr` jumps toward a caller — a two-key
+sequence (press `g` then `d`/`r`), mirroring neovim's own "go to
+definition"/"go to references" idiom
+([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md)). Works
+regardless of focus, but only when the cursor sits on a symbol row: zero
+candidates shows a status-line note, one candidate jumps immediately, and
+more than one opens a popup (`j`/`k` to choose, `enter` to jump, `esc` to
+cancel). A jump moves the tree cursor to the target symbol — expanding any
+collapsed ancestor directories along the way — and shows its Diff, without
+moving focus off the right pane, so you keep reading rather than switching
+back to tree browsing.
+
+Every jump is recorded in a jumplist: `ctrl-o` returns to where you jumped
+from, and `ctrl-i` moves forward again after a `ctrl-o` — the same
+back/forward history neovim's own jumplist keeps. Jumping to a new
+location from the middle of that history discards whatever forward
+entries existed, the same way neovim's does.
 
 ## Using rinkaku with LLM reviewers
 

--- a/docs/adr/0022-jump-navigation-and-jumplist.md
+++ b/docs/adr/0022-jump-navigation-and-jumplist.md
@@ -153,6 +153,24 @@ tick, following ADR 0020 decision 5's caching discipline (`crate::run_app`
 computes it once per handled key, hands it to `ui::draw`, which never
 calls the computation itself).
 
+Both the popup and the tree pane (`crate::ui::draw_jump_popup`/
+`draw_tree_pane`) window their content around the current cursor —
+`crate::ui::windowed_rows_with_indicators`, mirroring `crate::source::
+visible_window`'s centering approach for the source drill-down — so the
+highlighted candidate/row is always inside the visible viewport, with dim
+"… N more above/below" lines when the window does not reach an edge of the
+list. An earlier draft of this feature instead let excess content
+"wrap/scroll off" via `ratatui::widgets::Wrap` alone with no scroll offset
+at all (the same tradeoff `draw_help_overlay`'s fixed-size keymap box
+accepts, reasonable there since the keymap is fixed and short); caught in
+review, that meant a popup or tree taller than its box could highlight or
+land on a row with zero visual feedback — a jump feature whose own target
+is invisible defeats its purpose. The tree pane's own unscrolled-`Paragraph`
+gap predates this ADR (it already existed on `main`) but is fixed here too,
+since an invisible jump landing spot makes the tree pane's half of the same
+underlying bug block this feature just as completely as the popup's half
+would.
+
 ## Alternatives
 
 - **A general prefix-tree/chord parser in `translate_key` for arbitrary

--- a/docs/adr/0022-jump-navigation-and-jumplist.md
+++ b/docs/adr/0022-jump-navigation-and-jumplist.md
@@ -129,6 +129,23 @@ the mirror image. A recorded location is `(symbol_id, right_pane_scroll)`
 like the order mode or which overlay was open. Both are no-ops (with a
 status message) when their respective stack is empty.
 
+`crate::lib::translate_key` maps *both* a real `Ctrl-i` keypress
+(`KeyCode::Char('i')` + `CONTROL`) and plain `KeyCode::Tab` to
+`InputKey::JumpForward` — confirmed necessary via manual testing against a
+real terminal (tmux), not assumed from documentation: Ctrl-I and Tab share
+the same control code (0x09) at the terminal protocol level, so without
+Kitty's keyboard-enhancement protocol (which this crate does not enable),
+a genuine `Ctrl-i` press arrives as `KeyCode::Tab`, and the modifier-based
+pattern alone silently never matches in practice. `Ctrl-o` needed no such
+fallback (0x0F is not reused by another named key crossterm reports).
+
+**Verification note**: this Tab/Ctrl-I mapping gap was only caught by
+actually running the built binary in a real terminal and pressing the key
+— unit tests alone (which construct `KeyEvent`s directly with the
+modifier already set) could not have caught it, and did not. This is the
+exact class of bug CLAUDE.md's "dynamic verification" review step exists
+to catch.
+
 **5. The popup's view-model is pure, built the same way `crate::help`'s
 content is** — a plain struct (`JumpCandidate { id, name, path }` list)
 computed once when the popup opens, not re-derived on every draw

--- a/docs/adr/0022-jump-navigation-and-jumplist.md
+++ b/docs/adr/0022-jump-navigation-and-jumplist.md
@@ -1,0 +1,198 @@
+# 0022. Caller/callee jump navigation and a jumplist
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+ADR 0020 gave the detail pane a `callers`/`callees` pivot (`DetailView`)
+and the diff pane a hunk-jump binding (`]`/`[`), but reading a diff still
+frequently raises a question the interaction model has no answer for:
+"who calls this?" or "what does this call?" while looking at a symbol's
+diff, not its aggregated detail. Today the only way to act on that
+question is to press `d` to switch to the Detail pane, read the
+`callers`/`callees` list as plain text, then manually scroll/search the
+tree for a matching row — there is no way to jump the cursor there
+directly, and no way back to the exact spot in the diff the reviewer was
+reading before asking the question.
+
+This is the "follow" step of a reviewer's reading loop, in the same spirit
+as the map-assisted review workflow documented in
+[experiment 0001](../experiments/0001-map-assisted-llm-review/README.md):
+orient (map), read (diff pane), follow (jump to a related symbol), come
+back. ADR 0020 built "orient" and "read"; this ADR builds "follow" and
+"come back".
+
+**Reference model**: neovim's `gd` (go to definition), `gr` (go to
+references) and its jumplist (`Ctrl-o`/`Ctrl-i` to move backward/forward
+through visited locations) — the same reference model ADR 0020 already
+draws on for focus and hunk-jumping, so a reviewer fluent in neovim gets
+this gesture for free too, and a reviewer who is not still gets one
+consistent rule reinforced by the `?` overlay.
+
+## Decision
+
+**1. `gd`/`gr` jump to a callee/caller of the symbol under the cursor.**
+`gd` ("go to definition") jumps toward what the selected symbol *calls*
+(its callees); `gr` ("go to references") jumps toward what *calls* the
+selected symbol (its callers) — matching neovim's own mnemonic split
+(`gd` toward the thing defined, `gr` toward the things referencing it).
+Candidates are read from the same edge set `crate::detail::build_detail`
+already computes (`report.graph.edges`, deduped and self-edge-filtered)
+via a small pure function extracted from that logic (`crate::detail::
+symbol_mentions`) rather than a second, independent traversal — ADR
+0020's own "one file, one responsibility" precedent applies at function
+scope here too: the edge-walk-and-dedupe logic belongs in `detail.rs`
+regardless of which caller (the Detail pane or this feature) needs the
+result.
+
+Only a symbol row is a valid jump source — `gd`/`gr` pressed on a
+directory or file row sets a status-line message ("no symbol selected")
+and does nothing else, since callers/callees are a per-symbol relation
+with no defined meaning at the directory/file granularity (mirroring
+`App::selected_diff_target`'s own `NodeKind::Dir => None` precedent).
+Valid regardless of [`Focus`](../../rinkaku-tui/src/app.rs) (`Tree` or
+`Right`) — the "thing being read" is the selected symbol either way, and
+gating the gesture to one focus would only make the reviewer switch focus
+first for no reason.
+
+Candidate count decides what happens next:
+
+- **Zero candidates**: a status-line message ("no callees" / "no
+  callers") — a no-op otherwise, exactly like today's
+  `App::selected_diff_target`'s `None` cases render a placeholder rather
+  than erroring.
+- **One candidate**: jump immediately (decision 3 below) — no popup for a
+  single unambiguous target, since a selection UI for one option only
+  adds a keystroke.
+- **Multiple candidates**: open a selection popup listing every
+  candidate (name + path), `j`/`k` to move the popup's own selection,
+  `Enter` to jump to the highlighted one, `Esc` to cancel without
+  jumping. Styled and composited the same way `?`'s help overlay already
+  is (`ui::draw_help_overlay`'s `Clear` + centered bordered box) — a
+  second, independent overlay concept was considered and rejected (see
+  Alternatives) in favor of reusing that one.
+
+**2. `g` is a minimal two-key prefix, not a new general chord engine.**
+`App` gains one field, `pending_prefix: Option<PendingPrefix>`
+(`PendingPrefix` today has exactly one variant, `G`), set when `g` is
+pressed and cleared on the very next key regardless of what that key is.
+If the next key is `d` or `r`, it resolves to `GotoDefinition`/
+`GotoReferences`; any other key discards the pending prefix and falls
+through to that key's own ordinary meaning (so `gg`, `gx`, or `g` followed
+by an unrelated action never gets stuck waiting) — `crate::lib::
+translate_key` owns this, mirroring how it already owns the `?`-overlay
+short-circuit (ADR 0020) as the one place raw `crossterm` key sequences
+become this crate's `InputKey`s, rather than teaching `App::handle_key`
+about raw key codes. No timeout: a `g` press with no follow-up simply sits
+pending until the next key arrives, which is fine for a single hard-coded
+two-key sequence (unlike a general chord engine, where an un-resolving
+prefix would need a timeout to avoid confusing the reviewer about why nothing
+happened) — see Alternatives for why a general prefix-tree parser was
+rejected in favor of this hard-coded one.
+
+**3. A jump moves the tree cursor to the target symbol, expanding
+collapsed ancestors, and keeps focus on [`Focus::Right`] showing that
+symbol's Diff.** `crate::nav::Nav` gains
+`move_cursor_to_symbol(symbol_id)`, a sibling to the existing
+`move_cursor_to_path` (which deliberately excludes symbol rows — see that
+method's own doc comment) rather than a generalization of it: pivoting
+(`move_cursor_to_path`'s only caller) has no single-symbol-scoped
+meaning, and jump navigation has no directory/file-scoped meaning, so the
+two stay separate one-purpose functions instead of one function with a
+kind-filtering parameter that would make both call sites less obviously
+correct. `move_cursor_to_symbol` additionally expands every collapsed
+ancestor directory/file on the path to the target — unlike
+`move_cursor_to_path`'s "no-op if hidden under a collapsed ancestor"
+contract (appropriate for `--entry`'s startup-time pivot, where a fresh
+`App::new` is always fully expanded and a miss is genuinely a wrong
+path), a mid-session jump target is very likely to be hidden by then, and
+silently failing to jump because *some unrelated fold state* happens to
+hide it would defeat the feature's own purpose. Focus stays `Right` (does
+not force `Tree`) so the reviewer's reading flow is not interrupted —
+the diff pane simply now shows the jumped-to symbol.
+
+**4. A jumplist records where each jump came from, with `Ctrl-o`/
+`Ctrl-i` to move back/forward through it**, mirroring vim's own jumplist
+semantics: a new `Self::GotoDefinition`/`GotoReferences` jump pushes the
+*pre-jump* location onto a back-stack (capped at 100 entries, oldest
+dropped — a reviewing session realistically never needs more, and an
+unbounded stack is an unnecessary unbounded-growth risk for a
+long-running TUI session) and clears the forward-stack (any location the
+reviewer had already jumped back past is now stale — vim's own jumplist
+does the same: jumping to a new location from the middle of history
+discards the abandoned future). `Ctrl-o` pops the back-stack, pushes the
+*current* location onto the forward-stack, and moves there; `Ctrl-i` is
+the mirror image. A recorded location is `(symbol_id, right_pane_scroll)`
+— just enough to restore "what the reviewer was looking at", not a full
+`App` snapshot, since jumping back should not also undo unrelated state
+like the order mode or which overlay was open. Both are no-ops (with a
+status message) when their respective stack is empty.
+
+**5. The popup's view-model is pure, built the same way `crate::help`'s
+content is** — a plain struct (`JumpCandidate { id, name, path }` list)
+computed once when the popup opens, not re-derived on every draw
+tick, following ADR 0020 decision 5's caching discipline (`crate::run_app`
+computes it once per handled key, hands it to `ui::draw`, which never
+calls the computation itself).
+
+## Alternatives
+
+- **A general prefix-tree/chord parser in `translate_key` for arbitrary
+  future `g`-prefixed bindings**: over-engineered for exactly one
+  two-key sequence today: a real chord engine needs a timeout policy,
+  ambiguity resolution between prefixes of different lengths, and a way
+  to surface "waiting for next key" in the status line — none of which
+  this feature needs yet. Rejected in favor of the minimal
+  `pending_prefix: Option<PendingPrefix>` field; if a second `g`-prefixed
+  binding is added later, revisit then rather than speculatively now.
+- **A dedicated jump-target overlay type, separate from the `?` help
+  overlay's rendering path**: would duplicate the `Clear` + centered
+  bordered box + `Esc`-to-close plumbing `draw_help_overlay` already
+  has. Rejected in favor of a second content variant drawn through the
+  same compositing step (`ui::draw`'s "overlay draws last, on top of
+  whatever screen was already rendered" structure already generalizes to
+  more than one overlay kind without change).
+- **Automatically disambiguating multiple candidates by proximity (same
+  file first, same directory next) instead of a selection popup**: was
+  considered so a common case ("call this same-file helper") never needs
+  a popup at all. Rejected for v1: ADR 0020's own hunk-attribution
+  precedent (multiple-symbol overlap resolved by *first* source-order
+  match, not a fancier heuristic) favors the simplest rule that is still
+  correct; proximity ranking can be layered on top of the popup's sort
+  order later without changing this ADR's "0/1/many" branching.
+- **Forcing focus back to `Tree` on jump** (so the reviewer sees the
+  cursor land, tree-explorer style): rejected because the point of `gd`/
+  `gr` is to keep reading the *content* of the jumped-to symbol, not to
+  browse the tree — ADR 0020's own Enter-on-file/symbol-row behavior
+  already established "drilling in moves focus right", and a jump is a
+  more targeted version of the same drill-in, not a return to tree
+  browsing.
+- **Storing a full `App` snapshot per jumplist entry** (so `Ctrl-o` could
+  restore literally everything, including order mode and open panes):
+  rejected as both heavier (100 full `App` clones) and surprising —
+  jumping back should undo *where you were reading*, not silently flip
+  the order mode back too if the reviewer happened to toggle it in
+  between. A `(symbol_id, right_pane_scroll)` pair is the minimal state
+  that answers "what was I looking at".
+
+## Consequences
+
+- `App` gains two more pieces of state (`pending_prefix`, the jumplist's
+  two stacks) and `InputKey` gains five more variants — a real complexity
+  addition, accepted for the same reason ADR 0020 accepted `Focus`: a
+  concrete, board-level dogfooding gap ("I can't act on 'who calls
+  this?' without losing my place") costs more in practice than the added
+  state-machine surface.
+- `crate::detail::symbol_mentions`'s extraction is a pure refactor of
+  already-tested logic (`build_detail`'s existing dedup/self-edge-filter
+  tests continue to cover it indirectly); this feature's own tests cover
+  the extracted function directly rather than only through
+  `build_detail`.
+- The jumplist is session-local (cleared on process exit, like every
+  other piece of `App` state) — no persistence across TUI invocations is
+  attempted or implied by this ADR.
+- A future popup-driven feature (e.g. "jump to any hotspot") could reuse
+  the same overlay-compositing path this ADR generalizes
+  (`ui::draw`'s "draw last, on top" step) without another architectural
+  decision.

--- a/docs/experiments/0001-map-assisted-llm-review/rounds/012.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/012.md
@@ -1,0 +1,55 @@
+# Round 12
+
+- Subject: `gd`/`gr` caller/callee jump navigation plus a vim-style
+  jumplist (ADR 0022), 9 commits.
+- Map-assisted pass: the map showed 29 changed symbols across 5 files;
+  its hotspots (`App`, `InputKey`, `JumpPopup`, `JumplistEntry`,
+  `PendingPrefix`) routed attention straight to the state-machine
+  seams. Its finding: `pending_prefix` was only cleared inside
+  `App::handle_key`, but `run_app` intercepts `GotoDefinition`/
+  `GotoReferences` before `handle_key` runs — so the very next `d`/`r`
+  keystroke after a jump got misparsed as the start of another `gd`/
+  `gr` sequence, violating ADR 0022's own "any other key discards the
+  prefix" guarantee. This was invisible to the map itself (a
+  which-function-owns-this-state-update contract, not a signature
+  change); it was found by reading the doc comment against the two
+  dispatch paths it's supposed to govern. Existing unit tests missed it
+  because they drive `handle_key` directly, bypassing the `run_app`
+  route where the interception actually happens — the same
+  test-drives-the-wrong-entry-point gap as several earlier rounds.
+- Independent + dynamic pass: both blockers this round were dynamic-
+  only finds, invisible to any static or signature-level read. (a) The
+  jump popup had no windowing: candidates beyond the visible box were
+  still selectable but never rendered, provable only by pressing `j`
+  repeatedly and landing on a candidate that never appeared on screen.
+  (b) The tree pane never scroll-follows the cursor — a pre-existing
+  defect already on `main` (independently reported by the user
+  dogfooding `main` the same day) that the jump feature turns from a
+  minor annoyance into a feature-defeating bug, since a jump routinely
+  lands the cursor outside the visible window.
+- Two further dynamic-only finds bracketed the round outside the
+  formal two-pass review. During implementation, `Ctrl-i` arrived as
+  `Tab` (0x09) in a real terminal, so `JumpForward` silently never
+  fired despite its unit test passing — the test constructs a
+  `KeyEvent` with modifiers pre-set, which cannot exercise the
+  terminal-protocol collapse of `Ctrl-i` and `Tab` onto the same byte.
+  During the fix for the popup windowing, naive indicator rows
+  (showing "N more above/below") overflowed the popup viewport and
+  could push the cursor's own row off-screen; caught by a 25-candidate
+  draw test and fixed by reserving indicator rows via a fixed-point
+  search rather than appending them after the fact.
+- Fixes shipped: a single choke-point for clearing `pending_prefix`
+  (extracted into `dispatch_non_source_key`, with regression tests
+  driven through the same `run_app`-adjacent path the bug lived in,
+  verified fail-before/pass-after); a shared
+  `windowed_rows_with_indicators` helper windowing both the tree pane
+  and the jump popup around the cursor/selection.
+- This round's overlap pattern matches the experiment's running theme:
+  the map pass found a wiring/ownership defect one level below the
+  signature surface; the independent+dynamic pass found defects one
+  level below *that* — rendering geometry and live terminal key-flow
+  that no amount of static reading (map or otherwise) could have
+  shown. Nearly every real defect this round lived below both the
+  signature surface and the static-code surface, reinforcing that
+  dynamic verification remains the strongest predictor of real
+  behavioral findings.

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -10,7 +10,8 @@
 //! into `ratatui` to draw.
 
 use crate::detail::{
-    DetailView, DirDetail, FileDetail, build_detail, build_dir_detail, build_file_detail,
+    DetailView, DirDetail, FileDetail, SymbolMention, build_detail, build_dir_detail,
+    build_file_detail,
 };
 use crate::nav::{Action, Nav};
 use crate::order::{DirRank, OrderMode, rank_directories};
@@ -98,6 +99,49 @@ pub enum InputKey {
     /// physical key to this one variant either way, and `App::handle_key`
     /// treats it as a toggle.
     ToggleHelp,
+    /// `g`, when no `g`-prefixed sequence is already pending (ADR 0022):
+    /// records that `g` was just pressed so the very next key can resolve
+    /// `gd`/`gr` (`crate::lib::translate_key` consults
+    /// `App::pending_prefix` to do that resolution). Every key clears any
+    /// previously pending prefix (`App::handle_key`'s own doc comment) —
+    /// this variant is what *sets* it in the first place.
+    PendingGoto,
+    /// `gd` (a two-key sequence, ADR 0022): jump toward a callee of the
+    /// symbol under the cursor. Candidate resolution needs `report`
+    /// (`report.graph.edges`, via `crate::detail::symbol_mentions`), which
+    /// `App::handle_key` does not have access to — mirroring
+    /// `InputKey::NextHunk`/`PrevHunk`'s own precedent (that jump target
+    /// needs the shaped diff content `App` also lacks), `crate::run_app`
+    /// resolves candidates before calling into `App` at all, via
+    /// `App::begin_goto`/`App::jump_to_symbol`/`App::open_jump_popup`
+    /// rather than this `InputKey` variant reaching `App::handle_key`'s
+    /// match directly. Kept as its own `InputKey` variant regardless (rather
+    /// than folding the two `g`-prefixed keys into `PendingGoto`'s own
+    /// resolution) so `crate::lib::translate_key`'s key-to-intent mapping
+    /// stays legible independent of where the intent is actually processed.
+    GotoDefinition,
+    /// `gr`: the caller-direction mirror of [`Self::GotoDefinition`].
+    GotoReferences,
+    /// Ctrl-o: moves backward through the jumplist (ADR 0022) — the
+    /// mirror-image of vim's own `Ctrl-o`. A no-op (with a status message)
+    /// when the back-stack is empty.
+    JumpBack,
+    /// Ctrl-i: moves forward through the jumplist (ADR 0022), the reverse of
+    /// [`Self::JumpBack`]. A no-op (with a status message) when the
+    /// forward-stack is empty.
+    JumpForward,
+    /// Enter, while the jump-target popup (ADR 0022) is open: jumps to the
+    /// popup's currently highlighted candidate and closes it. Reuses
+    /// [`Self::Open`]'s physical key (`crate::lib::translate_key` maps Enter
+    /// to `Open` regardless of context, mirroring how `?` already maps to
+    /// the same [`Self::ToggleHelp`] variant whether the help overlay is
+    /// open or not) rather than adding a dedicated variant only the popup
+    /// would ever produce.
+    PopupConfirm,
+    /// Esc, while the jump-target popup is open: closes it without jumping.
+    /// Reuses [`Self::Back`]'s physical key for the same reason
+    /// `PopupConfirm` reuses `Open`'s.
+    PopupCancel,
 }
 
 /// Which pane currently receives motion keys (ADR 0020): [`Focus::Tree`]
@@ -197,6 +241,67 @@ pub enum PivotSelection {
     View(crate::pivot::PivotView),
 }
 
+/// A `g`-prefixed two-key sequence awaiting its second key (ADR 0022's
+/// minimal prefix state machine — not a general chord engine, see that
+/// ADR's own Alternatives). Today's only prefix is `g`; the variant exists
+/// so `App`'s `pending_prefix` field reads as "which prefix, if any" rather
+/// than a bare `bool` that would only ever mean "g was just pressed".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingPrefix {
+    G,
+}
+
+/// One candidate in the jump-target popup (ADR 0022) — the same identity
+/// [`SymbolMention`] already carries, kept as a separate type rather than
+/// reusing `SymbolMention` directly so the popup's own view-model is not
+/// coupled to the Detail pane's type if the two ever need to diverge (e.g.
+/// the popup later gaining a fan-in count `SymbolMention` doesn't carry).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JumpCandidate {
+    pub id: String,
+    pub name: String,
+    pub path: String,
+}
+
+impl From<&SymbolMention> for JumpCandidate {
+    fn from(mention: &SymbolMention) -> Self {
+        Self {
+            id: mention.id.clone(),
+            name: mention.name.clone(),
+            path: mention.path.clone(),
+        }
+    }
+}
+
+/// The jump-target popup's state (ADR 0022) while it is open: every
+/// candidate found for the pending `gd`/`gr` press, plus which one the
+/// popup's own `j`/`k` cursor currently highlights. Mirrors `help_open`'s
+/// flag-not-`Screen` design (`App::help_open`'s own doc comment) for the
+/// same reason: the popup sits on top of whatever was already showing and
+/// closing it (via `PopupConfirm` or `PopupCancel`) must not disturb that
+/// underlying state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JumpPopup {
+    pub candidates: Vec<JumpCandidate>,
+    pub cursor: usize,
+}
+
+/// One jumplist entry (ADR 0022): just enough state to restore "what the
+/// reviewer was looking at" — the symbol and the right pane's scroll offset
+/// into it — deliberately not a full `App` snapshot (see the ADR's own
+/// Alternatives on why a full snapshot was rejected).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct JumplistEntry {
+    symbol_id: String,
+    right_pane_scroll: usize,
+}
+
+/// The jumplist's cap (ADR 0022 decision 4): oldest entries are dropped
+/// once the back-stack would exceed this, since a reviewing session
+/// realistically never needs more and an unbounded stack is an unnecessary
+/// unbounded-growth risk for a long-running TUI session.
+const JUMPLIST_CAP: usize = 100;
+
 /// The whole interactive application's state: the stage-A view-models
 /// composed together, plus which screen is active and a status-line
 /// message for the caller to render. Rebuilt once per `Report` (in
@@ -251,6 +356,25 @@ pub struct App {
     /// free by construction: nothing else about `App`'s state changes while
     /// the overlay is open.
     help_open: bool,
+    /// A `g`-prefixed sequence's first key, awaiting its second (ADR 0022) —
+    /// `None` outside that one-key window. Set by `g` and cleared by
+    /// *every* subsequent key regardless of what it is (`crate::lib::
+    /// translate_key` owns the actual resolution into `GotoDefinition`/
+    /// `GotoReferences`/fall-through, this field only remembers that `g` was
+    /// the previous key so `translate_key` has something to consult).
+    pending_prefix: Option<PendingPrefix>,
+    /// The jump-target popup's state while open (ADR 0022), `None`
+    /// otherwise — see [`JumpPopup`]'s own doc comment.
+    jump_popup: Option<JumpPopup>,
+    /// The jumplist's back-stack (ADR 0022): locations to return to via
+    /// `Ctrl-o`, most-recently-visited last. Capped at [`JUMPLIST_CAP`].
+    jump_back: Vec<JumplistEntry>,
+    /// The jumplist's forward-stack: locations to return to via `Ctrl-i`
+    /// after at least one `Ctrl-o`. Cleared whenever a new jump
+    /// (`GotoDefinition`/`GotoReferences`) is made from the middle of
+    /// history, mirroring vim's own jumplist (a new jump abandons the
+    /// forward history rather than preserving it).
+    jump_forward: Vec<JumplistEntry>,
     /// A transient message for the status line (e.g. a source-read
     /// failure) — cleared on the next action that doesn't re-set it, so a
     /// stale error doesn't linger forever once the user has moved on.
@@ -283,6 +407,10 @@ impl App {
             right_pane_scroll: 0,
             focus: Focus::default(),
             help_open: false,
+            pending_prefix: None,
+            jump_popup: None,
+            jump_back: Vec::new(),
+            jump_forward: Vec::new(),
             status: None,
             should_quit: false,
         }
@@ -362,6 +490,20 @@ impl App {
     /// Whether the `?` help overlay (ADR 0020) is currently open.
     pub fn help_open(&self) -> bool {
         self.help_open
+    }
+
+    /// Whether a `g`-prefixed sequence (ADR 0022) is awaiting its second key
+    /// — consulted by `crate::lib::translate_key` to decide whether the next
+    /// key press should resolve `gd`/`gr` rather than its own ordinary
+    /// meaning.
+    pub fn pending_prefix(&self) -> Option<PendingPrefix> {
+        self.pending_prefix
+    }
+
+    /// The jump-target popup's state (ADR 0022) while it is open, `None`
+    /// otherwise.
+    pub fn jump_popup(&self) -> Option<&JumpPopup> {
+        self.jump_popup.as_ref()
     }
 
     /// The user's requested scroll offset into the right-hand pane — see
@@ -486,6 +628,91 @@ impl App {
         }
     }
 
+    /// The id of the *present* (non-removed) symbol under the cursor, or
+    /// `None` when the cursor is not on a symbol row at all, sits on a
+    /// removed symbol (no graph presence to jump from — same reasoning as
+    /// `selected_diff_target`'s own removed-symbol handling), or there are
+    /// no rows at all. Used by `crate::run_app` to resolve `gd`/`gr`
+    /// candidates (`crate::detail::symbol_mentions`) before calling back
+    /// into `App` — see [`InputKey::GotoDefinition`]'s own doc comment on
+    /// why that resolution cannot happen inside `App::handle_key` itself.
+    pub fn selected_symbol_id(&self) -> Option<&str> {
+        let rows = self.nav.rows(&self.tree);
+        let row = rows.get(self.nav.cursor())?;
+        match &row.node.kind {
+            NodeKind::Symbol(symbol_ref) if !symbol_ref.removed => Some(symbol_ref.id.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Jumps the cursor to `symbol_id` (ADR 0022): pushes the *current*
+    /// location onto the jumplist's back-stack (capped at
+    /// [`JUMPLIST_CAP`], oldest dropped) and clears the forward-stack (a new
+    /// jump abandons any history the reviewer had already jumped back past
+    /// — vim's own jumplist does the same), then moves the tree cursor via
+    /// [`Nav::move_cursor_to_symbol`] (expanding collapsed ancestors) and
+    /// resets the scroll offset to 0 so the jumped-to symbol's content
+    /// starts from its top. Focus is deliberately left untouched (ADR
+    /// 0022's own "keep reading" rationale).
+    ///
+    /// The jumplist push only happens when the cursor was already on a
+    /// present symbol row (`Self::selected_symbol_id`) — every real caller
+    /// (`crate::run_app`'s `resolve_goto`/`GotoOutcome` handling, and this
+    /// method's own popup-confirm caller in `Self::handle_key_with_popup_open`)
+    /// only reaches this method after confirming that already, per ADR
+    /// 0022's "only a symbol row is a valid jump source" rule, so this is a
+    /// defensive fallback (silently skip recording jumplist history) rather
+    /// than a precondition that blocks the jump itself — the cursor still
+    /// moves either way, since refusing to jump at all over a bookkeeping
+    /// detail would be a worse failure mode than an incomplete jumplist.
+    ///
+    /// A no-op (with a status message), without touching the jumplist, when
+    /// no row's symbol id matches `symbol_id` (defensive: callers are
+    /// expected to have already confirmed the id exists via
+    /// `crate::detail::symbol_mentions`, but `App` does not trust that
+    /// blindly).
+    pub fn jump_to_symbol(mut self, symbol_id: &str) -> Self {
+        let current_id = self.selected_symbol_id().map(str::to_string);
+
+        let mut nav = self.nav.clone();
+        if !nav.move_cursor_to_symbol(&self.tree, symbol_id) {
+            self.status = Some(format!("note: symbol {symbol_id} is no longer present"));
+            return self;
+        }
+
+        if let Some(current_id) = current_id {
+            self.push_jumplist_entry(JumplistEntry {
+                symbol_id: current_id,
+                right_pane_scroll: self.right_pane_scroll,
+            });
+            self.jump_forward.clear();
+        }
+        self.nav = nav;
+        self.right_pane_scroll = 0;
+        self
+    }
+
+    /// Opens the jump-target popup (ADR 0022) over `candidates` — called by
+    /// `crate::run_app` once it has resolved more than one candidate for a
+    /// pending `gd`/`gr` (`InputKey::GotoDefinition`/`GotoReferences`'s own
+    /// doc comment on why resolution happens there, not in `App`).
+    pub fn open_jump_popup(mut self, candidates: Vec<JumpCandidate>) -> Self {
+        self.jump_popup = Some(JumpPopup {
+            candidates,
+            cursor: 0,
+        });
+        self
+    }
+
+    /// Pushes `entry` onto the jumplist's back-stack, dropping the oldest
+    /// entry first if this would exceed [`JUMPLIST_CAP`].
+    fn push_jumplist_entry(&mut self, entry: JumplistEntry) {
+        if self.jump_back.len() >= JUMPLIST_CAP {
+            self.jump_back.remove(0);
+        }
+        self.jump_back.push(entry);
+    }
+
     /// Applies one [`InputKey`] and returns the next `App`. `report` is
     /// needed only for [`InputKey::Source`] (to confirm the row under the
     /// cursor is a present symbol before switching screens — the actual
@@ -514,6 +741,23 @@ impl App {
     /// (`ToggleOrder`) can do the same simply by changing which row now
     /// sits at the same cursor index — both used to leave a stale nonzero
     /// scroll offset pointing into the *new* row's unrelated content.
+    ///
+    /// The jump-target popup (ADR 0022) is handled next, mirroring the help
+    /// overlay's own "takes over the whole key space while open" structure:
+    /// `Up`/`Down` move the popup's own selection, `PopupConfirm` jumps to
+    /// the highlighted candidate and closes it, `PopupCancel` closes it
+    /// without jumping, and every other key is swallowed. This runs before
+    /// the `g`-prefix bookkeeping and the screen/focus dispatch below for
+    /// the same "no future variant can accidentally bypass it" reason the
+    /// help overlay's own check does.
+    ///
+    /// `pending_prefix` (ADR 0022's minimal `g`-prefix state machine) is
+    /// cleared by every key except [`InputKey::PendingGoto`] itself, which
+    /// sets it — a blanket rule (applied once, alongside the scroll-reset
+    /// rule above) rather than each arm deciding individually, so a `g`
+    /// press followed by anything other than `d`/`r` (already resolved by
+    /// `crate::lib::translate_key` before this function ever sees the key)
+    /// cannot leave a stale pending prefix behind.
     pub fn handle_key(mut self, key: InputKey) -> Self {
         self.status = None;
 
@@ -528,11 +772,30 @@ impl App {
             return self;
         }
 
+        if self.jump_popup.is_some() {
+            return self.handle_key_with_popup_open(key);
+        }
+
+        self.pending_prefix = if key == InputKey::PendingGoto {
+            Some(PendingPrefix::G)
+        } else {
+            None
+        };
+
         let preserve_scroll = matches!(
             (&self.screen, self.focus, key),
             (Screen::Entry, Focus::Right, InputKey::Up)
                 | (Screen::Entry, Focus::Right, InputKey::Down)
         );
+        // Set by the `JumpBack`/`JumpForward` arms below when they actually
+        // restore a jumplist entry's own scroll offset — that restored
+        // value must survive the blanket "reset scroll to 0" rule at the
+        // bottom of this function the same way `preserve_scroll` above lets
+        // right-focused `Up`/`Down` survive it, just via a second, separate
+        // flag rather than folding jump-restoration into `preserve_scroll`'s
+        // own `matches!` (which is keyed on `(screen, focus, key)` alone and
+        // has no way to express "only when the jump actually succeeded").
+        let mut preserve_scroll_after_jump = false;
 
         match (&self.screen, self.focus, key) {
             (Screen::Source { .. }, _, InputKey::Back) => {
@@ -695,10 +958,122 @@ impl App {
                 // Unreachable: handled above before this match, kept only
                 // so the match stays exhaustive against future refactors.
             }
+            (Screen::Entry, _, InputKey::PendingGoto) => {
+                // No other state to change here: `pending_prefix` was
+                // already set above, before this match, by the blanket rule
+                // this function's own doc comment describes.
+            }
+            // `gd`/`gr` candidate resolution needs `report`, which this
+            // function does not have — `crate::run_app` intercepts these two
+            // before they ever reach `handle_key` (`InputKey::
+            // GotoDefinition`'s own doc comment), calling
+            // `Self::jump_to_symbol`/`Self::open_jump_popup`/`Self::set_status`
+            // directly instead. Reaching this arm at all means `run_app`'s
+            // interception was bypassed (e.g. a future direct `handle_key`
+            // call in a test) — a no-op rather than a panic, since silently
+            // doing nothing is safer than crashing the TUI over a
+            // programming mistake in a caller.
+            (Screen::Entry, _, InputKey::GotoDefinition | InputKey::GotoReferences) => {}
+            (Screen::Entry, _, InputKey::JumpBack) => {
+                if let Some(entry) = self.jump_back.pop() {
+                    let current_id = self.selected_symbol_id().map(str::to_string);
+                    let mut nav = self.nav.clone();
+                    if nav.move_cursor_to_symbol(&self.tree, &entry.symbol_id) {
+                        if let Some(current_id) = current_id {
+                            self.jump_forward.push(JumplistEntry {
+                                symbol_id: current_id,
+                                right_pane_scroll: self.right_pane_scroll,
+                            });
+                        }
+                        self.nav = nav;
+                        self.right_pane_scroll = entry.right_pane_scroll;
+                        preserve_scroll_after_jump = true;
+                    } else {
+                        self.status = Some(format!(
+                            "note: symbol {} is no longer present",
+                            entry.symbol_id
+                        ));
+                    }
+                } else {
+                    self.status = Some("note: jumplist has no earlier location".to_string());
+                }
+            }
+            (Screen::Entry, _, InputKey::JumpForward) => {
+                if let Some(entry) = self.jump_forward.pop() {
+                    let current_id = self.selected_symbol_id().map(str::to_string);
+                    let mut nav = self.nav.clone();
+                    if nav.move_cursor_to_symbol(&self.tree, &entry.symbol_id) {
+                        if let Some(current_id) = current_id {
+                            self.push_jumplist_entry(JumplistEntry {
+                                symbol_id: current_id,
+                                right_pane_scroll: self.right_pane_scroll,
+                            });
+                        }
+                        self.nav = nav;
+                        self.right_pane_scroll = entry.right_pane_scroll;
+                        preserve_scroll_after_jump = true;
+                    } else {
+                        self.status = Some(format!(
+                            "note: symbol {} is no longer present",
+                            entry.symbol_id
+                        ));
+                    }
+                } else {
+                    self.status = Some("note: jumplist has no later location".to_string());
+                }
+            }
+            // Unreachable while `handle_key` is entered directly (the popup
+            // interception above returns before this match whenever
+            // `jump_popup.is_some()`), kept only so the match stays
+            // exhaustive against future refactors — same reasoning as the
+            // `ToggleHelp` arm just above.
+            (Screen::Entry, _, InputKey::PopupConfirm | InputKey::PopupCancel) => {}
         }
 
-        if !preserve_scroll {
+        if !preserve_scroll && !preserve_scroll_after_jump {
             self.right_pane_scroll = 0;
+        }
+
+        self
+    }
+
+    /// Handles one [`InputKey`] while the jump-target popup (ADR 0022) is
+    /// open — mirrors the help overlay's own "takes over the whole key
+    /// space" structure (`Self::handle_key`'s own doc comment): `Up`/`Down`
+    /// move the popup's own selection cursor (clamped, not wrapping, same
+    /// convention `Nav::handle`'s `CursorUp`/`CursorDown` already use),
+    /// `PopupConfirm` jumps to the highlighted candidate and closes the
+    /// popup, `PopupCancel` closes it without jumping, and every other key
+    /// is swallowed as a no-op.
+    fn handle_key_with_popup_open(mut self, key: InputKey) -> Self {
+        let Some(popup) = self.jump_popup.clone() else {
+            // Unreachable: this method is only called from `Self::handle_key`
+            // when `self.jump_popup.is_some()`.
+            return self;
+        };
+
+        match key {
+            InputKey::Up => {
+                if let Some(popup) = &mut self.jump_popup {
+                    popup.cursor = popup.cursor.saturating_sub(1);
+                }
+            }
+            InputKey::Down => {
+                if let Some(popup) = &mut self.jump_popup {
+                    popup.cursor = (popup.cursor + 1).min(popup.candidates.len().saturating_sub(1));
+                }
+            }
+            InputKey::PopupConfirm => {
+                let target = popup.candidates.get(popup.cursor).map(|c| c.id.clone());
+                self.jump_popup = None;
+                if let Some(target) = target {
+                    self = self.jump_to_symbol(&target);
+                }
+            }
+            InputKey::PopupCancel => {
+                self.jump_popup = None;
+            }
+            _ => {}
         }
 
         self
@@ -1837,5 +2212,379 @@ mod tests {
         let app = app.handle_key(InputKey::ToggleOrder);
 
         assert_eq!(0, app.right_pane_scroll());
+    }
+
+    // Jump navigation tests (ADR 0022): `selected_symbol_id`,
+    // `jump_to_symbol`, `open_jump_popup`, the popup's own key handling,
+    // `pending_prefix` bookkeeping, and the jumplist (`JumpBack`/
+    // `JumpForward`).
+
+    /// Two symbols in two files, "a::foo" calling "b::bar" — enough for a
+    /// jump to have a real target to land on and expand a collapsed
+    /// ancestor. Expanded row order: a(0), a/one.rs(1), foo(2), b(3),
+    /// b/two.rs(4), bar(5) — same shape as `report_with_two_directories`,
+    /// with a populated `graph` so `symbol_mentions`-driven callers can
+    /// exercise it directly (this module's own tests call `Nav`/`App`
+    /// methods directly rather than through `crate::lib::resolve_goto`,
+    /// which lives in a different module and is tested there instead).
+    fn report_with_caller_and_callee() -> Report {
+        let mut report = report_with_two_directories();
+        report.files[0].symbols[0].id = "a/one.rs::foo".to_string();
+        report.files[1].symbols[0].id = "b/two.rs::bar".to_string();
+        report.graph = rinkaku_core::graph::SymbolGraph {
+            nodes: vec![
+                rinkaku_core::graph::Node {
+                    id: "a/one.rs::foo".to_string(),
+                    path: "a/one.rs".to_string(),
+                    name: "foo".to_string(),
+                },
+                rinkaku_core::graph::Node {
+                    id: "b/two.rs::bar".to_string(),
+                    path: "b/two.rs".to_string(),
+                    name: "bar".to_string(),
+                },
+            ],
+            edges: vec![rinkaku_core::graph::Edge {
+                from: "a/one.rs::foo".to_string(),
+                to: "b/two.rs::bar".to_string(),
+                is_cycle: false,
+            }],
+            roots: vec!["a/one.rs::foo".to_string()],
+        };
+        report
+    }
+
+    #[test]
+    fn should_return_selected_symbol_id_when_cursor_is_on_a_present_symbol_row() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(InputKey::Down);
+
+        assert_eq!(Some("lib.rs::foo"), app.selected_symbol_id());
+    }
+
+    #[test]
+    fn should_return_none_selected_symbol_id_when_cursor_is_on_a_file_row() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+
+        assert_eq!(None, app.selected_symbol_id());
+    }
+
+    #[test]
+    fn should_return_none_selected_symbol_id_when_cursor_is_on_a_removed_symbol() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            removed: vec![rinkaku_core::extract::RemovedSymbol {
+                name: "gone".to_string(),
+                kind: SymbolKind::Function,
+                path: "lib.rs".to_string(),
+                signature: "fn gone()".to_string(),
+            }],
+            ..empty_report()
+        };
+        let app = App::new(&report).handle_key(InputKey::Down);
+
+        assert_eq!(None, app.selected_symbol_id());
+    }
+
+    #[test]
+    fn should_move_cursor_to_target_symbol_when_jump_to_symbol_is_called() {
+        let report = report_with_caller_and_callee();
+        let app = App::new(&report);
+
+        let app = app.jump_to_symbol("b/two.rs::bar");
+
+        let rows = app.nav().rows(app.tree());
+        assert_eq!("b/two.rs", rows[app.nav().cursor()].node.path);
+    }
+
+    #[test]
+    fn should_reset_scroll_when_jump_to_symbol_succeeds() {
+        let report = report_with_caller_and_callee();
+        let app = focused_right_and_scrolled_one_line(App::new(&report)); // cursor on "a/one.rs", scroll -> 1
+        assert_eq!(1, app.right_pane_scroll());
+
+        let app = app.jump_to_symbol("b/two.rs::bar");
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_keep_focus_unchanged_when_jump_to_symbol_succeeds() {
+        let report = report_with_caller_and_callee();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Open); // focus -> Right, cursor on "foo"
+        assert_eq!(Focus::Right, app.focus());
+
+        let app = app.jump_to_symbol("b/two.rs::bar");
+
+        assert_eq!(Focus::Right, app.focus());
+    }
+
+    #[test]
+    fn should_push_current_symbol_onto_jumplist_when_jump_to_symbol_succeeds() {
+        let report = report_with_caller_and_callee();
+        // Cursor on "foo" (row 2).
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Down);
+        assert_eq!(
+            "a/one.rs",
+            app.nav().rows(app.tree())[app.nav().cursor()].node.path
+        );
+
+        let app = app.jump_to_symbol("b/two.rs::bar");
+        let app = app.handle_key(InputKey::JumpBack);
+
+        // Ctrl-o after the jump must land back on "foo" — proof the
+        // pre-jump location was actually pushed.
+        let rows = app.nav().rows(app.tree());
+        assert_eq!("a/one.rs", rows[app.nav().cursor()].node.path);
+    }
+
+    #[test]
+    fn should_expand_collapsed_ancestor_when_jump_to_symbol_targets_a_hidden_row() {
+        let report = report_with_caller_and_callee();
+        let app = App::new(&report).handle_key(InputKey::CollapseAll);
+        assert_eq!(vec!["a", "b"], row_paths_of(&app));
+
+        let app = app.jump_to_symbol("b/two.rs::bar");
+
+        let rows = app.nav().rows(app.tree());
+        assert_eq!("b/two.rs", rows[app.nav().cursor()].node.path);
+    }
+
+    #[test]
+    fn should_set_status_and_leave_cursor_unmoved_when_jump_to_symbol_target_does_not_exist() {
+        let report = report_with_caller_and_callee();
+        let app = App::new(&report).handle_key(InputKey::Down);
+        let cursor_before = app.nav().cursor();
+
+        let app = app.jump_to_symbol("no/such::id");
+
+        assert_eq!(cursor_before, app.nav().cursor());
+        assert_eq!(
+            Some("note: symbol no/such::id is no longer present"),
+            app.status()
+        );
+    }
+
+    fn row_paths_of(app: &App) -> Vec<&str> {
+        app.nav()
+            .rows(app.tree())
+            .iter()
+            .map(|r| r.node.path.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn should_open_jump_popup_with_given_candidates() {
+        let report = empty_report();
+        let app = App::new(&report);
+        let candidates = vec![
+            JumpCandidate {
+                id: "a".to_string(),
+                name: "a".to_string(),
+                path: "a.rs".to_string(),
+            },
+            JumpCandidate {
+                id: "b".to_string(),
+                name: "b".to_string(),
+                path: "b.rs".to_string(),
+            },
+        ];
+
+        let app = app.open_jump_popup(candidates.clone());
+
+        assert_eq!(
+            Some(&JumpPopup {
+                candidates,
+                cursor: 0
+            }),
+            app.jump_popup()
+        );
+    }
+
+    fn two_candidates() -> Vec<JumpCandidate> {
+        vec![
+            JumpCandidate {
+                id: "a/one.rs::foo".to_string(),
+                name: "foo".to_string(),
+                path: "a/one.rs".to_string(),
+            },
+            JumpCandidate {
+                id: "b/two.rs::bar".to_string(),
+                name: "bar".to_string(),
+                path: "b/two.rs".to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn should_move_popup_cursor_down_when_down_is_pressed_while_popup_open() {
+        let report = empty_report();
+        let app = App::new(&report).open_jump_popup(two_candidates());
+
+        let app = app.handle_key(InputKey::Down);
+
+        assert_eq!(1, app.jump_popup().expect("popup open").cursor);
+    }
+
+    #[test]
+    fn should_clamp_popup_cursor_at_last_candidate_when_down_is_pressed_past_the_end() {
+        let report = empty_report();
+        let app = App::new(&report)
+            .open_jump_popup(two_candidates())
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Down);
+
+        assert_eq!(1, app.jump_popup().expect("popup open").cursor);
+    }
+
+    #[test]
+    fn should_clamp_popup_cursor_at_zero_when_up_is_pressed_past_the_top() {
+        let report = empty_report();
+        let app = App::new(&report).open_jump_popup(two_candidates());
+
+        let app = app.handle_key(InputKey::Up);
+
+        assert_eq!(0, app.jump_popup().expect("popup open").cursor);
+    }
+
+    #[test]
+    fn should_close_popup_without_jumping_when_popup_cancel_is_pressed() {
+        let report = report_with_caller_and_callee();
+        let cursor_before = App::new(&report).nav().cursor();
+        let app = App::new(&report).open_jump_popup(two_candidates());
+
+        let app = app.handle_key(InputKey::PopupCancel);
+
+        assert_eq!(None, app.jump_popup());
+        assert_eq!(cursor_before, app.nav().cursor());
+    }
+
+    #[test]
+    fn should_jump_to_highlighted_candidate_and_close_popup_when_popup_confirm_is_pressed() {
+        let report = report_with_caller_and_callee();
+        let app = App::new(&report)
+            .open_jump_popup(two_candidates())
+            .handle_key(InputKey::Down); // highlight "bar"
+
+        let app = app.handle_key(InputKey::PopupConfirm);
+
+        assert_eq!(None, app.jump_popup());
+        let rows = app.nav().rows(app.tree());
+        assert_eq!("b/two.rs", rows[app.nav().cursor()].node.path);
+    }
+
+    #[test]
+    fn should_ignore_navigation_keys_while_jump_popup_is_open() {
+        let report = report_with_caller_and_callee();
+        let app = App::new(&report).open_jump_popup(two_candidates());
+        let cursor_before = app.nav().cursor();
+
+        let app = app.handle_key(InputKey::ExpandAll);
+
+        assert_eq!(cursor_before, app.nav().cursor());
+        assert!(app.jump_popup().is_some());
+    }
+
+    #[test]
+    fn should_set_pending_prefix_when_pending_goto_is_pressed() {
+        let report = empty_report();
+        let app = App::new(&report);
+        assert_eq!(None, app.pending_prefix());
+
+        let app = app.handle_key(InputKey::PendingGoto);
+
+        assert_eq!(Some(PendingPrefix::G), app.pending_prefix());
+    }
+
+    #[test]
+    fn should_clear_pending_prefix_when_any_other_key_follows_pending_goto() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::PendingGoto);
+        assert_eq!(Some(PendingPrefix::G), app.pending_prefix());
+
+        let app = app.handle_key(InputKey::Down);
+
+        assert_eq!(None, app.pending_prefix());
+    }
+
+    #[test]
+    fn should_set_status_when_jump_back_is_pressed_with_an_empty_back_stack() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let app = app.handle_key(InputKey::JumpBack);
+
+        assert_eq!(Some("note: jumplist has no earlier location"), app.status());
+    }
+
+    #[test]
+    fn should_set_status_when_jump_forward_is_pressed_with_an_empty_forward_stack() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let app = app.handle_key(InputKey::JumpForward);
+
+        assert_eq!(Some("note: jumplist has no later location"), app.status());
+    }
+
+    #[test]
+    fn should_return_to_pre_jump_symbol_when_jump_back_is_pressed_after_a_jump() {
+        let report = report_with_caller_and_callee();
+        // Cursor on "foo" (row 2) before jumping.
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Down)
+            .jump_to_symbol("b/two.rs::bar");
+        assert_eq!(
+            "b/two.rs",
+            app.nav().rows(app.tree())[app.nav().cursor()].node.path
+        );
+
+        let app = app.handle_key(InputKey::JumpBack);
+
+        let rows = app.nav().rows(app.tree());
+        assert_eq!("a/one.rs", rows[app.nav().cursor()].node.path);
+    }
+
+    #[test]
+    fn should_return_to_post_jump_symbol_when_jump_forward_is_pressed_after_jump_back() {
+        let report = report_with_caller_and_callee();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Down)
+            .jump_to_symbol("b/two.rs::bar")
+            .handle_key(InputKey::JumpBack);
+        assert_eq!(
+            "a/one.rs",
+            app.nav().rows(app.tree())[app.nav().cursor()].node.path
+        );
+
+        let app = app.handle_key(InputKey::JumpForward);
+
+        let rows = app.nav().rows(app.tree());
+        assert_eq!("b/two.rs", rows[app.nav().cursor()].node.path);
+    }
+
+    #[test]
+    fn should_clear_forward_stack_when_a_new_jump_is_made_from_the_middle_of_history() {
+        // vim's own jumplist semantics: jumping to a new location abandons
+        // whatever forward history existed, rather than preserving it.
+        let report = report_with_caller_and_callee();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Down)
+            .jump_to_symbol("b/two.rs::bar")
+            .handle_key(InputKey::JumpBack); // back on "foo", forward-stack has "bar"
+
+        let app = app.jump_to_symbol("b/two.rs::bar"); // a fresh jump from "foo"
+
+        let app = app.handle_key(InputKey::JumpForward);
+        assert_eq!(Some("note: jumplist has no later location"), app.status());
     }
 }

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -112,13 +112,17 @@ pub enum InputKey {
     /// `App::handle_key` does not have access to — mirroring
     /// `InputKey::NextHunk`/`PrevHunk`'s own precedent (that jump target
     /// needs the shaped diff content `App` also lacks), `crate::run_app`
-    /// resolves candidates before calling into `App` at all, via
-    /// `App::begin_goto`/`App::jump_to_symbol`/`App::open_jump_popup`
-    /// rather than this `InputKey` variant reaching `App::handle_key`'s
-    /// match directly. Kept as its own `InputKey` variant regardless (rather
-    /// than folding the two `g`-prefixed keys into `PendingGoto`'s own
-    /// resolution) so `crate::lib::translate_key`'s key-to-intent mapping
-    /// stays legible independent of where the intent is actually processed.
+    /// resolves candidates and applies the outcome itself, via
+    /// `App::jump_to_symbol`/`App::open_jump_popup`/`App::set_status`. It
+    /// still calls `App::handle_key(input_key)` first, same as every other
+    /// key (`App::handle_key`'s own match arm for this variant is a no-op
+    /// stub, but the unconditional `pending_prefix` clear at the top of that
+    /// function is not — skipping the call entirely, an earlier version of
+    /// this feature did, left `pending_prefix` stuck after every `gd`/`gr`
+    /// press). Kept as its own `InputKey` variant (rather than folding the
+    /// two `g`-prefixed keys into `PendingGoto`'s own resolution) so
+    /// `crate::lib::translate_key`'s key-to-intent mapping stays legible
+    /// independent of where the intent is actually processed.
     GotoDefinition,
     /// `gr`: the caller-direction mirror of [`Self::GotoDefinition`].
     GotoReferences,
@@ -708,6 +712,16 @@ impl App {
     /// entry first if this would exceed [`JUMPLIST_CAP`].
     fn push_jumplist_entry(&mut self, entry: JumplistEntry) {
         if self.jump_back.len() >= JUMPLIST_CAP {
+            // `Vec::remove(0)` is O(n) (shifts every remaining element down
+            // one slot) rather than O(1) — a `VecDeque` would make this
+            // O(1), but at `JUMPLIST_CAP` = 100 small (`String` + `usize`)
+            // entries, shifting is at most ~100 pointer-sized moves, only
+            // once per jump and only once the cap is already full (every
+            // jump before that is a plain `push`, already O(1)) — not a
+            // measurable cost against a single keypress in an interactive
+            // TUI. `Vec` also keeps this consistent with `jump_forward`
+            // (`Vec<JumplistEntry>` too) without introducing a second
+            // container type for one already-negligible operation.
             self.jump_back.remove(0);
         }
         self.jump_back.push(entry);
@@ -753,13 +767,29 @@ impl App {
     ///
     /// `pending_prefix` (ADR 0022's minimal `g`-prefix state machine) is
     /// cleared by every key except [`InputKey::PendingGoto`] itself, which
-    /// sets it — a blanket rule (applied once, alongside the scroll-reset
-    /// rule above) rather than each arm deciding individually, so a `g`
-    /// press followed by anything other than `d`/`r` (already resolved by
-    /// `crate::lib::translate_key` before this function ever sees the key)
-    /// cannot leave a stale pending prefix behind.
+    /// sets it — a blanket rule applied *unconditionally at the very top of
+    /// this function*, before the `help_open`/`jump_popup` early returns
+    /// below, rather than alongside the scroll-reset rule further down
+    /// (post-review finding: clearing it after those early returns let a
+    /// pending prefix survive both of them — the help overlay's own early
+    /// return, and more importantly the jump-popup one, since opening the
+    /// popup is itself the direct result of a `gd`/`gr` press that
+    /// `crate::run_app` resolves *without ever calling this method at all*,
+    /// see that resolution's own doc comment — so the clear could not
+    /// safely live only "later in the normal path" the way scroll-reset
+    /// does; it has to run before anything can return early). Every key
+    /// this method is ever called with, from every call site, hits this one
+    /// line before doing anything else, so a `g` press followed by anything
+    /// other than `d`/`r` (already resolved by `crate::lib::translate_key`
+    /// before this function ever sees the key) cannot leave a stale pending
+    /// prefix behind regardless of which branch handles the key afterward.
     pub fn handle_key(mut self, key: InputKey) -> Self {
         self.status = None;
+        self.pending_prefix = if key == InputKey::PendingGoto {
+            Some(PendingPrefix::G)
+        } else {
+            None
+        };
 
         if self.help_open {
             if key == InputKey::ToggleHelp {
@@ -775,12 +805,6 @@ impl App {
         if self.jump_popup.is_some() {
             return self.handle_key_with_popup_open(key);
         }
-
-        self.pending_prefix = if key == InputKey::PendingGoto {
-            Some(PendingPrefix::G)
-        } else {
-            None
-        };
 
         let preserve_scroll = matches!(
             (&self.screen, self.focus, key),
@@ -964,15 +988,18 @@ impl App {
                 // this function's own doc comment describes.
             }
             // `gd`/`gr` candidate resolution needs `report`, which this
-            // function does not have — `crate::run_app` intercepts these two
-            // before they ever reach `handle_key` (`InputKey::
-            // GotoDefinition`'s own doc comment), calling
-            // `Self::jump_to_symbol`/`Self::open_jump_popup`/`Self::set_status`
-            // directly instead. Reaching this arm at all means `run_app`'s
-            // interception was bypassed (e.g. a future direct `handle_key`
-            // call in a test) — a no-op rather than a panic, since silently
-            // doing nothing is safer than crashing the TUI over a
-            // programming mistake in a caller.
+            // function does not have — `crate::run_app` reads
+            // `report.graph.edges` itself (`resolve_goto`) and applies the
+            // outcome via `Self::jump_to_symbol`/`Self::open_jump_popup`/
+            // `Self::set_status`. This arm is still reached, though: `run_app`
+            // calls `handle_key(input_key)` for these two variants same as
+            // every other key (post-review fix), specifically so the
+            // unconditional `pending_prefix` clear at the top of this
+            // function runs on this path too — before this fix, `run_app`
+            // skipped `handle_key` entirely for `gd`/`gr`, leaving
+            // `pending_prefix` stuck at `Some(G)` after every jump. The arm
+            // itself stays a no-op: `resolve_goto`/the actual jump/popup/
+            // status mutation happen in `run_app`, not here.
             (Screen::Entry, _, InputKey::GotoDefinition | InputKey::GotoReferences) => {}
             (Screen::Entry, _, InputKey::JumpBack) => {
                 if let Some(entry) = self.jump_back.pop() {

--- a/rinkaku-tui/src/detail.rs
+++ b/rinkaku-tui/src/detail.rs
@@ -109,55 +109,8 @@ pub fn build_detail(report: &Report, id: &str) -> Option<DetailView> {
         _ => SignatureView::Current(symbol.signature.clone()),
     };
 
-    let mentions_by_id = |target_id: &str| -> Option<SymbolMention> {
-        report.files.iter().find_map(|file| {
-            file.symbols
-                .iter()
-                .find(|s| s.id == target_id)
-                .map(|s| SymbolMention {
-                    id: s.id.clone(),
-                    name: s.name.clone(),
-                    path: file.path.clone(),
-                })
-        })
-    };
-
-    // Edge uniqueness within `graph.edges` is not a contractual guarantee —
-    // `compute_hotspots`'s own doc comment in `rinkaku-core::graph` notes
-    // that a repeated edge between the same pair of nodes is not something
-    // `build_graph` can currently produce, but nothing in this function's
-    // contract depends on that staying true either. Deduping by the other
-    // endpoint's id before collecting mentions keeps a duplicate edge from
-    // making the same caller/callee show up twice in the detail pane's
-    // pivots, mirroring `compute_hotspots`'s own dedup-by-referrer-id.
-    //
-    // Self-edges (`from == to == id`) are filtered the same defensive way:
-    // `collect_edges` in `rinkaku-core::graph` explicitly excludes them
-    // (`if target.id != from.id`), so they cannot occur through the normal
-    // pipeline today, but — same reasoning as the dedup above — this
-    // function's own contract does not want to depend on that staying true
-    // forever. Without this filter, a hypothetical self-edge would make a
-    // symbol list itself as its own caller/callee/used-by, which is never
-    // a meaningful pivot to show a reviewer.
-    let mut seen_callees = HashSet::new();
-    let callees: Vec<SymbolMention> = report
-        .graph
-        .edges
-        .iter()
-        .filter(|edge| edge.from == id && edge.to != id)
-        .filter(|edge| seen_callees.insert(edge.to.as_str()))
-        .filter_map(|edge| mentions_by_id(&edge.to))
-        .collect();
-
-    let mut seen_callers = HashSet::new();
-    let callers: Vec<SymbolMention> = report
-        .graph
-        .edges
-        .iter()
-        .filter(|edge| edge.to == id && edge.from != id)
-        .filter(|edge| seen_callers.insert(edge.from.as_str()))
-        .filter_map(|edge| mentions_by_id(&edge.from))
-        .collect();
+    let callees = symbol_mentions(report, id, MentionDirection::Callees);
+    let callers = symbol_mentions(report, id, MentionDirection::Callers);
 
     // `used_by` is every incoming edge, same set `callers` already
     // computed above — `report.hotspots` is not consulted here because it
@@ -182,6 +135,78 @@ pub fn build_detail(report: &Report, id: &str) -> Option<DetailView> {
         callees,
         callers,
     })
+}
+
+/// Which side of `report.graph.edges` [`symbol_mentions`] should walk: the
+/// symbols `id` references ([`Self::Callees`], outgoing edges) or the
+/// symbols referencing `id` ([`Self::Callers`], incoming edges).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MentionDirection {
+    Callees,
+    Callers,
+}
+
+/// Every present symbol directly connected to `id` in `report.graph.edges`,
+/// in the direction `direction` selects — the callee/caller pivot both
+/// [`build_detail`] (the Detail pane) and jump navigation (ADR 0022's
+/// `gd`/`gr`) need, extracted here rather than duplicated so both callers
+/// share one dedup/self-edge-filter contract instead of two independently
+/// maintained copies of it.
+///
+/// Edge uniqueness within `graph.edges` is not a contractual guarantee —
+/// `compute_hotspots`'s own doc comment in `rinkaku-core::graph` notes that
+/// a repeated edge between the same pair of nodes is not something
+/// `build_graph` can currently produce, but nothing in this function's
+/// contract depends on that staying true either. Deduping by the other
+/// endpoint's id before collecting mentions keeps a duplicate edge from
+/// making the same caller/callee show up twice, mirroring
+/// `compute_hotspots`'s own dedup-by-referrer-id.
+///
+/// Self-edges (`from == to == id`) are filtered the same defensive way:
+/// `collect_edges` in `rinkaku-core::graph` explicitly excludes them (`if
+/// target.id != from.id`), so they cannot occur through the normal pipeline
+/// today, but — same reasoning as the dedup above — this function's own
+/// contract does not want to depend on that staying true forever. Without
+/// this filter, a hypothetical self-edge would make a symbol list itself as
+/// its own caller/callee, which is never a meaningful pivot to show a
+/// reviewer.
+pub fn symbol_mentions(
+    report: &Report,
+    id: &str,
+    direction: MentionDirection,
+) -> Vec<SymbolMention> {
+    let mentions_by_id = |target_id: &str| -> Option<SymbolMention> {
+        report.files.iter().find_map(|file| {
+            file.symbols
+                .iter()
+                .find(|s| s.id == target_id)
+                .map(|s| SymbolMention {
+                    id: s.id.clone(),
+                    name: s.name.clone(),
+                    path: file.path.clone(),
+                })
+        })
+    };
+
+    let mut seen = HashSet::new();
+    match direction {
+        MentionDirection::Callees => report
+            .graph
+            .edges
+            .iter()
+            .filter(|edge| edge.from == id && edge.to != id)
+            .filter(|edge| seen.insert(edge.to.as_str()))
+            .filter_map(|edge| mentions_by_id(&edge.to))
+            .collect(),
+        MentionDirection::Callers => report
+            .graph
+            .edges
+            .iter()
+            .filter(|edge| edge.to == id && edge.from != id)
+            .filter(|edge| seen.insert(edge.from.as_str()))
+            .filter_map(|edge| mentions_by_id(&edge.from))
+            .collect(),
+    }
 }
 
 /// A cross-directory edge forming part of a directory cycle, as displayed
@@ -784,6 +809,104 @@ mod tests {
         assert_eq!(Vec::<SymbolMention>::new(), actual.callees);
         assert_eq!(Vec::<SymbolMention>::new(), actual.callers);
         assert_eq!(Vec::<SymbolMention>::new(), actual.used_by);
+    }
+
+    // symbol_mentions tests (ADR 0022): direct coverage of the function
+    // extracted out of `build_detail`'s own callee/caller computation, so
+    // jump navigation's use of it is pinned independently of the Detail
+    // pane's own tests above.
+
+    #[test]
+    fn should_return_outgoing_edges_as_callees_via_symbol_mentions() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::a", "a"), symbol("lib.rs::b", "b")],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("lib.rs::a", "lib.rs", "a"),
+                    node("lib.rs::b", "lib.rs", "b"),
+                ],
+                edges: vec![Edge {
+                    from: "lib.rs::a".to_string(),
+                    to: "lib.rs::b".to_string(),
+                    is_cycle: false,
+                }],
+                roots: vec!["lib.rs::a".to_string()],
+            },
+            ..empty_report()
+        };
+
+        let actual = symbol_mentions(&report, "lib.rs::a", MentionDirection::Callees);
+
+        assert_eq!(
+            vec![SymbolMention {
+                id: "lib.rs::b".to_string(),
+                name: "b".to_string(),
+                path: "lib.rs".to_string(),
+            }],
+            actual
+        );
+    }
+
+    #[test]
+    fn should_return_incoming_edges_as_callers_via_symbol_mentions() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::a", "a"), symbol("lib.rs::b", "b")],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("lib.rs::a", "lib.rs", "a"),
+                    node("lib.rs::b", "lib.rs", "b"),
+                ],
+                edges: vec![Edge {
+                    from: "lib.rs::a".to_string(),
+                    to: "lib.rs::b".to_string(),
+                    is_cycle: false,
+                }],
+                roots: vec!["lib.rs::a".to_string()],
+            },
+            ..empty_report()
+        };
+
+        let actual = symbol_mentions(&report, "lib.rs::b", MentionDirection::Callers);
+
+        assert_eq!(
+            vec![SymbolMention {
+                id: "lib.rs::a".to_string(),
+                name: "a".to_string(),
+                path: "lib.rs".to_string(),
+            }],
+            actual
+        );
+    }
+
+    #[test]
+    fn should_return_empty_mentions_when_symbol_has_no_edges() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::solo", "solo")],
+            }],
+            graph: SymbolGraph {
+                nodes: vec![node("lib.rs::solo", "lib.rs", "solo")],
+                edges: vec![],
+                roots: vec!["lib.rs::solo".to_string()],
+            },
+            ..empty_report()
+        };
+
+        let callees = symbol_mentions(&report, "lib.rs::solo", MentionDirection::Callees);
+        let callers = symbol_mentions(&report, "lib.rs::solo", MentionDirection::Callers);
+
+        assert_eq!(Vec::<SymbolMention>::new(), callees);
+        assert_eq!(Vec::<SymbolMention>::new(), callers);
     }
 
     // build_dir_detail / build_file_detail tests (TUI iteration 2).

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -102,6 +102,22 @@ const GLOBAL_BINDINGS: &[KeyBinding] = &[
         description: "Open the source view for the symbol under the cursor",
     },
     KeyBinding {
+        keys: "gd",
+        description: "Jump to a callee of the symbol under the cursor",
+    },
+    KeyBinding {
+        keys: "gr",
+        description: "Jump to a caller of the symbol under the cursor",
+    },
+    KeyBinding {
+        keys: "ctrl-o",
+        description: "Jump back to the previous location in the jumplist",
+    },
+    KeyBinding {
+        keys: "ctrl-i",
+        description: "Jump forward to the next location in the jumplist",
+    },
+    KeyBinding {
         keys: "?",
         description: "Toggle this help overlay",
     },
@@ -142,6 +158,10 @@ const GLOSSARY: &[GlossaryEntry] = &[
     GlossaryEntry {
         term: "cycle",
         explanation: "A closing back-edge in the dependency graph — two or more directories depend on each other",
+    },
+    GlossaryEntry {
+        term: "jumplist",
+        explanation: "The history of gd/gr jump locations — ctrl-o/ctrl-i move back/forward through it",
     },
 ];
 
@@ -188,6 +208,33 @@ mod tests {
 
         assert!(terms.contains(&"pivot"));
         assert!(terms.contains(&"cycle"));
+    }
+
+    #[test]
+    fn should_include_a_glossary_entry_for_jumplist() {
+        let terms: Vec<&str> = HELP_CONTENT
+            .glossary
+            .iter()
+            .map(|entry| entry.term)
+            .collect();
+
+        assert!(terms.contains(&"jumplist"));
+    }
+
+    #[test]
+    fn should_document_gd_gr_and_jumplist_bindings_in_the_global_group() {
+        let global = HELP_CONTENT
+            .keymap_groups
+            .iter()
+            .find(|group| group.title == "Global")
+            .expect("Global group present");
+
+        let keys: Vec<&str> = global.bindings.iter().map(|binding| binding.keys).collect();
+
+        assert!(keys.contains(&"gd"));
+        assert!(keys.contains(&"gr"));
+        assert!(keys.contains(&"ctrl-o"));
+        assert!(keys.contains(&"ctrl-i"));
     }
 
     #[test]

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -460,6 +460,17 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::Quit),
         KeyCode::Char('c') | KeyCode::Char('C') => Some(InputKey::CollapseAll),
         KeyCode::Char('o') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::JumpBack),
+        // Ctrl-I and Tab share the same control code (0x09) at the terminal
+        // protocol level — without Kitty's keyboard-enhancement protocol
+        // (which this crate does not enable), a real Ctrl-I keypress
+        // arrives here as plain `KeyCode::Tab`, not `KeyCode::Char('i')` +
+        // `CONTROL` (confirmed via manual tmux testing against a real
+        // terminal, not just documentation: the `Char('i') + CONTROL` arm
+        // alone never matched a real Ctrl-I press). Both patterns are kept
+        // so this still works correctly in an environment that *does*
+        // report the modifier form (e.g. a test harness constructing the
+        // event directly, as this module's own tests do).
+        KeyCode::Tab => Some(InputKey::JumpForward),
         KeyCode::Char('i') if modifiers.contains(KeyModifiers::CONTROL) => {
             Some(InputKey::JumpForward)
         }
@@ -1005,6 +1016,23 @@ mod tests {
         let app = App::new(&report);
 
         let actual = translate_key(KeyCode::Char('i'), KeyModifiers::CONTROL, &app);
+
+        assert_eq!(Some(InputKey::JumpForward), actual);
+    }
+
+    #[test]
+    fn should_translate_tab_to_jump_forward() {
+        // A real Ctrl-I keypress arrives here as `KeyCode::Tab`, not
+        // `KeyCode::Char('i')` + `CONTROL` — confirmed via manual testing
+        // against a real terminal (tmux), since Ctrl-I and Tab share the
+        // same control code (0x09) without Kitty's keyboard-enhancement
+        // protocol, which this crate does not enable. Without this mapping,
+        // Ctrl-i silently did nothing in practice despite the
+        // `Char('i') + CONTROL` test above passing.
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Tab, KeyModifiers::NONE, &app);
 
         assert_eq!(Some(InputKey::JumpForward), actual);
     }

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -225,6 +225,28 @@ fn run_app(
                 if let Some(target) = next {
                     app = app.handle_key(input_key).with_right_pane_scroll(target);
                 }
+            } else if let InputKey::GotoDefinition | InputKey::GotoReferences = input_key {
+                // `gd`/`gr` candidate resolution needs `report.graph.edges`
+                // (`crate::detail::symbol_mentions`), which `App::handle_key`
+                // has no access to (ADR 0022, mirroring `NextHunk`/`PrevHunk`'s
+                // own precedent just above) — resolved here, then applied via
+                // `App::jump_to_symbol`/`App::open_jump_popup`/`App::set_status`
+                // depending on the candidate count (`resolve_goto`'s own doc
+                // comment on the three-way split).
+                match resolve_goto(&app, report, input_key) {
+                    GotoOutcome::NoSymbolSelected => {
+                        app.set_status("note: no symbol selected");
+                    }
+                    GotoOutcome::NoCandidates(direction) => {
+                        app.set_status(format!("note: no {direction}"));
+                    }
+                    GotoOutcome::One(candidate) => {
+                        app = app.jump_to_symbol(&candidate.id);
+                    }
+                    GotoOutcome::Many(candidates) => {
+                        app = app.open_jump_popup(candidates);
+                    }
+                }
             } else {
                 app = app.handle_key(input_key);
             }
@@ -300,6 +322,54 @@ fn jump_scroll_target(
     }
 }
 
+/// What `crate::run_app` should do next for a pending `gd`/`gr` press (ADR
+/// 0022's "0/1/many" branching): no symbol was selected at all, the
+/// selected symbol has no candidates in the requested direction (carrying a
+/// human-readable direction label, `"callees"`/`"callers"`, for the status
+/// message — plain data, not formatted text, matching this crate's own
+/// "view-model, not string-building, outside `ui.rs`" convention), exactly
+/// one candidate (jump immediately), or more than one (open the popup).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GotoOutcome {
+    NoSymbolSelected,
+    NoCandidates(&'static str),
+    One(app::JumpCandidate),
+    Many(Vec<app::JumpCandidate>),
+}
+
+/// Resolves a pending [`InputKey::GotoDefinition`]/[`InputKey::GotoReferences`]
+/// press into a [`GotoOutcome`], given `app`'s current cursor selection and
+/// `report`'s graph — the computation `App::handle_key` cannot do itself
+/// (ADR 0022's own rationale on `InputKey::GotoDefinition`), extracted as
+/// its own pure function (rather than inlined in `run_app`, which takes a
+/// live terminal and so cannot be driven directly in a test) so the 0/1/many
+/// branching is unit-testable without one, mirroring `jump_scroll_target`'s
+/// own precedent just above.
+fn resolve_goto(app: &App, report: &Report, direction: InputKey) -> GotoOutcome {
+    let Some(symbol_id) = app.selected_symbol_id() else {
+        return GotoOutcome::NoSymbolSelected;
+    };
+
+    let (mention_direction, label) = match direction {
+        InputKey::GotoDefinition => (crate::detail::MentionDirection::Callees, "callees"),
+        InputKey::GotoReferences => (crate::detail::MentionDirection::Callers, "callers"),
+        _ => return GotoOutcome::NoSymbolSelected,
+    };
+
+    let mentions = crate::detail::symbol_mentions(report, symbol_id, mention_direction);
+    let mut candidates = mentions.iter().map(app::JumpCandidate::from);
+
+    match (candidates.next(), candidates.next()) {
+        (None, _) => GotoOutcome::NoCandidates(label),
+        (Some(only), None) => GotoOutcome::One(only),
+        (Some(first), Some(second)) => {
+            let mut all = vec![first, second];
+            all.extend(candidates);
+            GotoOutcome::Many(all)
+        }
+    }
+}
+
 /// Whether `crate::run_app`'s event loop should recompute the pivot
 /// selection this key, rather than keep showing the previously cached one
 /// (this function's own extraction is what makes that decision
@@ -330,6 +400,19 @@ fn should_recompute_pivot_selection(app: &App) -> bool {
 /// (swallowing every non-`ToggleHelp` key while open) — belt and braces,
 /// since "the overlay is a safe action that can never accidentally quit
 /// the app" is exactly the property ADR 0020 asks this feature to hold.
+///
+/// `app.jump_popup()` (ADR 0022) is the next short-circuit, mirroring the
+/// help overlay's own structure: while the jump-target popup is open,
+/// `j`/`k`/Up/Down move its own selection, Enter confirms (`PopupConfirm`),
+/// Esc cancels (`PopupCancel`), and every other key is swallowed.
+///
+/// `app.pending_prefix()` (ADR 0022) is consulted only for `d`/`r`: when a
+/// `g` press is still pending, `d` resolves to `GotoDefinition` and `r` to
+/// `GotoReferences` instead of their own ordinary meanings (`ToggleDiff`/
+/// unbound) — every other key falls through to its normal translation
+/// unconditionally, which is what lets the pending prefix's own state
+/// (`App::handle_key`'s blanket clear-unless-`PendingGoto` rule) correctly
+/// unwind on any key that is not `d`/`r`.
 fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<InputKey> {
     if app.help_open() {
         return match code {
@@ -338,8 +421,26 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         };
     }
 
+    if app.jump_popup().is_some() {
+        return match code {
+            KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
+            KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
+            KeyCode::Enter => Some(InputKey::PopupConfirm),
+            KeyCode::Esc => Some(InputKey::PopupCancel),
+            _ => None,
+        };
+    }
+
     let on_source_screen = matches!(app.screen(), Screen::Source { .. });
     let right_focused = app.focus() == app::Focus::Right;
+
+    if app.pending_prefix() == Some(app::PendingPrefix::G) {
+        match code {
+            KeyCode::Char('d') | KeyCode::Char('D') => return Some(InputKey::GotoDefinition),
+            KeyCode::Char('r') | KeyCode::Char('R') => return Some(InputKey::GotoReferences),
+            _ => {}
+        }
+    }
 
     match code {
         KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
@@ -358,6 +459,10 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         KeyCode::Char('e') | KeyCode::Char('E') => Some(InputKey::ExpandAll),
         KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::Quit),
         KeyCode::Char('c') | KeyCode::Char('C') => Some(InputKey::CollapseAll),
+        KeyCode::Char('o') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::JumpBack),
+        KeyCode::Char('i') if modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(InputKey::JumpForward)
+        }
         KeyCode::Char('o') | KeyCode::Char('O') => Some(InputKey::ToggleOrder),
         KeyCode::Char('d') | KeyCode::Char('D') => Some(InputKey::ToggleDiff),
         KeyCode::Char('p') | KeyCode::Char('P') => Some(InputKey::TogglePivot),
@@ -378,6 +483,12 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         KeyCode::Char(']') => Some(InputKey::NextHunk),
         KeyCode::Char('[') => Some(InputKey::PrevHunk),
         KeyCode::Char('s') | KeyCode::Char('S') => Some(InputKey::Source),
+        // `g` (ADR 0022): the first half of the `gd`/`gr` two-key sequence.
+        // Checked after the `pending_prefix` resolution above so a second
+        // `g` press (`gg`, not a bound sequence today) simply restarts the
+        // pending state rather than doing anything else — `App::handle_key`
+        // sets `pending_prefix` from this variant unconditionally.
+        KeyCode::Char('g') => Some(InputKey::PendingGoto),
         KeyCode::Char('?') => Some(InputKey::ToggleHelp),
         KeyCode::Esc if on_source_screen => Some(InputKey::Back),
         KeyCode::Char('q') if on_source_screen => Some(InputKey::Back),
@@ -819,5 +930,293 @@ mod tests {
         let actual = jump_scroll_target(&hunk_starts, 3, InputKey::NextHunk);
 
         assert_eq!(Some(10), actual);
+    }
+
+    // g-prefix and jump-popup translate_key tests (ADR 0022).
+
+    #[test]
+    fn should_translate_g_to_pending_goto() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::PendingGoto), actual);
+    }
+
+    #[test]
+    fn should_translate_d_to_goto_definition_when_g_is_pending() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::PendingGoto);
+
+        let actual = translate_key(KeyCode::Char('d'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::GotoDefinition), actual);
+    }
+
+    #[test]
+    fn should_translate_r_to_goto_references_when_g_is_pending() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::PendingGoto);
+
+        let actual = translate_key(KeyCode::Char('r'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::GotoReferences), actual);
+    }
+
+    #[test]
+    fn should_translate_d_to_toggle_diff_when_no_prefix_is_pending() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('d'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ToggleDiff), actual);
+    }
+
+    #[test]
+    fn should_fall_through_to_ordinary_meaning_when_a_non_dr_key_follows_pending_goto() {
+        // `gj` is not a bound sequence — `j` must still translate to its own
+        // ordinary `Down` meaning, not be swallowed just because a prefix
+        // was pending (`App::handle_key`'s blanket clear-unless-`PendingGoto`
+        // rule is what actually unwinds `pending_prefix` on the next key;
+        // this test only pins `translate_key`'s own half of that contract).
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::PendingGoto);
+
+        let actual = translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::Down), actual);
+    }
+
+    #[test]
+    fn should_translate_ctrl_o_to_jump_back() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('o'), KeyModifiers::CONTROL, &app);
+
+        assert_eq!(Some(InputKey::JumpBack), actual);
+    }
+
+    #[test]
+    fn should_translate_ctrl_i_to_jump_forward() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('i'), KeyModifiers::CONTROL, &app);
+
+        assert_eq!(Some(InputKey::JumpForward), actual);
+    }
+
+    #[test]
+    fn should_translate_plain_o_to_toggle_order_without_control_modifier() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('o'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ToggleOrder), actual);
+    }
+
+    fn candidate(id: &str, name: &str, path: &str) -> app::JumpCandidate {
+        app::JumpCandidate {
+            id: id.to_string(),
+            name: name.to_string(),
+            path: path.to_string(),
+        }
+    }
+
+    #[test]
+    fn should_translate_j_and_k_to_popup_motion_while_jump_popup_is_open() {
+        let report = empty_report();
+        let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
+
+        assert_eq!(
+            Some(InputKey::Down),
+            translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app)
+        );
+        assert_eq!(
+            Some(InputKey::Up),
+            translate_key(KeyCode::Char('k'), KeyModifiers::NONE, &app)
+        );
+    }
+
+    #[test]
+    fn should_translate_enter_to_popup_confirm_while_jump_popup_is_open() {
+        let report = empty_report();
+        let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
+
+        let actual = translate_key(KeyCode::Enter, KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::PopupConfirm), actual);
+    }
+
+    #[test]
+    fn should_translate_esc_to_popup_cancel_while_jump_popup_is_open() {
+        let report = empty_report();
+        let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
+
+        let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::PopupCancel), actual);
+    }
+
+    #[test]
+    fn should_translate_q_to_none_while_jump_popup_is_open() {
+        // `q` must not fall through to `Quit` while the popup is open —
+        // mirrors the help overlay's own "swallow everything but the
+        // close/confirm/cancel keys" contract.
+        let report = empty_report();
+        let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
+
+        let actual = translate_key(KeyCode::Char('q'), KeyModifiers::NONE, &app);
+
+        assert_eq!(None, actual);
+    }
+
+    // resolve_goto tests (ADR 0022): the 0/1/many candidate resolution that
+    // needs `report`, extracted so it is unit-testable without a live
+    // terminal (this function's own doc comment).
+
+    fn report_with_symbols_and_edges(
+        symbols_by_file: Vec<(&str, Vec<&str>)>,
+        edges: Vec<(&str, &str)>,
+    ) -> Report {
+        use rinkaku_core::diff::LineRange;
+        use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+        use rinkaku_core::graph::{Edge, Node, SymbolGraph};
+        use rinkaku_core::render::FileReport;
+
+        let files: Vec<FileReport> = symbols_by_file
+            .iter()
+            .map(|(path, names)| FileReport {
+                path: path.to_string(),
+                symbols: names
+                    .iter()
+                    .map(|name| ExtractedSymbol {
+                        id: format!("{path}::{name}"),
+                        name: name.to_string(),
+                        kind: SymbolKind::Function,
+                        signature: format!("fn {name}()"),
+                        range: LineRange { start: 1, end: 1 },
+                        container: None,
+                        referenced_names: vec![],
+                        dependencies: vec![],
+                        omitted_dependency_matches: 0,
+                        is_test: false,
+                        classification: None,
+                        previous_signature: None,
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        let nodes: Vec<Node> = symbols_by_file
+            .iter()
+            .flat_map(|(path, names)| {
+                names.iter().map(move |name| Node {
+                    id: format!("{path}::{name}"),
+                    path: path.to_string(),
+                    name: name.to_string(),
+                })
+            })
+            .collect();
+
+        let graph_edges: Vec<Edge> = edges
+            .into_iter()
+            .map(|(from, to)| Edge {
+                from: from.to_string(),
+                to: to.to_string(),
+                is_cycle: false,
+            })
+            .collect();
+
+        Report {
+            files,
+            graph: SymbolGraph {
+                nodes,
+                edges: graph_edges,
+                roots: vec![],
+            },
+            ..empty_report()
+        }
+    }
+
+    #[test]
+    fn should_return_no_symbol_selected_when_cursor_is_not_on_a_symbol_row() {
+        let report = report_with_symbols_and_edges(vec![("lib.rs", vec!["foo"])], vec![]);
+        let app = App::new(&report); // cursor on "lib.rs" (a File row)
+
+        let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
+
+        assert_eq!(GotoOutcome::NoSymbolSelected, actual);
+    }
+
+    #[test]
+    fn should_return_no_candidates_when_selected_symbol_has_no_callees() {
+        let report = report_with_symbols_and_edges(vec![("lib.rs", vec!["foo"])], vec![]);
+        let app = App::new(&report).handle_key(InputKey::Down); // cursor on "foo"
+
+        let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
+
+        assert_eq!(GotoOutcome::NoCandidates("callees"), actual);
+    }
+
+    #[test]
+    fn should_return_one_candidate_when_selected_symbol_has_exactly_one_callee() {
+        let report = report_with_symbols_and_edges(
+            vec![("lib.rs", vec!["foo", "bar"])],
+            vec![("lib.rs::foo", "lib.rs::bar")],
+        );
+        let app = App::new(&report).handle_key(InputKey::Down); // cursor on "foo"
+
+        let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
+
+        assert_eq!(
+            GotoOutcome::One(candidate("lib.rs::bar", "bar", "lib.rs")),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_return_many_candidates_when_selected_symbol_has_multiple_callees() {
+        let report = report_with_symbols_and_edges(
+            vec![("lib.rs", vec!["foo", "bar", "baz"])],
+            vec![
+                ("lib.rs::foo", "lib.rs::bar"),
+                ("lib.rs::foo", "lib.rs::baz"),
+            ],
+        );
+        let app = App::new(&report).handle_key(InputKey::Down); // cursor on "foo"
+
+        let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
+
+        assert_eq!(
+            GotoOutcome::Many(vec![
+                candidate("lib.rs::bar", "bar", "lib.rs"),
+                candidate("lib.rs::baz", "baz", "lib.rs"),
+            ]),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_resolve_callers_direction_when_goto_references_is_requested() {
+        let report = report_with_symbols_and_edges(
+            vec![("lib.rs", vec!["foo", "bar"])],
+            vec![("lib.rs::foo", "lib.rs::bar")],
+        );
+        // Cursor on "bar" (row 2): "foo" is its one caller.
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Down);
+
+        let actual = resolve_goto(&app, &report, InputKey::GotoReferences);
+
+        assert_eq!(
+            GotoOutcome::One(candidate("lib.rs::foo", "foo", "lib.rs")),
+            actual
+        );
     }
 }

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -210,45 +210,12 @@ fn run_app(
                         Err(message) => app.set_status(message),
                     }
                 }
-            } else if let InputKey::NextHunk | InputKey::PrevHunk = input_key
-                && should_apply_hunk_jump(&app)
-            {
-                // Hunk jumping needs the shaped diff content already
-                // cached above (`diff_pane_content`) to know where each
-                // hunk starts — `App::handle_key` itself has no notion of
-                // that content, so the jump target is computed here, at
-                // the one place both `app` and `diff_pane_content` are in
-                // scope, rather than threading the whole shaped content
-                // into `App` just for this.
-                let scroll = diff_shape::hunk_start_lines(&diff_pane_content);
-                let next = jump_scroll_target(&scroll, app.right_pane_scroll(), input_key);
-                if let Some(target) = next {
-                    app = app.handle_key(input_key).with_right_pane_scroll(target);
-                }
-            } else if let InputKey::GotoDefinition | InputKey::GotoReferences = input_key {
-                // `gd`/`gr` candidate resolution needs `report.graph.edges`
-                // (`crate::detail::symbol_mentions`), which `App::handle_key`
-                // has no access to (ADR 0022, mirroring `NextHunk`/`PrevHunk`'s
-                // own precedent just above) — resolved here, then applied via
-                // `App::jump_to_symbol`/`App::open_jump_popup`/`App::set_status`
-                // depending on the candidate count (`resolve_goto`'s own doc
-                // comment on the three-way split).
-                match resolve_goto(&app, report, input_key) {
-                    GotoOutcome::NoSymbolSelected => {
-                        app.set_status("note: no symbol selected");
-                    }
-                    GotoOutcome::NoCandidates(direction) => {
-                        app.set_status(format!("note: no {direction}"));
-                    }
-                    GotoOutcome::One(candidate) => {
-                        app = app.jump_to_symbol(&candidate.id);
-                    }
-                    GotoOutcome::Many(candidates) => {
-                        app = app.open_jump_popup(candidates);
-                    }
-                }
             } else {
-                app = app.handle_key(input_key);
+                // Every non-`Source` key's dispatch is pure (no IO), so it
+                // lives in its own function rather than inline here — see
+                // `dispatch_non_source_key`'s own doc comment for why this
+                // split exists (ADR 0022's `pending_prefix` regression).
+                app = dispatch_non_source_key(app, report, &diff_pane_content, input_key);
             }
 
             if should_recompute_pivot_selection(&app) {
@@ -263,6 +230,90 @@ fn run_app(
             }
         }
     }
+}
+
+/// Dispatches one [`InputKey`] that is not [`InputKey::Source`] (the one
+/// key `crate::run_app`'s loop handles inline instead, since it needs a
+/// real file read — ADR 0016's "IO isolated to one function" discipline
+/// keeps that read out of this otherwise-pure function) against `app`,
+/// given `report` and the already-cached `diff_pane_content` both
+/// `NextHunk`/`PrevHunk` and `GotoDefinition`/`GotoReferences` need but
+/// `App::handle_key` itself has no access to (`InputKey::NextHunk`'s own
+/// doc comment). Returns the next `App`.
+///
+/// Extracted out of `run_app`'s loop body specifically to make this
+/// dispatch sequence unit-testable without a live `ratatui::DefaultTerminal`
+/// — `run_app` itself cannot be driven directly in a test, so a bug in the
+/// *sequencing* of this dispatch (as opposed to a bug in one arm's own
+/// logic, which the arm's own unit tests already cover) had no regression
+/// coverage before this function existed. That gap is exactly how ADR
+/// 0022's `pending_prefix` bug survived review: every existing test called
+/// `App::handle_key` directly, which always runs its own unconditional
+/// `pending_prefix` clear — the bug was specifically that `run_app`'s old
+/// inline `GotoDefinition`/`GotoReferences` branch *skipped* that call
+/// entirely, a defect only visible by testing this exact dispatch sequence,
+/// not `handle_key` in isolation.
+fn dispatch_non_source_key(
+    mut app: App,
+    report: &Report,
+    diff_pane_content: &diff_shape::DiffPaneContent,
+    input_key: InputKey,
+) -> App {
+    if let InputKey::NextHunk | InputKey::PrevHunk = input_key
+        && should_apply_hunk_jump(&app)
+    {
+        // Hunk jumping needs the shaped diff content already cached by the
+        // caller (to know where each hunk starts — `App::handle_key` itself
+        // has no notion of that content), so the jump target is computed
+        // here rather than inside `App`.
+        let scroll = diff_shape::hunk_start_lines(diff_pane_content);
+        let next = jump_scroll_target(&scroll, app.right_pane_scroll(), input_key);
+        if let Some(target) = next {
+            return app.handle_key(input_key).with_right_pane_scroll(target);
+        }
+        return app;
+    }
+
+    if let InputKey::GotoDefinition | InputKey::GotoReferences = input_key {
+        // `gd`/`gr` candidate resolution needs `report.graph.edges`
+        // (`crate::detail::symbol_mentions`), which `App::handle_key` has no
+        // access to (ADR 0022, mirroring `NextHunk`/`PrevHunk`'s own
+        // precedent just above) — resolved here, then applied via
+        // `App::jump_to_symbol`/`App::open_jump_popup`/`App::set_status`
+        // depending on the candidate count (`resolve_goto`'s own doc
+        // comment on the three-way split).
+        //
+        // `app.handle_key(input_key)` is called first (post-review finding),
+        // even though its own match arm for these two variants is a no-op
+        // stub — what matters is not that arm, it is `handle_key`'s own
+        // unconditional `pending_prefix` clear at the top of the function.
+        // Skipping this call, an earlier version of this dispatch did,
+        // meant `gd`/`gr` was the one key in this whole function that never
+        // reached `App::handle_key` at all, so a `gd`/`gr` press left
+        // `pending_prefix` stuck at `Some(G)` and the *next* `d`/`r` the
+        // reviewer typed for its own ordinary reason (`ToggleDiff`, or
+        // nothing at all) silently re-resolved as another `GotoDefinition`/
+        // `GotoReferences` instead of its own meaning — violating ADR
+        // 0022's own "any other key discards the pending prefix" guarantee.
+        // Reading `app.selected_symbol_id()`/cursor state via `resolve_goto`
+        // *after* this call is safe: the no-op stub touches nothing but
+        // `pending_prefix` for these two variants.
+        app = app.handle_key(input_key);
+        return match resolve_goto(&app, report, input_key) {
+            GotoOutcome::NoSymbolSelected => {
+                app.set_status("note: no symbol selected");
+                app
+            }
+            GotoOutcome::NoCandidates(direction) => {
+                app.set_status(format!("note: no {direction}"));
+                app
+            }
+            GotoOutcome::One(candidate) => app.jump_to_symbol(&candidate.id),
+            GotoOutcome::Many(candidates) => app.open_jump_popup(candidates),
+        };
+    }
+
+    app.handle_key(input_key)
 }
 
 /// Whether `crate::run_app`'s event loop should recompute the diff pane's
@@ -353,6 +404,17 @@ fn resolve_goto(app: &App, report: &Report, direction: InputKey) -> GotoOutcome 
     let (mention_direction, label) = match direction {
         InputKey::GotoDefinition => (crate::detail::MentionDirection::Callees, "callees"),
         InputKey::GotoReferences => (crate::detail::MentionDirection::Callers, "callers"),
+        // Unreachable: this function's only call site (`dispatch_non_source_key`)
+        // already guards on `matches!(input_key, InputKey::GotoDefinition |
+        // InputKey::GotoReferences)` before calling here, so `direction` is
+        // never anything else in practice. `GotoOutcome::NoSymbolSelected`
+        // is a misleading label for this branch specifically (this has
+        // nothing to do with whether a symbol is selected — it is a
+        // different caller-contract violation entirely), but is reused
+        // rather than adding a dedicated `GotoOutcome` variant purely for an
+        // unreachable defensive fallback; the important part is that this
+        // never panics on a future caller mistake, not that its exact label
+        // is semantically precise for a branch that cannot be reached today.
         _ => return GotoOutcome::NoSymbolSelected,
     };
 
@@ -1245,6 +1307,100 @@ mod tests {
         assert_eq!(
             GotoOutcome::One(candidate("lib.rs::foo", "foo", "lib.rs")),
             actual
+        );
+    }
+
+    // dispatch_non_source_key regression tests: the `run_app`-equivalent
+    // dispatch sequence (as opposed to calling `App::handle_key` directly,
+    // which every test above this point does and which was exactly why the
+    // `pending_prefix` bug survived until manual/review testing caught it —
+    // `App::handle_key`'s own unconditional prefix-clear ran fine in every
+    // one of those tests, but `run_app`'s old inline `GotoDefinition`/
+    // `GotoReferences` branch skipped calling it in the first place).
+
+    #[test]
+    fn should_clear_pending_prefix_so_next_d_toggles_diff_after_a_one_candidate_gd_jump() {
+        let report = report_with_symbols_and_edges(
+            vec![("lib.rs", vec!["foo", "bar"])],
+            vec![("lib.rs::foo", "lib.rs::bar")],
+        );
+        // Cursor on "foo" (row 1): "bar" is its one callee, so `gd` jumps
+        // immediately rather than opening the popup.
+        let app = App::new(&report).handle_key(InputKey::Down);
+        let diff_content = diff_shape::DiffPaneContent::Empty;
+
+        // Simulates the real `g` then `d` key sequence: `translate_key`
+        // emits `PendingGoto` for `g`, then (because `pending_prefix` is
+        // now set) `GotoDefinition` for the following `d` — both routed
+        // through `dispatch_non_source_key`, the same function `run_app`
+        // itself calls, rather than `App::handle_key` directly.
+        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
+        assert_eq!(Some(app::PendingPrefix::G), app.pending_prefix());
+        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoDefinition);
+        assert_eq!(None, app.pending_prefix(), "gd must clear pending_prefix");
+
+        // The regression itself: a *plain* `d` right after the jump must
+        // toggle the right pane (`ToggleDiff`'s own ordinary meaning), not
+        // silently re-resolve as another `gd` because `pending_prefix` was
+        // still `Some(G)` — `crate::lib::translate_key` only produces
+        // `GotoDefinition` for a `d` when `pending_prefix() == Some(G)`, so
+        // this assertion on `right_pane()` is an indirect but faithful proxy
+        // for "the next `d` meant ToggleDiff, not gd".
+        let right_pane_before = app.right_pane();
+        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::ToggleDiff);
+        assert_ne!(
+            right_pane_before,
+            app.right_pane(),
+            "d after gd must toggle the right pane like an ordinary ToggleDiff press"
+        );
+    }
+
+    #[test]
+    fn should_clear_pending_prefix_so_next_d_toggles_diff_after_a_multi_candidate_gr_popup_is_cancelled()
+     {
+        let report = report_with_symbols_and_edges(
+            vec![("lib.rs", vec!["foo", "bar", "baz"])],
+            vec![
+                ("lib.rs::foo", "lib.rs::bar"),
+                ("lib.rs::baz", "lib.rs::bar"),
+            ],
+        );
+        // Cursor on "bar" (row 2): both "foo" and "baz" call it, so `gr`
+        // opens the popup rather than jumping immediately.
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Down);
+        let diff_content = diff_shape::DiffPaneContent::Empty;
+
+        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
+        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoReferences);
+        assert!(
+            app.jump_popup().is_some(),
+            "gr with 2 candidates must open the popup"
+        );
+        assert_eq!(
+            None,
+            app.pending_prefix(),
+            "gr must clear pending_prefix even though it opened a popup instead of jumping"
+        );
+
+        // Cancel the popup (Esc) — `App::handle_key`'s own popup-open early
+        // return is the second path the #61-review finding flagged: it used
+        // to return before the (then-later-positioned) `pending_prefix`
+        // clear, so a stale prefix could survive an entire popup session.
+        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PopupCancel);
+        assert_eq!(None, app.jump_popup());
+        assert_eq!(None, app.pending_prefix());
+
+        // Same regression check as the single-candidate test above: a plain
+        // `d` after the cancelled popup must toggle the right pane, not
+        // silently re-resolve as another `gr`.
+        let right_pane_before = app.right_pane();
+        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::ToggleDiff);
+        assert_ne!(
+            right_pane_before,
+            app.right_pane(),
+            "d after a cancelled gr popup must toggle the right pane like an ordinary ToggleDiff press"
         );
     }
 }

--- a/rinkaku-tui/src/nav.rs
+++ b/rinkaku-tui/src/nav.rs
@@ -125,6 +125,53 @@ impl Nav {
         true
     }
 
+    /// Moves the cursor to the [`NodeKind::Symbol`] row whose
+    /// [`crate::tree::SymbolRef::id`] equals `symbol_id`, expanding every
+    /// collapsed ancestor directory/file on the path to it, or leaves the
+    /// cursor untouched (returning `false`) when no row's symbol id matches
+    /// at all. Exists for jump navigation (ADR 0022's `gd`/`gr`), a sibling
+    /// to [`Self::move_cursor_to_path`] rather than a generalization of it —
+    /// that method deliberately excludes `Symbol` rows (its own doc comment)
+    /// because pivoting has no single-symbol-scoped meaning, and this method
+    /// is symbol-only for the mirror-image reason: a jump target is always a
+    /// specific symbol, never a directory/file.
+    ///
+    /// Unlike `move_cursor_to_path`'s "no-op if hidden under a collapsed
+    /// ancestor" contract (appropriate for `--entry`'s startup-time pivot,
+    /// where a fresh `App` is always fully expanded and a miss is genuinely
+    /// a wrong path), a mid-session jump target is very likely to be folded
+    /// away by the time the reviewer presses `gd`/`gr` — silently failing to
+    /// jump because of unrelated fold state would defeat the feature's own
+    /// purpose, so this method expands whatever stands in the way instead of
+    /// giving up.
+    pub fn move_cursor_to_symbol(&mut self, tree: &Tree, symbol_id: &str) -> bool {
+        let Some(path_chain) = find_symbol_ancestor_chain(tree, symbol_id) else {
+            return false;
+        };
+        // Expand every ancestor directory/file on the path to the target
+        // (all but the last entry, which is the symbol's own file — files
+        // have no `collapsed` entry of their own to expand, only their
+        // directory ancestors do, but removing a path that was never
+        // collapsed is a harmless no-op).
+        for ancestor_path in &path_chain {
+            self.collapsed.remove(ancestor_path);
+        }
+
+        let rows = self.rows(tree);
+        let Some(index) = rows.iter().position(|row| {
+            matches!(&row.node.kind, NodeKind::Symbol(symbol_ref) if symbol_ref.id == symbol_id)
+        }) else {
+            // Defensive: `find_symbol_ancestor_chain` already found this
+            // node in `tree`, and every ancestor was just expanded above, so
+            // the row must now be visible — this branch only guards against
+            // a future bug in the expansion logic rather than a reachable
+            // runtime condition.
+            return false;
+        };
+        self.cursor = index;
+        true
+    }
+
     fn push_rows<'a>(&self, node: &'a TreeNode, depth: usize, rows: &mut Vec<Row<'a>>) {
         let has_children = !node.children.is_empty();
         let expanded = has_children && !self.collapsed.contains(&node.path);
@@ -295,6 +342,39 @@ fn collect_collapsible(node: &TreeNode, paths: &mut HashSet<String>) {
     }
 }
 
+/// Every ancestor directory/file path (nearest first, i.e. the symbol's own
+/// containing file first, then that file's directory, out to the root) on
+/// the way to the [`NodeKind::Symbol`] row whose id equals `symbol_id`, or
+/// `None` when no such symbol exists anywhere in `tree` — a plain tree walk
+/// independent of any [`Nav`]'s collapse state (unlike
+/// [`Nav::push_rows`]/[`Nav::rows`], which skip collapsed subtrees), since
+/// [`Nav::move_cursor_to_symbol`] needs to find the target and its ancestors
+/// *regardless* of what is currently folded, precisely so it can expand
+/// them.
+fn find_symbol_ancestor_chain(tree: &Tree, symbol_id: &str) -> Option<Vec<String>> {
+    for root in &tree.roots {
+        if let Some(chain) = collect_symbol_ancestor_chain(root, symbol_id) {
+            return Some(chain);
+        }
+    }
+    None
+}
+
+fn collect_symbol_ancestor_chain(node: &TreeNode, symbol_id: &str) -> Option<Vec<String>> {
+    if let NodeKind::Symbol(symbol_ref) = &node.kind
+        && symbol_ref.id == symbol_id
+    {
+        return Some(Vec::new());
+    }
+    for child in &node.children {
+        if let Some(mut chain) = collect_symbol_ancestor_chain(child, symbol_id) {
+            chain.push(node.path.clone());
+            return Some(chain);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -406,6 +486,73 @@ mod tests {
 
         assert!(!actual);
         assert_eq!(0, nav.cursor());
+    }
+
+    #[test]
+    fn should_move_cursor_to_matching_symbol_row_when_symbol_id_matches() {
+        let tree = sample_tree();
+        let mut nav = Nav::new();
+
+        let actual = nav.move_cursor_to_symbol(&tree, "src/lib.rs::bar");
+
+        assert!(actual);
+        // Row 3 is "bar" (src(0), src/lib.rs(1), foo(2), bar(3)).
+        assert_eq!(3, nav.cursor());
+    }
+
+    #[test]
+    fn should_not_move_cursor_when_no_symbol_id_matches() {
+        let tree = sample_tree();
+        let mut nav = Nav::new().handle(Action::CursorDown, &tree);
+        assert_eq!(1, nav.cursor());
+
+        let actual = nav.move_cursor_to_symbol(&tree, "no/such/id");
+
+        assert!(!actual);
+        assert_eq!(1, nav.cursor());
+    }
+
+    #[test]
+    fn should_expand_collapsed_ancestor_when_jumping_to_a_hidden_symbol() {
+        let tree = sample_tree();
+        let mut nav = Nav::new().handle(Action::ToggleExpand, &tree); // collapse "src"
+        assert_eq!(vec!["src"], row_paths(&nav.rows(&tree)));
+
+        let actual = nav.move_cursor_to_symbol(&tree, "src/lib.rs::foo");
+
+        assert!(actual);
+        let rows = nav.rows(&tree);
+        assert_eq!(
+            vec!["src", "src/lib.rs", "src/lib.rs", "src/lib.rs"],
+            row_paths(&rows)
+        );
+        assert_eq!("foo", symbol_name(&rows[nav.cursor()]));
+    }
+
+    #[test]
+    fn should_expand_multiple_collapsed_ancestors_when_jumping_to_a_deeply_hidden_symbol() {
+        let tree = deep_tree();
+        let mut nav = Nav::new();
+        // Collapse both "src" and "src/pkg" so the target symbol is hidden
+        // two levels deep.
+        nav = nav.handle(Action::ToggleExpand, &tree); // collapse "src" (cursor was on it)
+        assert_eq!(vec!["src"], row_paths(&nav.rows(&tree)));
+
+        let actual = nav.move_cursor_to_symbol(&tree, "src/pkg/lib.rs::bar");
+
+        assert!(actual);
+        let rows = nav.rows(&tree);
+        assert_eq!(
+            vec![
+                "src",
+                "src/pkg",
+                "src/pkg/lib.rs",
+                "src/pkg/lib.rs",
+                "src/pkg/lib.rs"
+            ],
+            row_paths(&rows)
+        );
+        assert_eq!("bar", symbol_name(&rows[nav.cursor()]));
     }
 
     #[test]
@@ -566,6 +713,16 @@ mod tests {
 
     fn row_paths<'a>(rows: &'a [Row<'a>]) -> Vec<&'a str> {
         rows.iter().map(|r| r.node.path.as_str()).collect()
+    }
+
+    /// The `name` of a [`NodeKind::Symbol`] row — panics on any other row
+    /// kind, since every call site above already knows (from its own
+    /// fixture) that the cursor should have landed on a symbol row.
+    fn symbol_name<'a>(row: &Row<'a>) -> &'a str {
+        match &row.node.kind {
+            NodeKind::Symbol(symbol_ref) => symbol_ref.name.as_str(),
+            other => panic!("expected NodeKind::Symbol, got {other:?}"),
+        }
     }
 
     // CRITICAL 2 regression: `cursor()`'s doc comment invites

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -80,6 +80,9 @@ pub fn draw(
     if app.help_open() {
         draw_help_overlay(frame, area);
     }
+    if let Some(popup) = app.jump_popup() {
+        draw_jump_popup(frame, popup, area);
+    }
 }
 
 /// Draws the `?` help overlay (ADR 0020) centered over `full_area`: a
@@ -150,6 +153,45 @@ fn centered_rect(area: Rect, percent_width: u16, percent_height: u16) -> Rect {
     .areas(middle);
 
     center
+}
+
+/// Draws the jump-target popup (ADR 0022) centered over `full_area`,
+/// listing every candidate as `name (path)` with the currently highlighted
+/// one shown reversed — the same `Clear`-first, centered-bordered-box
+/// compositing `draw_help_overlay` already uses, just a narrower and
+/// shorter box (60% x 40%, vs. the help overlay's 80% x 90%) since a
+/// candidate list is typically much shorter than the whole keymap; content
+/// taller than the box simply wraps/scrolls off, the same tradeoff
+/// `draw_help_overlay` already accepts for a very long keymap on a small
+/// terminal rather than dynamically sizing the box to content.
+fn draw_jump_popup(frame: &mut Frame, popup: &crate::app::JumpPopup, full_area: Rect) {
+    let overlay_area = centered_rect(full_area, 60, 40);
+    frame.render_widget(Clear, overlay_area);
+
+    let lines: Vec<Line<'static>> = popup
+        .candidates
+        .iter()
+        .enumerate()
+        .map(|(index, candidate)| {
+            let text = format!("{} ({})", candidate.name, candidate.path);
+            if index == popup.cursor {
+                Line::styled(
+                    text,
+                    Style::default()
+                        .add_modifier(Modifier::REVERSED)
+                        .add_modifier(Modifier::BOLD),
+                )
+            } else {
+                Line::raw(text)
+            }
+        })
+        .collect();
+
+    let block = Block::bordered().title(" Jump to (enter: go, esc: cancel) ");
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(ratatui::widgets::Wrap { trim: false });
+    frame.render_widget(paragraph, overlay_area);
 }
 
 /// Left entry pane (directory tree) + right pane, split 60/40 — this
@@ -1092,13 +1134,13 @@ fn status_line_text(app: &App) -> String {
             };
             let keys = match app.focus() {
                 crate::app::Focus::Tree => {
-                    "j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  p: pivot  s: source  ?: help  q: quit"
+                    "j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  p: pivot  s: source  gd/gr: jump  ?: help  q: quit"
                 }
                 crate::app::Focus::Right if app.right_pane() == crate::app::RightPane::Diff => {
-                    "j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  p: pivot  ?: help  q: quit"
+                    "j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  p: pivot  gd/gr: jump  ?: help  q: quit"
                 }
                 crate::app::Focus::Right => {
-                    "j/k: scroll  h/esc: back  d: diff  p: pivot  ?: help  q: quit"
+                    "j/k: scroll  h/esc: back  d: diff  p: pivot  gd/gr: jump  ?: help  q: quit"
                 }
             };
             format!("order: {order}  |  {keys}")
@@ -1288,6 +1330,67 @@ mod tests {
 
         let text = buffer_text(&terminal);
         assert!(!text.contains("Glossary"));
+    }
+
+    #[test]
+    fn should_draw_jump_popup_with_every_candidate_when_jump_popup_is_open() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).open_jump_popup(vec![
+            crate::app::JumpCandidate {
+                id: "lib.rs::alpha".to_string(),
+                name: "alpha".to_string(),
+                path: "lib.rs".to_string(),
+            },
+            crate::app::JumpCandidate {
+                id: "lib.rs::beta".to_string(),
+                name: "beta".to_string(),
+                path: "lib.rs".to_string(),
+            },
+        ]);
+        let mut terminal = Terminal::new(TestBackend::new(100, 40)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &PivotSelection::NotApplicable,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Jump to"));
+        assert!(text.contains("alpha"));
+        assert!(text.contains("beta"));
+    }
+
+    #[test]
+    fn should_not_draw_jump_popup_when_no_jump_is_pending() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &PivotSelection::NotApplicable,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(!text.contains("Jump to"));
     }
 
     #[test]
@@ -2286,10 +2389,10 @@ index e69de29..4b825dc 100644
         let app = App::new(&report);
         // Wider than the default 80 columns used elsewhere in this test
         // module: the full help text (order mode + Tree-focus key hints,
-        // ADR 0020) is ~140 columns and would otherwise be truncated (the
-        // status line intentionally does not wrap), hiding the "quit"
+        // ADR 0020/0022) is ~155 columns and would otherwise be truncated
+        // (the status line intentionally does not wrap), hiding the "quit"
         // fragment this test checks for.
-        let mut terminal = Terminal::new(TestBackend::new(150, 20)).expect("terminal");
+        let mut terminal = Terminal::new(TestBackend::new(170, 20)).expect("terminal");
 
         terminal
             .draw(|frame| {
@@ -2465,7 +2568,7 @@ index e69de29..4b825dc 100644
         let actual = status_line_text(&app);
 
         assert_eq!(
-            "order: topological  |  j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  p: pivot  s: source  ?: help  q: quit"
+            "order: topological  |  j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  p: pivot  s: source  gd/gr: jump  ?: help  q: quit"
                 .to_string(),
             actual
         );
@@ -2493,7 +2596,7 @@ index e69de29..4b825dc 100644
         let actual = status_line_text(&app);
 
         assert_eq!(
-            "order: topological  |  j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  p: pivot  ?: help  q: quit"
+            "order: topological  |  j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  p: pivot  gd/gr: jump  ?: help  q: quit"
                 .to_string(),
             actual
         );
@@ -2514,7 +2617,7 @@ index e69de29..4b825dc 100644
         let actual = status_line_text(&app);
 
         assert_eq!(
-            "order: topological  |  j/k: scroll  h/esc: back  d: diff  p: pivot  ?: help  q: quit"
+            "order: topological  |  j/k: scroll  h/esc: back  d: diff  p: pivot  gd/gr: jump  ?: help  q: quit"
                 .to_string(),
             actual
         );

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -160,32 +160,56 @@ fn centered_rect(area: Rect, percent_width: u16, percent_height: u16) -> Rect {
 /// one shown reversed — the same `Clear`-first, centered-bordered-box
 /// compositing `draw_help_overlay` already uses, just a narrower and
 /// shorter box (60% x 40%, vs. the help overlay's 80% x 90%) since a
-/// candidate list is typically much shorter than the whole keymap; content
-/// taller than the box simply wraps/scrolls off, the same tradeoff
-/// `draw_help_overlay` already accepts for a very long keymap on a small
-/// terminal rather than dynamically sizing the box to content.
+/// candidate list is typically much shorter than the whole keymap.
+///
+/// Windowed around `popup.cursor` via [`windowed_rows_with_indicators`]
+/// (post-#61 review finding: this used to hand every candidate to
+/// `Paragraph` unscrolled, so a popup with more candidates than the box's
+/// height could select an off-screen candidate with no visual feedback at
+/// all) — the same cursor-follow scroll `draw_tree_pane` uses, plus dim
+/// "… N more above/below" lines inside the box when the window does not
+/// reach an edge of the candidate list.
 fn draw_jump_popup(frame: &mut Frame, popup: &crate::app::JumpPopup, full_area: Rect) {
     let overlay_area = centered_rect(full_area, 60, 40);
     frame.render_widget(Clear, overlay_area);
 
-    let lines: Vec<Line<'static>> = popup
-        .candidates
-        .iter()
-        .enumerate()
-        .map(|(index, candidate)| {
-            let text = format!("{} ({})", candidate.name, candidate.path);
-            if index == popup.cursor {
-                Line::styled(
-                    text,
-                    Style::default()
-                        .add_modifier(Modifier::REVERSED)
-                        .add_modifier(Modifier::BOLD),
-                )
-            } else {
-                Line::raw(text)
-            }
-        })
-        .collect();
+    // 2 rows for the top/bottom border, matching `render_scrollable_pane`'s
+    // own `saturating_sub(2)` convention for a bordered pane's inner height.
+    let viewport_height = overlay_area.height.saturating_sub(2) as usize;
+    let (start, end, above, below) =
+        windowed_rows_with_indicators(popup.candidates.len(), popup.cursor, viewport_height);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    if let Some(above) = above {
+        lines.push(Line::styled(
+            above,
+            Style::default().add_modifier(Modifier::DIM),
+        ));
+    }
+    lines.extend(
+        popup.candidates[start..end]
+            .iter()
+            .enumerate()
+            .map(|(offset, candidate)| {
+                let text = format!("{} ({})", candidate.name, candidate.path);
+                if start + offset == popup.cursor {
+                    Line::styled(
+                        text,
+                        Style::default()
+                            .add_modifier(Modifier::REVERSED)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                } else {
+                    Line::raw(text)
+                }
+            }),
+    );
+    if let Some(below) = below {
+        lines.push(Line::styled(
+            below,
+            Style::default().add_modifier(Modifier::DIM),
+        ));
+    }
 
     let block = Block::bordered().title(" Jump to (enter: go, esc: cancel) ");
     let paragraph = Paragraph::new(lines)
@@ -227,20 +251,64 @@ fn draw_entry_screen(
     }
 }
 
+/// Draws the entry tree, windowed around the cursor
+/// ([`windowed_rows_with_indicators`]) so the cursor row is always inside
+/// the viewport — post-#61 review finding: this used to hand `Nav::rows`'
+/// entire row list to `Paragraph` unscrolled, so moving the cursor past the
+/// bottom of the initial viewport (via repeated `j`, or a `gd`/`gr` jump
+/// landing far from the current scroll position) looked like the keypress
+/// had no effect at all, since the screen kept showing exactly the same
+/// rows. A `(first-last/total)` title suffix mirrors `render_scrollable_pane`'s
+/// own `scroll_indicator` convention, and the windowing also grows a dim
+/// "… N more above/below" line inside the pane itself when the window does
+/// not start/end at the list's own edge — belt and braces with the title
+/// suffix, since the title is easy to miss but the in-pane line sits right
+/// where the reviewer's eye already is.
 fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
     let rows = app.nav().rows(app.tree());
     let labels = relative_labels(&rows);
     let cursor = app.nav().cursor();
-
     let ranks = app.ranks();
-    let lines: Vec<Line<'static>> = rows
-        .iter()
-        .zip(labels.iter())
-        .enumerate()
-        .map(|(index, (row, label))| entry_row_line(row, label, ranks, index == cursor))
-        .collect();
 
-    let block = Block::bordered().title(" Entry ");
+    // 2 rows for the top/bottom border, matching `render_scrollable_pane`'s
+    // own `saturating_sub(2)` convention for a bordered pane's inner height.
+    let viewport_height = area.height.saturating_sub(2) as usize;
+    let (start, end, above, below) =
+        windowed_rows_with_indicators(rows.len(), cursor, viewport_height);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    if let Some(above) = above {
+        lines.push(Line::styled(
+            above,
+            Style::default().add_modifier(Modifier::DIM),
+        ));
+    }
+    lines.extend(
+        rows[start..end]
+            .iter()
+            .zip(labels[start..end].iter())
+            .enumerate()
+            .map(|(offset, (row, label))| {
+                entry_row_line(row, label, ranks, start + offset == cursor)
+            }),
+    );
+    if let Some(below) = below {
+        lines.push(Line::styled(
+            below,
+            Style::default().add_modifier(Modifier::DIM),
+        ));
+    }
+
+    // `end - start`, not the raw `viewport_height`, is the title
+    // indicator's own "how many rows are actually visible" — the two can
+    // differ once `windowed_rows_with_indicators` has reserved rows for the
+    // in-pane "… N more" lines, and `scroll_indicator` reporting the
+    // unreserved `viewport_height` would overstate the last visible row.
+    let title = match scroll_indicator(rows.len(), end - start, start) {
+        Some(indicator) => format!("{}{indicator} ", " Entry".trim_end()),
+        None => " Entry ".to_string(),
+    };
+    let block = Block::bordered().title(title);
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
 }
@@ -542,6 +610,114 @@ fn wrap_one_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
 fn clamp_scroll(content_len: usize, viewport_height: usize, requested_scroll: usize) -> usize {
     let max_scroll = content_len.saturating_sub(viewport_height);
     requested_scroll.min(max_scroll)
+}
+
+/// Computes the `[start, end)` window of `total_items` rows to display in a
+/// viewport `viewport_height` rows tall so that `cursor_index` is always
+/// inside `[start, end)` — the tree pane's own cursor-follow scroll
+/// (post-#61 review finding: `draw_tree_pane` used to hand `Nav::rows`'
+/// *entire* row list to `Paragraph` unscrolled, so jumping the cursor to a
+/// row outside the initial viewport — via `j`/`k` repeated past the bottom,
+/// or a `gd`/`gr` jump — left the screen showing exactly the same rows as
+/// before, looking like the keypress had no effect) and the jump-target
+/// popup's own candidate-list scroll (same underlying gap: `draw_jump_popup`
+/// used to hand every candidate to `Paragraph` unscrolled).
+///
+/// Mirrors `crate::source::visible_window`'s centering approach (keep the
+/// point of interest mid-viewport rather than pinned to an edge, so a few
+/// rows of context are visible on both sides) but for a single index rather
+/// than a highlighted range, and 0-based indices/half-open `[start, end)`
+/// throughout — matching this module's own row-index convention
+/// (`draw_tree_pane`'s `index == cursor` check) rather than `visible_window`'s
+/// 1-based line-number convention, so callers here never need to convert.
+///
+/// `total_items == 0` or `viewport_height == 0` returns `(0, 0)` — an empty
+/// window, nothing to show either way.
+fn visible_index_window(
+    total_items: usize,
+    cursor_index: usize,
+    viewport_height: usize,
+) -> (usize, usize) {
+    if total_items == 0 || viewport_height == 0 {
+        return (0, 0);
+    }
+
+    let half = viewport_height / 2;
+    let ideal_start = cursor_index.saturating_sub(half);
+
+    // Clamp so the window never runs past the end of the list, then clamp
+    // again at zero so a short list (fewer items than `viewport_height`)
+    // still yields a valid, in-bounds window rather than a negative start —
+    // same two-step clamp `visible_window` itself uses.
+    let max_start = total_items.saturating_sub(viewport_height);
+    let start = ideal_start.min(max_start);
+    let end = (start + viewport_height).min(total_items);
+
+    (start, end)
+}
+
+/// Builds a `"…N more above"`/`"…N more below"` pair of indicator lines for
+/// content windowed by [`visible_index_window`] — `above`/`below` are the
+/// counts of items hidden on each side (`start`/`total_items - end`
+/// respectively), formatted only when nonzero so a window that already
+/// shows everything (or sits at an edge) does not grow a spurious "…0 more"
+/// line. Returned as `(above, below)`, each `Option<String>`, for the caller
+/// to place immediately before/after the windowed content — kept as plain
+/// `String`s rather than `ratatui::text::Line` so this stays unit-testable
+/// without a `ratatui` type, matching [`scroll_indicator`]'s own precedent.
+fn window_overflow_indicators(
+    total_items: usize,
+    window_start: usize,
+    window_end: usize,
+) -> (Option<String>, Option<String>) {
+    let above = window_start;
+    let below = total_items.saturating_sub(window_end);
+    (
+        (above > 0).then(|| format!("… {above} more above")),
+        (below > 0).then(|| format!("… {below} more below")),
+    )
+}
+
+/// Ties [`visible_index_window`] and [`window_overflow_indicators`]
+/// together correctly for a caller that renders the indicator lines
+/// *inside* the same fixed-height viewport as the windowed content itself
+/// (`draw_tree_pane`/`draw_jump_popup`'s own layout): naively computing the
+/// content window against the *full* `viewport_height` and then
+/// unconditionally prepending/appending indicator lines on top overflows
+/// the viewport by up to 2 rows, silently clipping the last row or two of
+/// real content off the bottom of the pane (including, in the worst case,
+/// the cursor row itself — the exact bug this windowing feature exists to
+/// fix, reintroduced one layer up). This function reserves a row for each
+/// indicator *before* sizing the content window, so the total row count
+/// (indicators + content) never exceeds `viewport_height`.
+///
+/// Reserving is a small fixed-point search rather than a single
+/// calculation: whether the "above"/"below" indicator is needed at all
+/// depends on where the content window ends up, which itself depends on
+/// how many rows are reserved for indicators — so this recomputes the
+/// window with 0, then up to 2, reserved rows until the reservation and the
+/// window it produces agree. This always converges in at most 3 iterations
+/// (each iteration can only add a reservation, never remove one, and there
+/// are only two indicators to add), so a small bounded loop is used rather
+/// than proving a closed-form formula.
+///
+/// Returns `(content_start, content_end, above_indicator, below_indicator)`.
+fn windowed_rows_with_indicators(
+    total_items: usize,
+    cursor_index: usize,
+    viewport_height: usize,
+) -> (usize, usize, Option<String>, Option<String>) {
+    let mut reserved = 0;
+    loop {
+        let content_height = viewport_height.saturating_sub(reserved);
+        let (start, end) = visible_index_window(total_items, cursor_index, content_height);
+        let (above, below) = window_overflow_indicators(total_items, start, end);
+        let needed = above.is_some() as usize + below.is_some() as usize;
+        if needed <= reserved {
+            return (start, end, above, below);
+        }
+        reserved = needed;
+    }
 }
 
 /// Builds the `(first-last/total)` title suffix for a pane whose content
@@ -1209,6 +1385,32 @@ mod tests {
         std::path::PathBuf::from("/repo")
     }
 
+    /// `count` files (`f0.rs`..`f{count-1}.rs`), each with one symbol named
+    /// after the file — a tree tall enough to exceed any reasonably sized
+    /// terminal's viewport, for the tree pane's cursor-follow scroll tests
+    /// (#61-review finding: the tree pane used to hand every row to
+    /// `Paragraph` unscrolled).
+    fn report_with_many_files(count: usize) -> Report {
+        Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: (0..count)
+                .map(|i| FileReport {
+                    path: format!("f{i}.rs"),
+                    symbols: vec![symbol(&format!("f{i}.rs::sym{i}"), &format!("sym{i}"))],
+                })
+                .collect(),
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            removed: vec![],
+        }
+    }
+
     /// Builds the [`crate::diff_shape::DiffPaneContent`] `crate::run_app`
     /// would have cached for `app`'s current selection against `report`/
     /// `diff_files` — this module's tests recreate that one-shot
@@ -1277,6 +1479,99 @@ mod tests {
         // the detail pane actually rendered file-detail content rather than
         // asserting on the placeholder text that used to show here.
         assert!(text.contains("Symbols"));
+    }
+
+    #[test]
+    fn should_follow_cursor_downward_in_tree_pane_when_scrolling_past_the_bottom_of_the_viewport() {
+        // #61-review finding: the tree pane used to hand `Nav::rows`' entire
+        // row list to `Paragraph` unscrolled, so moving the cursor past the
+        // bottom of the initial viewport looked like the keypress had no
+        // effect (the screen kept showing exactly the same rows). A 60-file
+        // tree (each file has a symbol row too, so ~120 rows) in a 20-row
+        // terminal (18-row inner viewport after the border) is far taller
+        // than any single viewport.
+        let report = report_with_many_files(60);
+        let mut app = App::new(&report);
+        for _ in 0..100 {
+            app = app.handle_key(crate::app::InputKey::Down);
+        }
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &PivotSelection::NotApplicable,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        // The cursor's own row label must appear in the rendered pane — read
+        // back from `App` rather than hardcoding a guess, since which row
+        // 100 `Down` presses lands on is not a fixed, predictable filename
+        // in the first place (sibling files can be reordered by the default
+        // topological order, ADR 0016). A file row's own label is its path
+        // (`row_view::entry_row_line`'s `NodeKind::File` arm); a symbol
+        // row's is just its name, not the containing file's path.
+        let cursor_row = &app.nav().rows(app.tree())[app.nav().cursor()];
+        let cursor_label = match &cursor_row.node.kind {
+            crate::tree::NodeKind::Symbol(symbol_ref) => symbol_ref.name.clone(),
+            crate::tree::NodeKind::File | crate::tree::NodeKind::Dir => {
+                cursor_row.node.path.clone()
+            }
+        };
+        let text = buffer_text(&terminal);
+        assert!(
+            text.contains(&cursor_label),
+            "cursor row {cursor_label} not visible in:\n{text}"
+        );
+        // The very first file must have scrolled off given how far down the
+        // cursor moved, and an overflow indicator must say so.
+        assert!(!text.contains("f0.rs"), "f0.rs should have scrolled off");
+        assert!(text.contains("more above"));
+    }
+
+    #[test]
+    fn should_show_jump_target_row_in_tree_pane_when_it_lands_far_from_the_current_scroll_position()
+    {
+        // The exact user-facing scenario the #61-review finding describes:
+        // a gd/gr jump landing far down a long tree must actually scroll
+        // the tree pane there, not just move the cursor in state while the
+        // screen keeps showing the old scroll position.
+        let report = report_with_many_files(60);
+        let app = App::new(&report).jump_to_symbol("f55.rs::sym55");
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &PivotSelection::NotApplicable,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        // The jump must have actually landed on "sym55" (defensive: proves
+        // the rest of this assertion is exercising the intended row, not
+        // silently passing because the jump itself failed).
+        let cursor_row = &app.nav().rows(app.tree())[app.nav().cursor()];
+        match &cursor_row.node.kind {
+            crate::tree::NodeKind::Symbol(symbol_ref) => assert_eq!("sym55", symbol_ref.name),
+            other => panic!("expected jump to land on a Symbol row, got {other:?}"),
+        }
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("sym55"), "jump target row not visible");
     }
 
     #[test]
@@ -1367,6 +1662,52 @@ mod tests {
         assert!(text.contains("Jump to"));
         assert!(text.contains("alpha"));
         assert!(text.contains("beta"));
+    }
+
+    #[test]
+    fn should_window_candidates_around_cursor_when_popup_has_more_candidates_than_fit() {
+        // #61-review finding: the popup used to hand every candidate to
+        // `Paragraph` unscrolled, so a popup with more candidates than the
+        // box's own height could highlight an off-screen candidate with no
+        // visual feedback at all. 25 candidates, cursor moved to the last
+        // one (index 24) via repeated Down, is more than any reasonably
+        // sized popup box can show at once.
+        let report = report_with_one_symbol();
+        let candidates: Vec<crate::app::JumpCandidate> = (0..25)
+            .map(|i| crate::app::JumpCandidate {
+                id: format!("lib.rs::sym{i}"),
+                name: format!("sym{i}"),
+                path: "lib.rs".to_string(),
+            })
+            .collect();
+        let mut app = App::new(&report).open_jump_popup(candidates);
+        for _ in 0..24 {
+            app = app.handle_key(crate::app::InputKey::Down);
+        }
+        let mut terminal = Terminal::new(TestBackend::new(100, 40)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &PivotSelection::NotApplicable,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        // The highlighted candidate (the last one, cursor at index 24) must
+        // always be visible — the whole point of the windowing fix.
+        assert!(text.contains("sym24"), "cursor candidate sym24 not visible");
+        // The first candidate is far outside the window around index 24, so
+        // it must not be rendered, and an overflow indicator must say so.
+        assert!(!text.contains("sym0 ("), "sym0 should have scrolled off");
+        assert!(text.contains("more above"));
     }
 
     #[test]
@@ -2556,6 +2897,172 @@ index e69de29..4b825dc 100644
         let actual = scroll_indicator(20, 10, 10);
 
         assert_eq!(Some(" (11-20/20)".to_string()), actual);
+    }
+
+    // --- visible_index_window / window_overflow_indicators (pure helpers,
+    // #61-review fix: cursor-follow scroll for the tree pane and jump popup)
+
+    #[test]
+    fn should_return_empty_window_when_total_items_is_zero() {
+        let actual = visible_index_window(0, 0, 10);
+
+        assert_eq!((0, 0), actual);
+    }
+
+    #[test]
+    fn should_return_empty_window_when_viewport_height_is_zero() {
+        let actual = visible_index_window(20, 5, 0);
+
+        assert_eq!((0, 0), actual);
+    }
+
+    #[test]
+    fn should_show_whole_list_when_it_fits_entirely_within_viewport() {
+        let actual = visible_index_window(5, 2, 10);
+
+        assert_eq!((0, 5), actual);
+    }
+
+    #[test]
+    fn should_center_window_around_cursor_when_list_exceeds_viewport() {
+        // 100 items, cursor at index 49, viewport 10 -> half=5,
+        // ideal_start=44, max_start=90 (not clamped) -> (44, 54).
+        let actual = visible_index_window(100, 49, 10);
+
+        assert_eq!((44, 54), actual);
+    }
+
+    #[test]
+    fn should_clamp_window_to_start_of_list_when_cursor_is_near_the_top() {
+        let actual = visible_index_window(100, 1, 10);
+
+        assert_eq!((0, 10), actual);
+    }
+
+    #[test]
+    fn should_clamp_window_to_end_of_list_when_cursor_is_near_the_bottom() {
+        let actual = visible_index_window(100, 98, 10);
+
+        assert_eq!((90, 100), actual);
+    }
+
+    #[test]
+    fn should_keep_cursor_row_inside_the_window_when_jumping_far_from_the_current_position() {
+        // The exact scenario the #61-review finding describes: a cursor
+        // that jumps from near the top of a long list straight to near the
+        // bottom (e.g. a gd/gr jump) must land inside the returned window,
+        // not leave it showing the same rows as before the jump.
+        let (start, end) = visible_index_window(200, 180, 20);
+
+        assert!(
+            start <= 180 && 180 < end,
+            "cursor 180 not in [{start}, {end})"
+        );
+    }
+
+    #[test]
+    fn should_return_no_indicators_when_window_covers_the_whole_list() {
+        let actual = window_overflow_indicators(5, 0, 5);
+
+        assert_eq!((None, None), actual);
+    }
+
+    #[test]
+    fn should_return_above_indicator_only_when_window_starts_past_the_top() {
+        let actual = window_overflow_indicators(100, 10, 20);
+
+        assert_eq!(
+            (
+                Some("… 10 more above".to_string()),
+                Some("… 80 more below".to_string())
+            ),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_return_no_above_indicator_when_window_starts_at_the_top() {
+        let actual = window_overflow_indicators(100, 0, 20);
+
+        assert_eq!((None, Some("… 80 more below".to_string())), actual);
+    }
+
+    #[test]
+    fn should_return_no_below_indicator_when_window_reaches_the_end() {
+        let actual = window_overflow_indicators(100, 80, 100);
+
+        assert_eq!((Some("… 80 more above".to_string()), None), actual);
+    }
+
+    // --- windowed_rows_with_indicators (pure helper) ---
+    //
+    // Regression coverage for the reserved-row bug found while writing
+    // `should_window_candidates_around_cursor_when_popup_has_more_candidates_than_fit`:
+    // naively computing the content window against the full viewport height
+    // and then unconditionally prepending/appending indicator lines
+    // overflows the viewport by up to 2 rows, clipping the cursor row
+    // itself off the bottom in the worst case.
+
+    #[test]
+    fn should_return_whole_list_with_no_indicators_when_it_fits_the_viewport() {
+        let actual = windowed_rows_with_indicators(5, 2, 10);
+
+        assert_eq!((0, 5, None, None), actual);
+    }
+
+    #[test]
+    fn should_reserve_a_row_for_the_below_indicator_when_cursor_is_near_the_top() {
+        // 100 items, cursor at 0, viewport 10: without reservation the
+        // content window alone would be (0, 10), needing a "below"
+        // indicator — reserving 1 row for it must shrink the content
+        // window to (0, 9) so the indicator line has room without pushing
+        // total rows past the viewport.
+        let (start, end, above, below) = windowed_rows_with_indicators(100, 0, 10);
+
+        assert_eq!((0, 9), (start, end));
+        assert_eq!(None, above);
+        assert_eq!(Some("… 91 more below".to_string()), below);
+        // The rendered row count (indicator + content) must never exceed
+        // the viewport.
+        let below_rows = below.is_some() as usize;
+        assert!(end - start + below_rows <= 10);
+    }
+
+    #[test]
+    fn should_reserve_a_row_for_the_above_indicator_when_cursor_is_near_the_bottom() {
+        let (start, end, above, below) = windowed_rows_with_indicators(100, 99, 10);
+
+        assert_eq!((91, 100), (start, end));
+        assert_eq!(Some("… 91 more above".to_string()), above);
+        assert_eq!(None, below);
+        let above_rows = above.is_some() as usize;
+        assert!(end - start + above_rows <= 10);
+    }
+
+    #[test]
+    fn should_reserve_rows_for_both_indicators_when_cursor_is_in_the_middle() {
+        let (start, end, above, below) = windowed_rows_with_indicators(100, 50, 10);
+
+        assert!(above.is_some());
+        assert!(below.is_some());
+        // The cursor must still be inside the (possibly shrunk) content
+        // window — the entire point of this function.
+        assert!(start <= 50 && 50 < end, "cursor 50 not in [{start}, {end})");
+        // Total rendered rows (2 indicators + content) must never exceed
+        // the viewport.
+        assert!(end - start + 2 <= 10);
+    }
+
+    #[test]
+    fn should_keep_cursor_visible_after_reserving_indicator_rows_at_a_small_viewport() {
+        // A tight viewport (3 rows) where reserving rows for indicators
+        // could plausibly starve the content window down to nothing —
+        // pins that the cursor row itself is never sacrificed.
+        let (start, end, _above, below) = windowed_rows_with_indicators(50, 49, 3);
+
+        assert!(start <= 49 && 49 < end, "cursor 49 not in [{start}, {end})");
+        let below_rows = below.is_some() as usize;
+        assert!(end - start + below_rows <= 3);
     }
 
     // --- status_line_text (pure helper) ---


### PR DESCRIPTION
## Summary

- Adds `gd`/`gr` jump-to-callee/caller navigation and a vim-style
  jumplist (`Ctrl-o`/`Ctrl-i`/`Tab`) to the TUI, per
  [ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md). `gd`
  jumps toward what the selected symbol calls, `gr` toward what calls
  it; a two-key `g` prefix resolves in `translate_key`; multiple
  candidates open a selection popup (reusing the `?`-overlay
  compositing pattern from ADR 0020); a jump moves the tree cursor to
  the target, expanding collapsed ancestors, and keeps focus on the
  Diff pane.
- Along the way, this PR also fixes a **pre-existing gap on `main`**:
  the tree pane never scroll-followed the cursor. That was a minor
  annoyance before, but jump navigation regularly lands the cursor
  outside the visible window, which turns it into a feature-defeating
  bug — so the fix (a shared `windowed_rows_with_indicators` helper,
  used for both the tree pane and the new jump popup) is included
  here rather than filed separately. The user independently hit the
  same `main` defect while dogfooding the same day this was found.

## Review process

Reviewed per this repo's three-angle policy
([experiment 0001](docs/experiments/0001-map-assisted-llm-review/README.md),
round recorded in this PR as
[`rounds/012.md`](docs/experiments/0001-map-assisted-llm-review/rounds/012.md)):

- **Map-assisted pass**: hotspots (`App`, `InputKey`, `JumpPopup`,
  `JumplistEntry`, `PendingPrefix`) routed attention to the
  state-machine seams and found that `pending_prefix` was only cleared
  inside `App::handle_key`, while `run_app` intercepts
  `GotoDefinition`/`GotoReferences` before `handle_key` runs — so the
  very next `d`/`r` after a jump was misparsed as another `gd`/`gr`
  sequence, violating ADR 0022's own "any other key discards the
  prefix" guarantee. Fixed by extracting a single choke point
  (`dispatch_non_source_key`) that clears the prefix regardless of
  route, with regression tests driven through the `run_app`-adjacent
  path the bug actually lived in.
- **Independent + dynamic pass**: found two blockers only reachable by
  running the binary — the jump popup had no windowing (candidates
  beyond the visible box were selectable but never rendered), and the
  tree pane's missing scroll-follow (above). Also, during
  implementation, `Ctrl-i` arrived as `Tab` (0x09) in a real terminal
  so `JumpForward` silently never fired despite its unit test passing
  (the test pre-sets `KeyEvent` modifiers, which can't exercise the
  terminal-protocol collapse of `Ctrl-i` onto `Tab`) — fixed by mapping
  `Tab` alongside `Ctrl-i`.

## Verification

- `make test`: 418 passed, 0 failed.
- `make lint`: clean.
- Manual verification in a real terminal (tmux): 30-candidate popup
  windowing, 154-row tree scroll-follow, and a fail-before/pass-after
  sanity check on the `pending_prefix` fix and the `Ctrl-i`/`Tab`
  collapse.

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync
