### PR TITLE
feat(tui): scrollable source screen and half-page/top-bottom keys on the right pane

### DIFF
--- a/docs/adr/0026-tui-source-screen-scrolling.md
+++ b/docs/adr/0026-tui-source-screen-scrolling.md
@@ -1,0 +1,200 @@
+# 0026. TUI scrolling: reviewer-controlled motion in the source screen and the entry-view right pane
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+Two closely related complaints came out of dogfooding, addressed
+together because they share one root cause and one fix.
+
+**Source screen (`s` key, ADR 0015/0016).** `Screen::Source` reads the
+selected symbol's file from disk and shows a window centered on its
+definition (`crate::source::visible_window`,
+`crate::ui::draw_source_screen`). `App::handle_key`'s `Screen::Source`
+arm is deliberately minimal: `Back` returns to the entry view and every
+other key is a no-op — the pre-existing
+`should_return_none_from_draw_when_the_source_screen_is_open` test in
+`crate::ui` even asserts "the source screen scrolls via its own
+auto-centering window". This is the wrong end of the design space. The
+symbol under the cursor is the *entry point* the reviewer picked to
+read from, not the entirety of what they want to read: the caller a few
+lines above, the helper a few lines below, the imports at the top of
+the file, are all in scope for "understand this change" and none of
+them are reachable today without leaving the TUI.
+
+**Entry-view right pane on `Focus::Right` (ADR 0020).** `j`/`k` already
+scroll the right pane by one line (Diff, Detail, and BlastRadius all
+share `App::right_pane_scroll`), but there is no half-page motion and
+no top/bottom jump — for a long diff pane in particular, reaching the
+end takes a great many keypresses that vim's `Ctrl-d`/`G`
+equivalents would collapse into one.
+
+Both surfaces need the same three motion primitives (`j`/`k` is already
+in place on the entry-view side): half-page down/up and jump to
+top/bottom, with viewport-height-aware step sizes so the same key does
+the right thing on both a 6-line and a 60-line pane. The state
+discipline already exists once (`App::right_pane_scroll` as an
+unclamped request, `crate::ui::clamp_scroll` at draw time, fold the
+clamped value back via `App::with_right_pane_scroll` after every
+draw — `crate::lib::run_app`'s `clamp_right_pane_scroll_after_draw`);
+this ADR extends that same pattern rather than introducing a second
+mechanism.
+
+## Decision
+
+**1. `Screen::Source` carries a `scroll_top` line offset.** Change
+`Screen::Source { symbol_id: String }` to `Screen::Source { symbol_id:
+String, scroll_top: usize }` — 0-based, "first visible line", same
+shape `right_pane_scroll` uses. `scroll_top` is an unclamped *request*:
+`crate::ui::draw_source_screen` clamps it against the file's actual
+line count and the pane's rendered height at draw time, matching the
+`right_pane_scroll` clamp-at-draw discipline.
+
+**2. Initial `scroll_top` is `visible_window`'s centered start.** When
+`s` opens `Screen::Source`, `crate::run_app` computes
+`visible_window`'s start line (the same computation
+`draw_source_screen` performs today per frame, called once here at
+transition time) and stores it in `scroll_top`. The very first frame
+still shows the same centered window it does today; subsequent motion
+keys scroll away from that starting position rather than fighting an
+auto-recentering.
+
+**3. Four new `InputKey` variants** — `ScrollHalfPageDown`,
+`ScrollHalfPageUp`, `ScrollToTop`, `ScrollToBottom`. Named for what
+they do rather than the physical key (`InputKey::Down` already
+precedes: it is not `InputKey::J`), so key-to-intent mapping stays in
+`translate_key`. Bound identically on both surfaces:
+
+- **On `Screen::Source`**: acts on `Screen::Source.scroll_top`.
+- **On `Screen::Entry` + `Focus::Right`**: acts on
+  `App::right_pane_scroll`, whichever right pane
+  (`Diff`/`Detail`/`BlastRadius`) is currently showing — the same
+  "j/k scrolls whatever the right pane is showing" rule ADR 0020
+  already established, extended to these three additional motions.
+- **On `Screen::Entry` + `Focus::Tree`**: no-op. Consistent with how
+  today's `j`/`k` do not scroll the right pane while Tree-focused.
+
+**4. Key bindings** — vim-idiomatic, chosen to interlock with the
+existing `g`-prefix state machine (ADR 0022) rather than fight it:
+
+- `Ctrl-d`: `ScrollHalfPageDown`
+- `Ctrl-u`: `ScrollHalfPageUp`
+- `gg`: `ScrollToTop` — resolved by `translate_key` the same way
+  `gd`/`gr` are: when `App::pending_prefix()` is already `Some(G)` (set
+  by an earlier `g` press) and a second `g` arrives, emit
+  `ScrollToTop`. A single `g` press remains `InputKey::PendingGoto` as
+  today; `gd`/`gr` continue to resolve to
+  `GotoDefinition`/`GotoReferences` unchanged. `gg` is a strict addition
+  to the resolver table.
+- `G` (`Shift-g`): `ScrollToBottom`.
+
+`gg` is chosen over single-key `g` even on `Screen::Source` (which has
+no `gd`/`gr` to collide with) so the same two-key gesture works on both
+screens — reviewers do not have to relearn "top of pane" per screen.
+
+**5. Half-page step needs the viewport height.** `App::handle_key`
+does not know the pane's rendered height (a `ratatui::Rect` only
+`crate::ui` sees), so `ScrollHalfPageDown`/`ScrollHalfPageUp` cannot
+be handled by `App::handle_key` alone. `crate::ui::draw` already
+returns `Option<usize>` (the clamped right-pane scroll for
+`clamp_right_pane_scroll_after_draw`); it grows to also surface the
+last-drawn inner height of the currently-scrolling pane (source pane
+on `Screen::Source`, right pane on `Screen::Entry` + `Focus::Right`,
+`None` otherwise). `crate::run_app` remembers this height between
+frames and passes it into a new `App::handle_scroll_key(key,
+viewport_height)` entry point that only the four new variants use —
+`App::handle_key` itself keeps its current signature so the other
+~20 `InputKey` variants pay no plumbing cost for a feature that does
+not concern them.
+
+**6. Every other key on `Screen::Source` stays a no-op.** `Back` (Esc/
+`q`) continues to return to the entry view. `d`/`R`/`o`/`s` and the
+tree/right-pane keys do *not* leak through — the source screen is a
+reading surface with one action ("go back") beyond scrolling, and
+opening pane toggles here would re-open the "same key, different
+behavior per screen" trap ADR 0020 exists to close.
+
+## Alternatives
+
+- **Source-screen scrolling only, defer entry-view half-page/top-bottom
+  to a later ADR.** Considered because it is the smallest possible
+  change; rejected because the user's own request explicitly extended
+  to the diff pane, and both surfaces share the same four `InputKey`
+  variants, same `translate_key` cases, and same viewport-height
+  plumbing — splitting into two ADRs would duplicate the design
+  work for no real reduction in blast radius.
+- **Bind top/bottom to single-key `g`/`G` instead of `gg`/`G`.**
+  Rejected on `Screen::Entry`: `g` alone is already the leading key of
+  `gd`/`gr` (ADR 0022), and re-binding it to "top of pane" would
+  either break the two-key sequences or force a per-screen split of
+  what `g` means (the exact "same key, different behavior per screen"
+  trap the last paragraph of decision 6 calls out). `gg` also happens
+  to be what vim uses for this, so the transferability argument runs
+  the same direction anyway.
+- **Fold half-page steps into `App::handle_key` with a fixed constant
+  step (e.g. 12 lines) so `App` does not need viewport height.**
+  Rejected: on a 6-line pane that would jump nearly two full screens;
+  on a 60-line pane it would barely register. The viewport-height
+  plumbing is small and one-time; the height-agnostic constant would
+  be wrong forever after.
+- **Represent "scroll to bottom" as its own `Screen::Source` /
+  `RightPane` state variant rather than a `usize::MAX` sentinel that
+  the clamp folds down.** Rejected: every consumer that reads
+  `scroll_top`/`right_pane_scroll` would then have to match on two
+  variants forever after, for one boolean's worth of state that the
+  existing `scroll_top.min(max_start)` clamp already collapses cleanly.
+- **A separate scroll module with its own state machine for the
+  source screen.** Rejected: this is exactly the "start simple, split
+  when necessary" case where a parallel implementation of a pattern
+  the codebase already models once (`right_pane_scroll`) creates a
+  second surface for the two implementations to disagree, without
+  producing anything new.
+- **Auto-recenter on every scroll to keep the highlight visible.**
+  Rejected: this actively fights the reviewer trying to read *away*
+  from the highlight (the entire point of scrolling). Centering is
+  correct exactly once — as the initial position on entering the
+  screen — and becomes wrong as a per-frame rule the moment the
+  reviewer starts scrolling.
+- **Add a dedicated `App::handle_scroll_key(key, height)` entry point
+  vs. extend `App::handle_key`'s signature to take an
+  `Option<usize>`.** Rejected the latter: every `InputKey` variant
+  other than the four new ones has no use for a viewport height, and
+  every call site of `handle_key` (including every test) would grow
+  an argument for a feature that does not touch it. A separately named
+  entry point is the smaller, more targeted addition.
+
+## Consequences
+
+- The source screen now has scroll state that persists for the
+  lifetime of one `Screen::Source` entry (not across `Back`/re-open —
+  re-pressing `s` builds a fresh `Screen::Source` with a freshly
+  centered `scroll_top`). This matches how the entry view's
+  `right_pane_scroll` also resets on most transitions; a reviewer's
+  expectation on re-opening a symbol is "show me the symbol again",
+  not "resume where I left off".
+- `crate::ui::draw`'s return signature grows to surface the actively
+  scrolling pane's inner height alongside its existing clamped-scroll
+  return. Mirrors the seam already used by
+  `clamp_right_pane_scroll_after_draw`, so this is one more field on
+  the same seam rather than a new one.
+- `App` grows a small second entry point (`handle_scroll_key`) and the
+  four new `InputKey` variants. The three other screen/focus branches
+  of `handle_key` need no changes; `translate_key`'s `pending_prefix`
+  resolver gains one line for `gg`.
+- The pre-existing test asserting "the source screen scrolls via its
+  own auto-centering window, not …" (`crate::ui`) is deliberately
+  obsoleted by this ADR: its old assertion (source-screen `Up`/`Down`
+  produce no scroll offset for `run_app` to fold back) becomes false
+  by design. Rewritten to assert the new contract (source-screen
+  `Up`/`Down` update `Screen::Source.scroll_top`) rather than deleted,
+  so a future regression that silently reverts to no-op is caught.
+- The four new keys and the `gg` resolution get their own entries in
+  the `?` help overlay and the status-line hint set, so the addition
+  is discoverable without reading this ADR — this is what ADR 0020's
+  own "no in-app help" complaint was trying to prevent from
+  reappearing.
+- No backward-compatibility concern: the TUI has never shipped a
+  release (ADR 0015/0016), so this is a strict addition to the
+  interaction model. `Ctrl-d`/`Ctrl-u`/`gg`/`G` were previously
+  unbound on both screens.

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -1303,15 +1303,18 @@ impl App {
             // will no-op when Tree-focused, and having the gate live in
             // one place rather than duplicated here keeps the "which
             // focus/screen actually scrolls" answer discoverable in one
-            // spot. The blanket end-of-function scroll reset below still
-            // wipes `right_pane_scroll` for these variants, which is the
-            // correct behavior only for the Tree-focus no-op case;
-            // `handle_scroll_key` is called separately by `crate::run_app`
-            // after this method returns and sets the real value then.
+            // spot.
             //
-            // Also included in `preserve_scroll`'s exception list above
-            // for `Focus::Right`, so the blanket reset does not wipe the
-            // pane-scroll `handle_scroll_key` is about to set.
+            // On `Focus::Right`, the blanket end-of-function
+            // `right_pane_scroll = 0` reset is skipped via `preserve_scroll`'s
+            // exception list above, so `handle_scroll_key`'s subsequent write
+            // is not silently wiped. On `Focus::Tree`, that exception does
+            // *not* fire and the reset runs — which is fine because Tree
+            // focus never has a right-pane scroll to preserve in the first
+            // place (the reviewer is looking at the tree cursor, not a
+            // scrolled right pane), and `handle_scroll_key` also no-ops in
+            // that case, so this arm's blanket-reset behavior on Tree focus
+            // is a harmless zero-to-zero write rather than a data loss.
             (
                 Screen::Entry,
                 _,

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -122,6 +122,28 @@ pub enum InputKey {
     /// view is `InputKey::Quit`, a separate variant, since Esc has no
     /// "back" target to return to there).
     Back,
+    /// `Ctrl-d` (ADR 0026): scroll the reading pane down by half a viewport
+    /// (`Screen::Source`, or [`Screen::Entry`] + [`Focus::Right`]). The
+    /// actual step size depends on the pane's rendered height, which `App`
+    /// does not know, so this variant is handled by [`App::handle_scroll_key`]
+    /// (which takes the viewport height as an explicit argument) rather than
+    /// [`App::handle_key`]. A no-op on [`Screen::Entry`] + [`Focus::Tree`]
+    /// (nothing scrollable there — the tree already handles motion via
+    /// [`Self::Up`]/[`Self::Down`]).
+    ScrollHalfPageDown,
+    /// `Ctrl-u`: the reverse of [`Self::ScrollHalfPageDown`].
+    ScrollHalfPageUp,
+    /// `gg` (ADR 0026, resolved by `crate::lib::translate_key`'s `pending_prefix`
+    /// arm the same way `gd`/`gr` are, ADR 0022): scroll the reading pane
+    /// to the top (line 0). Handled by [`App::handle_scroll_key`] alongside
+    /// the half-page variants for uniformity, even though "top" itself does
+    /// not need the viewport height.
+    ScrollToTop,
+    /// `G` (`Shift-g`, ADR 0026): scroll the reading pane to the bottom.
+    /// Stored as `usize::MAX` and clamped down to
+    /// `total_lines - viewport_height` at draw time, matching
+    /// [`Screen::Source::scroll_top`]'s own sentinel convention.
+    ScrollToBottom,
     /// `q` or Ctrl-C on the entry view: exit the application.
     Quit,
     /// `?`: opens the help overlay (ADR 0020). While the overlay is open,
@@ -219,8 +241,31 @@ pub enum Screen {
     /// (not owned source text) so `App` stays cheap to clone/compare in
     /// tests — `crate::run`'s event loop resolves the actual file content
     /// via `crate::source` only when it redraws.
+    ///
+    /// `scroll_top` (ADR 0026) is the 0-based first-visible-line offset
+    /// requested by the reviewer — an unclamped request the same shape
+    /// [`App::right_pane_scroll`] uses. [`crate::ui::draw_source_screen`]
+    /// clamps it against the file's actual line count and the pane's
+    /// rendered height at draw time, keeping [`App`] free of any layout
+    /// concern.
+    ///
+    /// Initialized by `crate::run_app` (when the `s` key transitions into
+    /// this screen) to the same centered start [`crate::source::visible_window`]
+    /// already computes, so the first frame still shows the symbol's
+    /// definition centered in the viewport. Subsequent motion keys
+    /// (`j`/`k`/`Ctrl-d`/`Ctrl-u`/`gg`/`G`, ADR 0026) update this field
+    /// via [`App::handle_key`]/[`App::handle_scroll_key`] rather than
+    /// re-centering per frame — auto-recentering while the reviewer is
+    /// scrolling was the "wrong end of the design space" ADR 0026's
+    /// Context calls out.
+    ///
+    /// `usize::MAX` is the sentinel for "scroll to bottom": the
+    /// clamp-at-draw step folds it down to `total_lines - viewport_height`
+    /// cleanly, so no separate variant is needed for that state (see
+    /// ADR 0026's Alternatives).
     Source {
         symbol_id: String,
+        scroll_top: usize,
     },
 }
 
@@ -864,6 +909,18 @@ impl App {
             (&self.screen, self.focus, key),
             (Screen::Entry, Focus::Right, InputKey::Up)
                 | (Screen::Entry, Focus::Right, InputKey::Down)
+                // ADR 0026: half-page and top/bottom keys are dispatched
+                // through `handle_scroll_key` after this method returns
+                // (`crate::run_app`'s two-step dispatch). Without this
+                // exception, the blanket "reset scroll to 0" at the end
+                // of this function would wipe the scroll offset a moment
+                // before `handle_scroll_key` overwrote it — same class
+                // of bug the `Up`/`Down` case above already exists to
+                // prevent for plain j/k scrolling.
+                | (Screen::Entry, Focus::Right, InputKey::ScrollHalfPageDown)
+                | (Screen::Entry, Focus::Right, InputKey::ScrollHalfPageUp)
+                | (Screen::Entry, Focus::Right, InputKey::ScrollToTop)
+                | (Screen::Entry, Focus::Right, InputKey::ScrollToBottom)
                 // Independent-review finding: `crate::run_app`'s
                 // `dispatch_non_source_key` always calls `handle_key(input_key)`
                 // for `GotoDefinition`/`GotoReferences` first (ADR 0022's
@@ -924,6 +981,62 @@ impl App {
             (Screen::Source { .. }, _, InputKey::Back) => {
                 self.screen = Screen::Entry;
             }
+            // ADR 0026: `j`/`k` scroll the source pane by one line — the
+            // same "j/k scrolls the reading pane" rule ADR 0020 already
+            // applies to the entry view's right pane, extended here so a
+            // reviewer can read the caller a few lines above or the
+            // helper a few lines below the symbol they drilled into,
+            // rather than having to leave the TUI to see either.
+            //
+            // `scroll_top` is unclamped by design (see the field's own
+            // doc comment): `crate::ui::draw_source_screen` clamps it
+            // against the file's actual line count and the pane's
+            // rendered height at draw time, matching how
+            // `right_pane_scroll` already handles the same "App doesn't
+            // know the layout" problem.
+            (
+                Screen::Source {
+                    symbol_id,
+                    scroll_top,
+                },
+                _,
+                InputKey::Up,
+            ) => {
+                self.screen = Screen::Source {
+                    symbol_id: symbol_id.clone(),
+                    scroll_top: scroll_top.saturating_sub(1),
+                };
+            }
+            (
+                Screen::Source {
+                    symbol_id,
+                    scroll_top,
+                },
+                _,
+                InputKey::Down,
+            ) => {
+                self.screen = Screen::Source {
+                    symbol_id: symbol_id.clone(),
+                    scroll_top: scroll_top.saturating_add(1),
+                };
+            }
+            // Half-page steps and top/bottom jumps need the viewport
+            // height (or a `usize::MAX` sentinel) that `App::handle_key`
+            // doesn't know — they're handled by
+            // [`App::handle_scroll_key`] instead. This arm is still
+            // reached (via the ordinary `translate_key -> handle_key`
+            // path) so the blanket `status = None` /
+            // `pending_prefix = None` reset at the top of this function
+            // runs on this path too; the actual state mutation happens
+            // when `crate::run_app` calls `handle_scroll_key` next.
+            (
+                Screen::Source { .. },
+                _,
+                InputKey::ScrollHalfPageDown
+                | InputKey::ScrollHalfPageUp
+                | InputKey::ScrollToTop
+                | InputKey::ScrollToBottom,
+            ) => {}
             // Every other key is a no-op while the source view is open —
             // navigation/reordering only make sense against the entry
             // view's tree, and re-dispatching them would silently move
@@ -1030,8 +1143,19 @@ impl App {
                     && let NodeKind::Symbol(symbol_ref) = &row.node.kind
                     && !symbol_ref.removed
                 {
+                    // `scroll_top` starts at 0 here; `crate::run_app`
+                    // computes the centered start via `crate::source::
+                    // visible_window` once it has the file loaded, then
+                    // calls `Self::with_source_scroll_top` to overwrite
+                    // this initial 0. Kept as two steps (`App` transitions
+                    // to `Source`, then `run_app` back-fills the centered
+                    // scroll) because `App::handle_key` has no access to
+                    // the file's line count or the pane's rendered height
+                    // — the same seam `run_app` already uses to feed
+                    // `source_content` in after a file read.
                     self.screen = Screen::Source {
                         symbol_id: symbol_ref.id.clone(),
+                        scroll_top: 0,
                     };
                 }
             }
@@ -1171,6 +1295,31 @@ impl App {
                     self.status = Some("note: jumplist has no later location".to_string());
                 }
             }
+            // ADR 0026: half-page scroll and top/bottom jumps on the
+            // entry view are handled by [`App::handle_scroll_key`] (which
+            // has the viewport height) — same reasoning as the
+            // corresponding `Screen::Source` arm above. This is deliberately
+            // *not* gated on `Focus::Right`: `handle_scroll_key` itself
+            // will no-op when Tree-focused, and having the gate live in
+            // one place rather than duplicated here keeps the "which
+            // focus/screen actually scrolls" answer discoverable in one
+            // spot. The blanket end-of-function scroll reset below still
+            // wipes `right_pane_scroll` for these variants, which is the
+            // correct behavior only for the Tree-focus no-op case;
+            // `handle_scroll_key` is called separately by `crate::run_app`
+            // after this method returns and sets the real value then.
+            //
+            // Also included in `preserve_scroll`'s exception list above
+            // for `Focus::Right`, so the blanket reset does not wipe the
+            // pane-scroll `handle_scroll_key` is about to set.
+            (
+                Screen::Entry,
+                _,
+                InputKey::ScrollHalfPageDown
+                | InputKey::ScrollHalfPageUp
+                | InputKey::ScrollToTop
+                | InputKey::ScrollToBottom,
+            ) => {}
             // Unreachable while `handle_key` is entered directly (the popup
             // interception above returns before this match whenever
             // `jump_popup.is_some()`), kept only so the match stays
@@ -1247,6 +1396,120 @@ impl App {
     /// function's own comment on why the computation lives there).
     pub fn with_right_pane_scroll(mut self, scroll: usize) -> Self {
         self.right_pane_scroll = scroll;
+        self
+    }
+
+    /// Overwrites [`Screen::Source`]'s `scroll_top` to `scroll_top` —
+    /// used by `crate::run_app` right after the `s` key transitions to
+    /// [`Screen::Source`], to back-fill the centered starting position
+    /// [`crate::source::visible_window`] computes (see
+    /// [`InputKey::Source`]'s handling in [`Self::handle_key`]: the
+    /// transition itself sets `scroll_top = 0`, and this method
+    /// overwrites it with the centered value once `run_app` has loaded
+    /// the file and knows the layout). A no-op when the current screen
+    /// is [`Screen::Entry`] — defensive: callers are expected to check
+    /// [`Self::screen`] before invoking this, but `App` does not trust
+    /// that blindly.
+    pub fn with_source_scroll_top(mut self, scroll_top: usize) -> Self {
+        if let Screen::Source { symbol_id, .. } = &self.screen {
+            self.screen = Screen::Source {
+                symbol_id: symbol_id.clone(),
+                scroll_top,
+            };
+        }
+        self
+    }
+
+    /// Applies one of ADR 0026's four scroll [`InputKey`] variants against
+    /// whichever pane is scrollable right now, given `viewport_height` — the
+    /// last-drawn inner height of that pane, threaded in by `crate::run_app`
+    /// (which knows it from [`crate::ui::draw`]'s return value) since `App`
+    /// itself has no notion of the pane's layout.
+    ///
+    /// Split off from [`Self::handle_key`] rather than folded into it so
+    /// the other ~20 [`InputKey`] variants — which don't need viewport
+    /// height — don't pay the plumbing cost. `crate::run_app`'s two-step
+    /// dispatch is: call [`Self::handle_key`] first for the blanket
+    /// bookkeeping (`status`/`pending_prefix` reset, and — on the entry
+    /// view — `preserve_scroll` bookkeeping), then call this method for
+    /// the four scroll variants only. [`Self::handle_key`]'s own arms
+    /// for these four variants are deliberate no-ops that document this
+    /// split.
+    ///
+    /// Scoping:
+    ///
+    /// - On [`Screen::Source`], acts on `Screen::Source::scroll_top`.
+    /// - On [`Screen::Entry`] + [`Focus::Right`], acts on
+    ///   [`Self::right_pane_scroll`], the same field plain `j`/`k`
+    ///   already updates while Right-focused.
+    /// - On [`Screen::Entry`] + [`Focus::Tree`], a no-op — Tree-focused
+    ///   motion belongs on the tree cursor, not on any pane's scroll.
+    ///
+    /// `usize::MAX` is used as the "scroll to bottom" sentinel
+    /// ([`InputKey::ScrollToBottom`]'s doc comment): the clamp-at-draw
+    /// step folds it down to `total_lines - viewport_height` cleanly,
+    /// so no per-pane bottom sentinel is needed here.
+    pub fn handle_scroll_key(mut self, key: InputKey, viewport_height: usize) -> Self {
+        let step = viewport_height / 2;
+        match (&self.screen, self.focus, key) {
+            (
+                Screen::Source {
+                    symbol_id,
+                    scroll_top,
+                },
+                _,
+                InputKey::ScrollHalfPageDown,
+            ) => {
+                let next = scroll_top.saturating_add(step);
+                self.screen = Screen::Source {
+                    symbol_id: symbol_id.clone(),
+                    scroll_top: next,
+                };
+            }
+            (
+                Screen::Source {
+                    symbol_id,
+                    scroll_top,
+                },
+                _,
+                InputKey::ScrollHalfPageUp,
+            ) => {
+                let next = scroll_top.saturating_sub(step);
+                self.screen = Screen::Source {
+                    symbol_id: symbol_id.clone(),
+                    scroll_top: next,
+                };
+            }
+            (Screen::Source { symbol_id, .. }, _, InputKey::ScrollToTop) => {
+                self.screen = Screen::Source {
+                    symbol_id: symbol_id.clone(),
+                    scroll_top: 0,
+                };
+            }
+            (Screen::Source { symbol_id, .. }, _, InputKey::ScrollToBottom) => {
+                self.screen = Screen::Source {
+                    symbol_id: symbol_id.clone(),
+                    scroll_top: usize::MAX,
+                };
+            }
+            (Screen::Entry, Focus::Right, InputKey::ScrollHalfPageDown) => {
+                self.right_pane_scroll = self.right_pane_scroll.saturating_add(step);
+            }
+            (Screen::Entry, Focus::Right, InputKey::ScrollHalfPageUp) => {
+                self.right_pane_scroll = self.right_pane_scroll.saturating_sub(step);
+            }
+            (Screen::Entry, Focus::Right, InputKey::ScrollToTop) => {
+                self.right_pane_scroll = 0;
+            }
+            (Screen::Entry, Focus::Right, InputKey::ScrollToBottom) => {
+                self.right_pane_scroll = usize::MAX;
+            }
+            // Tree focus on the entry view, or any non-scroll key on the
+            // source screen — deliberate no-op. `crate::run_app` only
+            // calls this for the four scroll variants, so the non-scroll
+            // case is defensive.
+            _ => {}
+        }
         self
     }
 }
@@ -1362,7 +1625,8 @@ mod tests {
 
         assert_eq!(
             Screen::Source {
-                symbol_id: "lib.rs::foo".to_string()
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: 0,
             },
             *app.screen()
         );
@@ -1387,7 +1651,8 @@ mod tests {
             .handle_key(InputKey::Source);
         assert_eq!(
             Screen::Source {
-                symbol_id: "lib.rs::foo".to_string()
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: 0,
             },
             *app.screen()
         );
@@ -1398,7 +1663,14 @@ mod tests {
     }
 
     #[test]
-    fn should_ignore_navigation_keys_while_source_screen_is_open() {
+    fn should_scroll_source_screen_and_not_move_tree_cursor_when_down_is_pressed() {
+        // ADR 0026: `j`/`k` on the source screen scroll
+        // `Screen::Source::scroll_top` rather than moving the tree cursor
+        // (which the reviewer can't see move behind the source screen
+        // anyway — the point of ADR 0026's Context, and the whole reason
+        // Source used to be Back-only). Pins both halves of the new
+        // contract: the tree cursor stays put *and* the scroll offset
+        // moves.
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(InputKey::Down)
@@ -1410,7 +1682,8 @@ mod tests {
         assert_eq!(cursor_before, app.nav().cursor());
         assert_eq!(
             Screen::Source {
-                symbol_id: "lib.rs::foo".to_string()
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: 1,
             },
             *app.screen()
         );
@@ -1795,7 +2068,8 @@ mod tests {
         assert_eq!(RightPane::Diff, app.right_pane());
         assert_eq!(
             Screen::Source {
-                symbol_id: "lib.rs::foo".to_string()
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: 0,
             },
             *app.screen()
         );
@@ -2294,7 +2568,8 @@ mod tests {
             .handle_key(InputKey::Source); // opens Screen::Source
         assert_eq!(
             Screen::Source {
-                symbol_id: "lib.rs::foo".to_string()
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: 0,
             },
             *app.screen()
         );
@@ -2306,9 +2581,17 @@ mod tests {
     }
 
     #[test]
-    fn should_ignore_scroll_keys_while_source_screen_is_open() {
-        // Post-dogfooding-fix note: the source screen is now reached only
-        // via the dedicated `s` key (`InputKey::Source`), not `Enter` — see
+    fn should_scroll_source_screen_without_touching_right_pane_scroll_when_down_is_pressed() {
+        // ADR 0026: `j`/`k` on the source screen updates
+        // `Screen::Source::scroll_top`, not the entry view's own
+        // `right_pane_scroll` — the two are independent pieces of scroll
+        // state (see the field's own doc comment on why they were not
+        // unified). Pins both halves: `right_pane_scroll` stays at 0
+        // (the entry view has never scrolled) and the source screen's
+        // `scroll_top` moves.
+        //
+        // Post-dogfooding-fix note: the source screen is reached only via
+        // the dedicated `s` key (`InputKey::Source`), not `Enter` — see
         // `should_keep_right_pane_scroll_at_zero_when_returning_from_source_screen`'s
         // own note.
         let report = report_with_one_symbol();
@@ -2321,7 +2604,8 @@ mod tests {
         assert_eq!(0, app.right_pane_scroll());
         assert_eq!(
             Screen::Source {
-                symbol_id: "lib.rs::foo".to_string()
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: 1,
             },
             *app.screen()
         );
@@ -2845,5 +3129,204 @@ mod tests {
 
         let app = app.handle_key(InputKey::JumpForward);
         assert_eq!(Some("note: jumplist has no later location"), app.status());
+    }
+
+    // ADR 0026: scroll bindings — `App::handle_key`'s Source-screen `Up`/
+    // `Down` arms plus `App::handle_scroll_key`'s four scroll variants,
+    // exercised against both `Screen::Source` and `Screen::Entry` +
+    // `Focus::Right`.
+
+    #[test]
+    fn should_scroll_source_up_from_a_nonzero_position_when_up_is_pressed() {
+        // Complements `should_scroll_source_screen_and_not_move_tree_cursor_when_down_is_pressed`
+        // above (which covers the Down direction from 0). Starts at
+        // scroll_top = 3 (via `with_source_scroll_top`, mirroring how
+        // `crate::run_app` back-fills the centered initial position) so
+        // the `Up` press has somewhere to move from, and pins the
+        // `saturating_sub(1)` step size.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Source)
+            .with_source_scroll_top(3);
+
+        let app = app.handle_key(InputKey::Up);
+
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: 2,
+            },
+            *app.screen()
+        );
+    }
+
+    #[test]
+    fn should_saturate_source_scroll_up_at_zero_when_already_at_the_top() {
+        // A `k` at scroll 0 must stay at 0 rather than underflowing to
+        // `usize::MAX` — the same `saturating_sub` discipline the entry
+        // view's own Up arm already uses for `right_pane_scroll`.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Source);
+
+        let app = app.handle_key(InputKey::Up);
+
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: 0,
+            },
+            *app.screen()
+        );
+    }
+
+    #[test]
+    fn should_add_half_viewport_to_source_scroll_top_when_scroll_half_page_down_is_dispatched() {
+        // `handle_scroll_key` needs the viewport height, so this is
+        // exercised via `handle_scroll_key` directly (not `handle_key`)
+        // — the same two-step dispatch `crate::run_app` uses. Viewport
+        // height 20 → step size 10.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Source);
+
+        let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, 20);
+
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: 10,
+            },
+            *app.screen()
+        );
+    }
+
+    #[test]
+    fn should_saturate_source_scroll_half_page_up_at_zero() {
+        // Half-page up from a low scroll must not underflow — mirrors
+        // the Up arm's `saturating_sub` (`saturating_sub` inside
+        // `handle_scroll_key` for this one).
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Source)
+            .with_source_scroll_top(3);
+
+        let app = app.handle_scroll_key(InputKey::ScrollHalfPageUp, 20);
+
+        // 3 - 10 saturates to 0.
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: 0,
+            },
+            *app.screen()
+        );
+    }
+
+    #[test]
+    fn should_reset_source_scroll_top_to_zero_when_scroll_to_top_is_dispatched() {
+        // `gg` on the source screen. Viewport height is irrelevant for
+        // this variant (it does not read it) but still required by the
+        // shared `handle_scroll_key` signature.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Source)
+            .with_source_scroll_top(50);
+
+        let app = app.handle_scroll_key(InputKey::ScrollToTop, 20);
+
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: 0,
+            },
+            *app.screen()
+        );
+    }
+
+    #[test]
+    fn should_set_source_scroll_top_to_usize_max_sentinel_when_scroll_to_bottom_is_dispatched() {
+        // `G` on the source screen. `App` has no notion of the file's
+        // line count — the actual "bottom" is resolved by `ui`'s
+        // `clamped_window` at draw time — so `handle_scroll_key` records
+        // `usize::MAX` here and lets the draw-time clamp fold it down.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Down)
+            .handle_key(InputKey::Source);
+
+        let app = app.handle_scroll_key(InputKey::ScrollToBottom, 20);
+
+        assert_eq!(
+            Screen::Source {
+                symbol_id: "lib.rs::foo".to_string(),
+                scroll_top: usize::MAX,
+            },
+            *app.screen()
+        );
+    }
+
+    #[test]
+    fn should_add_half_viewport_to_right_pane_scroll_when_focus_right_scroll_half_page_down() {
+        // Entry-view side of ADR 0026: the same four scroll variants
+        // act on `right_pane_scroll` while `Focus::Right`. Reach
+        // `Focus::Right` via `Open` on the file row (ADR 0020) so the
+        // scroll actually applies to a real pane.
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(InputKey::Open);
+        assert_eq!(Focus::Right, app.focus());
+        assert_eq!(0, app.right_pane_scroll());
+
+        let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, 30);
+
+        assert_eq!(15, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_leave_right_pane_scroll_untouched_when_focus_tree_and_scroll_half_page_down() {
+        // Tree focus is the entry view's default; `handle_scroll_key` must
+        // no-op there (ADR 0026's decision 3), leaving `right_pane_scroll`
+        // at 0 rather than scrolling a pane the reviewer is not looking
+        // at.
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        assert_eq!(Focus::Tree, app.focus());
+
+        let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, 30);
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_reset_right_pane_scroll_to_zero_on_focus_right_scroll_to_top() {
+        // `gg` on the entry view + `Focus::Right`.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(InputKey::Open)
+            .with_right_pane_scroll(42);
+        assert_eq!(Focus::Right, app.focus());
+
+        let app = app.handle_scroll_key(InputKey::ScrollToTop, 30);
+
+        assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_set_right_pane_scroll_to_usize_max_sentinel_on_focus_right_scroll_to_bottom() {
+        // `G` on the entry view + `Focus::Right`. Same
+        // `usize::MAX`-sentinel-plus-draw-time-clamp discipline the
+        // source screen uses.
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(InputKey::Open);
+        assert_eq!(Focus::Right, app.focus());
+
+        let app = app.handle_scroll_key(InputKey::ScrollToBottom, 30);
+
+        assert_eq!(usize::MAX, app.right_pane_scroll());
     }
 }

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -71,6 +71,14 @@ const RIGHT_FOCUS_BINDINGS: &[KeyBinding] = &[
         description: "Scroll the right pane by one line",
     },
     KeyBinding {
+        keys: "ctrl-d / ctrl-u",
+        description: "Scroll the right pane by half a page",
+    },
+    KeyBinding {
+        keys: "gg / G",
+        description: "Jump to the top / bottom of the right pane",
+    },
+    KeyBinding {
         keys: "h / esc",
         description: "Return focus to the tree",
     },
@@ -81,6 +89,25 @@ const RIGHT_FOCUS_BINDINGS: &[KeyBinding] = &[
     KeyBinding {
         keys: "[",
         description: "Jump to the previous hunk (Diff pane only)",
+    },
+];
+
+const SOURCE_SCREEN_BINDINGS: &[KeyBinding] = &[
+    KeyBinding {
+        keys: "j / k / ↓ / ↑",
+        description: "Scroll the source pane by one line",
+    },
+    KeyBinding {
+        keys: "ctrl-d / ctrl-u",
+        description: "Scroll the source pane by half a page",
+    },
+    KeyBinding {
+        keys: "gg / G",
+        description: "Jump to the top / bottom of the file",
+    },
+    KeyBinding {
+        keys: "esc / q",
+        description: "Return to the entry view",
     },
 ];
 
@@ -137,6 +164,10 @@ const KEYMAP_GROUPS: &[KeyBindingGroup] = &[
         bindings: RIGHT_FOCUS_BINDINGS,
     },
     KeyBindingGroup {
+        title: "Source view",
+        bindings: SOURCE_SCREEN_BINDINGS,
+    },
+    KeyBindingGroup {
         title: "Global",
         bindings: GLOBAL_BINDINGS,
     },
@@ -177,14 +208,42 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn should_include_a_tree_focus_right_focus_and_global_group_in_that_order() {
+    fn should_list_keymap_groups_in_tree_right_source_global_order() {
         let titles: Vec<&str> = HELP_CONTENT
             .keymap_groups
             .iter()
             .map(|group| group.title)
             .collect();
 
-        assert_eq!(vec!["Tree focus", "Right focus", "Global"], titles);
+        assert_eq!(
+            vec!["Tree focus", "Right focus", "Source view", "Global"],
+            titles
+        );
+    }
+
+    #[test]
+    fn should_document_source_view_scroll_bindings_in_the_source_view_group() {
+        // ADR 0026: the source view has its own scroll bindings (j/k,
+        // Ctrl-d/Ctrl-u, gg/G) plus esc/q to return to the entry view.
+        // Pinned so a future rename/typo/omission of any of them is
+        // caught, and so the group's own presence is not silently
+        // dropped by a keymap refactor.
+        let source_view = HELP_CONTENT
+            .keymap_groups
+            .iter()
+            .find(|group| group.title == "Source view")
+            .expect("Source view group present");
+
+        let keys: Vec<&str> = source_view
+            .bindings
+            .iter()
+            .map(|binding| binding.keys)
+            .collect();
+
+        assert!(keys.contains(&"j / k / ↓ / ↑"));
+        assert!(keys.contains(&"ctrl-d / ctrl-u"));
+        assert!(keys.contains(&"gg / G"));
+        assert!(keys.contains(&"esc / q"));
     }
 
     #[test]

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -185,17 +185,24 @@ fn run_app(
     // carries the file *path*, not the symbol id, and two distinct symbols
     // in one file would otherwise share a cache entry indistinguishably.
     let mut source_content_symbol: Option<String> = None;
+    // The inner height (borders excluded) of whichever pane was scrollable
+    // as of the last drawn frame (`ui::DrawOutcome::scroll_viewport_height`),
+    // remembered here so the next `Ctrl-d`/`Ctrl-u`/`gg`/`G` key press
+    // (ADR 0026) can size its step against the same viewport the reviewer
+    // just saw — the very first keypress before any frame has drawn (a
+    // near-impossible edge case, but guarded rather than defaulting to a
+    // zero step) falls back to [`DEFAULT_SOURCE_VIEWPORT_HEIGHT`].
+    let mut last_scroll_viewport_height: Option<usize> = None;
 
     loop {
-        // `ui::draw`'s return value (the right-hand pane's scroll offset as
-        // actually clamped and rendered this frame, `ui::draw`'s own doc
+        // `ui::draw`'s return value (`DrawOutcome`, `ui::draw`'s own doc
         // comment) cannot flow out of the closure itself — `Terminal::draw`
         // requires an `FnOnce(&mut Frame)` returning `()` — so it is
         // captured into this outer binding instead and folded back into
-        // `app` right after, via `clamp_right_pane_scroll_after_draw`.
-        let mut clamped_scroll = None;
+        // `app`/`last_scroll_viewport_height` right after.
+        let mut outcome = ui::DrawOutcome::default();
         terminal.draw(|frame| {
-            clamped_scroll = ui::draw(
+            outcome = ui::draw(
                 frame,
                 &app,
                 report,
@@ -205,7 +212,10 @@ fn run_app(
                 source_content.as_ref(),
             );
         })?;
-        app = clamp_right_pane_scroll_after_draw(app, clamped_scroll);
+        app = clamp_right_pane_scroll_after_draw(app, outcome.clamped_right_pane_scroll);
+        if outcome.scroll_viewport_height.is_some() {
+            last_scroll_viewport_height = outcome.scroll_viewport_height;
+        }
 
         if app.should_quit() {
             return Ok(());
@@ -225,7 +235,7 @@ fn run_app(
         {
             if let InputKey::Source = input_key {
                 app = app.handle_key(input_key);
-                if let Screen::Source { symbol_id } = app.screen().clone()
+                if let Screen::Source { symbol_id, .. } = app.screen().clone()
                     && should_reload_source_content(
                         source_content_symbol.as_deref(),
                         source_content.as_ref(),
@@ -247,6 +257,43 @@ fn run_app(
                     source_content = Some(loaded);
                     source_content_symbol = Some(symbol_id);
                 }
+                // ADR 0026: back-fill `Screen::Source::scroll_top` with the
+                // centered starting position `crate::source::visible_window`
+                // computes, now that the file has been loaded and its line
+                // count is known. `App::handle_key(InputKey::Source)` above
+                // sets `scroll_top = 0` (it has no access to the file), so
+                // without this back-fill the first frame after `s` would
+                // land at the file's very top rather than centered on the
+                // symbol's definition — the old auto-centering behavior
+                // this ADR preserves as the initial position.
+                if let (Screen::Source { .. }, Some(Ok(highlighted))) =
+                    (app.screen(), source_content.as_ref())
+                {
+                    let viewport_height =
+                        last_scroll_viewport_height.unwrap_or(DEFAULT_SOURCE_VIEWPORT_HEIGHT);
+                    let (start, _end) = source::visible_window(
+                        highlighted.view.lines.len(),
+                        highlighted.view.highlight_start,
+                        highlighted.view.highlight_end,
+                        viewport_height,
+                    );
+                    app = app.with_source_scroll_top(start);
+                }
+            } else if is_scroll_input_key(input_key) {
+                // ADR 0026 two-step dispatch: `handle_key` first for the
+                // blanket `status`/`pending_prefix`/`preserve_scroll`
+                // bookkeeping every key needs (mirroring how
+                // `dispatch_non_source_key` also calls `handle_key`
+                // unconditionally for `GotoDefinition`/`GotoReferences`
+                // for the same reason), then `handle_scroll_key` with
+                // the last-drawn viewport height for the actual scroll
+                // mutation. `handle_key`'s own arm for these four
+                // variants is deliberately a no-op; the state change
+                // lives here.
+                app = app.handle_key(input_key);
+                let viewport_height =
+                    last_scroll_viewport_height.unwrap_or(DEFAULT_SOURCE_VIEWPORT_HEIGHT);
+                app = app.handle_scroll_key(input_key, viewport_height);
             } else {
                 // Every non-`Source` key's dispatch is pure (no IO), so it
                 // lives in its own function rather than inline here — see
@@ -305,6 +352,36 @@ fn run_app(
 /// shrinks their terminal mid-read and then grows it back finds the pane
 /// scrolled less far than before the resize — judged an acceptable, rare
 /// edge case relative to the far more common overshoot this fold-back fixes.
+/// Fallback viewport height used by [`run_app`]'s ADR 0026 scroll dispatch
+/// (`Ctrl-d`/`Ctrl-u`/`gg`/`G`) when a key press arrives *before* any frame
+/// has drawn — a near-impossible edge case in practice (a terminal that
+/// finished initializing and accepted its very first key press without ever
+/// polling for an idle draw once, or a `run_app` invocation whose first
+/// user action is somehow one of these keys with no intervening frame), but
+/// still gets a sensible half-page step (12 lines is roughly half a typical
+/// 24-row terminal) rather than a 0-line no-op. Not user-visible past this
+/// one edge; the very next frame's `DrawOutcome::scroll_viewport_height`
+/// replaces it with the real inner-pane height.
+const DEFAULT_SOURCE_VIEWPORT_HEIGHT: usize = 24;
+
+/// Whether `input_key` is one of ADR 0026's four scroll variants — the
+/// ones [`run_app`] routes through [`App::handle_scroll_key`] (which needs
+/// the viewport height) instead of the ordinary
+/// [`dispatch_non_source_key`] path. Kept as its own predicate rather than
+/// inlined into `run_app` so the two-step dispatch's exact set of variants
+/// stays in one obvious place, and so a future addition to that set
+/// (e.g. `ScrollLineToCenter`) is a one-line change here rather than a
+/// hunt through `run_app`.
+fn is_scroll_input_key(input_key: InputKey) -> bool {
+    matches!(
+        input_key,
+        InputKey::ScrollHalfPageDown
+            | InputKey::ScrollHalfPageUp
+            | InputKey::ScrollToTop
+            | InputKey::ScrollToBottom,
+    )
+}
+
 fn clamp_right_pane_scroll_after_draw(app: App, clamped: Option<usize>) -> App {
     match clamped {
         Some(scroll) => app.with_right_pane_scroll(scroll),
@@ -618,6 +695,14 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         match code {
             KeyCode::Char('d') | KeyCode::Char('D') => return Some(InputKey::GotoDefinition),
             KeyCode::Char('r') | KeyCode::Char('R') => return Some(InputKey::GotoReferences),
+            // `gg` (ADR 0026): scroll the reading pane to the top —
+            // resolved here the same way `gd`/`gr` are, piggybacking on
+            // the existing `g`-prefix state machine (ADR 0022) rather
+            // than reserving single-key `g` for this and breaking the
+            // two-key sequences above. Uppercase `G` is a *distinct*
+            // single-key gesture (`ScrollToBottom` below), unrelated to
+            // this prefix — a second `g` in this arm is what means "top".
+            KeyCode::Char('g') => return Some(InputKey::ScrollToTop),
             _ => {}
         }
     }
@@ -655,8 +740,27 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
             Some(InputKey::JumpForward)
         }
         KeyCode::Char('o') | KeyCode::Char('O') => Some(InputKey::ToggleOrder),
+        // `Ctrl-d`/`Ctrl-u` (ADR 0026): half-page scroll on the reading
+        // pane (`Screen::Source`, or `Screen::Entry` + `Focus::Right`).
+        // Must come *before* the plain `Char('d')`/`Char('u')` arms —
+        // otherwise a `Ctrl-d` press would match `ToggleDiff` first and
+        // the modifier would be ignored, silently rebinding "half-page
+        // down" to "toggle diff pane". Emitted regardless of screen/
+        // focus; `App::handle_scroll_key` no-ops on `Focus::Tree` in the
+        // entry view (ADR 0026 decision 3's Tree-focus rule).
+        KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(InputKey::ScrollHalfPageDown)
+        }
+        KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(InputKey::ScrollHalfPageUp)
+        }
         KeyCode::Char('d') | KeyCode::Char('D') => Some(InputKey::ToggleDiff),
         KeyCode::Char('r') | KeyCode::Char('R') => Some(InputKey::ToggleBlastRadius),
+        // `G` (`Shift-g`, ADR 0026): scroll to the bottom. Distinct from
+        // single-key lowercase `g` (`PendingGoto` below), which is the
+        // leading key of the `gd`/`gr`/`gg` two-key sequences resolved
+        // at the top of this function.
+        KeyCode::Char('G') => Some(InputKey::ScrollToBottom),
         // `h`, or Esc while the right pane has focus: return focus to the
         // tree (ADR 0020's neovim-style "move left/back"). Checked before
         // the source-screen Esc arm below so `h`/Esc while Right-focused
@@ -1355,6 +1459,60 @@ mod tests {
         let actual = translate_key(KeyCode::Char('o'), KeyModifiers::NONE, &app);
 
         assert_eq!(Some(InputKey::ToggleOrder), actual);
+    }
+
+    // ADR 0026 scroll bindings (translate_key half).
+
+    #[test]
+    fn should_translate_ctrl_d_to_scroll_half_page_down() {
+        // Must resolve *before* the plain `Char('d')` arm below (which
+        // maps to `ToggleDiff`) — a stale ordering would silently
+        // rebind Ctrl-d to Diff-toggle instead of half-page-down.
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('d'), KeyModifiers::CONTROL, &app);
+
+        assert_eq!(Some(InputKey::ScrollHalfPageDown), actual);
+    }
+
+    #[test]
+    fn should_translate_ctrl_u_to_scroll_half_page_up() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('u'), KeyModifiers::CONTROL, &app);
+
+        assert_eq!(Some(InputKey::ScrollHalfPageUp), actual);
+    }
+
+    #[test]
+    fn should_translate_second_g_to_scroll_to_top_when_g_prefix_is_pending() {
+        // `gg` (ADR 0026) resolves through the same `pending_prefix`
+        // arm `gd`/`gr` do (ADR 0022) — this test pins that a *second*
+        // `g` after a pending `g` means "scroll to top", not restart
+        // the prefix. Restarting is what a *first* `g` does when no
+        // prefix is pending (the `should_translate_g_to_pending_goto`
+        // test above); this arm's behavior is the second-key half of
+        // the two-key `gg` sequence.
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::PendingGoto);
+
+        let actual = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ScrollToTop), actual);
+    }
+
+    #[test]
+    fn should_translate_uppercase_g_to_scroll_to_bottom() {
+        // Distinct from single-key lowercase `g` (`PendingGoto`, tested
+        // above): `G` is a one-key gesture, not the leader of a sequence.
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = translate_key(KeyCode::Char('G'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ScrollToBottom), actual);
     }
 
     fn candidate(id: &str, name: &str, path: &str) -> app::JumpCandidate {

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -191,7 +191,7 @@ fn run_app(
     // (ADR 0026) can size its step against the same viewport the reviewer
     // just saw — the very first keypress before any frame has drawn (a
     // near-impossible edge case, but guarded rather than defaulting to a
-    // zero step) falls back to [`DEFAULT_SOURCE_VIEWPORT_HEIGHT`].
+    // zero step) falls back to [`DEFAULT_SCROLL_VIEWPORT_HEIGHT`].
     let mut last_scroll_viewport_height: Option<usize> = None;
 
     loop {
@@ -270,7 +270,7 @@ fn run_app(
                     (app.screen(), source_content.as_ref())
                 {
                     let viewport_height =
-                        last_scroll_viewport_height.unwrap_or(DEFAULT_SOURCE_VIEWPORT_HEIGHT);
+                        last_scroll_viewport_height.unwrap_or(DEFAULT_SCROLL_VIEWPORT_HEIGHT);
                     let (start, _end) = source::visible_window(
                         highlighted.view.lines.len(),
                         highlighted.view.highlight_start,
@@ -292,7 +292,7 @@ fn run_app(
                 // lives here.
                 app = app.handle_key(input_key);
                 let viewport_height =
-                    last_scroll_viewport_height.unwrap_or(DEFAULT_SOURCE_VIEWPORT_HEIGHT);
+                    last_scroll_viewport_height.unwrap_or(DEFAULT_SCROLL_VIEWPORT_HEIGHT);
                 app = app.handle_scroll_key(input_key, viewport_height);
             } else {
                 // Every non-`Source` key's dispatch is pure (no IO), so it
@@ -362,7 +362,7 @@ fn run_app(
 /// 24-row terminal) rather than a 0-line no-op. Not user-visible past this
 /// one edge; the very next frame's `DrawOutcome::scroll_viewport_height`
 /// replaces it with the real inner-pane height.
-const DEFAULT_SOURCE_VIEWPORT_HEIGHT: usize = 24;
+const DEFAULT_SCROLL_VIEWPORT_HEIGHT: usize = 24;
 
 /// Whether `input_key` is one of ADR 0026's four scroll variants — the
 /// ones [`run_app`] routes through [`App::handle_scroll_key`] (which needs

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -15,7 +15,7 @@ use crate::diff_shape::DiffSection;
 use crate::diff_view::{DiffLine, DiffLineKind};
 use crate::highlight::{self, HighlightedFile, PALETTE, TokenSpan};
 use crate::row_view::{entry_row_line, relative_labels};
-use crate::source::{HighlightedSourceView, SourceView, visible_window};
+use crate::source::{HighlightedSourceView, SourceView};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -52,17 +52,44 @@ use unicode_width::UnicodeWidthChar;
 /// the overlay is open or not, and the overlay is simply composited over
 /// it as a final step.
 ///
-/// Returns the right-hand pane's scroll offset as actually clamped and
-/// rendered this frame (`None` on [`Screen::Source`], which scrolls via its
-/// own auto-centering window rather than `App::right_pane_scroll`, or when
-/// the active right pane rendered a placeholder with nothing to scroll —
-/// `draw_entry_screen`'s own doc comment). `crate::run_app` feeds this back
-/// into `App` (`App::with_right_pane_scroll`) after every draw so an
-/// overshot scroll request (dogfooding finding: repeated `j` past the
-/// content's end used to keep incrementing `App`'s unclamped "requested"
-/// scroll with no visible effect, so winding back down again took as many
-/// `k` presses as it took to overshoot) never survives past the frame that
-/// visibly clamped it.
+/// Everything [`crate::run_app`] needs to fold back into `App` after each
+/// draw: the pane-scroll actually rendered this frame (so an overshot
+/// request never survives past the visible clamp) and the inner height of
+/// the currently-scrolling pane (so the next `Ctrl-d`/`Ctrl-u` half-page
+/// step, ADR 0026, can be sized against the real viewport rather than a
+/// magic constant).
+///
+/// Both fields are `Option<usize>` because a given frame may not have
+/// anything to fold back at all — no right pane on [`Screen::Source`],
+/// no scrolling pane at all when the tree has focus, etc. `crate::run_app`
+/// treats each `None` as "nothing to update on that seam this frame",
+/// mirroring the pre-existing single-`Option<usize>` return this replaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DrawOutcome {
+    /// The right-hand pane's scroll offset as actually clamped and
+    /// rendered this frame (`None` on [`Screen::Source`], which scrolls
+    /// via its own `Screen::Source::scroll_top` rather than
+    /// `App::right_pane_scroll`, or when the active right pane rendered
+    /// a placeholder with nothing to scroll — `draw_entry_screen`'s own
+    /// doc comment). `crate::run_app` feeds this back into `App`
+    /// (`App::with_right_pane_scroll`) after every draw so an overshot
+    /// scroll request (dogfooding finding: repeated `j` past the
+    /// content's end used to keep incrementing `App`'s unclamped
+    /// "requested" scroll with no visible effect, so winding back down
+    /// again took as many `k` presses as it took to overshoot) never
+    /// survives past the frame that visibly clamped it.
+    pub clamped_right_pane_scroll: Option<usize>,
+    /// The inner height (borders excluded) of whichever pane is currently
+    /// scrollable — the source pane on [`Screen::Source`], the right pane
+    /// on [`Screen::Entry`] + [`crate::app::Focus::Right`], and `None`
+    /// otherwise (Tree-focused on the entry view has no scrollable pane
+    /// receiving motion). `crate::run_app` remembers this between frames
+    /// and passes it into [`crate::app::App::handle_scroll_key`] when a
+    /// half-page (ADR 0026) key arrives, so the step size scales with
+    /// the actual pane rather than a magic constant.
+    pub scroll_viewport_height: Option<usize>,
+}
+
 pub fn draw(
     frame: &mut Frame,
     app: &App,
@@ -71,24 +98,49 @@ pub fn draw(
     diff_highlights: &[HighlightedFile],
     blast_radius_selection: &BlastRadiusSelection,
     source_content: Option<&Result<HighlightedSourceView, String>>,
-) -> Option<usize> {
+) -> DrawOutcome {
     let area = frame.area();
     let [body, status_area] =
         Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(area);
 
-    let clamped_scroll = match app.screen() {
-        Screen::Entry => draw_entry_screen(
-            frame,
-            app,
-            report,
-            diff_content,
-            diff_highlights,
-            blast_radius_selection,
-            body,
-        ),
-        Screen::Source { symbol_id } => {
-            draw_source_screen(frame, symbol_id, source_content, body);
-            None
+    let outcome = match app.screen() {
+        Screen::Entry => {
+            let clamped = draw_entry_screen(
+                frame,
+                app,
+                report,
+                diff_content,
+                diff_highlights,
+                blast_radius_selection,
+                body,
+            );
+            // Right-pane inner height (borders excluded), computed the
+            // same way `draw_entry_screen`'s split does when it actually
+            // renders — mirrored here so the scroll pipeline sees the
+            // very same viewport the reviewer just saw. Only reported
+            // while `Focus::Right` (the only state where scroll keys
+            // apply to the right pane); a Tree-focused frame has no
+            // scrolling pane to size, so returns `None`.
+            let scroll_viewport_height = if app.focus() == crate::app::Focus::Right {
+                Some(right_pane_viewport_height(body))
+            } else {
+                None
+            };
+            DrawOutcome {
+                clamped_right_pane_scroll: clamped,
+                scroll_viewport_height,
+            }
+        }
+        Screen::Source {
+            symbol_id,
+            scroll_top,
+        } => {
+            let inner_height = body.height.saturating_sub(2) as usize;
+            draw_source_screen(frame, symbol_id, *scroll_top, source_content, body);
+            DrawOutcome {
+                clamped_right_pane_scroll: None,
+                scroll_viewport_height: Some(inner_height),
+            }
         }
     };
 
@@ -101,8 +153,32 @@ pub fn draw(
         draw_jump_popup(frame, popup, area);
     }
 
-    clamped_scroll
+    outcome
 }
+
+/// The right pane's inner height (borders excluded), computed from `body`
+/// (the entry screen's full body area) using the same 60/40 horizontal
+/// split and `saturating_sub(2)` border deduction [`draw_entry_screen`]
+/// itself uses (`ENTRY_TREE_WIDTH_PERCENT`/`ENTRY_RIGHT_WIDTH_PERCENT`
+/// below, referenced both here and there so the two never drift).
+/// Extracted so [`DrawOutcome`]'s `scroll_viewport_height` reflects the
+/// exact viewport a reviewer just saw.
+fn right_pane_viewport_height(body: Rect) -> usize {
+    let [_, right] = Layout::horizontal([
+        Constraint::Percentage(ENTRY_TREE_WIDTH_PERCENT),
+        Constraint::Percentage(ENTRY_RIGHT_WIDTH_PERCENT),
+    ])
+    .areas(body);
+    right.height.saturating_sub(2) as usize
+}
+
+/// Tree-pane / right-pane horizontal split percentages for [`Screen::Entry`],
+/// shared between [`draw_entry_screen`]'s actual layout and
+/// [`right_pane_viewport_height`]'s report of that layout to
+/// [`DrawOutcome::scroll_viewport_height`] (ADR 0026) so the two cannot
+/// drift.
+const ENTRY_TREE_WIDTH_PERCENT: u16 = 60;
+const ENTRY_RIGHT_WIDTH_PERCENT: u16 = 40;
 
 /// Draws the `?` help overlay (ADR 0020) centered over `full_area`: a
 /// bordered box roughly 70% of the frame's width/height (capped so it
@@ -257,8 +333,11 @@ fn draw_entry_screen(
     blast_radius_selection: &BlastRadiusSelection,
     area: Rect,
 ) -> Option<usize> {
-    let [tree_area, right_area] =
-        Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)]).areas(area);
+    let [tree_area, right_area] = Layout::horizontal([
+        Constraint::Percentage(ENTRY_TREE_WIDTH_PERCENT),
+        Constraint::Percentage(ENTRY_RIGHT_WIDTH_PERCENT),
+    ])
+    .areas(area);
 
     draw_tree_pane(frame, app, tree_area);
     match app.right_pane() {
@@ -1288,9 +1367,18 @@ fn detail_lines(detail: &DetailView) -> Vec<Line<'static>> {
 /// idle poll tick too — the exact per-frame-recompute bug ADR 0018 already
 /// had to fix once for the diff pane, `crate::run_app`'s own doc comment on
 /// `diff_highlights`), this screen now only re-renders the already-computed
-/// `source_content` — including its windowing (`visible_window` below),
-/// which is cheap enough to stay per-frame and keeps the view correctly
-/// centered across a terminal resize without needing a new key event.
+/// `source_content`.
+///
+/// `scroll_top` (ADR 0026) is the reviewer's requested 0-based first-visible
+/// line — an unclamped value stored in [`Screen::Source::scroll_top`] that
+/// this function clamps against the file's actual line count and the pane's
+/// rendered height at draw time (`scroll_top.min(max_start)`). The initial
+/// value, set by `crate::run_app` when the `s` key opens this screen, is
+/// [`crate::source::visible_window`]'s centered start so the first frame
+/// still shows the symbol's definition centered in the viewport; subsequent
+/// motion keys move `scroll_top` away from that starting position.
+/// [`InputKey::ScrollToBottom`]'s `usize::MAX` sentinel folds cleanly through
+/// this same clamp — no per-variant special case needed here.
 ///
 /// `source_content` is `None` only when `crate::run_app` has not yet reached
 /// the point of computing it (defensive — `draw`'s own `Screen::Source` arm
@@ -1299,6 +1387,7 @@ fn detail_lines(detail: &DetailView) -> Vec<Line<'static>> {
 fn draw_source_screen(
     frame: &mut Frame,
     symbol_id: &str,
+    scroll_top: usize,
     source_content: Option<&Result<HighlightedSourceView, String>>,
     area: Rect,
 ) {
@@ -1331,16 +1420,33 @@ fn draw_source_screen(
     let source = &highlighted.view;
 
     let viewport_height = area.height.saturating_sub(2) as usize; // borders
-    let (start, end) = visible_window(
-        source.lines.len(),
-        source.highlight_start,
-        source.highlight_end,
-        viewport_height,
-    );
+    let (start, end) = clamped_window(source.lines.len(), scroll_top, viewport_height);
 
     let lines = source_lines(source, &highlighted.token_highlights, start, end);
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
+}
+
+/// Clamps a reviewer-requested `scroll_top` (ADR 0026) against a file of
+/// `total_lines` shown in a viewport `viewport_height` rows tall, returning
+/// the 0-based half-open `[start, end)` slice to render. Handles the two
+/// edge cases the source screen actually hits:
+///
+/// - `total_lines < viewport_height` — the whole file fits, so `start = 0`
+///   regardless of the requested `scroll_top`.
+/// - `scroll_top` past the end of the file (either a real overshoot from
+///   repeated `j`, or [`crate::app::InputKey::ScrollToBottom`]'s `usize::MAX`
+///   sentinel itself) — folded down to `total_lines - viewport_height` so
+///   the last line still lands at the bottom of the pane rather than
+///   scrolling off it.
+fn clamped_window(total_lines: usize, scroll_top: usize, viewport_height: usize) -> (usize, usize) {
+    if total_lines == 0 || viewport_height == 0 {
+        return (0, 0);
+    }
+    let max_start = total_lines.saturating_sub(viewport_height);
+    let start = scroll_top.min(max_start);
+    let end = (start + viewport_height).min(total_lines);
+    (start, end)
 }
 
 /// Background tint for a source-screen line inside the drilled-into symbol's
@@ -1434,15 +1540,17 @@ fn status_line_text(app: &App) -> String {
                     "j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
                 }
                 crate::app::Focus::Right if app.right_pane() == crate::app::RightPane::Diff => {
-                    "j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
+                    "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  ]/[: next/prev hunk  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
                 }
                 crate::app::Focus::Right => {
-                    "j/k: scroll  h/esc: back  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
+                    "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
                 }
             };
             format!("order: {order}  |  {keys}")
         }
-        Screen::Source { .. } => "esc/q: back".to_string(),
+        Screen::Source { .. } => {
+            "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  esc/q: back".to_string()
+        }
     };
 
     match app.status() {
@@ -1691,7 +1799,17 @@ mod tests {
     fn should_draw_help_overlay_with_keymap_and_glossary_when_help_is_open() {
         let report = report_with_one_symbol();
         let app = App::new(&report).handle_key(crate::app::InputKey::ToggleHelp);
-        let mut terminal = Terminal::new(TestBackend::new(100, 40)).expect("terminal");
+        // A 100x50 terminal (up from 100x40 before ADR 0026) so the
+        // overlay's 80% x 90% area (about 80x45 inner) fits every keymap
+        // group *and* the trailing Glossary section without the last
+        // section being pushed off the bottom. ADR 0026 added the
+        // "Source view" group and three extra "Right focus" entries
+        // (gg/G, Ctrl-d/u), which grew the pre-glossary content past
+        // the old 36-row overlay ceiling. Grown here rather than
+        // narrowing the keymap itself since discoverability of the new
+        // bindings is the whole point of adding them to the overlay in
+        // the first place.
+        let mut terminal = Terminal::new(TestBackend::new(100, 50)).expect("terminal");
 
         terminal
             .draw(|frame| {
@@ -1711,6 +1829,7 @@ mod tests {
         assert!(text.contains("Help"));
         assert!(text.contains("Tree focus"));
         assert!(text.contains("Right focus"));
+        assert!(text.contains("Source view"));
         assert!(text.contains("Global"));
         assert!(text.contains("Glossary"));
         assert!(text.contains("blast radius"));
@@ -3414,7 +3533,7 @@ index e69de29..4b825dc 100644
         let actual = status_line_text(&app);
 
         assert_eq!(
-            "order: topological  |  j/k: scroll  h/esc: back  ]/[: next/prev hunk  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
+            "order: topological  |  j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  ]/[: next/prev hunk  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
                 .to_string(),
             actual
         );
@@ -3435,17 +3554,20 @@ index e69de29..4b825dc 100644
         let actual = status_line_text(&app);
 
         assert_eq!(
-            "order: topological  |  j/k: scroll  h/esc: back  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
+            "order: topological  |  j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
                 .to_string(),
             actual
         );
     }
 
     #[test]
-    fn should_show_back_hint_only_on_source_screen_regardless_of_focus() {
+    fn should_show_source_view_scroll_hints_on_source_screen_regardless_of_focus() {
         // The source screen is reached only via the dedicated `s` key
         // (`InputKey::Source`) now, not `Enter` — a dogfooding fix to
         // `InputKey::Open`'s own arm (see its doc comment in `crate::app`).
+        // ADR 0026 adds this screen's own scroll bindings to the status
+        // line so the reviewer can discover them without opening the
+        // help overlay first.
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(crate::app::InputKey::Down)
@@ -3453,7 +3575,10 @@ index e69de29..4b825dc 100644
 
         let actual = status_line_text(&app);
 
-        assert_eq!("esc/q: back".to_string(), actual);
+        assert_eq!(
+            "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  esc/q: back".to_string(),
+            actual
+        );
     }
 
     #[test]
@@ -3667,7 +3792,7 @@ index e69de29..4b825dc 100644
         );
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
-        let mut actual = None;
+        let mut actual = DrawOutcome::default();
         terminal
             .draw(|frame| {
                 actual = draw(
@@ -3682,26 +3807,37 @@ index e69de29..4b825dc 100644
             })
             .expect("draw");
 
-        assert!(actual.is_some());
+        let clamped = actual
+            .clamped_right_pane_scroll
+            .expect("right pane rendered scrollable content, so a clamped offset must be reported");
         assert!(
-            actual.unwrap() < app.right_pane_scroll(),
+            clamped < app.right_pane_scroll(),
             "clamped scroll must be strictly less than the overshot request"
         );
     }
 
     #[test]
-    fn should_return_none_from_draw_when_the_source_screen_is_open() {
-        // The source screen scrolls via its own auto-centering window, not
-        // `App::right_pane_scroll` (`ui::draw`'s own doc comment) — `draw`
-        // must not report a clamped offset for `crate::run_app` to fold
-        // back in that case.
+    fn should_report_none_clamped_scroll_but_source_viewport_height_when_source_screen_is_open() {
+        // ADR 0026: the source screen scrolls via its own
+        // `Screen::Source::scroll_top`, not `App::right_pane_scroll`, so
+        // `DrawOutcome::clamped_right_pane_scroll` must stay `None` on this
+        // screen (otherwise `crate::run_app`'s
+        // `clamp_right_pane_scroll_after_draw` would fold a source-screen
+        // offset back into the wrong field). At the same time the source
+        // pane's inner height must be surfaced via
+        // `scroll_viewport_height` — otherwise `Ctrl-d`/`Ctrl-u`/`G` from
+        // the source screen would have no viewport to size their step
+        // against, defaulting to `DEFAULT_SOURCE_VIEWPORT_HEIGHT`.
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(crate::app::InputKey::Down)
             .handle_key(crate::app::InputKey::Source);
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
-        let mut actual = Some(999); // sentinel: must be overwritten to None
+        let mut actual = DrawOutcome {
+            clamped_right_pane_scroll: Some(999),
+            scroll_viewport_height: None,
+        };
         terminal
             .draw(|frame| {
                 actual = draw(
@@ -3716,7 +3852,14 @@ index e69de29..4b825dc 100644
             })
             .expect("draw");
 
-        assert_eq!(None, actual);
+        assert_eq!(None, actual.clamped_right_pane_scroll);
+        // A 20-row terminal with a 1-row status line leaves 19 rows for
+        // the body; the source pane's bordered box takes 2 of them,
+        // leaving 17 rows inside. Pinned exactly (rather than a range)
+        // so a future layout refactor that silently changes the split
+        // is caught, matching the specificity `ADR 0020`'s own
+        // `right_pane_viewport_height` shares with `draw_entry_screen`.
+        assert_eq!(Some(17), actual.scroll_viewport_height);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements ADR 0026: reviewer-controlled scrolling on the TUI source
drill-down (`s` key) and on the entry-view right pane while
`Focus::Right`.

- `j`/`k` (arrows) scroll by one line
- `Ctrl-d`/`Ctrl-u` scroll by half a viewport
- `gg`/`G` jump to the top/bottom

`gg` piggybacks on ADR 0022's existing `g`-prefix resolver so it never
collides with `gd`/`gr`; `Ctrl-d` is resolved *before* the plain `d`
arm in `translate_key` so it does not silently rebind to the
`ToggleDiff` gesture.

The source screen's initial position is unchanged — `run_app`
back-fills `Screen::Source::scroll_top` with the same centered start
`crate::source::visible_window` already computes, so the first frame
after `s` still opens on the symbol. Subsequent motion keys scroll
away from that position; there is no auto-recentering (fighting the
reviewer who is deliberately reading elsewhere is the "wrong end of
the design space" ADR 0026's Context calls out).

## Design decisions worth pointing at during review

- `ui::draw` now returns `DrawOutcome { clamped_right_pane_scroll,
  scroll_viewport_height }` — extends the pre-existing
  clamp-at-draw seam so `Ctrl-d`'s half-page step is sized against
  the actual pane rather than a magic constant.
- `App::handle_scroll_key(key, viewport_height)` is a small second
  entry point on `App`, called only for the four new `InputKey`
  variants — the other ~20 variants don't pay a `viewport_height`
  plumbing cost for a feature that doesn't concern them.
- `usize::MAX` sentinel for `ScrollToBottom` folds through
  `ui::clamped_window`'s `min(max_start)` step cleanly, so no
  additional `Screen::Source`/`RightPane` state variants are needed.

## Test plan

- [x] `make test` — 460 tests in `rinkaku-tui`, 336 in `rinkaku-core`,
  161 in `rinkaku` (all green).
- [x] `make lint` — `cargo fmt --all --check` + `cargo clippy
  --all-targets --all-features -- -D warnings` clean.
- [x] New ADR-0026 contract explicitly pinned:
  - `translate_key` gains tests for `Ctrl-d`, `Ctrl-u`, second-`g`-in-
    prefix → `ScrollToTop`, and `G` → `ScrollToBottom`.
  - `App::handle_key`'s Source-screen `Up`/`Down` arms tested for
    scroll delta and `saturating_sub` at 0.
  - `App::handle_scroll_key` tested per (screen, focus, key) matrix,
    including the `Focus::Tree` no-op and the `usize::MAX` sentinel.
  - `ui::draw` reports `scroll_viewport_height` for the source pane
    (test in `ui.rs`).
- [ ] Dynamic verification in a real terminal (out of scope for this
  automated PR run — needs a human at a live TTY): press `s` on a
  symbol row, then verify each of `j`/`k`/`Ctrl-d`/`Ctrl-u`/`gg`/`G`
  moves the source pane's scroll offset visibly, and that reopening
  `s` on the same row re-centers on the definition. Same on the
  entry view's right pane while `Focus::Right` (both Diff and
  Detail).

## Dogfooding notes

- `rinkaku`'s own map (running the merged-`main` binary against this
  branch's diff) flags `enum InputKey` as the top hotspot — expected,
  since the change adds four variants used by both `translate_key`
  and both `App` entry points. Every new variant has a translate-key
  test and either a `handle_key` or `handle_scroll_key` test; the
  hotspot is not code coverage debt.
- Independent review pass (map-free, line-level) confirmed the
  two-step dispatch (`handle_key` → `handle_scroll_key`),
  `preserve_scroll` list, `is_scroll_input_key` predicate,
  `usize::MAX` sentinel folding, and the shared
  `ENTRY_TREE_WIDTH_PERCENT`/`ENTRY_RIGHT_WIDTH_PERCENT` constants
  are all correct. No correctness bugs found; 3 nit-level suggestions
  will be addressed in follow-up commits on this PR.
- Experiment 0001 round 017 write-up will be added in a follow-up
  commit here once dynamic verification is done in a live terminal.