### PR TITLE
feat!: default to including test symbols; rename --include-tests to --exclude-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ with or without the defaults introduced in
 [ADR 0009](docs/adr/0009-exclude-test-symbols-from-output-by-default.md),
 [ADR 0010](docs/adr/0010-skip-files-marked-no-diff-or-generated-in-gitattributes.md),
 and [ADR 0011](docs/adr/0011-detect-generated-files-by-content-markers.md)
-— see `--include-tests`/`--include-generated` below for what changes when a
+— see `--exclude-tests`/`--include-generated` below for what changes when a
 diff does touch test symbols or generated files.
 
 Running `rinkaku` on
@@ -362,14 +362,21 @@ remains dramatically faster since indexing cost does not depend on diff
 size. Prefer `--deps 0` for quick iteration or CI checks where the
 dependency context isn't needed.
 
-### `--include-tests`
+### `--exclude-tests`
 
-By default (see [ADR 0009](docs/adr/0009-exclude-test-symbols-from-output-by-default.md)),
-test symbols are excluded from "Change graph"/"Definitions" — detected per
-language (Go's `*_test.go`, Python's `test_*.py`/`*_test.py` and `tests/`
-directories, TypeScript's `*.test.ts(x)`/`*.spec.ts(x)` and `__tests__/`,
-and Rust's `tests/` directory plus `#[cfg(test)]` modules and
-`#[test]`/`#[rstest]`/`#[tokio::test]`-attributed functions) — and
+By default (see [ADR 0025](docs/adr/0025-default-to-including-tests.md),
+superseding the prior ADR 0009 default), test symbols appear in
+"Change graph"/"Definitions" alongside production symbols, and the
+`## Tests` summary section is omitted — this shape is designed for LLM
+consumers of the Markdown/JSON output, for which "which contracts have
+which tests changed alongside them" is useful signal rather than noise.
+
+Pass `--exclude-tests` to opt into the previous behavior: test symbols
+are detected per language (Go's `*_test.go`, Python's
+`test_*.py`/`*_test.py` and `tests/` directories, TypeScript's
+`*.test.ts(x)`/`*.spec.ts(x)` and `__tests__/`, and Rust's `tests/`
+directory plus `#[cfg(test)]` modules and
+`#[test]`/`#[rstest]`/`#[tokio::test]`-attributed functions) and
 summarized instead as a per-file count under a `## Tests` section:
 
 ```markdown
@@ -378,10 +385,10 @@ summarized instead as a per-file count under a `## Tests` section:
 - rinkaku-core/src/pipeline.rs: 3 changed test symbols
 ```
 
-This keeps the primary output focused on implementation entry points while
-still surfacing "did this change come with tests?" as a signal. Pass
-`--include-tests` to restore the previous behavior (test symbols appear in
-the graph and definitions like any other symbol, and `## Tests` is omitted).
+Under `--exclude-tests`, `TagsResolver`'s repo-wide dependency index
+applies the same exclusion, so a changed production symbol's "Depends
+on:" cannot resolve to a same-named test helper or fixture elsewhere in
+the repo (ADR 0009).
 
 ### `--include-generated`
 

--- a/docs/adr/0009-exclude-test-symbols-from-output-by-default.md
+++ b/docs/adr/0009-exclude-test-symbols-from-output-by-default.md
@@ -1,6 +1,8 @@
 # 0009. Exclude test symbols from output by default
 
-- Status: accepted
+- Status: superseded by [ADR 0025](0025-default-to-including-tests.md)
+  (flag polarity and default flipped; per-language detection heuristics
+  and the `## Tests` summary section — now opt-in — are unchanged)
 - Date: 2026-07-12
 
 ## Context

--- a/docs/adr/0025-default-to-including-tests.md
+++ b/docs/adr/0025-default-to-including-tests.md
@@ -1,0 +1,101 @@
+# 0025. Default to including test symbols in output
+
+- Status: accepted
+- Date: 2026-07-13
+- Supersedes: parts of [ADR 0009](0009-exclude-test-symbols-from-output-by-default.md)
+  (the flag polarity and default; the per-language test-detection heuristics
+  and the `## Tests` summary section are unchanged)
+
+## Context
+
+ADR 0009 introduced `--include-tests` as an opt-in flag and made the
+default behavior *exclude* test symbols from `## Change graph` and
+`## Definitions`, on the assumption that Markdown/JSON output is read
+primarily by human reviewers who find test symbols noisy.
+
+Actual usage since [ADR 0015](0015-tui-for-humans-markdown-for-machines.md)
+inverted that assumption:
+
+- **Markdown/JSON is now written primarily for LLMs**, not humans. The
+  whole point of rinkaku's "outline" (輪郭) framing is to feed a
+  condensed API-surface view of a change to an LLM reviewer.
+- **Humans read the TUI**, which since #58 renders test files with a
+  distinct badge — the noise problem ADR 0009 solved for Markdown does
+  not exist in the TUI, because the TUI can distinguish tests visually
+  rather than by omission.
+- **For an LLM consumer, test symbols are useful signal**, not noise.
+  "Which contracts are exercised by which tests, and which tests
+  changed alongside which production symbols" is exactly the kind of
+  cross-referencing an LLM reviewer needs, and the `## Tests` summary
+  (a per-file count) hides that structure. Including test symbols in
+  the graph makes those relationships explicit as edges.
+
+The generated-file exclusion (`--include-generated`, ADR 0010/0011) is
+justified by a different reason — generated content is genuinely opaque
+noise for both audiences — and is unaffected by this change.
+
+## Decision
+
+Invert the CLI flag: rename `--include-tests` to `--exclude-tests` and
+flip the default from *exclude tests* to *include tests*.
+
+- Default behavior across every output mode (Markdown, JSON, TUI,
+  Mermaid): test symbols appear in `## Change graph` and
+  `## Definitions` alongside production symbols, and the `## Tests`
+  summary section is omitted (it only ever appeared when tests were
+  being excluded).
+- `--exclude-tests` restores the previous default: test symbols are
+  detected per language, dropped from `## Change graph`/`##
+  Definitions`, and summarized as per-file counts under `## Tests`.
+  `TagsResolver`'s repo-wide dependency index (ADR 0003) applies the
+  same exclusion under this flag, matching ADR 0009's original wiring.
+
+The per-language test-detection heuristics from ADR 0009 (Rust
+`#[cfg(test)]`/`#[test]`, Go `*_test.go`, Python `test_*.py`/`*_test.py`
+and `tests/` directories, TypeScript `*.test.ts(x)`/`*.spec.ts(x)` and
+`__tests__/`) stay in place unchanged — only the flag polarity and
+default value flip. `rinkaku-core` keeps its internal `include_tests:
+bool` parameter with its original meaning ("true means include tests");
+the CLI adapter passes `!cli.exclude_tests` when threading it through.
+
+## Alternatives
+
+- **TUI-only default flip**: leave `--include-tests` as-is for
+  Markdown/JSON, but make the TUI include tests by default regardless.
+  Rejected: the flag's meaning would become dependent on the output
+  mode, which is confusing for scripts that pipe stdout somewhere else
+  and for users who move between modes. The complexity of a
+  mode-dependent default is not worth the small benefit of preserving
+  ADR 0009's Markdown default given the audience shift documented
+  above.
+- **Keep ADR 0009's default unchanged**: rejected because the audience
+  the default was chosen for (human Markdown readers) is no longer the
+  primary Markdown audience.
+- **Drop test detection entirely**: rejected. `--exclude-tests` is a
+  real use case (e.g. an LLM reviewer that only cares about production
+  API surface), and the per-language heuristics from ADR 0009 remain
+  the right implementation for it.
+
+## Consequences
+
+- **Breaking CLI change**: any script using `--include-tests` breaks
+  and must switch to omitting the flag (to get the new default) or to
+  `--exclude-tests` (to keep the previous default's exclusion). This
+  tool has not shipped a stable CLI yet, so the breakage is acceptable
+  pre-1.0.
+- Default Markdown/JSON output grows: diffs that touch tests now show
+  those test symbols in the graph. This is the intended outcome given
+  the LLM-consumer framing above; users who want the old shape opt in
+  via `--exclude-tests`.
+- The `## Tests` summary section is now opt-in, only appearing under
+  `--exclude-tests`. `hotspots` fan-in counting (ADR 0013) already
+  operates on whatever symbols are present in the graph, so the fan-in
+  ranking naturally now includes test-to-production edges when tests
+  are included — this is a genuine signal for an LLM reviewer ("this
+  production symbol is exercised by N tests") rather than noise to
+  suppress.
+- The generated-file default (`--include-generated`) is not changed by
+  this ADR — the rationale for excluding generated content applies
+  equally to human and LLM consumers.
+- README, `--help` text, and any CI invocations of `rinkaku
+  --include-tests` must be updated in the same change.

--- a/rinkaku-core/src/deps.rs
+++ b/rinkaku-core/src/deps.rs
@@ -109,11 +109,13 @@ impl TagsResolver {
     /// name is referenced, so no definition needs to be found.
     ///
     /// `include_tests` mirrors `pipeline::analyze_diff`'s flag of the same
-    /// name (ADR 0009), extended to this repo-wide index: `false` (the CLI
-    /// default) excludes test symbols the same two ways `analyze_diff`
-    /// does — a whole file `language.is_test_path` considers a test file
-    /// is skipped entirely, and within every other file, only symbols
-    /// [`crate::extract::extract_all_symbols`] marked
+    /// name (ADR 0009's mechanism; ADR 0025 flipped the CLI-facing default
+    /// to include tests and renamed the flag to `--exclude-tests`),
+    /// extended to this repo-wide index: `false` (the CLI's
+    /// `--exclude-tests`) excludes test symbols the same two ways
+    /// `analyze_diff` does — a whole file `language.is_test_path`
+    /// considers a test file is skipped entirely, and within every other
+    /// file, only symbols [`crate::extract::extract_all_symbols`] marked
     /// `ExtractedSymbol::is_test` (AST context, e.g. Rust's `#[cfg(test)]`)
     /// are dropped from indexing. Without this, a changed production
     /// symbol's `referenced_names` could resolve to a same-named test
@@ -121,7 +123,7 @@ impl TagsResolver {
     /// would almost always read as coincidental noise in "Depends on:",
     /// not a real dependency, since production code should not actually
     /// depend on test-only definitions (see ADR 0009's Consequences).
-    /// `true` (`--include-tests`) indexes every symbol as before, matching
+    /// `true` (the CLI's new default) indexes every symbol, matching
     /// `analyze_diff`'s own `include_tests: true` behavior.
     ///
     /// `generated_paths` and `include_generated` extend the same exclusion

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -61,15 +61,17 @@ pub enum AnalyzeError {
 /// resolution entirely — no `Resolver::resolve` calls are made — which is
 /// how the CLI's `--deps 0` is wired (`main.rs`).
 ///
-/// `include_tests` controls ADR 0009's test-symbol exclusion: `false` (the
-/// CLI's default) drops every symbol a file's
+/// `include_tests` controls ADR 0009's test-symbol exclusion mechanism
+/// (kept intact, though ADR 0025 flipped the CLI-facing default to
+/// include tests and renamed the flag to `--exclude-tests`): `false`
+/// (the CLI's `--exclude-tests`) drops every symbol a file's
 /// [`crate::language::LanguageSupport`] considers a test — by path
 /// ([`LanguageSupport::is_test_path`], the whole file) or by AST context
 /// ([`ExtractedSymbol::is_test`], set per-definition during extraction) —
 /// from `files` before dependency resolution and graph-building run, and
 /// summarizes the excluded counts per file in the returned `Report`'s
-/// `tests`. `true` (`--include-tests`) keeps every symbol in `files` as
-/// before and leaves `tests` empty. Filtering happens before
+/// `tests`. `true` (the CLI's new default) keeps every symbol in `files`
+/// and leaves `tests` empty. Filtering happens before
 /// `resolve_dependencies`/`build_graph` rather than at render time so test
 /// symbols are excluded from the dependency graph and 1-hop resolution too,
 /// not just hidden from the rendered "Change graph"/"Definitions" sections.

--- a/rinkaku-core/src/render.rs
+++ b/rinkaku-core/src/render.rs
@@ -77,11 +77,12 @@ pub struct Report {
     /// entry points used to render "Change graph" in Markdown, exposed here
     /// too so JSON consumers get the same structure without recomputing it.
     pub graph: SymbolGraph,
-    /// Per-file counts of changed test symbols excluded from `files` by
-    /// default (ADR 0009) — empty when `--include-tests` is given, since
-    /// test symbols then stay in `files` like any other symbol instead of
-    /// being summarized here. Source order (the order files were first
-    /// encountered in the diff), same as `files`.
+    /// Per-file counts of changed test symbols excluded from `files`
+    /// under `--exclude-tests` (ADR 0009's mechanism; ADR 0025 flipped
+    /// the default so this is now opt-in). Empty in the default run
+    /// (test symbols stay in `files` like any other symbol) and only
+    /// populated when the CLI passes `--exclude-tests`. Source order (the
+    /// order files were first encountered in the diff), same as `files`.
     pub tests: Vec<TestFileSummary>,
     /// Fan-in hotspots (ADR 0013): changed symbols referenced by two or more
     /// other changed symbols, sorted by fan-in descending. Derived from

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -1164,7 +1164,7 @@ fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
             Style::default().fg(Color::Magenta),
         ));
         lines.push(Line::raw(
-            "Changed test-code symbols in this file are excluded from the default view (see --include-tests).",
+            "Changed test-code symbols in this file are excluded from the view because --exclude-tests is set (omit it to include them).",
         ));
         if !detail.symbols.is_empty() {
             lines.push(Line::raw(""));

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -115,11 +115,16 @@ struct Cli {
     #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u8).range(0..=1))]
     deps: u8,
 
-    /// Include test symbols in the "Change graph"/"Definitions" output
-    /// instead of excluding them by default and summarizing counts under
-    /// "Tests" (ADR 0009).
+    /// Exclude test symbols from the "Change graph"/"Definitions" output
+    /// and summarize their per-file counts under a "Tests" section
+    /// instead (ADR 0025, superseding the ADR 0009 default). Without
+    /// this flag, test symbols appear in the graph and definitions like
+    /// any other symbol — the default the Markdown/JSON output is
+    /// designed around now that its primary audience is LLM reviewers
+    /// (humans read the TUI, which badges test files rather than
+    /// omitting them).
     #[arg(long, default_value_t = false)]
-    include_tests: bool,
+    exclude_tests: bool,
 
     /// Include files `.gitattributes` marks `-diff` or `linguist-generated`
     /// instead of skipping them by default (ADR 0010).
@@ -280,7 +285,10 @@ fn main() -> anyhow::Result<()> {
         let report = rinkaku_core::pipeline::analyze_repo(
             &paths,
             read_working_tree_file,
-            cli.include_tests,
+            // Core's `include_tests: bool` keeps its original meaning
+            // ("true means include tests"). Only the CLI-side polarity is
+            // flipped by ADR 0025, so translate here.
+            !cli.exclude_tests,
             &generated_paths,
             cli.include_generated,
         );
@@ -308,7 +316,10 @@ fn main() -> anyhow::Result<()> {
             resolver
                 .as_ref()
                 .map(|r| r as &dyn rinkaku_core::deps::Resolver),
-            cli.include_tests,
+            // Same translation as the `analyze_repo` call above: core's
+            // `include_tests` is the semantic name, ADR 0025 flips only
+            // the CLI-facing polarity.
+            !cli.exclude_tests,
             &generated_paths,
             cli.include_generated,
         )?;
@@ -596,7 +607,9 @@ fn run_base_pipeline(
         resolver
             .as_ref()
             .map(|r| r as &dyn rinkaku_core::deps::Resolver),
-        cli.include_tests,
+        // See sibling `analyze_diff` call in `main` for why this negates
+        // `exclude_tests` rather than passing it straight through.
+        !cli.exclude_tests,
         &generated_paths,
         cli.include_generated,
     )?;
@@ -731,12 +744,13 @@ fn repo_outline_empty_note(report: &rinkaku_core::render::Report) -> Option<&'st
 /// a directory with no git repository would make `list_git_files` fail,
 /// so a passing `Ok(None)` there is proof the scan never ran).
 ///
-/// `cli.include_tests` is threaded straight through to `TagsResolver::new`
-/// (ADR 0009), so the repo-wide index excludes test symbols by the same
-/// default `analyze_diff` uses for the diff's own symbols — without this, a
-/// changed production symbol's "Depends on:" could resolve to a same-named
-/// test helper/fixture elsewhere in the repo, which is almost always a
-/// false match rather than a real dependency. `cli.include_generated` is
+/// `!cli.exclude_tests` is threaded through to `TagsResolver::new` (ADR
+/// 0009's exclusion mechanism, retained under ADR 0025's inverted CLI
+/// flag), so the repo-wide index applies the same test-inclusion decision
+/// `analyze_diff` uses for the diff's own symbols. With `--exclude-tests`,
+/// this stops a changed production symbol's "Depends on:" from resolving
+/// to a same-named test helper/fixture elsewhere in the repo (almost
+/// always a false match rather than a real dependency). `cli.include_generated` is
 /// threaded the same way, alongside a `generated_paths` set resolved for
 /// every tracked path via `check_generated_paths_batch` (ADR 0010's
 /// `.gitattributes` check, run once over the whole index rather than the
@@ -801,7 +815,9 @@ fn build_resolver(
         files,
         language_for_path,
         &reference_names,
-        cli.include_tests,
+        // Same CLI→core polarity flip as the `analyze_diff` /
+        // `analyze_repo` calls above (ADR 0025).
+        !cli.exclude_tests,
         &generated_paths,
         cli.include_generated,
     )))
@@ -1912,7 +1928,7 @@ mod tests {
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -1931,7 +1947,7 @@ mod tests {
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: true,
@@ -2017,7 +2033,7 @@ mod tests {
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -2036,7 +2052,7 @@ mod tests {
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -2055,7 +2071,7 @@ mod tests {
             pr: None,
             format: Some(Format::Json),
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -2081,7 +2097,7 @@ mod tests {
             pr: None,
             format: None,
             deps: 0,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -2099,7 +2115,7 @@ mod tests {
     }
 
     #[test]
-    fn should_set_include_tests_when_include_tests_flag_given() {
+    fn should_set_exclude_tests_when_exclude_tests_flag_given() {
         let expected = Cli {
             command: None,
             base: None,
@@ -2107,14 +2123,40 @@ mod tests {
             pr: None,
             format: None,
             deps: 1,
-            include_tests: true,
+            exclude_tests: true,
             include_generated: false,
             entry: None,
             tui: false,
         };
-        let actual = Cli::parse_from(["rinkaku", "--include-tests"]);
+        let actual = Cli::parse_from(["rinkaku", "--exclude-tests"]);
 
         assert_eq!(expected, actual);
+    }
+
+    // ADR 0025's flipped default: with no test-related flag given, the
+    // parsed `Cli` must land on `exclude_tests: false` — i.e. tests are
+    // included in Change graph/Definitions by default. The
+    // `should_default_to_markdown_head_and_no_base_when_no_args_given`
+    // above already exercises the whole default `Cli` shape, but this
+    // one pins the ADR 0025 decision specifically so a future default
+    // flip has to update this test on purpose rather than by
+    // consequence.
+    #[test]
+    fn should_default_to_including_tests_when_no_flag_given() {
+        let actual = Cli::parse_from(["rinkaku"]);
+
+        assert_eq!(false, actual.exclude_tests);
+    }
+
+    // Companion to the above: passing the old `--include-tests` flag
+    // must now fail parsing, so a stale script surfaces as an error
+    // instead of silently doing nothing. Pins the CLI break called out
+    // in ADR 0025's Consequences.
+    #[test]
+    fn should_reject_the_removed_include_tests_flag() {
+        let actual = Cli::try_parse_from(["rinkaku", "--include-tests"]);
+
+        assert!(actual.is_err());
     }
 
     #[test]
@@ -2126,7 +2168,7 @@ mod tests {
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: true,
             entry: None,
             tui: false,
@@ -2145,7 +2187,7 @@ mod tests {
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: Some("src/api".to_string()),
             tui: false,
@@ -2164,7 +2206,7 @@ mod tests {
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -2183,7 +2225,7 @@ mod tests {
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -2202,7 +2244,7 @@ mod tests {
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -2236,7 +2278,7 @@ mod tests {
             pr: Some("76".to_string()),
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -3067,7 +3109,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -3094,7 +3136,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: true,
             entry: None,
             tui: false,
@@ -3558,7 +3600,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             pr: None,
             format: None,
             deps: 0,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -3592,7 +3634,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -3638,7 +3680,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             pr: None,
             format: None,
             deps: 1,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,
@@ -3685,7 +3727,15 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
     // funnel through analyze_diff, so run_base_pipeline's coverage extends
     // to the stdin route too).
     #[test]
-    fn should_produce_test_only_report_without_garbage_input_shape_when_diff_touches_only_a_test() {
+    fn should_produce_test_only_report_without_garbage_input_shape_when_diff_touches_only_a_test_under_exclude_tests()
+     {
+        // ADR 0025 flipped the default to include tests, so the
+        // "test-only diff produces empty files + non-empty tests
+        // summary" shape this test pins down only occurs under
+        // `--exclude-tests`. The regression this guards is still real:
+        // garbage_input_note must not flag such a legitimate result as
+        // garbage input, and the test-detection wiring must actually
+        // populate `Report.tests` when the flag is set.
         let dir = tempfile::TempDir::new().expect("create tempdir");
         init_repo_with_committed_file(
             dir.path(),
@@ -3716,7 +3766,7 @@ fn should_add_two_numbers() {
             pr: None,
             format: None,
             deps: 0,
-            include_tests: false,
+            exclude_tests: true,
             include_generated: false,
             entry: None,
             tui: false,
@@ -3736,6 +3786,60 @@ fn should_add_two_numbers() {
             None,
             garbage_input_note("dummy non-empty diff text", &actual)
         );
+    }
+
+    // Companion to the above under the new default: a test-only diff
+    // with `exclude_tests: false` (the ADR 0025 default) should now put
+    // the test symbol into `files` like any production symbol, and
+    // leave `tests` empty. Pins that the flag actually flips the
+    // resulting shape — without this, the previous test would only
+    // prove the exclusion branch, and a regression that ignored the
+    // flag entirely could pass.
+    #[test]
+    fn should_include_test_symbol_in_files_when_diff_touches_only_a_test_under_default() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        init_repo_with_committed_file(
+            dir.path(),
+            "\
+#[test]
+fn should_add_two_numbers() {
+    assert_eq!(1, 1 + 0);
+}
+",
+        );
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            "\
+#[test]
+fn should_add_two_numbers() {
+    assert_eq!(2, 1 + 1);
+}
+",
+        )
+        .expect("edit src/lib.rs");
+        run_git(dir.path(), &["add", "src/lib.rs"]);
+        run_git(dir.path(), &["commit", "-m", "fix test assertion"]);
+
+        let cli = Cli {
+            command: None,
+            base: None,
+            head: "HEAD".to_string(),
+            pr: None,
+            format: None,
+            deps: 0,
+            exclude_tests: false,
+            include_generated: false,
+            entry: None,
+            tui: false,
+        };
+        let (actual, _diff_text) = run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()))
+            .expect("run_base_pipeline should succeed for a test-only diff");
+
+        let expected_tests: Vec<rinkaku_core::render::TestFileSummary> = Vec::new();
+        assert_eq!(expected_tests, actual.tests);
+        assert_eq!(1, actual.files.len());
+        assert_eq!(1, actual.files[0].symbols.len());
+        assert_eq!(true, actual.files[0].symbols[0].is_test);
     }
 
     // ADR 0014 end-to-end: `run_base_pipeline` must actually wire a
@@ -3765,7 +3869,7 @@ fn should_add_two_numbers() {
             pr: None,
             format: None,
             deps: 0,
-            include_tests: false,
+            exclude_tests: false,
             include_generated: false,
             entry: None,
             tui: false,


### PR DESCRIPTION
## Summary

Implements ADR 0025 — invert the CLI's test-symbol flag polarity and default to including test symbols in Markdown / JSON output.

- **Flag renamed**: `--include-tests` → `--exclude-tests`. Semantics also flip: omitting the flag now **includes** tests (new default); `--exclude-tests` reproduces the prior default (tests dropped from Change graph / Definitions, summarized under `## Tests`).
- **Scope**: only the CLI adapter polarity and default change. `rinkaku-core`'s `include_tests: bool` parameter, per-language test detection, and the `## Tests` summary section from ADR 0009 are **unchanged**. The CLI just threads `!cli.exclude_tests` into `analyze_diff` / `analyze_repo` / `TagsResolver::new`.
- **Generated-file exclusion is untouched** — this PR does not revisit that policy.
- **ADR 0025 supersedes only the flag polarity and default of ADR 0009**, not its detection heuristics or output shape. ADR 0009 has been marked accordingly.

### Why now

Dogfooding under experiment 0001 (see repo notes) showed the audience assumption behind ADR 0009 no longer holds:

- Markdown / JSON output has, since ADR 0015, primarily targeted **LLM consumers**, for which test symbols are useful signal (which contracts have coverage) rather than noise.
- **Humans read the TUI**, which badges test files (#58) so they can be identified at a glance — the "human reader noise" problem ADR 0009 solved does not recur there.

## Breaking change

This is a breaking CLI change (unreleased tool, but explicitly called out): any script or CI invocation of `rinkaku --include-tests` will now fail to parse. Migration:

- Want the **new default** (tests included)? Drop the flag.
- Want the **old default** (tests excluded, summarized under `## Tests`)? Pass `--exclude-tests`.

Commit is marked `feat!:` to make the break explicit.

## Review process

- **Self-verification** inside the implementation agent covered the three primary shapes:
  - Markdown default output includes test symbols in Change graph / Definitions.
  - `--exclude-tests` reproduces the pre-change behaviour (tests dropped from graph, listed under `## Tests`).
  - TUI: test-file detail-pane hint updated to point at the new flag; no behaviour change to the pane itself.
- **Orchestrator diff review** of the ADR + flag-polarity flip: verifying that only the CLI adapter flips, that `rinkaku-core`'s `include_tests` parameter keeps its "true means include" meaning, and that ADR 0009 is marked superseded only for polarity/default.

## Verification

- `make test` — 942 tests green (includes new pins: default-to-including, reject-old-flag guard, and the split "test-only diff" exclude / default-include branches).
- `make lint` — clean (`cargo fmt --check` + `cargo clippy --all-targets --all-features -- -D warnings`).
- Manual runs against the three modes above from a Markdown / JSON / TUI standpoint.

https://claude.ai/code/session_01WVB8PLzRRTJ43ckKxqwync
