### PR TITLE
feat(tui): rename the pivot pane to blast radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ count as entry points), not the direction fan-in itself measures, so
 scoping it to the re-rooted subset would misreport how much the rest of
 the repository actually depends on a symbol (see
 [ADR 0019](docs/adr/0019-entry-path-pivot-view.md)'s Consequences; the TUI
-naming itself is [ADR 0022](docs/adr/0022-tui-blast-radius-naming.md)).
+naming itself is [ADR 0023](docs/adr/0023-tui-blast-radius-naming.md)).
 
 ## Interactive TUI
 
@@ -547,7 +547,7 @@ blast radius, cycle, jumplist).
 - **Blast radius pane (right):** `r`/`R` toggles the right-hand pane to an
   entry-tree view rooted at the directory or file row under the cursor —
   "if this changes, what does it reach" ([ADR 0019](docs/adr/0019-entry-path-pivot-view.md)
-  for the re-rooting algorithm, [ADR 0022](docs/adr/0022-tui-blast-radius-naming.md)
+  for the re-rooting algorithm, [ADR 0023](docs/adr/0023-tui-blast-radius-naming.md)
   for the naming) — the interactive equivalent of `--entry <path>`. The
   tree follows the cursor: move to a different directory/file row while
   the pane is active and it re-renders rooted at the new row's path; a

--- a/README.md
+++ b/README.md
@@ -448,21 +448,22 @@ rinkaku --base main --entry src/api
 
 Works with every input mode (stdin / `--base` / `--pr` / whole-repo) and
 combines with `--tui`: the TUI opens with the cursor already on the tree
-row matching `path` and the right-hand pane already in Pivot mode (the `p`
-pivot below) — the interactive session starts exactly where `--entry`
-would have rooted the Markdown/JSON tree, rather than requiring you to
-locate the row and press `p` yourself. If no tree row's path matches `path`
-exactly, the TUI opens normally (cursor on the first row, Detail pane) with
-a status-line note instead.
+row matching `path` and the right-hand pane already showing its Blast
+radius (the `R` binding below) — the interactive session starts exactly
+where `--entry` would have rooted the Markdown/JSON tree, rather than
+requiring you to locate the row and press `R` yourself. If no tree row's
+path matches `path` exactly, the TUI opens normally (cursor on the first
+row, Detail pane) with a status-line note instead.
 
 Prints `note: no symbols under <path>` to stderr and renders an empty tree
 when no symbol's path falls under `path`. Fan-in counts (Hotspots, and the
-TUI tree's `^N` badge) stay whole-analysis under `--entry`/the TUI pivot —
-a pivot changes the vantage point (which symbols count as entry points),
-not the direction fan-in itself measures, so scoping it to the pivoted
-subset would misreport how much the rest of the repository actually
-depends on a symbol (see [ADR 0019](docs/adr/0019-entry-path-pivot-view.md)'s
-Consequences).
+TUI tree's `^N` badge) stay whole-analysis under `--entry`/the TUI blast-
+radius pane — re-rooting the tree changes the vantage point (which symbols
+count as entry points), not the direction fan-in itself measures, so
+scoping it to the re-rooted subset would misreport how much the rest of
+the repository actually depends on a symbol (see
+[ADR 0019](docs/adr/0019-entry-path-pivot-view.md)'s Consequences; the TUI
+naming itself is [ADR 0022](docs/adr/0022-tui-blast-radius-naming.md)).
 
 ## Interactive TUI
 
@@ -496,7 +497,7 @@ jumplist of those jumps, both borrowed from neovim too
 ([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md), see
 [Jump navigation](#jump-navigation-gd--gr) below). Press `?` any time for
 an in-app overlay listing every key and a short glossary (order modes,
-pivot, cycle, jumplist).
+blast radius, cycle, jumplist).
 
 ### What it shows
 
@@ -543,26 +544,32 @@ pivot, cycle, jumplist).
   its badge breakdown and top fan-in symbols, plus — when it participates
   in a dependency cycle — exactly which other directories it cycles with
   and the concrete symbol-to-symbol edges forming that cycle.
-- **Pivot pane (right):** `p`/`P` toggles the right-hand pane to an
-  entry-tree view rooted at the directory or file row under the cursor
-  ([ADR 0019](docs/adr/0019-entry-path-pivot-view.md)) — the interactive
-  equivalent of `--entry <path>`. The tree follows the cursor: move to a
-  different directory/file row while pivoted and it re-renders rooted at
-  the new row's path; a symbol row shows a placeholder instead, since
-  pivoting only makes sense on a directory/file scope. Nodes reached only
-  by expanding a dependency edge outward past the pivoted path are dimmed
-  so you can tell "the layer I pivoted on" from "what it reaches into".
-  Press `p` again, or `d`, to leave pivot mode.
+- **Blast radius pane (right):** `r`/`R` toggles the right-hand pane to an
+  entry-tree view rooted at the directory or file row under the cursor —
+  "if this changes, what does it reach" ([ADR 0019](docs/adr/0019-entry-path-pivot-view.md)
+  for the re-rooting algorithm, [ADR 0022](docs/adr/0022-tui-blast-radius-naming.md)
+  for the naming) — the interactive equivalent of `--entry <path>`. The
+  tree follows the cursor: move to a different directory/file row while
+  the pane is active and it re-renders rooted at the new row's path; a
+  symbol row shows a placeholder instead, since measuring blast radius
+  only makes sense on a directory/file scope. Nodes reached only by
+  expanding a dependency edge outward past the selected path are dimmed
+  so you can tell "the layer I'm measuring from" from "what it reaches
+  into". A repeated node is marked `(see above)` rather than expanded
+  again, and a dependency loop back to an ancestor already on screen is
+  marked `(cycle)` — you've seen it, no need to expand further. Press `r`
+  again, or `d`, to leave the blast-radius pane.
 - **Scrolling the right-hand pane:** move focus to the right pane
   (`enter` on a file/symbol row) and use `j`/`k` to scroll the
-  Detail/Diff/Pivot pane down/up by one line when its content is too long
-  to fit — the pane's title grows a `(first-last/total)` suffix (e.g.
-  `Detail (1-17/43)`) whenever there's more to see, so a long cycle-edge
-  list or a large file's diff doesn't quietly get cut off. While viewing
-  the Diff pane specifically, `]`/`[` jump straight to the next/previous
-  hunk. The scroll position resets to the top whenever the underlying
-  content could have changed: moving the cursor, toggling between the
-  detail/diff/pivot views, or returning from the source view.
+  Detail/Diff/Blast-radius pane down/up by one line when its content is
+  too long to fit — the pane's title grows a `(first-last/total)` suffix
+  (e.g. `Detail (1-17/43)`) whenever there's more to see, so a long
+  cycle-edge list or a large file's diff doesn't quietly get cut off.
+  While viewing the Diff pane specifically, `]`/`[` jump straight to the
+  next/previous hunk. The scroll position resets to the top whenever the
+  underlying content could have changed: moving the cursor, toggling
+  between the detail/diff/blast-radius views, or returning from the
+  source view.
 - **Source view:** `s` on a symbol row opens that file, scrolled to and
   highlighting the symbol's line range; `esc`/`q` returns to the entry
   view. Reads the working tree directly (not the historical commit a
@@ -587,7 +594,7 @@ grouped by focus.
 | `e` / `E` | Expand every row |
 | `c` / `C` | Collapse every row |
 
-**Right focus (Detail/Diff/Pivot pane):**
+**Right focus (Detail/Diff/Blast-radius pane):**
 
 | Key(s) | Action |
 | --- | --- |
@@ -602,7 +609,7 @@ grouped by focus.
 | --- | --- |
 | `o` / `O` | Toggle topological / alphabetical ordering |
 | `d` / `D` | Toggle the right-hand pane between diff and detail |
-| `p` / `P` | Toggle the right-hand pane to the pivot tree rooted at the selected directory/file |
+| `r` / `R` | Toggle the right-hand pane to the blast radius of the selected directory/file |
 | `s` / `S` | Open the source view for the symbol under the cursor |
 | `gd` | Jump to a callee of the symbol under the cursor ([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md)) |
 | `gr` | Jump to a caller of the symbol under the cursor |

--- a/docs/adr/0022-tui-blast-radius-naming.md
+++ b/docs/adr/0022-tui-blast-radius-naming.md
@@ -1,0 +1,163 @@
+# 0022. Renaming the TUI's pivot pane to "blast radius"
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+ADR 0019 added a right-pane mode, internally and in the UI called
+"pivot", that re-roots the dependency tree at a selected directory or
+file and shows what it reaches outward into. ADR 0020 gave it a key
+(`p`) and a glossary entry in the `?` help overlay. Dogfooding this
+interaction model (the same round that produced ADR 0020) surfaced two
+concrete complaints about the pane itself, independent of the
+interaction-model work ADR 0020 already fixed:
+
+- "pivot がなにかわからん" — "pivot" names the *mechanism* (re-rooting
+  the graph at a path) rather than the *question a reviewer is asking*
+  when they press the key. A reviewer scanning a PR is not thinking "I
+  want to re-root the dependency graph"; they are thinking "if I touch
+  this, what else breaks" — the exact framing ADR 0021 already uses in
+  its own Context section ("blast-radius help matters most").
+- "cycle の意味がわからん" — the `⚠️ <label> — dependency cycle, see
+  above` marker names the graph-theory concept (a closing back-edge)
+  without saying what it means for reading the tree: that the reviewer
+  already saw this node earlier in the same expansion and does not need
+  to expand it again.
+
+The underlying feature (ADR 0019's re-rooting) is not in question —
+dogfooding confirms it is useful, only mis-named. This ADR is scoped to
+naming and presentation in the TUI, not to the graph algorithm, the CLI
+flag, or `rinkaku-core`'s public API.
+
+## Decision
+
+**1. Rename the TUI-facing surface from "pivot" to "blast radius".**
+This covers:
+
+- The key: `p`/`P` is retired; `R` (mnemonic: **R**adius) toggles the
+  pane. Since the TUI has never shipped a release (ADR 0020's own
+  "no backward-compatibility concern" applies again here), this is a
+  plain rename, not a deprecation with a transition period.
+- The `RightPane` variant: `RightPane::Pivot` becomes
+  `RightPane::BlastRadius`. Likewise `PivotSelection` ->
+  `BlastRadiusSelection`, `InputKey::TogglePivot` ->
+  `InputKey::ToggleBlastRadius`, `pivot_return_pane` ->
+  `blast_radius_return_pane`, `App::selected_pivot_view` ->
+  `App::selected_blast_radius_view`, the `crate::pivot` module ->
+  `crate::blast_radius` (`PivotView`/`PivotLine` ->
+  `BlastRadiusView`/`BlastRadiusLine`), and `ui::draw_pivot_pane` ->
+  `ui::draw_blast_radius_pane`.
+- Pane chrome: the block title changes from `" Pivot "` to a header
+  that states the question the pane answers, not the mechanism —
+  `"Blast radius of <path>"` — so the pane is self-explanatory without
+  opening `?` first. The placeholder/empty-state text is updated to
+  match ("select a directory or file row to see its blast radius" /
+  "nothing under `<path>` is reachable").
+- Help overlay: the `KeyBindingGroup`/`GlossaryEntry` entries move from
+  "pivot" wording to "blast radius" wording (decision 3 below).
+
+**2. `rinkaku-core`'s graph API and the CLI's `--entry` flag are
+unchanged.** `graph::pivot_graph`, `graph::pivot_roots`, `--entry`,
+`apply_entry_pivot`, and `entry_pivot_empty_note` in `rinkaku/src/
+main.rs` keep their existing names. Rationale:
+
+- `--entry` is a released-to-users-mentally CLI surface name
+  independent of the TUI's internal pane naming — the flag re-roots the
+  *Markdown output*, which has no "pane" to name, and "entry point" is
+  already the vocabulary ADR 0008 established for the whole-report root
+  concept it extends. Renaming it would trade one unfamiliar term for
+  a different unfamiliar term with no dogfooding signal asking for it.
+- `graph::pivot_graph`/`pivot_roots` are internal `rinkaku-core` API,
+  consumed by both the CLI and the TUI; renaming them would touch a
+  crate this ADR has no dogfooding complaint about and couple an
+  internal-API rename to a UI-wording rename for no functional reason.
+  The TUI's `crate::blast_radius` module continues to call
+  `rinkaku_core::graph::pivot_graph` — a pure naming mismatch between
+  the layers is acceptable here the same way `rinkaku-tui`'s
+  `detail.rs` already uses "pivot" for a different, unrelated concept
+  (callers/callees framing, ADR 0015) without confusion, because that
+  usage is a doc-comment word, not UI-facing text.
+- This keeps the rename's blast radius (no pun escaped) to exactly the
+  TUI crate's user-facing surface plus its own internal names — the
+  layer boundary this project already draws between "what
+  `rinkaku-core` exposes" and "what the TUI calls it" absorbs the
+  rename without rippling into the CLI or core.
+
+**3. Cycle marker gets a plain-language rewrite, not just a rename.**
+The line `⚠️ <label> — dependency cycle, see above` becomes `⚠️ <label>
+— already shown above (cycle)`: leads with the actionable fact ("you've
+seen this, stop expanding") and demotes "cycle" to a parenthetical for
+readers who want the graph-theory term. The help overlay's glossary
+entry for "cycle" is rewritten the same way: from "A closing back-edge
+in the dependency graph — two or more directories depend on each
+other" to "A dependency loop: two or more symbols depend on each
+other, so the tree stops and points back to where it first appeared."
+The glossary's "pivot" entry is replaced by a "blast radius" entry:
+"The dependency tree rooted at a selected directory or file, showing
+what would be affected if it changed."
+
+**4. ADR 0019 and ADR 0020 are not edited.** They are historical
+records of the decisions made at the time, including the "pivot" name
+this ADR retires — rewriting their prose would misrepresent what was
+actually decided when. This ADR supersedes their *naming* only; their
+architectural content (the re-rooting algorithm in ADR 0019, the focus
+model and pane-mode state machine in ADR 0020) stands unchanged. Future
+readers of ADR 0019/0020 should cross-reference this ADR for the
+current UI vocabulary.
+
+## Alternatives
+
+- **Keep "pivot" as the internal name, only change the pane's display
+  title**: cheaper (one string change), but leaves the key hint
+  (`p: pivot`), the help overlay's keymap group entry, and every error
+  message using a term dogfooding already flagged as confusing —
+  rejected because it fixes the symptom the pane shows on first glance
+  and leaves the same word everywhere else the reviewer looks next
+  (status line, help overlay).
+- **Rename `rinkaku-core::graph::pivot_graph`/`pivot_roots` and
+  `--entry` too, for full-stack consistency**: rejected per decision 2
+  — no dogfooding complaint targets the CLI or core naming, and
+  bundling an uncomplained-about rename into this change would enlarge
+  the diff and the review surface without a matching benefit.
+- **Superseding ADR 0019 outright (marking it superseded, not just
+  cross-referenced)**: ADR supersession in this project (see ADR
+  0021's own precedent of adding new decisions alongside old ones
+  rather than rewriting them) is reserved for when a *decision* is
+  reversed, not when a *name* changes; the re-rooting behavior ADR
+  0019 decided is still exactly what ships. Rejected in favor of a
+  cross-reference.
+- **Keep the emoji-based `⚠️` cycle marker as-is, only reword the
+  text**: considered, but since the wording change already touches
+  every call site that constructs the line, this ADR takes the
+  opportunity to confirm (rather than assume) the marker renders
+  correctly in the terminal during implementation, per CLAUDE.md's
+  "Dynamic verification" review requirement — if `⚠️` proves to have
+  width/rendering issues in practice, the implementation substitutes an
+  ASCII marker and this ADR's Consequences section is amended to note
+  it, rather than the choice being made speculatively here.
+
+## Consequences
+
+- The TUI's public vocabulary (key hints, pane titles, help overlay,
+  README) now names the reviewer's *question* ("what's the blast
+  radius of this change") rather than the *mechanism* ("re-root the
+  graph at this path") — directly answering the dogfooding complaint
+  that motivated this ADR.
+- A one-time rename cost across `rinkaku-tui`: every `Pivot`-prefixed
+  type, field, and function in the crate moves to `BlastRadius`-
+  prefixed, touching `app.rs`, `lib.rs`, `ui.rs`, `help.rs`, and the
+  renamed `pivot.rs` -> `blast_radius.rs`, plus their tests. This is a
+  mechanical, crate-internal rename (decision 2 keeps it from crossing
+  into `rinkaku-core` or the CLI), so the risk is test-update volume,
+  not design risk.
+- `rinkaku-core`'s `pivot_graph`/`pivot_roots` and the CLI's `--entry`
+  flag now use different vocabulary than the TUI pane built on top of
+  them. This is an accepted, explicit split (decision 2), not an
+  oversight — a future reader diffing `crate::blast_radius`'s calls
+  into `rinkaku_core::graph::pivot_graph` should not read the name
+  mismatch as a bug.
+- Future TUI panes should default to naming the reviewer's question
+  first and reserve mechanism-derived names (like the original
+  "pivot") for internal/doc-comment use only — this ADR is the
+  concrete precedent to point to next time a pane's UI name is chosen.

--- a/docs/adr/0022-tui-blast-radius-naming.md
+++ b/docs/adr/0022-tui-blast-radius-naming.md
@@ -85,17 +85,27 @@ main.rs` keep their existing names. Rationale:
   rename without rippling into the CLI or core.
 
 **3. Cycle marker gets a plain-language rewrite, not just a rename.**
-The line `⚠️ <label> — dependency cycle, see above` becomes `⚠️ <label>
+The line `⚠️ <label> — dependency cycle, see above` becomes `! <label>
 — already shown above (cycle)`: leads with the actionable fact ("you've
 seen this, stop expanding") and demotes "cycle" to a parenthetical for
-readers who want the graph-theory term. The help overlay's glossary
-entry for "cycle" is rewritten the same way: from "A closing back-edge
-in the dependency graph — two or more directories depend on each
-other" to "A dependency loop: two or more symbols depend on each
-other, so the tree stops and points back to where it first appeared."
-The glossary's "pivot" entry is replaced by a "blast radius" entry:
-"The dependency tree rooted at a selected directory or file, showing
-what would be affected if it changed."
+readers who want the graph-theory term. The marker itself is a plain
+`!`, not `⚠️` — dynamic verification (`tmux capture-pane` against a real
+build, per this project's mandatory review step) caught `⚠️` (U+26A0 +
+a U+FE0F variation selector) desyncing `unicode-width`'s column count
+from the terminal's actual double-column rendering of the pair, which
+left a stray character on screen in the blast-radius pane; this was the
+exact risk flagged in this ADR's own Alternatives before implementation,
+confirmed rather than assumed. `rinkaku-core::render`'s Markdown output
+keeps `⚠️` unchanged — it is plain text there, never fed through a
+terminal-cell width calculation, so the bug is specific to the TUI's
+`ratatui`-rendered pane. The help overlay's glossary entry for "cycle"
+is rewritten the same way: from "A closing back-edge in the dependency
+graph — two or more directories depend on each other" to "A dependency
+loop: two or more symbols depend on each other, so the tree stops and
+points back to where it first appeared." The glossary's "pivot" entry
+is replaced by a "blast radius" entry: "The dependency tree rooted at a
+selected directory or file, showing what would be affected if it
+changed."
 
 **4. ADR 0019 and ADR 0020 are not edited.** They are historical
 records of the decisions made at the time, including the "pivot" name
@@ -132,10 +142,10 @@ current UI vocabulary.
   every call site that constructs the line, this ADR takes the
   opportunity to confirm (rather than assume) the marker renders
   correctly in the terminal during implementation, per CLAUDE.md's
-  "Dynamic verification" review requirement — if `⚠️` proves to have
-  width/rendering issues in practice, the implementation substitutes an
-  ASCII marker and this ADR's Consequences section is amended to note
-  it, rather than the choice being made speculatively here.
+  "Dynamic verification" review requirement. It does not: `tmux
+  capture-pane` against a real build showed a stray character next to
+  the marker (decision 3's own explanation). Rejected in favor of a
+  plain `!`, confirmed rather than assumed.
 
 ## Consequences
 
@@ -161,3 +171,13 @@ current UI vocabulary.
   first and reserve mechanism-derived names (like the original
   "pivot") for internal/doc-comment use only — this ADR is the
   concrete precedent to point to next time a pane's UI name is chosen.
+- `rinkaku-tui` should treat multi-codepoint emoji (base glyph +
+  variation selector, e.g. `⚠️` = U+26A0 + U+FE0F) as suspect for any
+  string that passes through `crate::ui::wrap_lines`'s column
+  accounting, not just visually — `unicode-width`'s per-`char` model
+  does not necessarily agree with a real terminal's rendered column
+  width for such pairs. This ADR's own dynamic-verification step is the
+  concrete instance; future additions of emoji markers to TUI-rendered
+  (not Markdown) text should verify in a real terminal before landing,
+  not just in a `TestBackend` snapshot (which does not model this
+  particular class of desync).

--- a/docs/adr/0023-tui-blast-radius-naming.md
+++ b/docs/adr/0023-tui-blast-radius-naming.md
@@ -1,4 +1,4 @@
-# 0022. Renaming the TUI's pivot pane to "blast radius"
+# 0023. Renaming the TUI's pivot pane to "blast radius"
 
 - Status: accepted
 - Date: 2026-07-13

--- a/docs/experiments/0001-map-assisted-llm-review/rounds/013.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/013.md
@@ -1,0 +1,42 @@
+# Round 13
+
+- Subject: pivot → blast radius rename in the TUI (ADR 0023), 6
+  commits. Driven by direct dogfooding feedback ("pivot がなにかわか
+  らん", "cycle の意味がわからん") — the feature was useful but its
+  name explained nothing.
+- Map-assisted pass: the map showed 21 changed symbols across 5 files;
+  hotspots were exactly the renamed types, and the map's
+  removed-symbols list enumerated the old `Pivot*` API in full — for a
+  rename PR the map worked as a mechanical completeness checklist,
+  confirming no `Pivot*` name survived anywhere it could see. Its
+  find: the empty-pane placeholder string diverged from ADR 0023's
+  specified wording, with no test pinning it — invisible to the map
+  itself, since it is a string-literal content difference rather than
+  a signature change, and only surfaced by reading the ADR text
+  against `ui.rs`.
+- Independent + dynamic pass: found the CLI `--help` text for
+  `--entry` still telling users to "press `p`" in a "Pivot mode" that
+  no longer exists — a doc comment in `main.rs` surfacing directly in
+  clap's user-visible help output — and commit subjects still
+  referencing the pre-renumber ADR id. Dynamic verification covered
+  the full key matrix (`r`/`R` toggle, `gd`/`gr` popup → `Esc` → `r`
+  non-interference on the choke-point-cleared `pending_prefix`),
+  `--entry` startup, the cycle marker on a real cyclic fixture,
+  long-path rendering, and confirmed zero pivot/blast-radius leakage
+  into Markdown/JSON/mermaid outputs (core untouched by this rename).
+- Implementation-phase dynamic find worth recording outside the formal
+  two-pass review: U+26A0+FE0F (⚠️ with variant selector) rendered 2
+  cells wide in the real terminal while `unicode-width` computed less,
+  leaving stray characters on screen — caught by a `tmux` capture-pane
+  check, fixed by switching to an ASCII marker, and the terminal-width
+  mismatch noted in ADR 0023 itself.
+- Fixes shipped: the empty-pane placeholder text corrected to match
+  ADR 0023's wording; the `--entry` help text updated to describe
+  `r`/`R` instead of the removed `p`/Pivot mode; the ADR renumbered to
+  0023 with commit subjects and cross-references updated to match.
+- Takeaway: a rename PR's failure mode is textual, not structural. The
+  map enumerates removed/renamed symbols as a checklist and is good at
+  confirming the old name is fully gone from code, but every miss this
+  round lived in prose — CLI help, ADR wording, commit subjects —
+  places only cross-reading text against code catches, not something
+  a signature-level diff can represent.

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -68,7 +68,7 @@ pub enum InputKey {
     /// `R`: toggle the right-hand pane between [`RightPane::BlastRadius`]
     /// and whichever mode was active before ([`RightPane::Detail`] or
     /// [`RightPane::Diff`]) — ADR 0019's entry-path re-rooting, named "blast
-    /// radius" in the UI per ADR 0022. Pressing `R` again while already in
+    /// radius" in the UI per ADR 0023. Pressing `R` again while already in
     /// `BlastRadius` mode returns to the prior mode (stored in `App`'s
     /// `blast_radius_return_pane` field the moment `BlastRadius` was
     /// entered), mirroring `d`'s own toggle rather than a one-way "enter
@@ -180,7 +180,7 @@ pub enum Screen {
 }
 
 /// Which content the right-hand pane shows on [`Screen::Entry`] (TUI
-/// iteration 2/ADR 0019, named "blast radius" per ADR 0022): the existing
+/// iteration 2/ADR 0019, named "blast radius" per ADR 0023): the existing
 /// signature/used-by/callers detail, the raw diff hunks touching the
 /// selected row, or the dependency tree rooted at the selected directory/
 /// file's path. Independent of [`Screen`] — it is a display mode for the
@@ -240,7 +240,7 @@ pub enum DiffTarget {
 }
 
 /// What [`App::selected_blast_radius_view`] resolved the cursor's row to
-/// (ADR 0019, named "blast radius" per ADR 0022) — see that method's own
+/// (ADR 0019, named "blast radius" per ADR 0023) — see that method's own
 /// doc comment for the three-way split.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BlastRadiusSelection {
@@ -597,7 +597,7 @@ impl App {
         }
     }
 
-    /// What the blast-radius pane ([`RightPane::BlastRadius`], ADR 0019/0022)
+    /// What the blast-radius pane ([`RightPane::BlastRadius`], ADR 0019/0023)
     /// should show for the row currently under the cursor:
     /// [`BlastRadiusSelection::View`] when the cursor sits on a directory or
     /// file row and at least one symbol falls under that row's path,
@@ -1420,7 +1420,7 @@ mod tests {
 
     #[test]
     fn should_switch_from_blast_radius_to_diff_when_toggle_diff_is_pressed() {
-        // ADR 0019/0022: "R" re-press or "d" both leave blast-radius mode —
+        // ADR 0019/0023: "R" re-press or "d" both leave blast-radius mode —
         // "d" always lands on Diff regardless of `blast_radius_return_pane`
         // (a deliberate, unconditional gesture — see `handle_key`'s
         // `ToggleDiff` arm). Uses Detail (not the default Diff) as the pane

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -65,15 +65,16 @@ pub enum InputKey {
     /// selected row instead of resetting on every cursor move. Global
     /// regardless of [`Focus`] (ADR 0020).
     ToggleDiff,
-    /// `p`/`P`: toggle the right-hand pane between [`RightPane::Pivot`] and
-    /// whichever mode was active before ([`RightPane::Detail`] or
-    /// [`RightPane::Diff`]) — ADR 0019's entry-path pivot. Pressing `p`
-    /// again while already in `Pivot` mode returns to the prior mode (stored
-    /// in `App`'s `pivot_return_pane` field the moment `Pivot` was entered),
-    /// mirroring `d`'s own toggle rather than a one-way "enter pivot mode"
-    /// action, since the ADR describes `p` as a per-row toggle. Global
-    /// regardless of [`Focus`] (ADR 0020).
-    TogglePivot,
+    /// `R`: toggle the right-hand pane between [`RightPane::BlastRadius`]
+    /// and whichever mode was active before ([`RightPane::Detail`] or
+    /// [`RightPane::Diff`]) — ADR 0019's entry-path re-rooting, named "blast
+    /// radius" in the UI per ADR 0022. Pressing `R` again while already in
+    /// `BlastRadius` mode returns to the prior mode (stored in `App`'s
+    /// `blast_radius_return_pane` field the moment `BlastRadius` was
+    /// entered), mirroring `d`'s own toggle rather than a one-way "enter
+    /// blast-radius mode" action, since the ADR describes `R` as a per-row
+    /// toggle. Global regardless of [`Focus`] (ADR 0020).
+    ToggleBlastRadius,
     /// `h` or Esc while [`Focus::Right`]: returns focus to [`Focus::Tree`]
     /// (ADR 0020's neovim-style "move left/back"). A no-op while already
     /// [`Focus::Tree`] on the entry screen (nothing to return from) — Esc's
@@ -179,33 +180,35 @@ pub enum Screen {
 }
 
 /// Which content the right-hand pane shows on [`Screen::Entry`] (TUI
-/// iteration 2/ADR 0019): the existing signature/used-by/callers detail,
-/// the raw diff hunks touching the selected row, or the pivot tree rooted
-/// at the selected directory/file's path. Independent of [`Screen`] — it is
-/// a display mode for the entry view's right pane, not a separate screen
-/// reached via drill-down the way [`Screen::Source`] is.
+/// iteration 2/ADR 0019, named "blast radius" per ADR 0022): the existing
+/// signature/used-by/callers detail, the raw diff hunks touching the
+/// selected row, or the dependency tree rooted at the selected directory/
+/// file's path. Independent of [`Screen`] — it is a display mode for the
+/// entry view's right pane, not a separate screen reached via drill-down
+/// the way [`Screen::Source`] is.
 ///
-/// [`RightPane::Pivot`] carries no path of its own — unlike a hypothetical
-/// `Pivot(String)` variant, the pivoted path is always read fresh off the
-/// cursor's current row (`App::selected_pivot_view`) each time the pane is
-/// drawn, the same way [`RightPane::Detail`]/[`RightPane::Diff`] already
-/// derive their content from the cursor rather than storing it. This is
-/// what makes "follow the cursor while pivoted" (ADR 0019) free: moving the
-/// cursor while already in `Pivot` mode need not touch `RightPane` at all,
+/// [`RightPane::BlastRadius`] carries no path of its own — unlike a
+/// hypothetical `BlastRadius(String)` variant, the rooted path is always
+/// read fresh off the cursor's current row
+/// (`App::selected_blast_radius_view`) each time the pane is drawn, the
+/// same way [`RightPane::Detail`]/[`RightPane::Diff`] already derive their
+/// content from the cursor rather than storing it. This is what makes
+/// "follow the cursor while active" (ADR 0019) free: moving the cursor
+/// while already in `BlastRadius` mode need not touch `RightPane` at all,
 /// only re-run the lookup the next time `crate::ui` draws.
 ///
 /// Defaults to [`Self::Diff`] (ADR 0020): "what changed" is what a
 /// reviewer wants to see first, ahead of the aggregated used-by/callers
 /// view `Detail` shows. `App::with_entry_pivot` (the `--entry --tui`
 /// startup path) still overrides this default unconditionally by setting
-/// `right_pane` to `Pivot` itself right after `App::new`, so this default
-/// only matters for the ordinary (non-`--entry`) startup path.
+/// `right_pane` to `BlastRadius` itself right after `App::new`, so this
+/// default only matters for the ordinary (non-`--entry`) startup path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RightPane {
     Detail,
     #[default]
     Diff,
-    Pivot,
+    BlastRadius,
 }
 
 /// The right-hand pane's content for the row currently under the cursor
@@ -236,13 +239,14 @@ pub enum DiffTarget {
     },
 }
 
-/// What [`App::selected_pivot_view`] resolved the cursor's row to (ADR
-/// 0019) — see that method's own doc comment for the three-way split.
+/// What [`App::selected_blast_radius_view`] resolved the cursor's row to
+/// (ADR 0019, named "blast radius" per ADR 0022) — see that method's own
+/// doc comment for the three-way split.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PivotSelection {
+pub enum BlastRadiusSelection {
     NotApplicable,
     Empty { path: String },
-    View(crate::pivot::PivotView),
+    View(crate::blast_radius::BlastRadiusView),
 }
 
 /// A `g`-prefixed two-key sequence awaiting its second key (ADR 0022's
@@ -319,18 +323,20 @@ pub struct App {
     order_mode: OrderMode,
     screen: Screen,
     right_pane: RightPane,
-    /// Which non-`Pivot` [`RightPane`] to return to when the user leaves
-    /// [`RightPane::Pivot`] via a `p` re-press (`InputKey::TogglePivot`) —
-    /// always [`RightPane::Detail`] or [`RightPane::Diff`], never `Pivot`
-    /// itself, since it exists only to answer "what was showing right
-    /// before the user pivoted". Updated the moment `right_pane` transitions
-    /// *into* `Pivot` (capturing whatever it was showing at that instant),
-    /// left untouched while already in `Pivot` (so moving the cursor or
-    /// scrolling while pivoted does not disturb it), and consulted only by
-    /// `TogglePivot`'s own re-press branch — `ToggleDiff` pressed from
-    /// `Pivot` is a distinct, unconditional "go to Diff" gesture (see that
-    /// branch's own comment) and does not read this field at all.
-    pivot_return_pane: RightPane,
+    /// Which non-`BlastRadius` [`RightPane`] to return to when the user
+    /// leaves [`RightPane::BlastRadius`] via an `R` re-press
+    /// (`InputKey::ToggleBlastRadius`) — always [`RightPane::Detail`] or
+    /// [`RightPane::Diff`], never `BlastRadius` itself, since it exists
+    /// only to answer "what was showing right before the user opened the
+    /// blast-radius pane". Updated the moment `right_pane` transitions
+    /// *into* `BlastRadius` (capturing whatever it was showing at that
+    /// instant), left untouched while already in `BlastRadius` (so moving
+    /// the cursor or scrolling while active does not disturb it), and
+    /// consulted only by `ToggleBlastRadius`'s own re-press branch —
+    /// `ToggleDiff` pressed from `BlastRadius` is a distinct, unconditional
+    /// "go to Diff" gesture (see that branch's own comment) and does not
+    /// read this field at all.
+    blast_radius_return_pane: RightPane,
     /// The user's requested scroll offset (in lines) into the right-hand
     /// pane's content, as an unclamped "how far down would the user like to
     /// be" value rather than an authoritative display position: `App` has
@@ -407,7 +413,7 @@ impl App {
             order_mode,
             screen: Screen::Entry,
             right_pane: RightPane::default(),
-            pivot_return_pane: RightPane::default(),
+            blast_radius_return_pane: RightPane::default(),
             right_pane_scroll: 0,
             focus: Focus::default(),
             help_open: false,
@@ -425,9 +431,9 @@ impl App {
     /// [`App::new`], only when `main.rs`'s `--entry` flag was passed):
     /// moves the cursor onto the tree row matching `path`
     /// (`Nav::move_cursor_to_path`) and switches straight to
-    /// [`RightPane::Pivot`], so the TUI opens exactly where the CLI's own
+    /// [`RightPane::BlastRadius`], so the TUI opens exactly where the CLI's own
     /// `--entry` would have rooted the Markdown/JSON tree, rather than
-    /// requiring the reviewer to hunt for the row and press `p` themselves.
+    /// requiring the reviewer to hunt for the row and press `R` themselves.
     ///
     /// When no visible row's path matches `path` exactly (wrong path, a
     /// typo, or a path that only exists nested under a collapsed ancestor —
@@ -441,15 +447,15 @@ impl App {
     /// the tree/nav pane and Detail's fan-in do not read).
     pub fn with_entry_pivot(mut self, path: &str) -> Self {
         if self.nav.move_cursor_to_path(&self.tree, path) {
-            self.right_pane = RightPane::Pivot;
+            self.right_pane = RightPane::BlastRadius;
             // Deliberately `RightPane::Detail`, not `RightPane::default()`
             // (ADR 0020 made the default `Diff`): this session never
-            // actually showed a pane before pivoting straight in at
-            // startup, so there is no real "what was showing before" to
-            // restore — `Detail` is this method's own independent choice
-            // of `p`-re-press destination, unaffected by `RightPane`'s
-            // default changing.
-            self.pivot_return_pane = RightPane::Detail;
+            // actually showed a pane before opening the blast-radius pane
+            // straight in at startup, so there is no real "what was
+            // showing before" to restore — `Detail` is this method's own
+            // independent choice of `R`-re-press destination, unaffected
+            // by `RightPane`'s default changing.
+            self.blast_radius_return_pane = RightPane::Detail;
         } else {
             self.status = Some(format!("note: no tree row matches {path}"));
         }
@@ -591,40 +597,43 @@ impl App {
         }
     }
 
-    /// What the pivot pane ([`RightPane::Pivot`], ADR 0019) should show for
-    /// the row currently under the cursor: [`PivotSelection::View`] when the
-    /// cursor sits on a directory or file row and at least one symbol falls
-    /// under that row's path, [`PivotSelection::Empty`] for a directory/file
-    /// row whose path matches no symbol at all (still a valid selection,
-    /// just nothing to draw a tree from), or [`PivotSelection::NotApplicable`]
-    /// on a symbol row or when there are no rows at all — mirroring
+    /// What the blast-radius pane ([`RightPane::BlastRadius`], ADR 0019/0022)
+    /// should show for the row currently under the cursor:
+    /// [`BlastRadiusSelection::View`] when the cursor sits on a directory or
+    /// file row and at least one symbol falls under that row's path,
+    /// [`BlastRadiusSelection::Empty`] for a directory/file row whose path
+    /// matches no symbol at all (still a valid selection, just nothing to
+    /// draw a tree from), or [`BlastRadiusSelection::NotApplicable`] on a
+    /// symbol row or when there are no rows at all — mirroring
     /// `selected_diff_target`'s three-way split between "not this kind of
     /// row", "this kind of row but nothing to show", and "here is the
-    /// content", except pivot additionally needs to render its own "no
-    /// symbols under `<path>`" message rather than reuse a diff-pane-style
-    /// generic placeholder, hence the extra variant instead of `Option`.
+    /// content", except the blast-radius pane additionally needs to render
+    /// its own "no symbols under `<path>`" message rather than reuse a
+    /// diff-pane-style generic placeholder, hence the extra variant instead
+    /// of `Option`.
     ///
-    /// Not cached on `App` itself (ADR 0019's "recompute on pivot toggle or
-    /// cursor move while pivoted, not per frame" stance) — but this method
+    /// Not cached on `App` itself (ADR 0019's "recompute on toggle or
+    /// cursor move while active, not per frame" stance) — but this method
     /// still recomputes from scratch (cost O(V+E), see
-    /// `crate::pivot::build_pivot_view`'s own doc comment) on *every* call,
+    /// `crate::blast_radius::build_blast_radius_view`'s own doc comment) on *every* call,
     /// so satisfying that stance is the caller's responsibility: `crate::run`'s
-    /// event loop calls this once per handled key (when the pivot pane is
-    /// active and the selection could have changed), caches the result, and
-    /// hands the cached [`PivotSelection`] into `crate::ui::draw` — which
-    /// must not call this method itself, since `terminal.draw` runs on every
-    /// ~100ms idle poll tick as well as on an actual key press.
-    pub fn selected_pivot_view(&self, report: &Report) -> PivotSelection {
+    /// event loop calls this once per handled key (when the blast-radius
+    /// pane is active and the selection could have changed), caches the
+    /// result, and hands the cached [`BlastRadiusSelection`] into
+    /// `crate::ui::draw` — which must not call this method itself, since
+    /// `terminal.draw` runs on every ~100ms idle poll tick as well as on an
+    /// actual key press.
+    pub fn selected_blast_radius_view(&self, report: &Report) -> BlastRadiusSelection {
         let rows = self.nav.rows(&self.tree);
         let Some(row) = rows.get(self.nav.cursor()) else {
-            return PivotSelection::NotApplicable;
+            return BlastRadiusSelection::NotApplicable;
         };
         match &row.node.kind {
-            NodeKind::Symbol(_) => PivotSelection::NotApplicable,
+            NodeKind::Symbol(_) => BlastRadiusSelection::NotApplicable,
             NodeKind::Dir | NodeKind::File => {
-                match crate::pivot::build_pivot_view(report, &row.node.path) {
-                    Some(view) => PivotSelection::View(view),
-                    None => PivotSelection::Empty {
+                match crate::blast_radius::build_blast_radius_view(report, &row.node.path) {
+                    Some(view) => BlastRadiusSelection::View(view),
+                    None => BlastRadiusSelection::Empty {
                         path: row.node.path.clone(),
                     },
                 }
@@ -918,30 +927,32 @@ impl App {
             (Screen::Entry, _, InputKey::ToggleDiff) => {
                 self.right_pane = match self.right_pane {
                     RightPane::Diff => RightPane::Detail,
-                    // From Detail or Pivot, `d` always lands on Diff — a
-                    // deliberate, unconditional "go to Diff" gesture rather
-                    // than consulting `pivot_return_pane`. Only `p`'s own
-                    // re-press (`TogglePivot` below) restores the
-                    // pre-pivot pane; `d` pressed while pivoted is its own
+                    // From Detail or BlastRadius, `d` always lands on Diff —
+                    // a deliberate, unconditional "go to Diff" gesture
+                    // rather than consulting `blast_radius_return_pane`.
+                    // Only `R`'s own re-press (`ToggleBlastRadius` below)
+                    // restores the pre-blast-radius pane; `d` pressed while
+                    // the blast-radius pane is active is its own
                     // independent choice of destination, matching this
                     // arm's existing "from Detail, `d` always lands on
                     // Diff" behavior rather than growing a second "restore
                     // the previous pane" rule that would only apply to
                     // some keys and not others.
-                    RightPane::Detail | RightPane::Pivot => RightPane::Diff,
+                    RightPane::Detail | RightPane::BlastRadius => RightPane::Diff,
                 };
             }
-            (Screen::Entry, _, InputKey::TogglePivot) => {
+            (Screen::Entry, _, InputKey::ToggleBlastRadius) => {
                 self.right_pane = match self.right_pane {
                     // Restore whichever pane was showing right before this
-                    // pivot session started, rather than unconditionally
-                    // Detail — `pivot_return_pane` was captured below the
-                    // moment `Pivot` was entered, so e.g. `d` -> `p` -> `p`
-                    // returns to Diff, not Detail.
-                    RightPane::Pivot => self.pivot_return_pane,
+                    // blast-radius session started, rather than
+                    // unconditionally Detail — `blast_radius_return_pane`
+                    // was captured below the moment `BlastRadius` was
+                    // entered, so e.g. `d` -> `R` -> `R` returns to Diff,
+                    // not Detail.
+                    RightPane::BlastRadius => self.blast_radius_return_pane,
                     RightPane::Detail | RightPane::Diff => {
-                        self.pivot_return_pane = self.right_pane;
-                        RightPane::Pivot
+                        self.blast_radius_return_pane = self.right_pane;
+                        RightPane::BlastRadius
                     }
                 };
             }
@@ -963,7 +974,7 @@ impl App {
             // gates that jump on `Focus::Right` *and* `RightPane::Diff`
             // (not just `Focus::Right`, which is all this match can see) —
             // so pressing `]c` while Tree-focused, or while Right-focused
-            // but viewing Detail/Pivot, is a no-op there too, rather than
+            // but viewing Detail/BlastRadius, is a no-op there too, rather than
             // scrolling those panes against a hunk-offset table computed
             // for the Diff pane.
             (Screen::Entry, Focus::Right, InputKey::NextHunk | InputKey::PrevHunk) => {}
@@ -1395,31 +1406,32 @@ mod tests {
     }
 
     #[test]
-    fn should_toggle_right_pane_between_diff_and_pivot() {
+    fn should_toggle_right_pane_between_diff_and_blast_radius() {
         let report = empty_report();
         let app = App::new(&report);
         assert_eq!(RightPane::Diff, app.right_pane());
 
-        let app = app.handle_key(InputKey::TogglePivot);
-        assert_eq!(RightPane::Pivot, app.right_pane());
+        let app = app.handle_key(InputKey::ToggleBlastRadius);
+        assert_eq!(RightPane::BlastRadius, app.right_pane());
 
-        let app = app.handle_key(InputKey::TogglePivot);
+        let app = app.handle_key(InputKey::ToggleBlastRadius);
         assert_eq!(RightPane::Diff, app.right_pane());
     }
 
     #[test]
-    fn should_switch_from_pivot_to_diff_when_toggle_diff_is_pressed() {
-        // ADR 0019: "p" re-press or "d" both leave pivot mode — "d" always
-        // lands on Diff regardless of `pivot_return_pane` (a deliberate,
-        // unconditional gesture — see `handle_key`'s `ToggleDiff` arm). Uses
-        // Detail (not the default Diff) as the pane pivoted from, so this
-        // test still shows something once "d" is pressed even though the
-        // destination is unconditional either way.
+    fn should_switch_from_blast_radius_to_diff_when_toggle_diff_is_pressed() {
+        // ADR 0019/0022: "R" re-press or "d" both leave blast-radius mode —
+        // "d" always lands on Diff regardless of `blast_radius_return_pane`
+        // (a deliberate, unconditional gesture — see `handle_key`'s
+        // `ToggleDiff` arm). Uses Detail (not the default Diff) as the pane
+        // the blast-radius pane was opened from, so this test still shows
+        // something once "d" is pressed even though the destination is
+        // unconditional either way.
         let report = empty_report();
         let app = App::new(&report)
             .handle_key(InputKey::ToggleDiff) // Diff -> Detail
-            .handle_key(InputKey::TogglePivot);
-        assert_eq!(RightPane::Pivot, app.right_pane());
+            .handle_key(InputKey::ToggleBlastRadius);
+        assert_eq!(RightPane::BlastRadius, app.right_pane());
 
         let app = app.handle_key(InputKey::ToggleDiff);
 
@@ -1427,85 +1439,88 @@ mod tests {
     }
 
     #[test]
-    fn should_switch_from_detail_to_pivot_when_toggle_pivot_is_pressed() {
+    fn should_switch_from_detail_to_blast_radius_when_toggle_blast_radius_is_pressed() {
         let report = empty_report();
         let app = App::new(&report).handle_key(InputKey::ToggleDiff); // Diff -> Detail
         assert_eq!(RightPane::Detail, app.right_pane());
 
-        let app = app.handle_key(InputKey::TogglePivot);
+        let app = app.handle_key(InputKey::ToggleBlastRadius);
 
-        assert_eq!(RightPane::Pivot, app.right_pane());
+        assert_eq!(RightPane::BlastRadius, app.right_pane());
     }
 
     #[test]
-    fn should_return_to_diff_when_pivot_is_toggled_off_after_entering_from_the_default_diff_pane() {
-        // Pivoting straight from `App::new`'s own default (Diff, ADR 0020)
-        // must restore Diff specifically on `p`'s re-press, pinning that
-        // `pivot_return_pane` is actually captured on entry rather than
-        // this behavior being a coincidence of `RightPane::default()`.
+    fn should_return_to_diff_when_blast_radius_is_toggled_off_after_entering_from_the_default_diff_pane()
+     {
+        // Opening the blast-radius pane straight from `App::new`'s own
+        // default (Diff, ADR 0020) must restore Diff specifically on `R`'s
+        // re-press, pinning that `blast_radius_return_pane` is actually
+        // captured on entry rather than this behavior being a coincidence
+        // of `RightPane::default()`.
         let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::TogglePivot);
-        assert_eq!(RightPane::Pivot, app.right_pane());
+        let app = App::new(&report).handle_key(InputKey::ToggleBlastRadius);
+        assert_eq!(RightPane::BlastRadius, app.right_pane());
 
-        let app = app.handle_key(InputKey::TogglePivot);
+        let app = app.handle_key(InputKey::ToggleBlastRadius);
 
         assert_eq!(RightPane::Diff, app.right_pane());
     }
 
     #[test]
-    fn should_return_to_detail_when_pivot_is_toggled_off_after_entering_from_detail() {
-        // Companion to the Diff-return-pane test above: pivoting from
-        // Detail (reached via `d`, not the default) must still restore
-        // Detail specifically, not "whatever the default happens to be".
+    fn should_return_to_detail_when_blast_radius_is_toggled_off_after_entering_from_detail() {
+        // Companion to the Diff-return-pane test above: opening the
+        // blast-radius pane from Detail (reached via `d`, not the default)
+        // must still restore Detail specifically, not "whatever the default
+        // happens to be".
         let report = empty_report();
         let app = App::new(&report)
             .handle_key(InputKey::ToggleDiff) // Diff -> Detail
-            .handle_key(InputKey::TogglePivot);
-        assert_eq!(RightPane::Pivot, app.right_pane());
+            .handle_key(InputKey::ToggleBlastRadius);
+        assert_eq!(RightPane::BlastRadius, app.right_pane());
 
-        let app = app.handle_key(InputKey::TogglePivot);
+        let app = app.handle_key(InputKey::ToggleBlastRadius);
 
         assert_eq!(RightPane::Detail, app.right_pane());
     }
 
     #[test]
-    fn should_ignore_toggle_pivot_while_source_screen_is_open() {
+    fn should_ignore_toggle_blast_radius_while_source_screen_is_open() {
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(InputKey::Down)
             .handle_key(InputKey::Source);
         assert_eq!(RightPane::Diff, app.right_pane());
 
-        let app = app.handle_key(InputKey::TogglePivot);
+        let app = app.handle_key(InputKey::ToggleBlastRadius);
 
         assert_eq!(RightPane::Diff, app.right_pane());
     }
 
     #[test]
-    fn should_reset_right_pane_scroll_when_toggling_pivot_pane() {
+    fn should_reset_right_pane_scroll_when_toggling_blast_radius_pane() {
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(InputKey::Open)
             .handle_key(InputKey::Down);
         assert_eq!(1, app.right_pane_scroll());
 
-        let app = app.handle_key(InputKey::TogglePivot);
+        let app = app.handle_key(InputKey::ToggleBlastRadius);
 
         assert_eq!(0, app.right_pane_scroll());
     }
 
     #[test]
-    fn should_return_not_applicable_pivot_selection_when_cursor_is_on_a_symbol_row() {
+    fn should_return_not_applicable_blast_radius_selection_when_cursor_is_on_a_symbol_row() {
         let report = report_with_one_symbol();
         let app = App::new(&report).handle_key(InputKey::Down);
 
-        let actual = app.selected_pivot_view(&report);
+        let actual = app.selected_blast_radius_view(&report);
 
-        assert_eq!(PivotSelection::NotApplicable, actual);
+        assert_eq!(BlastRadiusSelection::NotApplicable, actual);
     }
 
     #[test]
-    fn should_return_pivot_view_when_cursor_is_on_a_directory_row() {
+    fn should_return_blast_radius_view_when_cursor_is_on_a_directory_row() {
         let report = Report {
             origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
@@ -1530,31 +1545,31 @@ mod tests {
         // further since "src/lib.rs" is a file, not a subdirectory).
         let app = App::new(&report);
 
-        let actual = app.selected_pivot_view(&report);
+        let actual = app.selected_blast_radius_view(&report);
 
         match actual {
-            PivotSelection::View(view) => assert_eq!("src".to_string(), view.path),
-            other => panic!("expected PivotSelection::View, got {other:?}"),
+            BlastRadiusSelection::View(view) => assert_eq!("src".to_string(), view.path),
+            other => panic!("expected BlastRadiusSelection::View, got {other:?}"),
         }
     }
 
     #[test]
-    fn should_return_not_applicable_pivot_selection_when_there_are_no_rows_at_all() {
+    fn should_return_not_applicable_blast_radius_selection_when_there_are_no_rows_at_all() {
         // The cursor has no row to sit on when the tree itself is empty —
-        // distinct from `should_return_empty_pivot_selection_when_file_row_path_matches_no_graph_node`
-        // below, which pins the actual `PivotSelection::Empty` trigger
+        // distinct from `should_return_empty_blast_radius_selection_when_file_row_path_matches_no_graph_node`
+        // below, which pins the actual `BlastRadiusSelection::Empty` trigger
         // (a real File row whose path matches no graph node).
         let report = empty_report();
         let app = App::new(&report);
 
-        let actual = app.selected_pivot_view(&report);
+        let actual = app.selected_blast_radius_view(&report);
 
-        assert_eq!(PivotSelection::NotApplicable, actual);
+        assert_eq!(BlastRadiusSelection::NotApplicable, actual);
     }
 
     #[test]
-    fn should_return_empty_pivot_selection_when_file_row_path_matches_no_graph_node() {
-        // The real-world trigger for `PivotSelection::Empty` (not the
+    fn should_return_empty_blast_radius_selection_when_file_row_path_matches_no_graph_node() {
+        // The real-world trigger for `BlastRadiusSelection::Empty` (not the
         // previous version of this test, which used an empty report and so
         // only ever exercised `NotApplicable` — the cursor had no row at
         // all): a `FileReport` with an empty `symbols` list (e.g. a file
@@ -1574,10 +1589,10 @@ mod tests {
         };
         let app = App::new(&report);
 
-        let actual = app.selected_pivot_view(&report);
+        let actual = app.selected_blast_radius_view(&report);
 
         assert_eq!(
-            PivotSelection::Empty {
+            BlastRadiusSelection::Empty {
                 path: "lib.rs".to_string()
             },
             actual
@@ -1586,8 +1601,8 @@ mod tests {
 
     /// Same shape as `report_with_two_directories`, but with a populated
     /// `graph` (that fixture leaves `graph` empty since none of its own
-    /// nav-focused tests need one) — required for `selected_pivot_view` to
-    /// return `PivotSelection::View` rather than `Empty` for either
+    /// nav-focused tests need one) — required for `selected_blast_radius_view` to
+    /// return `BlastRadiusSelection::View` rather than `Empty` for either
     /// directory.
     fn report_with_two_directories_and_graph() -> Report {
         let report = report_with_two_directories();
@@ -1596,13 +1611,13 @@ mod tests {
     }
 
     #[test]
-    fn should_follow_cursor_when_moving_between_directory_rows_while_pivoted() {
+    fn should_follow_cursor_when_moving_between_directory_rows_while_blast_radius_pane_is_active() {
         let report = report_with_two_directories_and_graph();
-        let app = App::new(&report).handle_key(InputKey::TogglePivot);
+        let app = App::new(&report).handle_key(InputKey::ToggleBlastRadius);
 
-        let first = match app.selected_pivot_view(&report) {
-            PivotSelection::View(view) => view.path,
-            other => panic!("expected PivotSelection::View, got {other:?}"),
+        let first = match app.selected_blast_radius_view(&report) {
+            BlastRadiusSelection::View(view) => view.path,
+            other => panic!("expected BlastRadiusSelection::View, got {other:?}"),
         };
         assert_eq!("a".to_string(), first);
 
@@ -1613,21 +1628,21 @@ mod tests {
             .handle_key(InputKey::Down)
             .handle_key(InputKey::Down)
             .handle_key(InputKey::Down);
-        let second = match app.selected_pivot_view(&report) {
-            PivotSelection::View(view) => view.path,
-            other => panic!("expected PivotSelection::View, got {other:?}"),
+        let second = match app.selected_blast_radius_view(&report) {
+            BlastRadiusSelection::View(view) => view.path,
+            other => panic!("expected BlastRadiusSelection::View, got {other:?}"),
         };
         assert_eq!("b".to_string(), second);
     }
 
     #[test]
-    fn should_move_cursor_and_open_pivot_pane_when_entry_pivot_path_matches_a_row() {
+    fn should_move_cursor_and_open_blast_radius_pane_when_entry_pivot_path_matches_a_row() {
         let report = report_with_two_directories_and_graph();
         let app = App::new(&report);
         // ADR 0020 made Diff the default right pane; this pins that
-        // `with_entry_pivot` still unconditionally overrides it to Pivot
-        // regardless, since it sets `right_pane` directly after `App::new`
-        // rather than consulting `RightPane::default()`.
+        // `with_entry_pivot` still unconditionally overrides it to
+        // BlastRadius regardless, since it sets `right_pane` directly after
+        // `App::new` rather than consulting `RightPane::default()`.
         assert_eq!(RightPane::Diff, app.right_pane());
 
         let app = app.with_entry_pivot("b");
@@ -1635,11 +1650,11 @@ mod tests {
         // Row 3 is "b" (per `report_with_two_directories`'s own doc comment
         // on expanded row order).
         assert_eq!(3, app.nav().cursor());
-        assert_eq!(RightPane::Pivot, app.right_pane());
+        assert_eq!(RightPane::BlastRadius, app.right_pane());
         assert_eq!(None, app.status());
-        let selected = match app.selected_pivot_view(&report) {
-            PivotSelection::View(view) => view.path,
-            other => panic!("expected PivotSelection::View, got {other:?}"),
+        let selected = match app.selected_blast_radius_view(&report) {
+            BlastRadiusSelection::View(view) => view.path,
+            other => panic!("expected BlastRadiusSelection::View, got {other:?}"),
         };
         assert_eq!("b".to_string(), selected);
     }

--- a/rinkaku-tui/src/blast_radius.rs
+++ b/rinkaku-tui/src/blast_radius.rs
@@ -55,9 +55,20 @@ pub struct BlastRadiusLine {
     /// convention as `rinkaku-core::render`'s Markdown tree.
     pub already_printed: bool,
     /// `true` when this line is a cycle marker rather than a node line —
-    /// `crate::ui` styles it distinctly (matching the `⚠️` Markdown
-    /// warning), and `label` is the *target* node's label the cycle points
-    /// back to.
+    /// `crate::ui` styles it distinctly (yellow/bold, mirroring the
+    /// severity `rinkaku-core::render`'s Markdown `⚠️` warning signals),
+    /// and `label` is the *target* node's label the cycle points back to.
+    /// The label itself uses a plain `!` marker rather than `⚠️`
+    /// deliberately (ADR 0022): `⚠️` is U+26A0 followed by a U+FE0F
+    /// variation selector, and dynamic verification in a real terminal
+    /// (`tmux capture-pane`) showed `unicode-width`'s single-column measurement
+    /// of that pair disagreeing with the terminal's actual double-column
+    /// rendering, desyncing `crate::ui::wrap_lines`'s column accounting from
+    /// what the terminal draws and leaving a stray character on screen —
+    /// exactly the risk ADR 0022 flagged before implementation.
+    /// `rinkaku-core::render`'s Markdown output keeps `⚠️` unaffected: it
+    /// is plain text there, never fed through a terminal-cell width
+    /// calculation.
     pub is_cycle_warning: bool,
 }
 
@@ -219,7 +230,7 @@ fn walk(
             if let Some(child_label) = lookup.label(child_id) {
                 lines.push(BlastRadiusLine {
                     depth: depth + 1,
-                    label: format!("⚠️ {child_label} — already shown above (cycle)"),
+                    label: format!("! {child_label} — already shown above (cycle)"),
                     outside_prefix: false,
                     already_printed: false,
                     is_cycle_warning: true,
@@ -457,7 +468,7 @@ mod tests {
             },
             BlastRadiusLine {
                 depth: 2,
-                label: "⚠️ fn foo (src/api/handler.rs) — already shown above (cycle)".to_string(),
+                label: "! fn foo (src/api/handler.rs) — already shown above (cycle)".to_string(),
                 outside_prefix: false,
                 already_printed: false,
                 is_cycle_warning: true,

--- a/rinkaku-tui/src/blast_radius.rs
+++ b/rinkaku-tui/src/blast_radius.rs
@@ -1,4 +1,4 @@
-//! Blast-radius view-model (ADR 0019 for the re-rooting algorithm, ADR 0022
+//! Blast-radius view-model (ADR 0019 for the re-rooting algorithm, ADR 0023
 //! for the "blast radius" naming): given a directory or file path, builds
 //! the entry-tree text the right pane shows when the user presses `R` on
 //! that row — the interactive equivalent of `rinkaku --entry <path>`'s
@@ -23,7 +23,7 @@
 //! every idle poll tick, not only on a key press.
 //!
 //! `rinkaku-core`'s graph API (`pivot_graph`/`pivot_roots`) keeps its
-//! existing name deliberately — ADR 0022 scopes the "blast radius" rename
+//! existing name deliberately — ADR 0023 scopes the "blast radius" rename
 //! to this crate's user-facing surface, not to `rinkaku-core` or the CLI's
 //! `--entry` flag.
 
@@ -59,13 +59,13 @@ pub struct BlastRadiusLine {
     /// severity `rinkaku-core::render`'s Markdown `⚠️` warning signals),
     /// and `label` is the *target* node's label the cycle points back to.
     /// The label itself uses a plain `!` marker rather than `⚠️`
-    /// deliberately (ADR 0022): `⚠️` is U+26A0 followed by a U+FE0F
+    /// deliberately (ADR 0023): `⚠️` is U+26A0 followed by a U+FE0F
     /// variation selector, and dynamic verification in a real terminal
     /// (`tmux capture-pane`) showed `unicode-width`'s single-column measurement
     /// of that pair disagreeing with the terminal's actual double-column
     /// rendering, desyncing `crate::ui::wrap_lines`'s column accounting from
     /// what the terminal draws and leaving a stray character on screen —
-    /// exactly the risk ADR 0022 flagged before implementation.
+    /// exactly the risk ADR 0023 flagged before implementation.
     /// `rinkaku-core::render`'s Markdown output keeps `⚠️` unaffected: it
     /// is plain text there, never fed through a terminal-cell width
     /// calculation.

--- a/rinkaku-tui/src/blast_radius.rs
+++ b/rinkaku-tui/src/blast_radius.rs
@@ -1,85 +1,91 @@
-//! Pivot-view view-model (ADR 0019): given a directory or file path, builds
-//! the entry-tree text the right pane shows when the user presses `p` on
+//! Blast-radius view-model (ADR 0019 for the re-rooting algorithm, ADR 0022
+//! for the "blast radius" naming): given a directory or file path, builds
+//! the entry-tree text the right pane shows when the user presses `R` on
 //! that row — the interactive equivalent of `rinkaku --entry <path>`'s
 //! Markdown "Change graph"/"Repository graph" section, flattened into plain
-//! [`PivotLine`]s instead of Markdown text since the pane draws with
+//! [`BlastRadiusLine`]s instead of Markdown text since the pane draws with
 //! `ratatui`, not a Markdown renderer.
 //!
-//! [`build_pivot_view`] is a pure function of a [`Report`] and a path: no
-//! IO, no `ratatui` types (mirrors `crate::detail`'s discipline). It calls
-//! [`rinkaku_core::graph::pivot_graph`] once per invocation rather than
-//! caching a re-rooted graph on `App` — matching ADR 0019's own "recompute
-//! on pivot toggle or cursor move while pivoted, not per frame" stance
+//! [`build_blast_radius_view`] is a pure function of a [`Report`] and a
+//! path: no IO, no `ratatui` types (mirrors `crate::detail`'s discipline).
+//! It calls [`rinkaku_core::graph::pivot_graph`] once per invocation rather
+//! than caching a re-rooted graph on `App` — matching ADR 0019's own
+//! "recompute on toggle or cursor move while active, not per frame" stance
 //! (ADR 0016's existing recompute-not-cache philosophy) and `crate::app`'s
 //! wider convention of deriving view-models fresh from `Report` on each
 //! call rather than threading derived state through `App`. That "not per
 //! frame" half of the stance is enforced by the caller, not by this
 //! function itself: `crate::run_app`'s event loop calls
-//! [`crate::app::App::selected_pivot_view`] (which wraps this function) at
-//! most once per handled key, caches the result, and hands the cached value
-//! into `crate::ui::draw` — `crate::ui::draw_pivot_pane` must not call
-//! either function itself, since `terminal.draw` also runs on every idle
-//! poll tick, not only on a key press.
+//! [`crate::app::App::selected_blast_radius_view`] (which wraps this
+//! function) at most once per handled key, caches the result, and hands the
+//! cached value into `crate::ui::draw` — `crate::ui::draw_blast_radius_pane`
+//! must not call either function itself, since `terminal.draw` also runs on
+//! every idle poll tick, not only on a key press.
+//!
+//! `rinkaku-core`'s graph API (`pivot_graph`/`pivot_roots`) keeps its
+//! existing name deliberately — ADR 0022 scopes the "blast radius" rename
+//! to this crate's user-facing surface, not to `rinkaku-core` or the CLI's
+//! `--entry` flag.
 
 use rinkaku_core::extract::ExtractedSymbol;
 use rinkaku_core::graph::{SymbolGraph, path_under_prefix, pivot_graph};
 use rinkaku_core::render::Report;
 use std::collections::{HashMap, HashSet};
 
-/// One flattened line of the pivot tree: a node's label at a given
+/// One flattened line of the blast-radius tree: a node's label at a given
 /// indentation depth, already carrying every display decision (whether it
 /// is outside the pivoted prefix, already printed elsewhere, or a cycle
-/// warning) so `crate::ui` only needs to lay the strings out, not re-derive
+/// marker) so `crate::ui` only needs to lay the strings out, not re-derive
 /// them.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PivotLine {
+pub struct BlastRadiusLine {
     pub depth: usize,
     /// `{kind} {name} ({path})`, matching `rinkaku-core::render`'s tree
-    /// label shape so the pivot pane reads consistently with the Markdown
-    /// "Change graph"/"Repository graph" section a reviewer may already be
-    /// cross-referencing.
+    /// label shape so the blast-radius pane reads consistently with the
+    /// Markdown "Change graph"/"Repository graph" section a reviewer may
+    /// already be cross-referencing.
     pub label: String,
     /// `true` when this node's path falls outside the pivoted prefix
     /// (reached by expanding a dependency edge outward past the prefix
     /// boundary) — `crate::ui` dims these so the reviewer can tell "this is
-    /// the layer I pivoted on" from "this is what it reaches into".
+    /// the layer I'm measuring from" from "this is what it reaches into".
     pub outside_prefix: bool,
     /// `true` when this node was already printed earlier in the tree; the
     /// line reads `{label} (see above)` and is not expanded further, same
     /// convention as `rinkaku-core::render`'s Markdown tree.
     pub already_printed: bool,
-    /// `true` when this line is a cycle-edge warning marker rather than a
-    /// node line — `crate::ui` styles it distinctly (matching the `⚠️`
-    /// Markdown warning), and `label` is the *target* node's label the
-    /// cycle points back to.
+    /// `true` when this line is a cycle marker rather than a node line —
+    /// `crate::ui` styles it distinctly (matching the `⚠️` Markdown
+    /// warning), and `label` is the *target* node's label the cycle points
+    /// back to.
     pub is_cycle_warning: bool,
 }
 
-/// The pivot pane's content for a chosen path: either a tree of
-/// [`PivotLine`]s, or `None` when no symbol's path falls under the pivoted
-/// prefix at all (`crate::ui` shows a "no symbols under `<path>`" style
-/// placeholder in that case, mirroring `main.rs`'s CLI-side
+/// The blast-radius pane's content for a chosen path: either a tree of
+/// [`BlastRadiusLine`]s, or `None` when no symbol's path falls under the
+/// pivoted prefix at all (`crate::ui` shows a "no symbols under `<path>`"
+/// style placeholder in that case, mirroring `main.rs`'s CLI-side
 /// `entry_pivot_empty_note`).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PivotView {
+pub struct BlastRadiusView {
     pub path: String,
-    pub lines: Vec<PivotLine>,
+    pub lines: Vec<BlastRadiusLine>,
 }
 
-/// Builds the pivot view for `path` against `report`: re-roots
+/// Builds the blast-radius view for `path` against `report`: re-roots
 /// `report.graph` at `path` ([`pivot_graph`]) and flattens the resulting
-/// tree into [`PivotLine`]s via a pre-order DFS from the pivoted roots,
-/// mirroring `rinkaku-core::render::render_change_graph`'s walk (same
-/// "(see above)" dedup, same cycle-edge warning treatment) but without that
+/// tree into [`BlastRadiusLine`]s via a pre-order DFS from the pivoted
+/// roots, mirroring `rinkaku-core::render::render_change_graph`'s walk
+/// (same "(see above)" dedup, same cycle marker treatment) but without that
 /// module's folding-into-parent-line behavior (ADR 0012 decision 1) — the
-/// pivot pane is a compact secondary view, not the primary Markdown output,
-/// and keeping every node on its own line is simpler to scan at a glance in
-/// the pane's limited width.
+/// blast-radius pane is a compact secondary view, not the primary Markdown
+/// output, and keeping every node on its own line is simpler to scan at a
+/// glance in the pane's limited width.
 ///
 /// Returns `None` when the pivoted graph has no roots at all: either no
 /// node's path matched `path` (`pivot_graph` returns empty `roots` in that
 /// case), or `report.graph` itself has no nodes to begin with.
-pub fn build_pivot_view(report: &Report, path: &str) -> Option<PivotView> {
+pub fn build_blast_radius_view(report: &Report, path: &str) -> Option<BlastRadiusView> {
     let graph = pivot_graph(&report.graph, path);
     if graph.roots.is_empty() {
         return None;
@@ -108,7 +114,7 @@ pub fn build_pivot_view(report: &Report, path: &str) -> Option<PivotView> {
         );
     }
 
-    Some(PivotView {
+    Some(BlastRadiusView {
         path: path.to_string(),
         lines,
     })
@@ -170,7 +176,7 @@ fn children_by_node(graph: &SymbolGraph) -> HashMap<&str, Vec<(&str, bool)>> {
     children
 }
 
-/// Recursive pre-order walk building [`PivotLine`]s, mirroring
+/// Recursive pre-order walk building [`BlastRadiusLine`]s, mirroring
 /// `rinkaku-core::render::render_tree_node`'s dedup/cycle handling without
 /// its inline-folding step (this module's own doc comment on why).
 #[allow(clippy::too_many_arguments)]
@@ -181,7 +187,7 @@ fn walk(
     prefix_ids: &HashSet<&str>,
     printed: &mut HashSet<String>,
     depth: usize,
-    lines: &mut Vec<PivotLine>,
+    lines: &mut Vec<BlastRadiusLine>,
 ) {
     let Some(label) = lookup.label(id) else {
         return;
@@ -189,7 +195,7 @@ fn walk(
     let outside_prefix = !prefix_ids.contains(id);
 
     if !printed.insert(id.to_string()) {
-        lines.push(PivotLine {
+        lines.push(BlastRadiusLine {
             depth,
             label,
             outside_prefix,
@@ -199,7 +205,7 @@ fn walk(
         return;
     }
 
-    lines.push(PivotLine {
+    lines.push(BlastRadiusLine {
         depth,
         label,
         outside_prefix,
@@ -211,9 +217,9 @@ fn walk(
     for &(child_id, is_cycle) in kids {
         if is_cycle {
             if let Some(child_label) = lookup.label(child_id) {
-                lines.push(PivotLine {
+                lines.push(BlastRadiusLine {
                     depth: depth + 1,
-                    label: format!("⚠️ {child_label} — dependency cycle, see above"),
+                    label: format!("⚠️ {child_label} — already shown above (cycle)"),
                     outside_prefix: false,
                     already_printed: false,
                     is_cycle_warning: true,
@@ -277,7 +283,7 @@ mod tests {
 
     /// Builds a `Report` whose `graph`/`files`/symbol ids are all mutually
     /// consistent — `build_graph` assigns real ids and `stamp_ids` copies
-    /// them back onto `files`, since `SymbolLookup`/`build_pivot_view` join
+    /// them back onto `files`, since `SymbolLookup`/`build_blast_radius_view` join
     /// the two by id, the same way `rinkaku-core::render`'s own tests do
     /// (`graph.rs`'s `should_stamp_each_symbol_id_...` fixtures).
     fn report_from(mut files: Vec<FileReport>) -> Report {
@@ -297,7 +303,7 @@ mod tests {
             symbols: vec![symbol("foo", vec![])],
         }]);
 
-        let actual = build_pivot_view(&report, "no/such/path");
+        let actual = build_blast_radius_view(&report, "no/such/path");
 
         assert_eq!(None, actual);
     }
@@ -306,7 +312,7 @@ mod tests {
     fn should_return_none_when_report_has_no_symbols_at_all() {
         let report = empty_report();
 
-        let actual = build_pivot_view(&report, "src/api");
+        let actual = build_blast_radius_view(&report, "src/api");
 
         assert_eq!(None, actual);
     }
@@ -318,11 +324,11 @@ mod tests {
             symbols: vec![symbol("api", vec![])],
         }]);
 
-        let actual = build_pivot_view(&report, "src/api");
+        let actual = build_blast_radius_view(&report, "src/api");
 
-        let expected = PivotView {
+        let expected = BlastRadiusView {
             path: "src/api".to_string(),
-            lines: vec![PivotLine {
+            lines: vec![BlastRadiusLine {
                 depth: 0,
                 label: "fn api (src/api/handler.rs)".to_string(),
                 outside_prefix: false,
@@ -350,17 +356,17 @@ mod tests {
             },
         ]);
 
-        let actual = build_pivot_view(&report, "src/api").expect("pivot view");
+        let actual = build_blast_radius_view(&report, "src/api").expect("blast radius view");
 
         let expected_lines = vec![
-            PivotLine {
+            BlastRadiusLine {
                 depth: 0,
                 label: "fn api (src/api/handler.rs)".to_string(),
                 outside_prefix: false,
                 already_printed: false,
                 is_cycle_warning: false,
             },
-            PivotLine {
+            BlastRadiusLine {
                 depth: 1,
                 label: "fn helper (src/util.rs)".to_string(),
                 outside_prefix: true,
@@ -387,31 +393,31 @@ mod tests {
             ],
         }]);
 
-        let actual = build_pivot_view(&report, "src/api").expect("pivot view");
+        let actual = build_blast_radius_view(&report, "src/api").expect("blast radius view");
 
         let expected_lines = vec![
-            PivotLine {
+            BlastRadiusLine {
                 depth: 0,
                 label: "fn foo (src/api/handler.rs)".to_string(),
                 outside_prefix: false,
                 already_printed: false,
                 is_cycle_warning: false,
             },
-            PivotLine {
+            BlastRadiusLine {
                 depth: 1,
                 label: "fn shared (src/api/handler.rs)".to_string(),
                 outside_prefix: false,
                 already_printed: false,
                 is_cycle_warning: false,
             },
-            PivotLine {
+            BlastRadiusLine {
                 depth: 0,
                 label: "fn bar (src/api/handler.rs)".to_string(),
                 outside_prefix: false,
                 already_printed: false,
                 is_cycle_warning: false,
             },
-            PivotLine {
+            BlastRadiusLine {
                 depth: 1,
                 label: "fn shared (src/api/handler.rs)".to_string(),
                 outside_prefix: false,
@@ -426,32 +432,32 @@ mod tests {
     fn should_mark_cycle_edge_as_warning_line_when_pivot_root_participates_in_a_cycle() {
         // foo -> bar -> foo under src/api: pivoting at src/api re-roots at
         // "foo" (the sole SCC representative), and the back edge bar -> foo
-        // must render as a cycle-warning line, not be walked into again.
+        // must render as a cycle marker line, not be walked into again.
         let report = report_from(vec![FileReport {
             path: "src/api/handler.rs".to_string(),
             symbols: vec![symbol("foo", vec!["bar"]), symbol("bar", vec!["foo"])],
         }]);
 
-        let actual = build_pivot_view(&report, "src/api").expect("pivot view");
+        let actual = build_blast_radius_view(&report, "src/api").expect("blast radius view");
 
         let expected_lines = vec![
-            PivotLine {
+            BlastRadiusLine {
                 depth: 0,
                 label: "fn foo (src/api/handler.rs)".to_string(),
                 outside_prefix: false,
                 already_printed: false,
                 is_cycle_warning: false,
             },
-            PivotLine {
+            BlastRadiusLine {
                 depth: 1,
                 label: "fn bar (src/api/handler.rs)".to_string(),
                 outside_prefix: false,
                 already_printed: false,
                 is_cycle_warning: false,
             },
-            PivotLine {
+            BlastRadiusLine {
                 depth: 2,
-                label: "⚠️ fn foo (src/api/handler.rs) — dependency cycle, see above".to_string(),
+                label: "⚠️ fn foo (src/api/handler.rs) — already shown above (cycle)".to_string(),
                 outside_prefix: false,
                 already_printed: false,
                 is_cycle_warning: true,
@@ -467,17 +473,17 @@ mod tests {
             symbols: vec![symbol("foo", vec![]), symbol("bar", vec![])],
         }]);
 
-        let actual = build_pivot_view(&report, "src/api").expect("pivot view");
+        let actual = build_blast_radius_view(&report, "src/api").expect("blast radius view");
 
         let expected_lines = vec![
-            PivotLine {
+            BlastRadiusLine {
                 depth: 0,
                 label: "fn foo (src/api/handler.rs)".to_string(),
                 outside_prefix: false,
                 already_printed: false,
                 is_cycle_warning: false,
             },
-            PivotLine {
+            BlastRadiusLine {
                 depth: 0,
                 label: "fn bar (src/api/handler.rs)".to_string(),
                 outside_prefix: false,
@@ -507,7 +513,7 @@ mod tests {
             ..empty_report()
         };
 
-        let actual = build_pivot_view(&report, "other");
+        let actual = build_blast_radius_view(&report, "other");
 
         assert_eq!(None, actual);
     }

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -8,14 +8,14 @@
 //! header up front when the symbol's contract changed.
 //!
 //! Pure and free of `ratatui` types, mirroring every other view-model in
-//! this crate (`crate::tree`/`crate::nav`/`crate::detail`/`crate::pivot`):
+//! this crate (`crate::tree`/`crate::nav`/`crate::detail`/`crate::blast_radius`):
 //! `Report` + `&[FileHunks]` + a selection in, plain [`DiffPaneContent`]
 //! data out. `crate::run_app` computes this once per handled key (the same
-//! cache-on-selection-change discipline `crate::app::App::selected_pivot_view`'s
+//! cache-on-selection-change discipline `crate::app::App::selected_blast_radius_view`'s
 //! own doc comment already establishes, after that pane's own past
 //! per-frame recompute bug — see this crate's `lib.rs` regression test);
 //! `crate::ui::draw` must not call it, for the identical reason
-//! `ui::draw` must not call `App::selected_pivot_view` either.
+//! `ui::draw` must not call `App::selected_blast_radius_view` either.
 
 use crate::app::DiffTarget;
 use crate::diff_view::{FileHunks, Hunk, file_hunks};

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -1,6 +1,6 @@
-//! The `?` help overlay's content (ADR 0020): a static keymap plus a short
-//! glossary, assembled as plain data so `crate::ui` only has to lay it out,
-//! not decide what belongs in it.
+//! The `?` help overlay's content (ADR 0020, glossary wording per ADR
+//! 0022): a static keymap plus a short glossary, assembled as plain data so
+//! `crate::ui` only has to lay it out, not decide what belongs in it.
 //!
 //! The keymap itself is fixed (not derived from `crate::app::InputKey` or
 //! `crate::lib::translate_key` — both already carry their own doc comments
@@ -18,7 +18,7 @@ pub struct KeyBinding {
 }
 
 /// One glossary entry: a term used elsewhere in the UI (an order mode name,
-/// "pivot", "cycle") paired with a short explanation — the answer to
+/// "blast radius", "cycle") paired with a short explanation — the answer to
 /// "what does that word on the status line/tree actually mean".
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlossaryEntry {
@@ -90,8 +90,8 @@ const GLOBAL_BINDINGS: &[KeyBinding] = &[
         description: "Toggle the right pane between Detail and Diff",
     },
     KeyBinding {
-        keys: "p / P",
-        description: "Toggle the right pane to the pivot tree rooted at the selected row",
+        keys: "r / R",
+        description: "Toggle the right pane to the blast radius of the selected row",
     },
     KeyBinding {
         keys: "o / O",
@@ -152,12 +152,12 @@ const GLOSSARY: &[GlossaryEntry] = &[
         explanation: "Directories ordered A-Z, ignoring dependency direction",
     },
     GlossaryEntry {
-        term: "pivot",
-        explanation: "Re-roots the dependency tree at the selected directory/file's path",
+        term: "blast radius",
+        explanation: "The dependency tree rooted at a selected directory or file, showing what would be affected if it changed",
     },
     GlossaryEntry {
         term: "cycle",
-        explanation: "A closing back-edge in the dependency graph — two or more directories depend on each other",
+        explanation: "A dependency loop: two or more symbols depend on each other, so the tree stops and points back to where it first appeared",
     },
     GlossaryEntry {
         term: "jumplist",
@@ -199,14 +199,14 @@ mod tests {
     }
 
     #[test]
-    fn should_include_a_glossary_entry_for_pivot_and_cycle() {
+    fn should_include_a_glossary_entry_for_blast_radius_and_cycle() {
         let terms: Vec<&str> = HELP_CONTENT
             .glossary
             .iter()
             .map(|entry| entry.term)
             .collect();
 
-        assert!(terms.contains(&"pivot"));
+        assert!(terms.contains(&"blast radius"));
         assert!(terms.contains(&"cycle"));
     }
 

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -1,5 +1,5 @@
 //! The `?` help overlay's content (ADR 0020, glossary wording per ADR
-//! 0022): a static keymap plus a short glossary, assembled as plain data so
+//! 0023): a static keymap plus a short glossary, assembled as plain data so
 //! `crate::ui` only has to lay it out, not decide what belongs in it.
 //!
 //! The keymap itself is fixed (not derived from `crate::app::InputKey` or

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -75,7 +75,7 @@ use std::time::Duration;
 /// `entry_path` is `main.rs`'s `--entry <path>` flag (ADR 0019), passed
 /// through unchanged when the user combines it with `--tui`: `None` when
 /// `--entry` was not given (the ordinary case), `Some(path)` to open
-/// straight into [`app::RightPane::BlastRadius`] (ADR 0022) with the cursor
+/// straight into [`app::RightPane::BlastRadius`] (ADR 0023) with the cursor
 /// already on the matching tree row (`App::with_entry_pivot`) instead of
 /// requiring the reviewer to hunt for the row and press `R` themselves. Note
 /// this crate does *not* itself re-root `report.graph` — `main.rs` already

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -29,6 +29,7 @@
 //! carries hunk text once extraction has run).
 
 pub mod app;
+pub mod blast_radius;
 pub mod detail;
 pub mod diff_shape;
 pub mod diff_view;
@@ -36,13 +37,12 @@ pub mod help;
 pub mod highlight;
 pub mod nav;
 pub mod order;
-pub mod pivot;
 pub mod row_view;
 pub mod source;
 pub mod tree;
 pub mod ui;
 
-use app::{App, InputKey, PivotSelection, Screen};
+use app::{App, BlastRadiusSelection, InputKey, Screen};
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use rinkaku_core::render::Report;
 use std::time::Duration;
@@ -75,14 +75,14 @@ use std::time::Duration;
 /// `entry_path` is `main.rs`'s `--entry <path>` flag (ADR 0019), passed
 /// through unchanged when the user combines it with `--tui`: `None` when
 /// `--entry` was not given (the ordinary case), `Some(path)` to open
-/// straight into [`app::RightPane::Pivot`] with the cursor already on the
-/// matching tree row (`App::with_entry_pivot`) instead of requiring the
-/// reviewer to hunt for the row and press `p` themselves. Note this crate
-/// does *not* itself re-root `report.graph` — `main.rs` already applied
-/// `--entry`'s `pivot_graph` re-rooting to `report` before calling here (the
-/// same `Report` both the TUI and Markdown/JSON render from), so this
-/// parameter only drives where the TUI *starts*, not what the underlying
-/// graph looks like.
+/// straight into [`app::RightPane::BlastRadius`] (ADR 0022) with the cursor
+/// already on the matching tree row (`App::with_entry_pivot`) instead of
+/// requiring the reviewer to hunt for the row and press `R` themselves. Note
+/// this crate does *not* itself re-root `report.graph` — `main.rs` already
+/// applied `--entry`'s `pivot_graph` re-rooting to `report` before calling
+/// here (the same `Report` both the TUI and Markdown/JSON render from), so
+/// this parameter only drives where the TUI *starts*, not what the
+/// underlying graph looks like.
 ///
 /// `repo_root` anchors `Report` paths (always repository-root-relative) for
 /// the source drill-down's file reads (`crate::source::load_symbol_source`)
@@ -127,33 +127,34 @@ fn run_app(
     // the render loop either.
     let diff_highlights = highlight::highlight_diff_files(&diff_hunks);
     // Computed once up front (then on demand below, once per handled key —
-    // unlike `diff_hunks`/`diff_highlights` above, the pivot view depends on
-    // `app`'s cursor position and right-pane mode, both of which change as
-    // keys are handled) and cached here across idle poll ticks for the same
-    // reason those two are computed outside the draw loop at all: `ui::draw`
-    // itself runs on every ~100ms idle poll timeout, not just on an actual
-    // key press, and `crate::pivot::build_pivot_view` is an O(V+E) graph
-    // walk — recomputing it on every one of those idle ticks while the
-    // pivot pane merely sits on screen was the per-frame recompute bug this
-    // cache exists to fix (`App::selected_pivot_view`'s own doc comment).
-    // The up-front computation (rather than starting at `NotApplicable`
-    // unconditionally) matters specifically for `--entry --tui`: when
-    // `entry_path` above already opened `RightPane::Pivot`, the very first
-    // frame must show the pivot tree immediately, not an empty placeholder
-    // until the first key press recomputes it.
-    let mut pivot_selection = if should_recompute_pivot_selection(&app) {
-        app.selected_pivot_view(report)
+    // unlike `diff_hunks`/`diff_highlights` above, the blast-radius view
+    // depends on `app`'s cursor position and right-pane mode, both of which
+    // change as keys are handled) and cached here across idle poll ticks for
+    // the same reason those two are computed outside the draw loop at all:
+    // `ui::draw` itself runs on every ~100ms idle poll timeout, not just on
+    // an actual key press, and `crate::blast_radius::build_blast_radius_view`
+    // is an O(V+E) graph walk — recomputing it on every one of those idle
+    // ticks while the blast-radius pane merely sits on screen was the
+    // per-frame recompute bug this cache exists to fix
+    // (`App::selected_blast_radius_view`'s own doc comment). The up-front
+    // computation (rather than starting at `NotApplicable` unconditionally)
+    // matters specifically for `--entry --tui`: when `entry_path` above
+    // already opened `RightPane::BlastRadius`, the very first frame must
+    // show the blast-radius tree immediately, not an empty placeholder until
+    // the first key press recomputes it.
+    let mut blast_radius_selection = if should_recompute_blast_radius_selection(&app) {
+        app.selected_blast_radius_view(report)
     } else {
-        PivotSelection::NotApplicable
+        BlastRadiusSelection::NotApplicable
     };
     // Computed once up front then on demand below, once per handled key —
     // same reasoning and cache-on-selection-change discipline as
-    // `pivot_selection` above (ADR 0020: `crate::diff_shape`'s own doc
+    // `blast_radius_selection` above (ADR 0020: `crate::diff_shape`'s own doc
     // comment on why this must not be recomputed inside `ui::draw`, after
-    // the pivot pane's own past per-frame recompute bug). The up-front
-    // computation matters for the ordinary (non-`--entry`) startup path
-    // too now, since ADR 0020 also made Diff the default right pane: the
-    // very first frame must already show shaped diff content, not an
+    // the blast-radius pane's own past per-frame recompute bug). The
+    // up-front computation matters for the ordinary (non-`--entry`) startup
+    // path too now, since ADR 0020 also made Diff the default right pane:
+    // the very first frame must already show shaped diff content, not an
     // empty placeholder until the first key press recomputes it.
     let mut diff_pane_content = if should_recompute_diff_pane_content(&app) {
         diff_shape::build_diff_pane_content(
@@ -173,7 +174,7 @@ fn run_app(
                 report,
                 &diff_pane_content,
                 &diff_highlights,
-                &pivot_selection,
+                &blast_radius_selection,
                 repo_root,
             )
         })?;
@@ -218,8 +219,8 @@ fn run_app(
                 app = dispatch_non_source_key(app, report, &diff_pane_content, input_key);
             }
 
-            if should_recompute_pivot_selection(&app) {
-                pivot_selection = app.selected_pivot_view(report);
+            if should_recompute_blast_radius_selection(&app) {
+                blast_radius_selection = app.selected_blast_radius_view(report);
             }
             if should_recompute_diff_pane_content(&app) {
                 diff_pane_content = diff_shape::build_diff_pane_content(
@@ -318,8 +319,8 @@ fn dispatch_non_source_key(
 
 /// Whether `crate::run_app`'s event loop should recompute the diff pane's
 /// shaped content this key, rather than keep showing the previously cached
-/// one — mirrors `should_recompute_pivot_selection`'s own contract and
-/// reasoning, just for [`RightPane::Diff`] instead of `RightPane::Pivot`.
+/// one — mirrors `should_recompute_blast_radius_selection`'s own contract and
+/// reasoning, just for [`RightPane::Diff`] instead of `RightPane::BlastRadius`.
 fn should_recompute_diff_pane_content(app: &App) -> bool {
     matches!(app.screen(), Screen::Entry) && app.right_pane() == app::RightPane::Diff
 }
@@ -328,14 +329,14 @@ fn should_recompute_diff_pane_content(app: &App) -> bool {
 /// [`InputKey::NextHunk`]/[`InputKey::PrevHunk`] press by jumping
 /// `diff_pane_content`'s scroll offset, rather than treating the key as a
 /// no-op. `true` only while [`app::Focus::Right`] *and* [`app::RightPane::Diff`]
-/// is showing — gating on focus alone let `]`/`[` scroll the Detail/Pivot
+/// is showing — gating on focus alone let `]`/`[` scroll the Detail/BlastRadius
 /// pane using `diff_pane_content`'s hunk-start table, which is only ever
 /// recomputed for the Diff pane (`should_recompute_diff_pane_content` above),
 /// so it goes stale (pinned to whichever file/symbol was selected the last
 /// time Diff was shown) the moment the user switches away from Diff. That
 /// produced a jump with no relation to what is actually on screen.
 ///
-/// Extracted as its own pure function, mirroring `should_recompute_pivot_selection`'s
+/// Extracted as its own pure function, mirroring `should_recompute_blast_radius_selection`'s
 /// own reasoning, so this exact gate is unit-testable without a live
 /// `ratatui::DefaultTerminal`.
 fn should_apply_hunk_jump(app: &App) -> bool {
@@ -432,18 +433,18 @@ fn resolve_goto(app: &App, report: &Report, direction: InputKey) -> GotoOutcome 
     }
 }
 
-/// Whether `crate::run_app`'s event loop should recompute the pivot
+/// Whether `crate::run_app`'s event loop should recompute the blast-radius
 /// selection this key, rather than keep showing the previously cached one
 /// (this function's own extraction is what makes that decision
 /// unit-testable without a live `ratatui::DefaultTerminal` — `run_app`
 /// itself takes one and so cannot be driven directly in a test). `true`
-/// only when the pivot pane is actually the active right pane on the entry
-/// screen; every other key/screen combination leaves the cached value
+/// only when the blast-radius pane is actually the active right pane on the
+/// entry screen; every other key/screen combination leaves the cached value
 /// untouched rather than resetting it to `NotApplicable`, so switching away
-/// from and back to the pivot pane (e.g. `p` -> `d` -> `p`) does not need a
-/// wasted recompute on the `d` press that briefly leaves it.
-fn should_recompute_pivot_selection(app: &App) -> bool {
-    matches!(app.screen(), Screen::Entry) && app.right_pane() == app::RightPane::Pivot
+/// from and back to the blast-radius pane (e.g. `R` -> `d` -> `R`) does not
+/// need a wasted recompute on the `d` press that briefly leaves it.
+fn should_recompute_blast_radius_selection(app: &App) -> bool {
+    matches!(app.screen(), Screen::Entry) && app.right_pane() == app::RightPane::BlastRadius
 }
 
 /// Translates a raw `crossterm` key press into this crate's
@@ -538,7 +539,7 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         }
         KeyCode::Char('o') | KeyCode::Char('O') => Some(InputKey::ToggleOrder),
         KeyCode::Char('d') | KeyCode::Char('D') => Some(InputKey::ToggleDiff),
-        KeyCode::Char('p') | KeyCode::Char('P') => Some(InputKey::TogglePivot),
+        KeyCode::Char('r') | KeyCode::Char('R') => Some(InputKey::ToggleBlastRadius),
         // `h`, or Esc while the right pane has focus: return focus to the
         // tree (ADR 0020's neovim-style "move left/back"). Checked before
         // the source-screen Esc arm below so `h`/Esc while Right-focused
@@ -684,6 +685,26 @@ mod tests {
     }
 
     #[test]
+    fn should_translate_lowercase_r_to_toggle_blast_radius() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('r'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ToggleBlastRadius), actual);
+    }
+
+    #[test]
+    fn should_translate_uppercase_r_to_toggle_blast_radius() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('R'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ToggleBlastRadius), actual);
+    }
+
+    #[test]
     fn should_translate_right_bracket_to_next_hunk() {
         let report = empty_report();
         let app = App::new(&report);
@@ -759,53 +780,53 @@ mod tests {
         assert_eq!(Some(InputKey::Down), actual);
     }
 
-    // Regression guard for the per-frame pivot recompute bug: `run_app`
-    // used to call `App::selected_pivot_view` from inside `ui::draw`, which
-    // runs on every ~100ms idle poll tick, not only on a key press. Pinning
-    // `should_recompute_pivot_selection`'s contract (recompute exactly when
-    // the pivot pane is the active right pane on the entry screen, and
-    // nowhere else) is the closest unit-testable proxy for that fix, since
-    // `run_app` itself takes a live `ratatui::DefaultTerminal` and cannot be
-    // driven directly in a test.
+    // Regression guard for the per-frame blast-radius recompute bug:
+    // `run_app` used to call `App::selected_blast_radius_view` from inside
+    // `ui::draw`, which runs on every ~100ms idle poll tick, not only on a
+    // key press. Pinning `should_recompute_blast_radius_selection`'s
+    // contract (recompute exactly when the blast-radius pane is the active
+    // right pane on the entry screen, and nowhere else) is the closest
+    // unit-testable proxy for that fix, since `run_app` itself takes a live
+    // `ratatui::DefaultTerminal` and cannot be driven directly in a test.
     #[test]
-    fn should_recompute_pivot_selection_when_pivot_pane_is_active_on_entry_screen() {
+    fn should_recompute_blast_radius_selection_when_blast_radius_pane_is_active_on_entry_screen() {
         let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::TogglePivot);
+        let app = App::new(&report).handle_key(InputKey::ToggleBlastRadius);
 
-        let actual = should_recompute_pivot_selection(&app);
+        let actual = should_recompute_blast_radius_selection(&app);
 
         assert!(actual);
     }
 
     #[test]
-    fn should_not_recompute_pivot_selection_when_right_pane_is_detail() {
+    fn should_not_recompute_blast_radius_selection_when_right_pane_is_detail() {
         let report = empty_report();
         let app = App::new(&report);
 
-        let actual = should_recompute_pivot_selection(&app);
+        let actual = should_recompute_blast_radius_selection(&app);
 
         assert!(!actual);
     }
 
     #[test]
-    fn should_not_recompute_pivot_selection_when_right_pane_is_diff() {
+    fn should_not_recompute_blast_radius_selection_when_right_pane_is_diff() {
         let report = empty_report();
         let app = App::new(&report).handle_key(InputKey::ToggleDiff);
 
-        let actual = should_recompute_pivot_selection(&app);
+        let actual = should_recompute_blast_radius_selection(&app);
 
         assert!(!actual);
     }
 
     #[test]
-    fn should_not_recompute_pivot_selection_while_source_screen_is_open() {
+    fn should_not_recompute_blast_radius_selection_while_source_screen_is_open() {
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(InputKey::Down)
-            .handle_key(InputKey::TogglePivot)
+            .handle_key(InputKey::ToggleBlastRadius)
             .handle_key(InputKey::Source);
 
-        let actual = should_recompute_pivot_selection(&app);
+        let actual = should_recompute_blast_radius_selection(&app);
 
         assert!(!actual);
     }
@@ -859,9 +880,9 @@ mod tests {
     }
 
     #[test]
-    fn should_not_recompute_diff_pane_content_when_right_pane_is_pivot() {
+    fn should_not_recompute_diff_pane_content_when_right_pane_is_blast_radius() {
         let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::TogglePivot);
+        let app = App::new(&report).handle_key(InputKey::ToggleBlastRadius);
 
         let actual = should_recompute_diff_pane_content(&app);
 
@@ -888,8 +909,8 @@ mod tests {
     // right pane was actually showing — so opening a file (Focus::Right,
     // RightPane::Diff by default), pressing `d` to switch to Detail, then
     // pressing `]`, silently jumped the Detail pane's scroll to a Diff-pane
-    // offset that has no meaning there. `should_recompute_pivot_selection`'s
-    // own existing tests only pin cache-staleness for the pivot pane's
+    // offset that has no meaning there. `should_recompute_blast_radius_selection`'s
+    // own existing tests only pin cache-staleness for the blast-radius pane's
     // *recompute* trigger; none of them cover this key's *application* gate,
     // which is a separate condition (`run_app` applies the jump only when
     // this returns true, independent of whether anything gets recomputed).
@@ -924,13 +945,13 @@ mod tests {
     }
 
     #[test]
-    fn should_not_apply_hunk_jump_when_right_focused_on_pivot_pane() {
+    fn should_not_apply_hunk_jump_when_right_focused_on_blast_radius_pane() {
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(InputKey::Open)
-            .handle_key(InputKey::TogglePivot);
+            .handle_key(InputKey::ToggleBlastRadius);
         assert_eq!(app::Focus::Right, app.focus());
-        assert_eq!(app::RightPane::Pivot, app.right_pane());
+        assert_eq!(app::RightPane::BlastRadius, app.right_pane());
 
         let actual = should_apply_hunk_jump(&app);
 

--- a/rinkaku-tui/src/nav.rs
+++ b/rinkaku-tui/src/nav.rs
@@ -108,11 +108,11 @@ impl Nav {
     /// [`NodeKind::Symbol`] rows even though a symbol row's own `node.path`
     /// equals its containing file's path (`TreeNode::path`'s own doc
     /// comment) — this method exists for `--entry`-style directory/file
-    /// pivoting (`crate::app::App`'s own entry-path wiring), which has no
+    /// re-rooting (`crate::app::App`'s own entry-path wiring), which has no
     /// single-symbol-scoped meaning (ADR 0019, mirroring
-    /// `App::selected_pivot_view`'s symbol-row `NotApplicable` case), so
-    /// landing on a same-path symbol row instead of the file/dir row itself
-    /// would silently change what the pivot pane shows.
+    /// `App::selected_blast_radius_view`'s symbol-row `NotApplicable` case),
+    /// so landing on a same-path symbol row instead of the file/dir row
+    /// itself would silently change what the blast-radius pane shows.
     pub fn move_cursor_to_path(&mut self, tree: &Tree, path: &str) -> bool {
         let rows = self.rows(tree);
         let Some(index) = rows

--- a/rinkaku-tui/src/tree.rs
+++ b/rinkaku-tui/src/tree.rs
@@ -118,8 +118,8 @@ pub struct TreeNode {
     /// see `SkipReason`), `None` for every other node including an
     /// ordinary analyzed `File`. Kept as a field on `TreeNode` rather than a
     /// new `NodeKind` variant so `crate::app`/`crate::order`'s existing
-    /// exhaustive `match`es over `NodeKind` (dispatching detail/diff/pivot
-    /// panes and sibling ordering) keep treating a skipped file exactly
+    /// exhaustive `match`es over `NodeKind` (dispatching detail/diff/blast-
+    /// radius panes and sibling ordering) keep treating a skipped file exactly
     /// like any other file row — it already has the right shape (a
     /// childless file with a path), it just additionally carries *why*
     /// rinkaku skipped it, for `row_view`/the detail pane to surface.

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -391,7 +391,7 @@ fn draw_diff_pane(
 }
 
 /// Draws the blast-radius pane (ADR 0019 for the re-rooting algorithm, ADR
-/// 0022 for the "blast radius" naming — [`RightPane::BlastRadius`]): the
+/// 0023 for the "blast radius" naming — [`RightPane::BlastRadius`]): the
 /// entry-tree text rooted at the directory/file row under the cursor,
 /// following the cursor as it moves. `selection` is already computed by
 /// `crate::run_app` (via `App::selected_blast_radius_view`) once per handled

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -404,11 +404,11 @@ fn draw_diff_pane(
 /// directory-scoped meaning (ADR 0019's `path_prefix` is meant to carve out
 /// a layer, not re-derive what a single symbol's own detail pane already
 /// shows). A directory/file row whose path matches no symbol shows its own
-/// "no symbols under `<path>`" message, mirroring `main.rs`'s `--entry` CLI
-/// note.
+/// "nothing under `<path>` is reachable" message, mirroring `main.rs`'s
+/// `--entry` CLI note.
 ///
 /// The pane's title states the question the tree answers ("Blast radius of
-/// `<path>`") rather than the re-rooting mechanism, per ADR 0022's own
+/// `<path>`") rather than the re-rooting mechanism, per ADR 0023's own
 /// rationale for the rename — a reviewer opening the pane for the first
 /// time should not need `?`'s glossary to understand what it shows.
 fn draw_blast_radius_pane(
@@ -428,7 +428,7 @@ fn draw_blast_radius_pane(
         }
         BlastRadiusSelection::Empty { path } => {
             let block = Block::bordered().title(format!(" Blast radius of {path} "));
-            let paragraph = Paragraph::new(format!("(nothing under {path} depends on anything)"))
+            let paragraph = Paragraph::new(format!("(nothing under {path} is reachable)"))
                 .block(block)
                 .wrap(ratatui::widgets::Wrap { trim: false });
             frame.render_widget(paragraph, area);
@@ -2426,6 +2426,52 @@ index e69de29..4b825dc 100644
         // fragment checks (e.g. `should_draw_entry_and_detail_panes_...`'s
         // "Symbols" check).
         assert!(text.contains("directory"));
+    }
+
+    #[test]
+    fn should_draw_blast_radius_empty_message_when_file_row_path_matches_no_graph_node() {
+        // `report_with_one_symbol`'s `graph.nodes` is empty (that fixture
+        // exists for Detail/Diff pane tests that don't need a populated
+        // graph), so the cursor's default position on the "lib.rs" file row
+        // matches no graph node — the real-world trigger for
+        // `BlastRadiusSelection::Empty` (`App`'s own
+        // `should_return_empty_blast_radius_selection_when_file_row_path_matches_no_graph_node`
+        // test pins the same fixture shape at the `App` layer; this test
+        // pins the rendered pane text ADR 0023 promises, which nothing
+        // previously asserted).
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleBlastRadius);
+        let blast_radius_selection = app.selected_blast_radius_view(&report);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &blast_radius_selection,
+                    &test_repo_root(),
+                )
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Blast radius of lib.rs"));
+        // NOTE: asserting a substring, not the full parenthesized sentence —
+        // the pane is narrow enough (40% of an 80-column terminal) that
+        // `Paragraph`'s word-wrapping can split the sentence across rows,
+        // and `buffer_text` joins rows with `\n`, so a wrapped multi-row
+        // substring would never match a single-line `contains` check
+        // (mirroring `should_draw_blast_radius_placeholder_when_cursor_is_on_a_symbol_row`'s
+        // own "directory" fragment check just above, for the same reason).
+        // Still pins the exact wording ADR 0023 specifies ("is reachable",
+        // not the earlier "depends on anything" this test was added to
+        // catch a future drift away from).
+        assert!(text.contains("nothing under lib.rs is"));
+        assert!(text.contains("reachable"));
     }
 
     /// Finds the buffer cell for `token`'s first character within the row

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -9,7 +9,7 @@
 //! is covered separately... kept few and coarse — enough to catch a broken
 //! layout, not to pin every pixel").
 
-use crate::app::{App, DiffTarget, PivotSelection, RightPane, Screen, SelectedDetail};
+use crate::app::{App, BlastRadiusSelection, DiffTarget, RightPane, Screen, SelectedDetail};
 use crate::detail::{DetailView, DirDetail, FileDetail, SignatureView};
 use crate::diff_shape::DiffSection;
 use crate::diff_view::{DiffLine, DiffLineKind};
@@ -32,9 +32,9 @@ use unicode_width::UnicodeWidthChar;
 /// re-parsed/re-highlighted here on every frame — see that function's doc
 /// comment on why that work lives outside the draw loop), consulted only
 /// when the right pane is in [`RightPane::Diff`] mode. `diff_content` and
-/// `pivot_selection` are likewise computed once per handled key by
-/// `crate::run_app` (not here), for [`RightPane::Diff`]/[`RightPane::Pivot`]
-/// respectively — see `App::selected_pivot_view`'s own doc comment on why
+/// `blast_radius_selection` are likewise computed once per handled key by
+/// `crate::run_app` (not here), for [`RightPane::Diff`]/[`RightPane::BlastRadius`]
+/// respectively — see `App::selected_blast_radius_view`'s own doc comment on why
 /// this function must not call either computation itself. `repo_root` is
 /// only consulted on [`Screen::Source`] (forwarded to
 /// [`load_symbol_source`], see that function's doc comment for why
@@ -53,7 +53,7 @@ pub fn draw(
     report: &Report,
     diff_content: &crate::diff_shape::DiffPaneContent,
     diff_highlights: &[HighlightedFile],
-    pivot_selection: &PivotSelection,
+    blast_radius_selection: &BlastRadiusSelection,
     repo_root: &std::path::Path,
 ) {
     let area = frame.area();
@@ -67,7 +67,7 @@ pub fn draw(
             report,
             diff_content,
             diff_highlights,
-            pivot_selection,
+            blast_radius_selection,
             body,
         ),
         Screen::Source { symbol_id } => {
@@ -230,7 +230,7 @@ fn draw_entry_screen(
     report: &Report,
     diff_content: &crate::diff_shape::DiffPaneContent,
     diff_highlights: &[HighlightedFile],
-    pivot_selection: &PivotSelection,
+    blast_radius_selection: &BlastRadiusSelection,
     area: Rect,
 ) {
     let [tree_area, right_area] =
@@ -247,7 +247,9 @@ fn draw_entry_screen(
             diff_highlights,
             right_area,
         ),
-        RightPane::Pivot => draw_pivot_pane(frame, app, pivot_selection, right_area),
+        RightPane::BlastRadius => {
+            draw_blast_radius_pane(frame, app, blast_radius_selection, right_area)
+        }
     }
 }
 
@@ -338,7 +340,7 @@ fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
 /// section) for a file row — `diff_content` is already shaped by
 /// `crate::diff_shape::build_diff_pane_content`, computed once per handled
 /// key by `crate::run_app` (this function must not call it itself, mirroring
-/// `App::selected_pivot_view`'s own "must not call from `ui::draw`"
+/// `App::selected_blast_radius_view`'s own "must not call from `ui::draw`"
 /// constraint and the reason it exists — see that method's doc comment).
 /// A directory row, or a row with nothing to show (no hunks found, e.g. a
 /// mismatch between `report` and the diff), falls back to a placeholder
@@ -388,44 +390,58 @@ fn draw_diff_pane(
     render_scrollable_pane(frame, " Diff ", &lines, app.right_pane_scroll(), area);
 }
 
-/// Draws the pivot pane (ADR 0019, [`RightPane::Pivot`]): the entry-tree
-/// text rooted at the directory/file row under the cursor, following the
-/// cursor as it moves. `selection` is already computed by `crate::run_app`
-/// (via `App::selected_pivot_view`) once per handled key, not here — this
-/// function only lays it out, since `terminal.draw` itself runs on every
-/// ~100ms idle poll tick as well as on an actual key press, and re-deriving
-/// the pivot tree (an O(V+E) graph walk) on every one of those idle ticks
-/// was exactly the per-frame recompute this split avoids. A symbol row
-/// shows a placeholder asking for a directory/file row instead — pivoting
-/// on a single symbol has no directory-scoped meaning (ADR 0019's
-/// `path_prefix` is meant to carve out a layer, not re-derive what a single
-/// symbol's own detail pane already shows). A directory/file row whose path
-/// matches no symbol shows its own "no symbols under `<path>`" message,
-/// mirroring `main.rs`'s `--entry` CLI note.
-fn draw_pivot_pane(frame: &mut Frame, app: &App, selection: &PivotSelection, area: Rect) {
+/// Draws the blast-radius pane (ADR 0019 for the re-rooting algorithm, ADR
+/// 0022 for the "blast radius" naming — [`RightPane::BlastRadius`]): the
+/// entry-tree text rooted at the directory/file row under the cursor,
+/// following the cursor as it moves. `selection` is already computed by
+/// `crate::run_app` (via `App::selected_blast_radius_view`) once per handled
+/// key, not here — this function only lays it out, since `terminal.draw`
+/// itself runs on every ~100ms idle poll tick as well as on an actual key
+/// press, and re-deriving the blast-radius tree (an O(V+E) graph walk) on
+/// every one of those idle ticks was exactly the per-frame recompute this
+/// split avoids. A symbol row shows a placeholder asking for a directory/
+/// file row instead — measuring blast radius from a single symbol has no
+/// directory-scoped meaning (ADR 0019's `path_prefix` is meant to carve out
+/// a layer, not re-derive what a single symbol's own detail pane already
+/// shows). A directory/file row whose path matches no symbol shows its own
+/// "no symbols under `<path>`" message, mirroring `main.rs`'s `--entry` CLI
+/// note.
+///
+/// The pane's title states the question the tree answers ("Blast radius of
+/// `<path>`") rather than the re-rooting mechanism, per ADR 0022's own
+/// rationale for the rename — a reviewer opening the pane for the first
+/// time should not need `?`'s glossary to understand what it shows.
+fn draw_blast_radius_pane(
+    frame: &mut Frame,
+    app: &App,
+    selection: &BlastRadiusSelection,
+    area: Rect,
+) {
     match selection {
-        PivotSelection::NotApplicable => {
-            let block = Block::bordered().title(" Pivot ");
-            let paragraph = Paragraph::new("(select a directory or file row to pivot)")
+        BlastRadiusSelection::NotApplicable => {
+            let block = Block::bordered().title(" Blast radius ");
+            let paragraph =
+                Paragraph::new("(select a directory or file row to see its blast radius)")
+                    .block(block)
+                    .wrap(ratatui::widgets::Wrap { trim: false });
+            frame.render_widget(paragraph, area);
+        }
+        BlastRadiusSelection::Empty { path } => {
+            let block = Block::bordered().title(format!(" Blast radius of {path} "));
+            let paragraph = Paragraph::new(format!("(nothing under {path} depends on anything)"))
                 .block(block)
                 .wrap(ratatui::widgets::Wrap { trim: false });
             frame.render_widget(paragraph, area);
         }
-        PivotSelection::Empty { path } => {
-            let block = Block::bordered().title(" Pivot ");
-            let paragraph = Paragraph::new(format!("(no symbols under {path})"))
-                .block(block)
-                .wrap(ratatui::widgets::Wrap { trim: false });
-            frame.render_widget(paragraph, area);
-        }
-        PivotSelection::View(view) => {
-            let lines = pivot_pane_lines(view);
-            render_scrollable_pane(frame, " Pivot ", &lines, app.right_pane_scroll(), area);
+        BlastRadiusSelection::View(view) => {
+            let lines = blast_radius_pane_lines(view);
+            let title = format!(" Blast radius of {} ", view.path);
+            render_scrollable_pane(frame, &title, &lines, app.right_pane_scroll(), area);
         }
     }
 }
 
-/// Formats a [`crate::pivot::PivotView`]'s flattened [`crate::pivot::PivotLine`]s
+/// Formats a [`crate::blast_radius::BlastRadiusView`]'s flattened [`crate::blast_radius::BlastRadiusLine`]s
 /// into styled [`Line`]s: indentation by depth (same `INDENT_WIDTH`-per-level
 /// convention as `crate::row_view::entry_row_line`), a dimmed style for
 /// `outside_prefix` lines (reached only by expanding a dependency edge past
@@ -433,7 +449,7 @@ fn draw_pivot_pane(frame: &mut Frame, app: &App, selection: &PivotSelection, are
 /// (matching `rinkaku-core::render`'s Markdown tree), and yellow/bold for a
 /// cycle-warning line (matching `entry_row_line`'s existing `(cycle)`
 /// marker styling).
-fn pivot_pane_lines(view: &crate::pivot::PivotView) -> Vec<Line<'static>> {
+fn blast_radius_pane_lines(view: &crate::blast_radius::BlastRadiusView) -> Vec<Line<'static>> {
     const INDENT_WIDTH: usize = 2;
     view.lines
         .iter()
@@ -1293,9 +1309,9 @@ fn draw_status_line(frame: &mut Frame, app: &App, area: Rect) {
 /// The `]/[: next/prev hunk` hint only appears while Right-focused *and*
 /// [`RightPane::Diff`] is showing — `crate::run_app` only wires up the
 /// `]`/`[` jump for that pane/focus combination (it needs the Diff pane's
-/// shaped hunk-offset table, which Detail/Pivot have no equivalent of), so
-/// advertising the key while Detail/Pivot is showing would describe a
-/// binding that does nothing there.
+/// shaped hunk-offset table, which Detail/BlastRadius have no equivalent
+/// of), so advertising the key while Detail/BlastRadius is showing would
+/// describe a binding that does nothing there.
 ///
 /// Extracted as its own pure function (no `ratatui` types) so the text
 /// itself — not just that *something* renders — is unit-testable, mirroring
@@ -1310,13 +1326,13 @@ fn status_line_text(app: &App) -> String {
             };
             let keys = match app.focus() {
                 crate::app::Focus::Tree => {
-                    "j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  p: pivot  s: source  gd/gr: jump  ?: help  q: quit"
+                    "j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
                 }
                 crate::app::Focus::Right if app.right_pane() == crate::app::RightPane::Diff => {
-                    "j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  p: pivot  gd/gr: jump  ?: help  q: quit"
+                    "j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
                 }
                 crate::app::Focus::Right => {
-                    "j/k: scroll  h/esc: back  d: diff  p: pivot  gd/gr: jump  ?: help  q: quit"
+                    "j/k: scroll  h/esc: back  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
                 }
             };
             format!("order: {order}  |  {keys}")
@@ -1414,9 +1430,9 @@ mod tests {
     /// Builds the [`crate::diff_shape::DiffPaneContent`] `crate::run_app`
     /// would have cached for `app`'s current selection against `report`/
     /// `diff_files` — this module's tests recreate that one-shot
-    /// computation by hand (mirroring how `should_draw_pivot_pane_...`
-    /// already recreates `App::selected_pivot_view`'s own one-shot
-    /// computation for `pivot_selection`), since `draw` itself must not
+    /// computation by hand (mirroring how `should_draw_blast_radius_pane_...`
+    /// already recreates `App::selected_blast_radius_view`'s own one-shot
+    /// computation for `blast_radius_selection`), since `draw` itself must not
     /// compute it (`draw_diff_pane`'s own doc comment).
     fn diff_content_for(
         report: &Report,
@@ -1463,7 +1479,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1505,7 +1521,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1555,7 +1571,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1588,7 +1604,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1600,7 +1616,7 @@ mod tests {
         assert!(text.contains("Right focus"));
         assert!(text.contains("Global"));
         assert!(text.contains("Glossary"));
-        assert!(text.contains("pivot"));
+        assert!(text.contains("blast radius"));
     }
 
     #[test]
@@ -1617,7 +1633,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1652,7 +1668,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1694,7 +1710,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1724,7 +1740,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1763,7 +1779,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1807,7 +1823,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1856,7 +1872,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1911,7 +1927,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -1963,7 +1979,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2020,7 +2036,7 @@ mod tests {
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2061,7 +2077,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &diff_content,
                     &diff_highlights,
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2122,7 +2138,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
                     &report,
                     &diff_content,
                     &diff_highlights,
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2189,7 +2205,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &diff_content,
                     &diff_highlights,
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2254,7 +2270,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &diff_content,
                     &diff_highlights,
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2314,7 +2330,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &diff_content,
                     &diff_highlights,
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2330,11 +2346,12 @@ index e69de29..4b825dc 100644
     }
 
     #[test]
-    fn should_draw_pivot_pane_with_tree_lines_when_toggled_on_a_file_row() {
+    fn should_draw_blast_radius_pane_with_tree_lines_when_toggled_on_a_file_row() {
         // Same fixture shape as `report_with_one_symbol`, but with a graph
         // actually populated (that fixture leaves `graph` empty since most
-        // of this module's tests don't need one) so pivoting on "lib.rs"
-        // yields a real `PivotSelection::View` instead of `Empty`.
+        // of this module's tests don't need one) so opening the blast-radius
+        // pane on "lib.rs" yields a real `BlastRadiusSelection::View` instead
+        // of `Empty`.
         let report = Report {
             graph: SymbolGraph {
                 nodes: vec![rinkaku_core::graph::Node {
@@ -2348,12 +2365,12 @@ index e69de29..4b825dc 100644
             ..report_with_one_symbol()
         };
         // Row 0 is the "lib.rs" file row itself (cursor starts there).
-        let app = App::new(&report).handle_key(crate::app::InputKey::TogglePivot);
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleBlastRadius);
         // `crate::run_app` computes this once per handled key and hands it
         // into `draw` (see `draw`'s own doc comment on why `draw` itself
-        // must not call `App::selected_pivot_view`) — this test recreates
+        // must not call `App::selected_blast_radius_view`) — this test recreates
         // that same one-shot computation rather than a per-frame one.
-        let pivot_selection = app.selected_pivot_view(&report);
+        let blast_radius_selection = app.selected_blast_radius_view(&report);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -2364,24 +2381,24 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &pivot_selection,
+                    &blast_radius_selection,
                     &test_repo_root(),
                 )
             })
             .expect("draw");
 
         let text = buffer_text(&terminal);
-        assert!(text.contains("Pivot"));
+        assert!(text.contains("Blast radius of lib.rs"));
         assert!(text.contains("fn foo (lib.rs)"));
     }
 
     #[test]
-    fn should_draw_pivot_placeholder_when_cursor_is_on_a_symbol_row() {
+    fn should_draw_blast_radius_placeholder_when_cursor_is_on_a_symbol_row() {
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::TogglePivot);
-        let pivot_selection = app.selected_pivot_view(&report);
+            .handle_key(crate::app::InputKey::ToggleBlastRadius);
+        let blast_radius_selection = app.selected_blast_radius_view(&report);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
@@ -2392,14 +2409,14 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &pivot_selection,
+                    &blast_radius_selection,
                     &test_repo_root(),
                 )
             })
             .expect("draw");
 
         let text = buffer_text(&terminal);
-        assert!(text.contains("Pivot"));
+        assert!(text.contains("Blast radius"));
         // Not the full placeholder sentence: the pane is narrow enough
         // (40% of an 80-column terminal) that `Paragraph`'s word-wrapping
         // splits it across rows, and `buffer_text` joins rows with `\n` —
@@ -2486,7 +2503,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &diff_content,
                     &diff_highlights,
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2532,7 +2549,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &diff_content,
                     &diff_highlights,
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2571,7 +2588,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &diff_content,
                     &diff_highlights,
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2617,7 +2634,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &diff_content,
                     &diff_highlights,
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2676,7 +2693,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &diff_content,
                     &diff_highlights,
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2713,7 +2730,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2743,7 +2760,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2770,7 +2787,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -2810,7 +2827,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -3075,7 +3092,7 @@ index e69de29..4b825dc 100644
         let actual = status_line_text(&app);
 
         assert_eq!(
-            "order: topological  |  j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  p: pivot  s: source  gd/gr: jump  ?: help  q: quit"
+            "order: topological  |  j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
                 .to_string(),
             actual
         );
@@ -3103,7 +3120,7 @@ index e69de29..4b825dc 100644
         let actual = status_line_text(&app);
 
         assert_eq!(
-            "order: topological  |  j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  p: pivot  gd/gr: jump  ?: help  q: quit"
+            "order: topological  |  j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
                 .to_string(),
             actual
         );
@@ -3124,7 +3141,7 @@ index e69de29..4b825dc 100644
         let actual = status_line_text(&app);
 
         assert_eq!(
-            "order: topological  |  j/k: scroll  h/esc: back  d: diff  p: pivot  gd/gr: jump  ?: help  q: quit"
+            "order: topological  |  j/k: scroll  h/esc: back  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
                 .to_string(),
             actual
         );
@@ -3219,7 +3236,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -3250,7 +3267,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -3283,7 +3300,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -3322,7 +3339,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -3359,7 +3376,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -3525,7 +3542,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })
@@ -3575,7 +3592,7 @@ index e69de29..4b825dc 100644
                     &report,
                     &crate::diff_shape::DiffPaneContent::Empty,
                     &[],
-                    &PivotSelection::NotApplicable,
+                    &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
                 )
             })

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -135,9 +135,9 @@ struct Cli {
     /// themselves. Compatible with every input mode (stdin/`--base`/`--pr`/
     /// whole-repo) and with `--tui`: combined, the TUI opens with the
     /// cursor already on the tree row matching `path` and the right pane
-    /// already in Pivot mode (`rinkaku_tui::run`'s `entry_path` parameter),
-    /// rather than requiring the reviewer to find the row and press `p`
-    /// themselves.
+    /// already showing its Blast radius (`rinkaku_tui::run`'s `entry_path`
+    /// parameter; ADR 0023), rather than requiring the reviewer to find the
+    /// row and press `R` themselves.
     #[arg(long)]
     entry: Option<String>,
 }


### PR DESCRIPTION
## Summary

- Renames the TUI's "pivot" pane to "blast radius" (ADR 0023), driven
  directly by dogfooding feedback that the old name explained nothing
  ("pivot がなにかわからん", "cycle の意味がわからん"): the pane is
  useful, it was just mis-named.
- The toggle key moves from `p`/`P` to `r`/`R` (mnemonic: **R**adius).
  Every `Pivot`-prefixed type/field/function in `rinkaku-tui` is
  renamed to `BlastRadius`-prefixed (`RightPane::Pivot` ->
  `RightPane::BlastRadius`, `crate::pivot` -> `crate::blast_radius`,
  etc.), and the pane title/placeholder text and help-overlay glossary
  entries are reworded to state the reviewer's question ("blast radius
  of `<path>`") instead of the mechanism ("re-root the graph").
- The dependency-cycle marker gets a plain-language rewrite (`! <label>
  — already shown above (cycle)` instead of `⚠️ <label> — dependency
  cycle, see above`), and switches from the `⚠️` emoji to a plain `!`
  after dynamic verification showed the emoji's variation-selector
  pair desyncing `unicode-width`'s column count from the terminal's
  actual rendering.
- `rinkaku-core`'s graph API (`pivot_graph`/`pivot_roots`) and the
  CLI's `--entry` flag are intentionally left unchanged — this is
  scoped to the TUI-facing surface only (see ADR 0023 decision 2 for
  the rationale). The `--entry` help text is updated to describe the
  current `r`/`R` key instead of the removed `p`/"Pivot mode" wording.

## Review process

Reviewed per this repo's three-angle dogfooding process (map-assisted
+ independent + mandatory dynamic verification); recorded as
[experiment 0001 round 13](docs/experiments/0001-map-assisted-llm-review/rounds/013.md).

- Map-assisted pass: 21 changed symbols across 5 files; hotspots
  landed exactly on the renamed types, and the map's removed-symbols
  list gave a mechanical completeness checklist confirming no `Pivot*`
  name survived where the map could see. Its find: the empty-pane
  placeholder text had drifted from ADR 0023's specified wording, with
  no test pinning it — a string-literal mismatch invisible to the map
  itself, caught by reading the ADR against `ui.rs`.
- Independent + dynamic pass: found the CLI `--entry` help text still
  telling users to "press `p`" in a "Pivot mode" that no longer
  exists, and commit subjects still referencing the pre-renumber ADR
  id. Both fixed.

## Verification

- `make lint` and `make test` pass (421 tests).
- Dynamic verification: full key matrix (`r`/`R` toggle, `gd`/`gr`
  popup -> `Esc` -> `r` non-interference on the choke-point-cleared
  `pending_prefix`), `--entry` startup, the cycle marker against a
  real cyclic fixture, long-path rendering, and confirmed zero
  pivot/blast-radius leakage into Markdown/JSON/mermaid outputs (core
  is untouched by this rename).
- Implementation-time dynamic find: the `⚠️` marker rendered 2 cells
  wide in a real terminal (`tmux capture-pane`) while `unicode-width`
  computed less, leaving a stray character on screen — fixed by
  switching to an ASCII `!` marker, noted in ADR 0023.

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync
