### PR TITLE
fix(tui): unify Enter on the diff pane and fix scroll behavior

### DIFF
--- a/docs/adr/0020-tui-interaction-model-v2.md
+++ b/docs/adr/0020-tui-interaction-model-v2.md
@@ -265,3 +265,49 @@ predictable state transitions and `s` is the deliberate "go read the real
 file" action. No other decision in this ADR changes: the diff-shaping
 rules (decision 4), the pane-scoped `]`/`[` hunk jump (decision 1's Right
 focus bullet), and the help overlay are all unaffected.
+
+## Amendment 2 (map-assisted review, post-acceptance)
+
+Two further scroll-semantics refinements, found by a map-assisted review
+round rather than dogfooding, but belonging with the two amendments above
+since both touch `right_pane_scroll`'s reset/clamp rules this ADR and
+Amendment 1 already document:
+
+- **Enter while already reading Diff must be a true no-op.** Amendment 1
+  above unified `Enter` to always mean "switch to `RightPane::Diff` and
+  move focus to `Right`" — but `App::handle_key`'s `(Screen::Entry, _,
+  InputKey::Open)` arm matched regardless of `Focus`, so pressing `Enter`
+  a second time mid-read (already `Focus::Right`, already `RightPane::Diff`)
+  still fell through to the function's blanket "reset scroll to 0 unless
+  `preserve_scroll`" rule and threw away the reviewer's reading position.
+  `Focus::Right` now branches on the *current* `right_pane`: `Diff` already
+  showing is a genuine no-op (scroll preserved, mirroring plain `j`/`k`
+  scrolling's own `preserve_scroll` case), while `Detail`/`BlastRadius`
+  showing is still a real pane switch to `Diff` and keeps the ordinary
+  scroll-reset behavior, since that case *is* a content change.
+- **`gd`/`gr` jumplist entries always recorded scroll 0.** `dispatch_non_source_key`
+  (`crate/lib.rs`) must call `App::handle_key(GotoDefinition | GotoReferences)`
+  before resolving candidates, purely so that call's unconditional
+  `pending_prefix` clear runs (ADR 0022) — but that same call also hit the
+  blanket scroll reset *before* `App::jump_to_symbol` read
+  `right_pane_scroll` to save it into the jumplist entry being jumped
+  *from*, so every entry's saved scroll was always 0 and `Ctrl-o` could
+  never restore a real reading position. `GotoDefinition`/`GotoReferences`
+  are now added to `preserve_scroll`'s exception list; `App::jump_to_symbol`
+  (and `PopupConfirm`, which also calls it) still does its own explicit
+  `right_pane_scroll = 0` reset for the *new* target once a jump actually
+  happens, so this only protects the *old* position's snapshot, not the
+  reset a real jump still performs.
+
+A third, smaller point from the same review round was confirmed as an
+already-intentional trade-off rather than a bug: `crate::run_app` folds
+`ui::draw`'s clamped scroll back into `App` on *every* draw (Amendment to
+`clamp_right_pane_scroll_after_draw`'s own doc comment, `lib.rs`), including
+idle poll ticks, not only key presses — so shrinking the terminal
+mid-read permanently clamps `App`'s own scroll offset down, and growing
+the terminal back afterward does not restore the pre-shrink position.
+Accepted as-is: `right_pane_scroll` is deliberately single-valued (no
+separate "requested vs. actually-applied" pair to fall back to), and a
+reviewer resizing mid-read and losing a few lines of scroll position is a
+far rarer, lower-cost edge case than the overshoot-unwind bug this
+fold-back exists to fix.

--- a/docs/adr/0020-tui-interaction-model-v2.md
+++ b/docs/adr/0020-tui-interaction-model-v2.md
@@ -237,3 +237,31 @@ needing to fit everything on one line.
   internals without changing this ADR's pane semantics — the module
   boundary (`Report` + `FileHunks` + selection in, shaped content out)
   is deliberately drawn to allow that later.
+
+## Amendment (dogfooding, post-acceptance)
+
+Decision 1 above states that a file/symbol row's `Enter` "additionally
+moves focus to `Right`", without itself deciding what a symbol row's
+`Enter` shows — that pre-dates this ADR (accreted incrementally, the
+same way this ADR's own Context describes) and had a symbol row's `Enter`
+open `Screen::Source` directly, reading the symbol's file from the
+working tree, while a file row's `Enter` only switched focus. Dogfooding
+surfaced this as an unpredictable failure ("enter だと source を出そうとし
+てエラーになったりならなかったりする"): the working tree does not always
+have the file in the state `Report` describes (a deleted file, a file not
+yet checked out, a stale local branch), so the *same physical keypress*
+sometimes worked and sometimes errored depending on row kind and
+filesystem state the reviewer had no way to predict from the keymap
+alone.
+
+`Enter` on a file or symbol row now always performs the identical,
+never-failing transition this ADR already describes for both row kinds:
+switch the right pane to `RightPane::Diff` and move focus to `Right`.
+Opening `Screen::Source` (the one operation in this whole interaction
+model that touches the filesystem, and so is the only one that can fail)
+stays behind the dedicated `s` key ([`InputKey::Source`]) exclusively —
+consistent with this ADR's own frame that motion/pane keys are cheap,
+predictable state transitions and `s` is the deliberate "go read the real
+file" action. No other decision in this ADR changes: the diff-shaping
+rules (decision 4), the pane-scoped `]`/`[` hunk jump (decision 1's Right
+focus bullet), and the help overlay are all unaffected.

--- a/docs/experiments/0001-map-assisted-llm-review/rounds/014.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/014.md
@@ -1,0 +1,28 @@
+# Round 14
+
+- Subject: two dogfooding fixes (ADR 0020 Amendment): Enter unified to
+  always open the diff pane (never Source — the old symbol-row asymmetry
+  read the working tree and failed intermittently), and right-pane
+  overscroll eliminated by feeding `ui`'s draw-time clamp back into `App`
+  each frame.
+- Map-assisted pass: hotspot `render_scrollable_pane` routed reading to
+  the 3-pane call chain. Its find: Enter pressed while already
+  Right-focused fell through to the blanket scroll reset — a
+  match-arm-granularity behavior invisible at signature level.
+- Independent + dynamic pass: confirmed both fixes live (including
+  deleting a file mid-session: `s` shows a clean error, Enter shows the
+  diff with no error). Its find: a pre-existing #62 bug — the jumplist
+  recorded scroll AFTER `handle_key`'s blanket reset, so Ctrl-o always
+  restored scroll 0.
+- The round's standout: the first regression test for that jumplist bug
+  passed while the real 2-key sequence still reproduced the bug in tmux
+  — the `g` prefix key itself dispatched through `handle_key` and reset
+  the scroll before `gd` ever resolved. The test had skipped the
+  PendingGoto step by injecting `GotoDefinition` directly. Neither
+  review pass caught this; only live 2-key input did. The test was
+  rewritten to drive the real g→d sequence (verified fail-before/
+  pass-after).
+- Takeaway: for interactive state machines, a regression test that
+  enters the pipeline downstream of the real input sequence can
+  validate a fix that doesn't work. Drive tests through the same entry
+  point the user's keys take.

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -62,6 +62,21 @@ pub enum InputKey {
     /// never fails; opening the source view (which can fail, since it reads
     /// a real file) stays behind the dedicated `s` key ([`Self::Source`])
     /// only.
+    ///
+    /// Map-assisted-review finding: while already [`Focus::Right`] and the
+    /// right pane is already [`RightPane::Diff`] (i.e. Enter is pressed a
+    /// second time on the same row, mid-read), this is a **complete no-op**
+    /// — `App::handle_key`'s own doc comment on why this needs a dedicated
+    /// `preserve_scroll` case, distinct from `Focus::Tree`'s "switch to Diff"
+    /// case just below. Without this, Enter matched regardless of focus (the
+    /// `(Screen::Entry, _, InputKey::Open)` arm), so pressing it again while
+    /// deep in a long diff silently reset `right_pane_scroll` to 0 via the
+    /// blanket end-of-function reset, throwing the reviewer's reading
+    /// position away for no visible reason. While [`Focus::Right`] but the
+    /// right pane is [`RightPane::Detail`]/[`RightPane::BlastRadius`], Enter
+    /// still switches to Diff (a real pane change, so the existing
+    /// scroll-reset-on-other-keys rule is the correct behavior there, not a
+    /// bug).
     Open,
     /// `e`/`E`: expand every row.
     ExpandAll,
@@ -120,6 +135,14 @@ pub enum InputKey {
     /// `App::pending_prefix` to do that resolution). Every key clears any
     /// previously pending prefix (`App::handle_key`'s own doc comment) —
     /// this variant is what *sets* it in the first place.
+    ///
+    /// Also included in `App::handle_key`'s `preserve_scroll` exception list
+    /// (independent-review finding): being the leading key of the `gd`/`gr`
+    /// sequence, `g` alone is dispatched through `handle_key` one keypress
+    /// before `GotoDefinition`/`GotoReferences` itself — without this
+    /// exception, `g`'s own blanket scroll reset would have zeroed
+    /// `right_pane_scroll` before the following `d`/`r` even ran, defeating
+    /// [`Self::GotoDefinition`]'s own fix for the same jumplist-scroll bug.
     PendingGoto,
     /// `gd` (a two-key sequence, ADR 0022): jump toward a callee of the
     /// symbol under the cursor. Candidate resolution needs `report`
@@ -138,6 +161,14 @@ pub enum InputKey {
     /// two `g`-prefixed keys into `PendingGoto`'s own resolution) so
     /// `crate::lib::translate_key`'s key-to-intent mapping stays legible
     /// independent of where the intent is actually processed.
+    ///
+    /// Independent-review finding: that same required `handle_key(input_key)`
+    /// call (for `pending_prefix`) used to also run this function's blanket
+    /// end-of-function scroll reset *before* `App::jump_to_symbol` recorded
+    /// the jumplist entry, so every jumplist entry's saved scroll offset was
+    /// always 0 and `Ctrl-o`/`Ctrl-i` could never actually restore a reading
+    /// position — see `App::handle_key`'s `preserve_scroll`, which now
+    /// special-cases these two variants for that reason.
     GotoDefinition,
     /// `gr`: the caller-direction mirror of [`Self::GotoDefinition`].
     GotoReferences,
@@ -833,6 +864,51 @@ impl App {
             (&self.screen, self.focus, key),
             (Screen::Entry, Focus::Right, InputKey::Up)
                 | (Screen::Entry, Focus::Right, InputKey::Down)
+                // Independent-review finding: `crate::run_app`'s
+                // `dispatch_non_source_key` always calls `handle_key(input_key)`
+                // for `GotoDefinition`/`GotoReferences` first (ADR 0022's
+                // `pending_prefix`-clear requirement, this arm's own doc
+                // comment below), *before* `resolve_goto`/`Self::jump_to_symbol`
+                // ever runs. Without this case, that first call hit the
+                // blanket reset at the bottom of this function and zeroed
+                // `right_pane_scroll` *before* `jump_to_symbol` read it to
+                // record the jumplist entry the reviewer is jumping *from* —
+                // so every `Ctrl-o` (`InputKey::JumpBack`) landed back at
+                // scroll 0 regardless of how far down the reviewer had
+                // actually scrolled. `InputKey::PendingGoto` (the leading
+                // `g` of the two-key `gd`/`gr` sequence) needs the same
+                // exception for the identical reason: it is a real,
+                // separately-dispatched `handle_key` call in the actual
+                // `crate::run_app` event loop (unlike a test calling
+                // `dispatch_non_source_key(..., GotoDefinition)` directly,
+                // which skips straight past this — the gap an earlier
+                // version of this fix's own regression test had, caught only
+                // by a real terminal run), so scroll was already zeroed by
+                // the `g` press itself, one key before `GotoDefinition`/
+                // `GotoReferences` even had a chance to matter.
+                // `Self::jump_to_symbol` (and
+                // `Self::handle_key_with_popup_open`'s `PopupConfirm`, which
+                // calls it too) already does its own correct
+                // `self.right_pane_scroll = 0` reset for the *new* target
+                // once the jump actually happens, so preserving scroll
+                // through this first call only protects the jumplist
+                // snapshot of the *old* position — it does not defeat the
+                // reset a real jump still performs.
+                | (Screen::Entry, _, InputKey::PendingGoto)
+                | (Screen::Entry, _, InputKey::GotoDefinition)
+                | (Screen::Entry, _, InputKey::GotoReferences)
+        ) || matches!(
+            (&self.screen, self.focus, self.right_pane, key),
+            // Map-assisted-review finding (`InputKey::Open`'s own doc
+            // comment): Enter pressed again while already Right-focused on
+            // an already-showing Diff pane is a complete no-op — reading
+            // position must survive it, the same way plain scrolling does
+            // just above. Gated on `right_pane` too (not just `screen`/
+            // `focus`/`key`, unlike the `Up`/`Down` case above), since the
+            // *other* `Focus::Right` case — Detail/BlastRadius showing —
+            // is a real pane switch to Diff and must still fall through to
+            // the blanket reset below.
+            (Screen::Entry, Focus::Right, RightPane::Diff, InputKey::Open)
         );
         // Set by the `JumpBack`/`JumpForward` arms below when they actually
         // restore a jumplist entry's own scroll offset — that restored
@@ -889,6 +965,22 @@ impl App {
             // (`h`/Esc), which is the kind of spooky-action-at-a-distance
             // this gate closes off.
             (Screen::Entry, Focus::Right, InputKey::Select) => {}
+            // Map-assisted-review finding (`InputKey::Open`'s own doc
+            // comment): while already `Focus::Right`, Enter no longer
+            // re-derives "what row is this" from the tree cursor at all —
+            // it only ever means "make sure Diff is showing". When Diff is
+            // already showing this is a true no-op (nothing in `self`
+            // changes, including `right_pane_scroll` — this arm plus
+            // `preserve_scroll`'s matching `RightPane::Diff` case above are
+            // what make that hold); when Detail/BlastRadius is showing, it
+            // switches to Diff, matching `InputKey::ToggleDiff`'s own "from
+            // Detail or BlastRadius, land on Diff" precedent just below.
+            // Must come before the `(Screen::Entry, _, InputKey::Open)` arm
+            // below (whose `Focus::Tree`-only tree-cursor dispatch this arm
+            // deliberately bypasses) since match arms are tried in order.
+            (Screen::Entry, Focus::Right, InputKey::Open) => {
+                self.right_pane = RightPane::Diff;
+            }
             (Screen::Entry, _, InputKey::Open) => {
                 let rows = self.nav.rows(&self.tree);
                 match rows.get(self.nav.cursor()).map(|row| &row.node.kind) {
@@ -1868,6 +1960,75 @@ mod tests {
         assert_eq!(Focus::Right, app.focus());
         assert_eq!(Screen::Entry, *app.screen());
         assert_eq!(RightPane::Diff, app.right_pane());
+    }
+
+    #[test]
+    fn should_leave_scroll_unchanged_when_open_is_pressed_while_right_focused_on_diff() {
+        // Map-assisted-review finding: Enter pressed a second time while
+        // already reading the Diff pane (Focus::Right, RightPane::Diff) must
+        // be a complete no-op — before this fix, the `(Screen::Entry, _,
+        // InputKey::Open)` arm matched regardless of focus and the blanket
+        // "reset scroll to 0" rule at the end of `handle_key` then threw
+        // away the reviewer's reading position for no visible reason.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down) // cursor -> "foo" (a Symbol row)
+            .handle_key(InputKey::Open) // focus -> Right, RightPane::Diff
+            .handle_key(InputKey::Down) // scroll -> 1
+            .handle_key(InputKey::Down); // scroll -> 2
+        assert_eq!(Focus::Right, app.focus());
+        assert_eq!(RightPane::Diff, app.right_pane());
+        assert_eq!(2, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::Open);
+
+        assert_eq!(Focus::Right, app.focus());
+        assert_eq!(RightPane::Diff, app.right_pane());
+        assert_eq!(2, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_switch_to_diff_pane_when_open_is_pressed_while_right_focused_on_detail() {
+        // The other half of the map-assisted-review finding just above:
+        // while Focus::Right but the pane showing is Detail (not Diff yet),
+        // Enter is a *real* pane switch, so the ordinary scroll-reset-on-
+        // other-keys rule is correct here, not a bug to preserve around.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down) // cursor -> "foo" (a Symbol row)
+            .handle_key(InputKey::Open) // focus -> Right, RightPane::Diff
+            .handle_key(InputKey::ToggleDiff); // RightPane::Detail, focus stays Right
+        assert_eq!(Focus::Right, app.focus());
+        assert_eq!(RightPane::Detail, app.right_pane());
+
+        let app = app.handle_key(InputKey::Open);
+
+        assert_eq!(Focus::Right, app.focus());
+        assert_eq!(RightPane::Diff, app.right_pane());
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_leave_scroll_unchanged_when_pending_goto_is_pressed() {
+        // Independent-review finding (`InputKey::PendingGoto`'s own doc
+        // comment): `g`, the leading key of the two-key `gd`/`gr` sequence,
+        // is dispatched through `handle_key` on its own, one keypress before
+        // `GotoDefinition`/`GotoReferences` — its own blanket scroll reset
+        // must not fire, or the jumplist entry recorded once `d`/`r`
+        // eventually runs would already have lost the reviewer's scroll
+        // position before the jump even started.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down) // cursor -> "foo" (a Symbol row)
+            .handle_key(InputKey::Open) // focus -> Right, RightPane::Diff
+            .handle_key(InputKey::Down) // scroll -> 1
+            .handle_key(InputKey::Down); // scroll -> 2
+        assert_eq!(2, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::PendingGoto);
+
+        assert_eq!(Some(PendingPrefix::G), app.pending_prefix());
+        assert_eq!(2, app.right_pane_scroll());
     }
 
     #[test]

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -41,13 +41,27 @@ pub enum InputKey {
     /// a distinct variant from [`Self::Open`] because Space must never move
     /// focus even on a file/symbol row, only Enter does.
     Select,
-    /// Enter on a file/symbol row: opens the source view on a symbol row
-    /// (unchanged from before ADR 0020) and additionally moves focus to
-    /// [`Focus::Right`] (ADR 0020's "drilling into a row is also a focus
-    /// change") — a no-op on a directory row (`App::handle_key`'s doc
-    /// comment; a directory row's Enter is [`Self::Select`]/`crate::run`'s
-    /// `translate_key`, matching on `KeyCode::Enter`, always emits `Open`
-    /// and lets `handle_key` decide what that means per row kind).
+    /// Enter on a file/symbol row: switches the right pane to
+    /// [`RightPane::Diff`] and moves focus to [`Focus::Right`] (ADR 0020's
+    /// "drilling into a row is also a focus change") — a no-op on a
+    /// directory row (`App::handle_key`'s doc comment; a directory row's
+    /// Enter is [`Self::Select`]/`crate::run`'s `translate_key`, matching on
+    /// `KeyCode::Enter`, always emits `Open` and lets `handle_key` decide
+    /// what that means per row kind).
+    ///
+    /// Post-ADR-0020 dogfooding finding: this used to open
+    /// [`Screen::Source`] for a symbol row specifically (reading the file
+    /// straight from the working tree, `crate::source::load_symbol_source`)
+    /// while a file row's Enter only changed focus — an asymmetry a
+    /// reviewer could not predict from the keypress alone, and one that
+    /// surfaced as an apparently random failure whenever the working tree
+    /// did not have the symbol's file in the expected state (a deleted or
+    /// not-yet-checked-out file, reported as "enter だと source を出そうとして
+    /// エラーになったりならなかったりする"). Enter now always means "show me
+    /// the diff for this row", which never touches the filesystem and so
+    /// never fails; opening the source view (which can fail, since it reads
+    /// a real file) stays behind the dedicated `s` key ([`Self::Source`])
+    /// only.
     Open,
     /// `e`/`E`: expand every row.
     ExpandAll,
@@ -885,19 +899,24 @@ impl App {
                     Some(NodeKind::Dir) => {
                         self.nav = self.nav.handle(Action::ToggleExpand, &self.tree);
                     }
-                    Some(NodeKind::File) => {
+                    // File and symbol rows behave identically (dogfooding
+                    // fix, `Self::Open`'s own doc comment): switch to the
+                    // Diff pane and move focus there. A symbol row used to
+                    // additionally jump into `Screen::Source` here, which
+                    // read the file from the working tree and could fail —
+                    // an asymmetric, occasionally-erroring behavior a file
+                    // row's Enter never had. Enter is now always a pure,
+                    // never-failing screen/pane transition regardless of row
+                    // kind (including a removed symbol, which no longer
+                    // needs its own guard here — this arm never touches the
+                    // filesystem, unlike `InputKey::Source`'s own
+                    // `!symbol_ref.removed` guard below, which still applies
+                    // there since that key does open the source view).
+                    Some(NodeKind::File) | Some(NodeKind::Symbol(_)) => {
+                        self.right_pane = RightPane::Diff;
                         self.focus = Focus::Right;
                     }
-                    Some(NodeKind::Symbol(symbol_ref)) if !symbol_ref.removed => {
-                        self.focus = Focus::Right;
-                        self.screen = Screen::Source {
-                            symbol_id: symbol_ref.id.clone(),
-                        };
-                    }
-                    // A removed symbol has no source to open (mirrors
-                    // `InputKey::Source`'s own `!symbol_ref.removed` guard
-                    // below) and no row at all is simply a no-op.
-                    Some(NodeKind::Symbol(_)) | None => {}
+                    None => {}
                 }
             }
             (Screen::Entry, _, InputKey::ExpandAll) => {
@@ -1808,19 +1827,47 @@ mod tests {
     }
 
     #[test]
-    fn should_move_focus_to_right_and_open_source_when_open_is_pressed_on_a_symbol_row() {
+    fn should_move_focus_to_right_and_switch_to_diff_pane_when_open_is_pressed_on_a_symbol_row() {
+        // Dogfooding fix: a symbol row's Enter used to open `Screen::Source`
+        // directly (reading the file from the working tree, which could
+        // fail), asymmetric with a file row's Enter, which only switched
+        // panes. Both row kinds now behave identically — see `InputKey::Open`'s
+        // own doc comment.
         let report = report_with_one_symbol();
         let app = App::new(&report).handle_key(InputKey::Down);
 
         let app = app.handle_key(InputKey::Open);
 
         assert_eq!(Focus::Right, app.focus());
-        assert_eq!(
-            Screen::Source {
-                symbol_id: "lib.rs::foo".to_string()
-            },
-            *app.screen()
-        );
+        assert_eq!(Screen::Entry, *app.screen());
+        assert_eq!(RightPane::Diff, app.right_pane());
+    }
+
+    #[test]
+    fn should_move_focus_to_right_and_switch_to_diff_pane_when_open_is_pressed_on_a_removed_symbol_row()
+     {
+        // A removed symbol has no source to open, but Enter no longer opens
+        // source at all (`InputKey::Open`'s own doc comment) — it is a pure
+        // pane switch regardless of row kind, so a removed symbol's Enter no
+        // longer needs a special no-op case the way `InputKey::Source`'s own
+        // `!symbol_ref.removed` guard still does.
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            removed: vec![rinkaku_core::extract::RemovedSymbol {
+                name: "gone".to_string(),
+                kind: SymbolKind::Function,
+                path: "lib.rs".to_string(),
+                signature: "fn gone()".to_string(),
+            }],
+            ..empty_report()
+        };
+        let app = App::new(&report).handle_key(InputKey::Down);
+
+        let app = app.handle_key(InputKey::Open);
+
+        assert_eq!(Focus::Right, app.focus());
+        assert_eq!(Screen::Entry, *app.screen());
+        assert_eq!(RightPane::Diff, app.right_pane());
     }
 
     #[test]
@@ -2066,7 +2113,7 @@ mod tests {
     #[test]
     fn should_keep_right_pane_scroll_at_zero_when_returning_from_source_screen() {
         // Opening the source screen itself always resets scroll to 0
-        // (`InputKey::Open`'s own reset, per the blanket rule) and every
+        // (`InputKey::Source`'s own reset, per the blanket rule) and every
         // key but `Back` is then a no-op while `Screen::Source` is active
         // (`App::handle_key`'s `Screen::Source` arm) — so scroll can never
         // become nonzero while the source screen is open in the first
@@ -2075,10 +2122,15 @@ mod tests {
         // swallowed but which could still be pending from before entering.
         // This test pins that invariant end to end: `Back` finds scroll
         // already at 0 and leaves it there.
+        //
+        // Post-dogfooding-fix note: the source screen is now reached only
+        // via the dedicated `s` key (`InputKey::Source`), not `Enter`
+        // (`InputKey::Open`'s own doc comment) — `Open` is exercised
+        // separately by the `Open`-specific tests above.
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(InputKey::Down) // cursor -> "foo" (a Symbol row)
-            .handle_key(InputKey::Open); // opens Screen::Source, focus -> Right
+            .handle_key(InputKey::Source); // opens Screen::Source
         assert_eq!(
             Screen::Source {
                 symbol_id: "lib.rs::foo".to_string()
@@ -2094,10 +2146,14 @@ mod tests {
 
     #[test]
     fn should_ignore_scroll_keys_while_source_screen_is_open() {
+        // Post-dogfooding-fix note: the source screen is now reached only
+        // via the dedicated `s` key (`InputKey::Source`), not `Enter` — see
+        // `should_keep_right_pane_scroll_at_zero_when_returning_from_source_screen`'s
+        // own note.
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(InputKey::Down)
-            .handle_key(InputKey::Open); // opens source, focus -> Right
+            .handle_key(InputKey::Source); // opens source
 
         let app = app.handle_key(InputKey::Down);
 

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -167,8 +167,15 @@ fn run_app(
     };
 
     loop {
+        // `ui::draw`'s return value (the right-hand pane's scroll offset as
+        // actually clamped and rendered this frame, `ui::draw`'s own doc
+        // comment) cannot flow out of the closure itself — `Terminal::draw`
+        // requires an `FnOnce(&mut Frame)` returning `()` — so it is
+        // captured into this outer binding instead and folded back into
+        // `app` right after, via `clamp_right_pane_scroll_after_draw`.
+        let mut clamped_scroll = None;
         terminal.draw(|frame| {
-            ui::draw(
+            clamped_scroll = ui::draw(
                 frame,
                 &app,
                 report,
@@ -176,8 +183,9 @@ fn run_app(
                 &diff_highlights,
                 &blast_radius_selection,
                 repo_root,
-            )
+            );
         })?;
+        app = clamp_right_pane_scroll_after_draw(app, clamped_scroll);
 
         if app.should_quit() {
             return Ok(());
@@ -230,6 +238,37 @@ fn run_app(
                 );
             }
         }
+    }
+}
+
+/// Folds `ui::draw`'s clamped scroll offset (`ui::draw`'s own doc comment)
+/// back into `app`, given `clamped` — `Some(scroll)` when the active right
+/// pane rendered scrollable content this frame, `None` on the source screen
+/// or a placeholder pane.
+///
+/// Dogfooding finding: `App::right_pane_scroll` is deliberately an
+/// *unclamped* "requested" offset (that field's own doc comment) — `App`
+/// has no notion of the pane's rendered height, so clamping was left to
+/// `crate::ui` at draw time (`ui::clamp_scroll`). That is still correct as
+/// far as *what gets drawn*, but left `App`'s own notion of "how far down
+/// the user asked to scroll" free to run past the content's actual end:
+/// holding `j` past the bottom kept incrementing the request with no
+/// visible change once the pane was already showing its last screenful, so
+/// the very next `k` had to first unwind that whole invisible overshoot
+/// before the pane visibly moved at all — indistinguishable, from the
+/// keyboard, from the key simply not responding. Writing the clamped value
+/// straight back after every draw keeps `App`'s own state in sync with what
+/// is actually on screen, so the next `j`/`k` always has an immediate,
+/// visible effect.
+///
+/// Applied unconditionally (not gated on `clamped != app.right_pane_scroll()`)
+/// since `App::with_right_pane_scroll` is a plain field write — the branch
+/// would only save a redundant assignment, not a meaningfully different
+/// state, so it is not worth the extra branch.
+fn clamp_right_pane_scroll_after_draw(app: App, clamped: Option<usize>) -> App {
+    match clamped {
+        Some(scroll) => app.with_right_pane_scroll(scroll),
+        None => app,
     }
 }
 
@@ -1024,6 +1063,41 @@ mod tests {
         let actual = jump_scroll_target(&hunk_starts, 3, InputKey::NextHunk);
 
         assert_eq!(Some(10), actual);
+    }
+
+    // --- clamp_right_pane_scroll_after_draw ---
+    //
+    // Dogfooding fix: `render_scrollable_pane`'s clamp only ever affected
+    // what was drawn, never `App`'s own `right_pane_scroll` — so an
+    // overshot scroll request stayed recorded in `App` even once the pane
+    // visibly stopped moving, and winding it back down took as many `k`
+    // presses as it took to overshoot in the first place. These tests pin
+    // the fold-back that keeps `App`'s state in sync with the frame that
+    // was actually drawn.
+
+    #[test]
+    fn should_overwrite_right_pane_scroll_with_the_clamped_value_when_some() {
+        let report = empty_report();
+        let app = App::new(&report).with_right_pane_scroll(999);
+
+        let app = clamp_right_pane_scroll_after_draw(app, Some(7));
+
+        assert_eq!(7, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_leave_right_pane_scroll_untouched_when_none() {
+        // `None` means the drawn pane had nothing scrollable this frame
+        // (`ui::draw`'s own doc comment: the source screen, or a
+        // placeholder) — `App`'s own requested scroll must survive
+        // unchanged rather than being zeroed or otherwise disturbed by a
+        // frame that never consulted it.
+        let report = empty_report();
+        let app = App::new(&report).with_right_pane_scroll(3);
+
+        let app = clamp_right_pane_scroll_after_draw(app, None);
+
+        assert_eq!(3, app.right_pane_scroll());
     }
 
     // g-prefix and jump-popup translate_key tests (ADR 0022).

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -265,6 +265,18 @@ fn run_app(
 /// since `App::with_right_pane_scroll` is a plain field write — the branch
 /// would only save a redundant assignment, not a meaningfully different
 /// state, so it is not worth the extra branch.
+///
+/// Deliberate trade-off (recorded in ADR 0020's Amendment too): this runs on
+/// *every* draw, including the idle ~100ms poll ticks `crate::run_app`'s doc
+/// comment already notes, not only after a key press — so shrinking the
+/// terminal (fewer visible rows, a smaller `max_scroll`) permanently clamps
+/// `App`'s own scroll offset down, and growing the terminal back afterward
+/// does not restore the pre-shrink position; there is no separate "requested
+/// vs. actually-applied" pair of fields to fall back to; `right_pane_scroll`
+/// is single-valued by design (that field's own doc comment). A reviewer who
+/// shrinks their terminal mid-read and then grows it back finds the pane
+/// scrolled less far than before the resize — judged an acceptable, rare
+/// edge case relative to the far more common overshoot this fold-back fixes.
 fn clamp_right_pane_scroll_after_draw(app: App, clamped: Option<usize>) -> App {
     match clamped {
         Some(scroll) => app.with_right_pane_scroll(scroll),
@@ -1496,6 +1508,71 @@ mod tests {
             right_pane_before,
             app.right_pane(),
             "d after a cancelled gr popup must toggle the right pane like an ordinary ToggleDiff press"
+        );
+    }
+
+    #[test]
+    fn should_restore_the_scroll_offset_the_reviewer_was_at_when_jumping_back_after_gd() {
+        // Independent-review finding: `dispatch_non_source_key` always calls
+        // `app.handle_key(GotoDefinition)` first (for the `pending_prefix`
+        // clear — see the test group above), and before this fix that call
+        // hit `App::handle_key`'s own blanket scroll reset before
+        // `App::jump_to_symbol` ever read `right_pane_scroll` to save it into
+        // the jumplist entry — so every jumplist entry's saved scroll was
+        // always 0 and `Ctrl-o` could never restore a real reading position.
+        //
+        // This test drives the *real* two-key `g` then `d` sequence
+        // (`InputKey::PendingGoto` then `InputKey::GotoDefinition`), each
+        // through `dispatch_non_source_key` — not `App::handle_key` directly,
+        // and not `GotoDefinition` alone. An earlier version of this test did
+        // call `GotoDefinition` alone and passed while the underlying bug was
+        // still only half-fixed: `PendingGoto` (the leading `g`) is also
+        // dispatched through `handle_key` on its own, one keypress *before*
+        // `GotoDefinition`, and its own blanket scroll reset zeroed
+        // `right_pane_scroll` before `d` was even pressed — a gap only a
+        // real terminal run surfaced (see `InputKey::PendingGoto`'s own doc
+        // comment). Scrolls to a nonzero offset, jumps via the real `gd` key
+        // sequence, then jumps back via `Ctrl-o` (`InputKey::JumpBack`) and
+        // asserts the original scroll offset is restored rather than 0.
+        let report = report_with_symbols_and_edges(
+            vec![("lib.rs", vec!["foo", "bar"])],
+            vec![("lib.rs::foo", "lib.rs::bar")],
+        );
+        let diff_content = diff_shape::DiffPaneContent::Empty;
+
+        // Cursor on "foo" (row 1), scrolled 5 lines into its Diff pane.
+        let mut app = App::new(&report).handle_key(InputKey::Down);
+        app = dispatch_non_source_key(app, &report, &diff_content, InputKey::Open); // focus -> Right, RightPane::Diff
+        for _ in 0..5 {
+            app = dispatch_non_source_key(app, &report, &diff_content, InputKey::Down);
+        }
+        assert_eq!(5, app.right_pane_scroll());
+
+        // The real `gd` key sequence: `g` (PendingGoto) then `d`
+        // (GotoDefinition) — "bar" is "foo"'s one callee, so this jumps
+        // immediately (`GotoOutcome::One`) rather than opening the popup.
+        app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
+        assert_eq!(
+            5,
+            app.right_pane_scroll(),
+            "the leading g of gd must not disturb scroll either"
+        );
+        app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoDefinition);
+        assert_eq!(Some("lib.rs::bar"), app.selected_symbol_id());
+        assert_eq!(
+            0,
+            app.right_pane_scroll(),
+            "the new target's own scroll must start at 0 (App::jump_to_symbol's own reset)"
+        );
+
+        // Ctrl-o: jump back to "foo" — the regression this test guards.
+        app = dispatch_non_source_key(app, &report, &diff_content, InputKey::JumpBack);
+
+        assert_eq!(Some("lib.rs::foo"), app.selected_symbol_id());
+        assert_eq!(
+            5,
+            app.right_pane_scroll(),
+            "jumping back must restore the scroll offset recorded when gd was pressed, not 0"
         );
     }
 }

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -47,6 +47,18 @@ use unicode_width::UnicodeWidthChar;
 /// comment), so the underlying frame is built exactly the same way whether
 /// the overlay is open or not, and the overlay is simply composited over
 /// it as a final step.
+///
+/// Returns the right-hand pane's scroll offset as actually clamped and
+/// rendered this frame (`None` on [`Screen::Source`], which scrolls via its
+/// own auto-centering window rather than `App::right_pane_scroll`, or when
+/// the active right pane rendered a placeholder with nothing to scroll —
+/// `draw_entry_screen`'s own doc comment). `crate::run_app` feeds this back
+/// into `App` (`App::with_right_pane_scroll`) after every draw so an
+/// overshot scroll request (dogfooding finding: repeated `j` past the
+/// content's end used to keep incrementing `App`'s unclamped "requested"
+/// scroll with no visible effect, so winding back down again took as many
+/// `k` presses as it took to overshoot) never survives past the frame that
+/// visibly clamped it.
 pub fn draw(
     frame: &mut Frame,
     app: &App,
@@ -55,12 +67,12 @@ pub fn draw(
     diff_highlights: &[HighlightedFile],
     blast_radius_selection: &BlastRadiusSelection,
     repo_root: &std::path::Path,
-) {
+) -> Option<usize> {
     let area = frame.area();
     let [body, status_area] =
         Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(area);
 
-    match app.screen() {
+    let clamped_scroll = match app.screen() {
         Screen::Entry => draw_entry_screen(
             frame,
             app,
@@ -71,9 +83,10 @@ pub fn draw(
             body,
         ),
         Screen::Source { symbol_id } => {
-            draw_source_screen(frame, report, symbol_id, repo_root, body)
+            draw_source_screen(frame, report, symbol_id, repo_root, body);
+            None
         }
-    }
+    };
 
     draw_status_line(frame, app, status_area);
 
@@ -83,6 +96,8 @@ pub fn draw(
     if let Some(popup) = app.jump_popup() {
         draw_jump_popup(frame, popup, area);
     }
+
+    clamped_scroll
 }
 
 /// Draws the `?` help overlay (ADR 0020) centered over `full_area`: a
@@ -224,6 +239,11 @@ fn draw_jump_popup(frame: &mut Frame, popup: &crate::app::JumpPopup, full_area: 
 /// than the right pane has fields, so it gets the larger share. The right
 /// pane itself shows either the detail view or the diff view depending on
 /// `app.right_pane()` (`d`/`D` toggles between them, TUI iteration 2).
+///
+/// Returns the clamped right-pane scroll offset actually applied — whichever
+/// of `draw_detail_pane`/`draw_diff_pane`/`draw_blast_radius_pane` ran for
+/// `app.right_pane()` (`render_scrollable_pane`'s doc comment on why
+/// `crate::run_app` needs this).
 fn draw_entry_screen(
     frame: &mut Frame,
     app: &App,
@@ -232,7 +252,7 @@ fn draw_entry_screen(
     diff_highlights: &[HighlightedFile],
     blast_radius_selection: &BlastRadiusSelection,
     area: Rect,
-) {
+) -> Option<usize> {
     let [tree_area, right_area] =
         Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)]).areas(area);
 
@@ -315,14 +335,18 @@ fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(paragraph, area);
 }
 
-fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
+/// Returns the clamped scroll offset actually applied (`render_scrollable_pane`'s
+/// own doc comment on why the caller — ultimately `crate::run_app` — needs
+/// this), or `None` when the placeholder path was taken (nothing scrollable
+/// was rendered at all).
+fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) -> Option<usize> {
     let Some(detail) = app.selected_detail(report) else {
         let block = Block::bordered().title(" Detail ");
         let paragraph = Paragraph::new("(select a row to see its detail)")
             .block(block)
             .wrap(ratatui::widgets::Wrap { trim: false });
         frame.render_widget(paragraph, area);
-        return;
+        return None;
     };
 
     let lines = match &detail {
@@ -330,7 +354,13 @@ fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
         SelectedDetail::Dir(detail) => dir_detail_lines(detail, report.origin),
         SelectedDetail::File(detail) => file_detail_lines(detail),
     };
-    render_scrollable_pane(frame, " Detail ", &lines, app.right_pane_scroll(), area);
+    Some(render_scrollable_pane(
+        frame,
+        " Detail ",
+        &lines,
+        app.right_pane_scroll(),
+        area,
+    ))
 }
 
 /// Draws the diff pane (TUI iteration 2, [`RightPane::Diff`]; ADR 0020
@@ -351,6 +381,10 @@ fn draw_detail_pane(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
 /// by `source_index` rather than pointer identity now that hunks are cloned
 /// into shaped sections (`crate::diff_shape::AttributedHunk`'s own doc
 /// comment).
+///
+/// Returns the clamped scroll offset actually applied, or `None` when the
+/// placeholder path was taken — mirrors `draw_detail_pane`'s own return
+/// value for the identical reason (`render_scrollable_pane`'s doc comment).
 fn draw_diff_pane(
     frame: &mut Frame,
     app: &App,
@@ -358,7 +392,7 @@ fn draw_diff_pane(
     diff_content: &crate::diff_shape::DiffPaneContent,
     diff_highlights: &[HighlightedFile],
     area: Rect,
-) {
+) -> Option<usize> {
     use crate::diff_shape::DiffPaneContent;
 
     let target = app.selected_diff_target(report);
@@ -378,7 +412,7 @@ fn draw_diff_pane(
                 .block(block)
                 .wrap(ratatui::widgets::Wrap { trim: false });
             frame.render_widget(paragraph, area);
-            return;
+            return None;
         }
         DiffPaneContent::Symbol(section) => vec![section],
         DiffPaneContent::File(sections) => sections.iter().collect(),
@@ -387,7 +421,13 @@ fn draw_diff_pane(
     let highlighted_file = highlight::highlighted_file(diff_highlights, path);
     let is_file_selection = matches!(diff_content, DiffPaneContent::File(_));
     let lines = diff_pane_lines(&sections, is_file_selection, highlighted_file);
-    render_scrollable_pane(frame, " Diff ", &lines, app.right_pane_scroll(), area);
+    Some(render_scrollable_pane(
+        frame,
+        " Diff ",
+        &lines,
+        app.right_pane_scroll(),
+        area,
+    ))
 }
 
 /// Draws the blast-radius pane (ADR 0019 for the re-rooting algorithm, ADR
@@ -411,12 +451,16 @@ fn draw_diff_pane(
 /// `<path>`") rather than the re-rooting mechanism, per ADR 0023's own
 /// rationale for the rename — a reviewer opening the pane for the first
 /// time should not need `?`'s glossary to understand what it shows.
+///
+/// Returns the clamped scroll offset actually applied, or `None` when a
+/// placeholder path was taken — mirrors `draw_detail_pane`'s own return
+/// value for the identical reason (`render_scrollable_pane`'s doc comment).
 fn draw_blast_radius_pane(
     frame: &mut Frame,
     app: &App,
     selection: &BlastRadiusSelection,
     area: Rect,
-) {
+) -> Option<usize> {
     match selection {
         BlastRadiusSelection::NotApplicable => {
             let block = Block::bordered().title(" Blast radius ");
@@ -425,6 +469,7 @@ fn draw_blast_radius_pane(
                     .block(block)
                     .wrap(ratatui::widgets::Wrap { trim: false });
             frame.render_widget(paragraph, area);
+            None
         }
         BlastRadiusSelection::Empty { path } => {
             let block = Block::bordered().title(format!(" Blast radius of {path} "));
@@ -432,11 +477,18 @@ fn draw_blast_radius_pane(
                 .block(block)
                 .wrap(ratatui::widgets::Wrap { trim: false });
             frame.render_widget(paragraph, area);
+            None
         }
         BlastRadiusSelection::View(view) => {
             let lines = blast_radius_pane_lines(view);
             let title = format!(" Blast radius of {} ", view.path);
-            render_scrollable_pane(frame, &title, &lines, app.right_pane_scroll(), area);
+            Some(render_scrollable_pane(
+                frame,
+                &title,
+                &lines,
+                app.right_pane_scroll(),
+                area,
+            ))
         }
     }
 }
@@ -497,13 +549,24 @@ fn blast_radius_pane_lines(view: &crate::blast_radius::BlastRadiusView) -> Vec<L
 /// everything is visible. Wrapping first makes every one of
 /// `clamp_scroll`/`scroll_indicator`/`Paragraph::scroll` operate on the same
 /// "one rendered terminal row" unit.
+///
+/// Returns the actually-applied (clamped) scroll offset — dogfooding
+/// finding: `App::right_pane_scroll` is deliberately an *unclamped*
+/// "requested" value (its own doc comment), so repeated `j` past the
+/// content's end kept incrementing that request with no visible effect,
+/// and winding it back down again took as many `k` presses as it took to
+/// overshoot — the scrollbar-less pane gave no feedback that this had
+/// happened. `crate::run_app` feeds this return value back into `App` via
+/// `App::with_right_pane_scroll` after every draw, so the *next* `k` moves
+/// the visible content immediately instead of first re-tracing the
+/// overshoot.
 fn render_scrollable_pane(
     frame: &mut Frame,
     title: &str,
     lines: &[Line<'static>],
     requested_scroll: usize,
     area: Rect,
-) {
+) -> usize {
     // 2 columns/rows for the left/right and top/bottom border, matching
     // `draw_source_screen`'s own `saturating_sub(2)` convention for a
     // bordered pane's inner height.
@@ -526,6 +589,7 @@ fn render_scrollable_pane(
         .block(block)
         .scroll((scroll as u16, 0));
     frame.render_widget(paragraph, area);
+    scroll
 }
 
 /// Wraps each of `lines` to `width` display columns, splitting a logical
@@ -1481,7 +1545,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1523,7 +1587,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1573,7 +1637,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1606,7 +1670,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1635,7 +1699,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1670,7 +1734,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1712,7 +1776,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1742,7 +1806,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1781,7 +1845,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1825,7 +1889,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1874,7 +1938,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1929,7 +1993,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -1981,7 +2045,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2038,7 +2102,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2079,7 +2143,7 @@ index e69de29..4b825dc 100644
                     &diff_highlights,
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2140,7 +2204,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
                     &diff_highlights,
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2207,7 +2271,7 @@ index e69de29..4b825dc 100644
                     &diff_highlights,
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2272,7 +2336,7 @@ index e69de29..4b825dc 100644
                     &diff_highlights,
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2332,7 +2396,7 @@ index e69de29..4b825dc 100644
                     &diff_highlights,
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2383,7 +2447,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &blast_radius_selection,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2411,7 +2475,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &blast_radius_selection,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2454,7 +2518,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &blast_radius_selection,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2551,7 +2615,7 @@ index e69de29..4b825dc 100644
                     &diff_highlights,
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2597,7 +2661,7 @@ index e69de29..4b825dc 100644
                     &diff_highlights,
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2636,7 +2700,7 @@ index e69de29..4b825dc 100644
                     &diff_highlights,
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2682,7 +2746,7 @@ index e69de29..4b825dc 100644
                     &diff_highlights,
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2741,7 +2805,7 @@ index e69de29..4b825dc 100644
                     &diff_highlights,
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2778,7 +2842,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2808,7 +2872,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2835,7 +2899,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -2875,7 +2939,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -3195,10 +3259,13 @@ index e69de29..4b825dc 100644
 
     #[test]
     fn should_show_back_hint_only_on_source_screen_regardless_of_focus() {
+        // The source screen is reached only via the dedicated `s` key
+        // (`InputKey::Source`) now, not `Enter` — a dogfooding fix to
+        // `InputKey::Open`'s own arm (see its doc comment in `crate::app`).
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::Open); // opens Screen::Source
+            .handle_key(crate::app::InputKey::Source); // opens Screen::Source
 
         let actual = status_line_text(&app);
 
@@ -3284,7 +3351,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -3315,7 +3382,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -3348,7 +3415,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -3387,13 +3454,85 @@ index e69de29..4b825dc 100644
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
         let text = buffer_text(&terminal);
         // The last symbol must be visible once clamped to the final page.
         assert!(text.contains("sym39"));
+    }
+
+    #[test]
+    fn should_return_the_clamped_scroll_from_draw_when_requested_scroll_overshoots() {
+        // Dogfooding fix: `draw` must hand back the *clamped* offset it
+        // actually rendered (not the caller's unclamped `right_pane_scroll`
+        // request), since `crate::run_app` folds this return value back into
+        // `App` so an overshot scroll request cannot silently outlive the
+        // frame that visibly clamped it.
+        let report = report_with_many_symbols(40);
+        let mut app = App::new(&report)
+            .handle_key(crate::app::InputKey::Open)
+            .handle_key(crate::app::InputKey::ToggleDiff);
+        for _ in 0..1000 {
+            app = app.handle_key(crate::app::InputKey::Down);
+        }
+        assert!(
+            app.right_pane_scroll() > 100,
+            "the unclamped request must actually have overshot for this test to be meaningful"
+        );
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        let mut actual = None;
+        terminal
+            .draw(|frame| {
+                actual = draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    &test_repo_root(),
+                );
+            })
+            .expect("draw");
+
+        assert!(actual.is_some());
+        assert!(
+            actual.unwrap() < app.right_pane_scroll(),
+            "clamped scroll must be strictly less than the overshot request"
+        );
+    }
+
+    #[test]
+    fn should_return_none_from_draw_when_the_source_screen_is_open() {
+        // The source screen scrolls via its own auto-centering window, not
+        // `App::right_pane_scroll` (`ui::draw`'s own doc comment) — `draw`
+        // must not report a clamped offset for `crate::run_app` to fold
+        // back in that case.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::Source);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        let mut actual = Some(999); // sentinel: must be overwritten to None
+        terminal
+            .draw(|frame| {
+                actual = draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    &test_repo_root(),
+                );
+            })
+            .expect("draw");
+
+        assert_eq!(None, actual);
     }
 
     #[test]
@@ -3424,7 +3563,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -3590,7 +3729,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 
@@ -3640,7 +3779,7 @@ index e69de29..4b825dc 100644
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     &test_repo_root(),
-                )
+                );
             })
             .expect("draw");
 


### PR DESCRIPTION
## Summary

Two dogfooding fixes to the TUI's interaction model (ADR 0020 Amendment):

- **Enter now always opens the diff pane.** The old symbol-row behavior
  read the working tree to decide between opening the diff or the
  source view, and that read could fail intermittently. Enter is
  unified to always show the diff, removing the asymmetry and the
  failure mode.
- **Right-pane overscroll is eliminated.** `App::right_pane_scroll` is
  a deliberately unclamped "requested" offset (clamping happens at draw
  time), so holding `j` past the content's end kept incrementing that
  request with no visible effect — the next `k` had to first unwind the
  invisible overshoot before the pane moved, which was indistinguishable
  from the key not responding. `ui::draw` now returns the offset it
  actually clamped and rendered, and `run_app` folds it back into `App`
  every frame.

During review, two more bugs surfaced and were fixed on this branch:

- Enter pressed while already `Focus::Right` on an already-showing diff
  fell through to the blanket scroll reset used for fresh drill-ins,
  discarding the reading position on a second Enter mid-read. It is now
  a true no-op when the diff pane is already showing.
- A pre-existing jumplist bug (#62): scroll was recorded into the
  jumplist entry *after* `handle_key`'s blanket reset had already run,
  so `Ctrl-o` always restored scroll 0 instead of the real reading
  position. Both `InputKey::PendingGoto` and `GotoDefinition`/
  `GotoReferences` are now added to `preserve_scroll`'s exception list;
  `jump_to_symbol` still does its own explicit reset once a jump
  actually happens.

Also documents (ADR 0020 Amendment 2) that the scroll-clamp fold-back
deliberately does not restore scroll after a terminal shrink-then-grow,
since `right_pane_scroll` is single-valued by design.

## Review process

Reviewed per this repo's three-angle policy
([experiment 0001](docs/experiments/0001-map-assisted-llm-review/README.md),
round recorded in this PR as
[`rounds/014.md`](docs/experiments/0001-map-assisted-llm-review/rounds/014.md)):

- **Map-assisted pass**: hotspot `render_scrollable_pane` routed
  reading to the 3-pane call chain and found the Right-focused-Enter
  fallthrough into the blanket scroll reset — a match-arm-granularity
  behavior invisible at the signature level.
- **Independent + dynamic pass**: confirmed both original fixes live
  (including a mid-session file deletion: `s` shows a clean error,
  Enter shows the diff with no error) and found the pre-existing
  jumplist scroll-0 bug (#62).
- The first regression test written for the jumplist bug passed while
  the fix was still incomplete: it called `GotoDefinition` directly,
  skipping the `PendingGoto` (`g`) keypress that a real `gd` sequence
  dispatches first — and that leading `g` keypress itself hit the
  blanket scroll reset before `d` ever resolved. Live 2-key input in
  tmux reproduced the bug that the shortcut test missed. The test was
  rewritten to drive the real `g` → `d` sequence through
  `dispatch_non_source_key` (verified fail-before / pass-after).

## Verification

- `make test`: 924 tests passing (158 + 336 + 430 across workspace
  crates), `make lint` clean.
- Manual verification in a real terminal (tmux): Enter from a symbol
  row always opens the diff pane, including after deleting the
  underlying file mid-session; holding `j` past content end no longer
  causes an unresponsive-feeling `k`; re-pressing Enter on an
  already-shown diff preserves scroll position; `gd`/`gr` followed by
  `Ctrl-o` restores the real pre-jump scroll position (previously
  always 0).
- Regression test for the jumplist bug rewritten to drive the actual
  two-keypress `g` → `d` sequence rather than injecting `GotoDefinition`
  directly, confirmed fail-before/pass-after against the fix.

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync
