### PR TITLE
docs: restructure README around TUI and GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,53 +2,32 @@
 
 > rinkaku (輪郭, "outline" in Japanese)
 
-A CLI that condenses large PR diffs — especially LLM-generated ones — into
-just the **signatures of changed symbols and their dependencies**, so
-reviewers and LLMs can grasp the API surface of a change without reading
-every implementation line.
+**A map of what a PR changes** — browse it interactively in your terminal,
+or read it inline in the PR itself as a mermaid graph.
 
-## What it is
+For any pull request rinkaku picks out the *changed symbols* (and their
+1-hop dependencies), turns them into a compact call/dependency graph, and
+renders that graph two ways:
 
-- **Input**: a unified diff via stdin (`gh pr diff 123 | rinkaku`),
-  `rinkaku --base main` to run `git diff` internally, or
-  `rinkaku --pr 123` to review a GitHub PR directly. In `--base` mode,
-  file contents are read via `git show <head>:<path>` so extraction always
-  matches the diffed commit, regardless of the working tree's state.
-  `--pr` mode resolves the PR's base and head via `gh pr view`, fetches
-  both, and reuses the same `git show`-backed read strategy as `--base`
-  (see [ADR 0004](docs/adr/0004-pr-input-mode-via-gh-in-local-clone.md)).
-  A bare PR number requires running inside a local clone of the target
-  repository; a URL also works from any directory, preferring an existing
-  [ghq](https://github.com/x-motemen/ghq)-managed clone when one matches
-  and otherwise auto-cloning a blobless copy into a cache (see
-  [ADR 0005](docs/adr/0005-auto-clone-into-cache-for-pr-urls.md) and
-  [ADR 0006](docs/adr/0006-prefer-ghq-managed-clones-over-cache.md)). `gh`
-  must be installed and authenticated either way. In
-  stdin mode, file contents are read off the working tree, which assumes
-  **the piped diff is consistent with the current working tree** (e.g. it
-  was just produced by `git diff` or already applied); a stale or
-  unrelated diff piped via stdin can produce misaligned line numbers.
-- **Core**: tree-sitter parses the changed files, finds the definitions
-  that contain changed lines, and slices out their signatures.
-- **Dependency expansion**: each changed symbol is expanded one hop out to
-  the definitions it references, via tree-sitter tags queries (v1).
-  LSP-based resolvers (pyright, gopls, etc.) are a pluggable extension
-  point (`Resolver` trait) planned for a later release. Same-name matches
-  are ranked by path proximity to the referencing file and capped at 3 to
-  keep "Depends on" readable; see Known limitations below.
-- **Languages (v1, built-in)**: Rust, Go, Python, TypeScript. Each is a
-  `LanguageSupport` trait implementation (grammar crate + tags query +
-  signature-slicing rule), so language support is additive.
-- **Output**: Markdown or JSON, designed to be fed to an LLM or read by a
-  human reviewer.
+1. **[Interactive TUI](#interactive-tui-recommended)** — a terminal-native
+   viewer with a directory tree, a diff pane, and a "blast radius" pane
+   for asking "if this changes, what does it reach?" Built for humans
+   reading a PR before diving into files.
+2. **[GitHub Action](#github-action)** — a composite action that posts (or
+   updates) a sticky PR comment with a mermaid graph rendered natively by
+   GitHub, plus the full signature outline collapsed underneath.
 
-See [`docs/adr/`](docs/adr) for the reasoning behind these choices.
+Both are backed by the same core: tree-sitter-based extraction of changed
+symbols, 1-hop dependency expansion, and structural summarizers
+(hotspots, contract markers, entry-point trees, blast radius). Rust, Go,
+Python, and TypeScript are supported out of the box.
 
 ## Status
 
 Early development. Diff parsing, tree-sitter extraction, the CLI
-(stdin/`--base`/`--pr` input, Markdown/JSON output), and 1-hop dependency
-expansion (`--deps`, the tags-based `Resolver`) are implemented.
+(stdin/`--base`/`--pr` input, Markdown/JSON/Mermaid output), 1-hop
+dependency expansion (`--deps`, the tags-based `Resolver`), the
+interactive TUI (`--tui`), and the GitHub Action are all implemented.
 
 ## Installation
 
@@ -111,68 +90,284 @@ By default this prompts for confirmation before installing. Pass `--yes`
 rinkaku self-update --yes
 ```
 
-When stdin is not a terminal (e.g. run from a script or CI) and `--yes` is
-not given, `self-update` refuses to run rather than silently proceeding.
+When stdin is not a terminal (e.g. run from a script or CI) and `--yes`
+is not given, `self-update` refuses to run rather than silently
+proceeding.
 
-## Usage
+## Interactive TUI (recommended)
+
+The TUI is the intended path for humans reading a PR
+([ADR 0015](docs/adr/0015-tui-for-humans-markdown-for-machines.md));
+it's built with [ratatui](https://ratatui.rs)
+([ADR 0016](docs/adr/0016-tui-crate-and-stack.md)) and follows a
+neovim-style focus model
+([ADR 0020](docs/adr/0020-tui-interaction-model-v2.md)).
 
 ```sh
-# Bare invocation, run interactively inside a repository: no diff
-# involved, opens the TUI with a whole-repo outline — every symbol and
-# its dependency structure, for onboarding or architecture review
-# (see ADR 0017)
+# Whole-repo outline — bare invocation opens the TUI on an interactive
+# terminal (ADR 0017), useful for onboarding or architecture review
 rinkaku
 
-# Same whole-repo outline, printed as Markdown instead of opening the TUI
-# (this also happens automatically whenever stdout isn't a terminal, e.g.
-# `rinkaku > outline.md`)
-rinkaku --format md
+# A PR by number (inside a local clone of the target repository)
+rinkaku --pr 123 --tui
 
-# From a GitHub PR (stdin, no local clone required)
-gh pr diff 123 | rinkaku
+# A PR from any directory (URL form; auto-picks an existing ghq clone or
+# auto-clones a blobless copy into a cache — see ADR 0005/0006)
+rinkaku --pr https://github.com/octocat/hello-world/pull/123 --tui
 
-# From a GitHub PR by number: run inside a local clone of the target
-# repository (fetches the PR via `gh`/`git`; requires `gh` installed and
-# authenticated)
-rinkaku --pr 123
+# A local git diff against a base branch
+rinkaku --base main --tui
 
-# From a GitHub PR URL: works from any directory. If the cwd isn't already
-# a clone of that repository, rinkaku prefers an existing ghq-managed
-# clone (see ADR 0006) when ghq is installed, else auto-clones a blobless
-# copy into $RINKAKU_CACHE_DIR / $XDG_CACHE_HOME/rinkaku / ~/.cache/rinkaku
-# and runs there instead (see ADR 0005). Private repos need
-# `gh auth setup-git` so later `git fetch`s can authenticate too.
-rinkaku --pr https://github.com/octocat/hello-world/pull/123
-
-# From a local git diff against a base branch
-rinkaku --base main
-
-# JSON output for feeding into another tool or LLM
-rinkaku --base main --format json
-
-# A human-oriented call/dependency graph as a mermaid flowchart (ADR
-# 0021) — opt-in, meant for pasting into a GitHub PR comment/description
-# where mermaid renders natively, not for piping into an LLM
-rinkaku --base main --format mermaid
-
-# Skip dependency resolution (faster, no repo-wide index — see below)
-rinkaku --base main --deps 0
+# Diff piped in from anywhere (keyboard input is read from the
+# controlling terminal independently of stdin — ADR 0016)
+gh pr diff 123 | rinkaku --tui
 ```
 
-### What it looks like
+`--tui` replaces `--format`, so the two conflict rather than combining.
 
-All examples below are captured from the `cargo build --release` binary
-post-[ADR 0008](docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md)
-(entry-point tree rendering) and
-[ADR 0012](docs/adr/0012-condense-change-graph-rendering.md)
-(condensed rendering), not fabricated. The example diff below
-touches no test symbols and no generated files, so it renders the same
-with or without the defaults introduced in
-[ADR 0009](docs/adr/0009-exclude-test-symbols-from-output-by-default.md),
-[ADR 0010](docs/adr/0010-skip-files-marked-no-diff-or-generated-in-gitattributes.md),
-and [ADR 0011](docs/adr/0011-detect-generated-files-by-content-markers.md)
-— see `--exclude-tests`/`--include-generated` below for what changes when a
-diff does touch test symbols or generated files.
+### Layout
+
+The screen is split into a **tree pane** on the left and one of three
+**right-hand panes**:
+
+- **Tree pane** — a directory tree of *changed files* (not the call
+  graph), so nesting mirrors your repository layout. Rows carry badges:
+  `~N` changed symbols, `!N` contract changes (added/removed/signature-
+  changed), `^N` fan-in (hotspot aggregate). Directories that
+  participate in a dependency cycle are marked `(cycle)`. Sibling
+  directories default to topological order — entry points (least
+  depended-on) first, foundations last — with `o` to toggle plain
+  alphabetical order. Symbol rows show a kind abbreviation (`fn`,
+  `struct`, ...) and a classification marker: `+` added, `~`
+  signature-changed, `x` removed (dimmed, crossed out). Files rinkaku
+  couldn't analyze (unsupported language, binary, deleted) still
+  appear, dimmed and marked `(skipped: <reason>)`; a file whose changes
+  were entirely test code shows up as `[test] (N symbols)` (ADR 0009).
+- **Diff pane (default right pane)** — the raw unified-diff hunks
+  touching the selected row. Symbol rows clip to that symbol's line
+  range; file rows group hunks under per-symbol section headers, with
+  import-only hunks collected under a trailing `(module level)`
+  section. When a symbol's signature itself changed, a 2-line old/new
+  header (`- <old>` / `+ <new>`) precedes its hunks. Hunks in the four
+  built-in languages are syntax-highlighted
+  ([ADR 0018](docs/adr/0018-syntax-highlight-tui-diff-pane.md));
+  added/removed lines keep their green/red diff signal as a background
+  tint so it doesn't compete with token colors. Any other file falls
+  back to plain green/red text.
+- **Detail pane** (`d`) — what the cursor is on. A symbol row shows its
+  classification, signature (an old/new diff when the contract
+  changed), who depends on it ("used by"), and its callees. A file row
+  shows every symbol changed in that file. A directory row shows its
+  badge breakdown, top fan-in symbols, and — when it participates in a
+  dependency cycle — exactly which other directories it cycles with and
+  the concrete symbol-to-symbol edges forming that cycle.
+- **Blast radius pane** (`r`) — an entry-tree view rooted at the
+  directory or file row under the cursor: *"if this changes, what does
+  it reach?"* The interactive equivalent of the CLI's `--entry <path>`
+  ([ADR 0019](docs/adr/0019-entry-path-pivot-view.md), named per
+  [ADR 0023](docs/adr/0023-tui-blast-radius-naming.md)). The tree
+  follows the cursor: move to a different row and it re-renders rooted
+  at the new path. Nodes reached only past the selected path are
+  dimmed, repeated nodes are marked `(see above)` instead of expanded
+  again, and cycles are marked `(cycle)`.
+
+### Key bindings
+
+Press `?` in the TUI for the always-up-to-date version, grouped by
+focus.
+
+**Tree focus (default):**
+
+| Key(s) | Action |
+| --- | --- |
+| `j` / `k` / `↓` / `↑` | Move the cursor |
+| `enter` | Expand/collapse a directory row, or open a file/symbol row (moves focus right) |
+| `space` | Expand or collapse a directory/file row (never moves focus) |
+| `e` / `E` | Expand every row |
+| `c` / `C` | Collapse every row |
+
+**Right focus (Detail/Diff/Blast-radius pane):**
+
+| Key(s) | Action |
+| --- | --- |
+| `j` / `k` / `↓` / `↑` | Scroll the pane by one line |
+| `h` / `esc` | Return focus to the tree |
+| `]` | Jump to the next hunk (Diff pane only) |
+| `[` | Jump to the previous hunk (Diff pane only) |
+
+**Global (any focus):**
+
+| Key(s) | Action |
+| --- | --- |
+| `o` / `O` | Toggle topological / alphabetical ordering |
+| `d` / `D` | Toggle the right-hand pane between diff and detail |
+| `r` / `R` | Toggle the right-hand pane to the blast radius of the selected directory/file |
+| `s` / `S` | Open the source view for the symbol under the cursor |
+| `gd` | Jump to a callee of the symbol under the cursor ([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md)) |
+| `gr` | Jump to a caller of the symbol under the cursor |
+| `ctrl-o` | Jump back to the previous jumplist location |
+| `ctrl-i` | Jump forward to the next jumplist location |
+| `?` | Toggle the help overlay (keymap + glossary) |
+| `esc` / `q` | Return to the entry view (from the source view) |
+| `q` / `ctrl-c` | Quit (from the entry view) |
+
+Glyphs are plain ASCII (`~`/`!`/`^`/`+`/`x`, `v`/`>` for expand state)
+rather than Unicode/emoji, for compatibility with plainer terminal
+configurations.
+
+### Jump navigation (`gd` / `gr`)
+
+While reading a diff or its detail, `gd` jumps toward a callee of the
+symbol under the cursor and `gr` jumps toward a caller — a two-key
+sequence (press `g` then `d`/`r`), mirroring neovim's own "go to
+definition"/"go to references" idiom
+([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md)). Zero
+candidates shows a status-line note, one candidate jumps immediately,
+and more than one opens a popup (`j`/`k` to choose, `enter` to jump,
+`esc` to cancel). A jump moves the tree cursor to the target symbol —
+expanding any collapsed ancestor directories along the way — and shows
+its Diff, without moving focus off the right pane.
+
+Every jump is recorded in a jumplist: `ctrl-o` returns to where you
+jumped from, and `ctrl-i` moves forward again after a `ctrl-o` — the
+same back/forward history neovim's own jumplist keeps. Jumping to a new
+location from the middle of that history discards whatever forward
+entries existed.
+
+### Source view
+
+`s` on a symbol row opens the file, scrolled to and highlighting the
+symbol's line range; `esc`/`q` returns to the entry view. Reads the
+working tree directly (not the historical commit a `--base`/`--pr`
+diff was computed against), so it always shows the file's current
+content — note that the highlighted line range itself is from analysis
+time, so it can drift (or, if the file has since shrunk, get clamped to
+the end of the file) if you edit the file after opening the TUI.
+
+## GitHub Action
+
+The composite [`action.yaml`](action.yaml) runs rinkaku against a pull
+request's diff and posts (or updates) a sticky PR comment: a
+[`--format mermaid`](#format-mermaid-graph-for-pr-comments)
+call/dependency graph up front — rendered natively by GitHub in the
+comment — with the full Markdown outline collapsed underneath for
+anyone who wants signature-level detail.
+
+```yaml
+name: rinkaku PR report
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      - uses: hiro-o918/rinkaku@main
+        with:
+          github-token: ${{ github.token }}
+```
+
+Inputs: `version` (a release tag to download, default `latest`),
+`binary` (path to an already-built rinkaku binary, skipping the
+download entirely), `repo-path` (the checkout rinkaku should analyze;
+defaults to the current directory), `base` (defaults to the PR's base
+ref), `github-token` (defaults to `github.token`), and `comment` (set
+`false` to skip posting and just get the `mermaid-path`/`markdown-path`
+outputs).
+
+### Trusted-base posture
+
+The snippet above is the simple case (a pinned release binary,
+`permissions: pull-requests: write` scoped to only what posting a
+comment needs). If you build rinkaku yourself instead of using a
+release binary, **build it from the PR's base ref, not the PR head** —
+same rule this repository's own [dogfooding
+workflow](.github/workflows/rinkaku-report.yaml) follows, and for the
+same reason the [LLM-review recipe](#advanced-using-rinkaku-with-llm-reviewers)
+below always builds its map from a trusted checkout: a PR is exactly
+the input an attacker controls, and this job runs with a write token
+before anyone has reviewed it. That workflow checks out the PR's base
+ref at the job's default location (so `uses: ./` resolves *its own
+action code* — not just the binary — from the trusted checkout too)
+and checks out the PR head into a subdirectory purely as data, passed
+to this action via `repo-path`.
+
+**Fork PRs** get a read-only token from the `pull_request` trigger
+regardless of `permissions:` — this action detects that and falls back
+to writing the report into the job's step summary instead of posting a
+comment, so a fork PR's run still succeeds (exit 0) rather than
+failing on a 403.
+
+## CLI reference
+
+The TUI and Action are the recommended entry points, but the same
+analysis is available as plain CLI output — useful for scripting, CI
+gates, custom tooling, or feeding downstream processors.
+
+### Input modes
+
+- **stdin**: `gh pr diff 123 | rinkaku` — file contents are read off
+  the working tree, which assumes the piped diff is consistent with
+  the current working tree (e.g. it was just produced by `git diff`
+  or already applied). A stale or unrelated diff piped via stdin can
+  produce misaligned line numbers.
+- **`--base <ref>`**: `rinkaku --base main` — runs `git diff`
+  internally and reads file contents via `git show <head>:<path>`, so
+  extraction always matches the diffed commit regardless of the
+  working tree's state.
+- **`--pr <number-or-url>`**: `rinkaku --pr 123` or
+  `rinkaku --pr https://github.com/owner/repo/pull/123` — resolves
+  the PR's base and head via `gh pr view`, fetches both, and reuses
+  the same `git show`-backed read strategy as `--base`
+  ([ADR 0004](docs/adr/0004-pr-input-mode-via-gh-in-local-clone.md)).
+  A bare PR number requires running inside a local clone of the
+  target repository; a URL also works from any directory, preferring
+  an existing [ghq](https://github.com/x-motemen/ghq)-managed clone
+  when one matches and otherwise auto-cloning a blobless copy into a
+  cache ([ADR 0005](docs/adr/0005-auto-clone-into-cache-for-pr-urls.md),
+  [ADR 0006](docs/adr/0006-prefer-ghq-managed-clones-over-cache.md)).
+  `gh` must be installed and authenticated. Private repos also need
+  `gh auth setup-git` so later `git fetch`s can authenticate.
+- **Whole-repo (no diff)**: bare `rinkaku` run inside a repository,
+  with stdout piped anywhere — no diff involved, produces an outline
+  of every symbol and its dependency structure
+  ([ADR 0017](docs/adr/0017-whole-repo-outline-as-default-input-mode.md)).
+  On an interactive terminal, bare `rinkaku` opens the TUI instead
+  (same whole-repo outline); pass `--format md` to force Markdown
+  even on a TTY.
+
+### Output formats (`--format`)
+
+```sh
+# Markdown (default when stdout is not a TTY) — designed to be fed to
+# an LLM or read by a human reviewer
+rinkaku --base main --format md
+
+# JSON — structured data for another tool
+rinkaku --base main --format json
+
+# Mermaid — a call/dependency flowchart for pasting into a PR
+# comment/description (ADR 0021), where GitHub renders it natively
+rinkaku --base main --format mermaid
+```
+
+`--tui` is not a `--format` value; it replaces the output stage
+entirely and conflicts with `--format`.
+
+### Markdown output example
 
 Running `rinkaku` on
 [a real rinkaku commit](https://github.com/hiro-o918/rinkaku/commit/aa7ca34)
@@ -221,36 +416,36 @@ fn run_base_pipeline( cli: &Cli, base: &str, head: &str, cwd: Option<&std::path:
 
 ````
 
-The line under the heading summarizes the shape of the change — how many
-symbols changed, across how many files, and (for multi-file diffs) which
-file concentrates most of them, e.g.
+The line under the heading summarizes the shape of the change — how
+many symbols changed, across how many files, and (for multi-file
+diffs) which file concentrates most of them, e.g.
 `16 changed symbols in 3 files — most in store/items.go (11)` — so a
 reviewer sees the epicenter before reading a single tree line.
 
-"Change graph" reads top-down in call-hierarchy order: `main` is the only
-entry point (nothing else changed in this diff calls it), and every
-function it reaches is nested beneath it. `build_resolver` is reachable
-from both `main` and `run_base_pipeline`; it is rendered in full once,
-under `main` (the first place it's reached), and referenced by name only
-(`(see above)`) the second time — so a reviewer never sees the same
-signature twice. When two changed symbols depend on each other (a
-mutual-recursion cycle), the edge that closes the loop is marked
-`⚠️ ... — dependency cycle, see above` instead of being walked into again;
-see [ADR 0008](docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md)
-for the full rationale.
+"Change graph" reads top-down in call-hierarchy order
+([ADR 0008](docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md)):
+`main` is the only entry point, and every function it reaches is
+nested beneath it. `build_resolver` is reachable from both `main` and
+`run_base_pipeline`; it is rendered in full once, under `main` (the
+first place it's reached), and referenced by name only (`(see above)`)
+the second time — so a reviewer never sees the same signature twice.
+When two changed symbols depend on each other (a mutual-recursion
+cycle), the edge that closes the loop is marked
+`⚠️ ... — dependency cycle, see above` instead of being walked into
+again.
 
 Two more condensations
 ([ADR 0012](docs/adr/0012-condense-change-graph-rendering.md)) keep
 request/response-style diffs readable. Changed **data-carrier types**
-(structs/enums/type aliases with no outgoing edges of their own) don't get
-tree lines; they're folded into the line of each symbol that references
-them as a `— uses:` annotation, with their full signatures still listed
-under "Definitions". And an **interface/trait declaration is linked to its
-changed methods** by method-spec name, so the methods nest under the
-interface instead of duplicating it at top level. A Go diff adding an
-`ItemStore` interface, two receiver-method implementations, and four
-request/response structs — 8 changed symbols — renders as just three tree
-lines:
+(structs/enums/type aliases with no outgoing edges of their own) don't
+get tree lines; they're folded into the line of each symbol that
+references them as a `— uses:` annotation, with their full signatures
+still listed under "Definitions". And an **interface/trait declaration
+is linked to its changed methods** by method-spec name, so the methods
+nest under the interface instead of duplicating it at top level. A Go
+diff adding an `ItemStore` interface, two receiver-method
+implementations, and four request/response structs — 8 changed symbols
+— renders as just three tree lines:
 
 ```markdown
 ## Change graph
@@ -262,19 +457,18 @@ lines:
   - fn SaveItem (store.go) — uses: SaveItemRequest, SaveItemResponse, itemStore
 ```
 
-(The "Definitions" section, omitted here, still carries all 8 full
-signatures.)
+Unchanged 1-hop dependencies (ADR 0003) — functions/types the diff
+touches but did not itself change — show up as a `Depends on:` list
+under each definition; they're omitted from the example above
+(`--deps 0`) to keep it focused on the tree shape.
 
-Unchanged 1-hop dependencies (ADR 0003) — functions/types the diff touches
-but did not itself change — still show up as a `Depends on:` list under
-each definition, same as before ADR 0008; they're omitted from the example
-above (`--deps 0`) to keep it focused on the tree shape.
+### JSON output
 
-`--format json` renders the same data as structured JSON instead
+`--format json` renders the same data as structured JSON
 (`{"files": [...], "skipped": [...], "graph": {"nodes", "edges", "roots"}}`),
 for piping into `jq` or another tool. The `graph` field is the same
-call-graph data "Change graph" renders as a tree, so JSON consumers don't
-need to recompute it from `referenced_names`:
+call-graph data "Change graph" renders as a tree, so JSON consumers
+don't need to recompute it from `referenced_names`:
 
 ```sh
 $ git show aa7ca34 --format="" | rinkaku --format json --deps 0 | jq '.graph'
@@ -298,78 +492,47 @@ $ git show aa7ca34 --format="" | rinkaku --format json --deps 0 | jq '.graph'
 }
 ```
 
-Each symbol in `files[].symbols` also carries an `id` field matching its
-`graph` node's `id`, so a consumer can join a symbol's full signature back
-to its position in the graph without recomputing the `{path}::{name}` id
-scheme itself.
+Each symbol in `files[].symbols` also carries an `id` field matching
+its `graph` node's `id`, so a consumer can join a symbol's full
+signature back to its position in the graph without recomputing the
+`{path}::{name}` id scheme itself.
 
 The top-level JSON report also carries `"tests": [{"path", "symbol_count"}]`
-(ADR 0009's per-file test-symbol counts, empty unless the diff touched any)
-and `skipped[].reason` can be `"generated"` (ADR 0010 attribute-based
-detection, or ADR 0011 content-marker detection — both report the same
-reason value) alongside the existing
+(ADR 0009's per-file test-symbol counts, empty unless the diff touched
+any) and `skipped[].reason` can be `"generated"` (ADR 0010
+attribute-based detection, or ADR 0011 content-marker detection — both
+report the same reason value) alongside the existing
 `"unsupported_language"`/`"binary"`/`"deleted"` values.
 
-### When same-name matches are capped
+### `--format mermaid` (graph for PR comments)
 
-On a repository with many same-named definitions, the same-name cap (see
-Known limitations below) shows up directly in the output. Running
-`rinkaku` against [astral-sh/ruff](https://github.com/astral-sh/ruff)
-commit `6237ecb4d` ("[ty] Add progress reporting to workspace
-diagnostics"), a changed `LazyWorkDoneProgress` struct references `Inner`,
-a name defined 14 times across the repo (mostly unrelated Python test
-fixtures and formatter cases named `class Inner`) — the 3 closest matches
-by path proximity are shown, and the rest are reported as a count instead
-of listed in full or silently dropped:
-
-````markdown
-### struct LazyWorkDoneProgress (crates/ty_server/src/server/lazy_work_done_progress.rs)
-
-```
-pub(super) struct LazyWorkDoneProgress { inner: Arc<Inner>, }
-```
-
-Depends on:
-- `crates/ruff_linter/resources/test/fixtures/pyupgrade/UP046_0.py`: `class Inner(Generic[T]): var: T`
-- `crates/ruff_python_formatter/resources/test/fixtures/black/cases/class_methods_new_line.py`: `class Inner: pass`
-- `crates/ruff_python_formatter/resources/test/fixtures/black/cases/class_methods_new_line.py`: `class Inner: """Just a docstring.""" def __init__(self):`
-- (+11 more definitions matched by name)
-````
-
-This same 810-line diff also shows the noise reduction from filtering `_`
-and single-character identifiers out of referenced names entirely (see
-Known limitations): the pre-#9 QA pass on this exact diff found 76 of 188
-"Depends on" lines were unrelated `def _(...)` matches (~40% noise); on
-the current `main`, the same diff produces 384 output lines (up from 295
-pre-ADR-0008 due to the added "Change graph" tree section, and down from
-405 pre-#9) with zero `_`-related entries, since `_` is no longer looked
-up at all.
+`--format mermaid` emits the same call/dependency graph as a mermaid
+flowchart
+([ADR 0021](docs/adr/0021-mermaid-output-format.md)), designed for
+pasting into a GitHub PR comment or description where mermaid renders
+natively. This is the format the [GitHub Action](#github-action) uses
+for the top of its sticky comment.
 
 ### `--deps`
 
-`--deps 1` (the default) resolves each changed symbol's 1-hop dependencies
-by indexing every file `git ls-files` tracks in the repository — this
-makes the output more useful (you see what a changed function calls) but
-costs an up-front repo-wide scan. `TagsResolver::new` prefilters which
-files are worth parsing (skipping any file whose content cannot contain
-any referenced name at all), which helps when referenced names are
-distinctive but has limited effect when they include common
-standard-library-style names (see Known limitations). On the ruff
-`6237ecb4d` diff above, `--deps 1` took ~6.5s post-#9 (down from ~9.5s
-pre-#9) versus ~0.05s for `--deps 0` on the same diff — `--deps 0` skips
-resolution entirely (no "Depends on" sections, no repository scan) and
-remains dramatically faster since indexing cost does not depend on diff
-size. Prefer `--deps 0` for quick iteration or CI checks where the
-dependency context isn't needed.
+`--deps 1` (the default) resolves each changed symbol's 1-hop
+dependencies by indexing every file `git ls-files` tracks in the
+repository — this makes the output more useful (you see what a changed
+function calls) but costs an up-front repo-wide scan. On a large
+diff/repo, `--deps 1` can take several seconds versus ~50ms for
+`--deps 0`. Prefer `--deps 0` for quick iteration or CI checks where
+the dependency context isn't needed. See
+[Known limitations](#known-limitations) for the resolver's precision
+caveats.
 
 ### `--exclude-tests`
 
-By default (see [ADR 0025](docs/adr/0025-default-to-including-tests.md),
-superseding the prior ADR 0009 default), test symbols appear in
-"Change graph"/"Definitions" alongside production symbols, and the
-`## Tests` summary section is omitted — this shape is designed for LLM
-consumers of the Markdown/JSON output, for which "which contracts have
-which tests changed alongside them" is useful signal rather than noise.
+By default ([ADR 0025](docs/adr/0025-default-to-including-tests.md)),
+test symbols appear in "Change graph"/"Definitions" alongside
+production symbols, and the `## Tests` summary section is omitted —
+this shape is designed for LLM consumers of the Markdown/JSON output,
+for which "which contracts have which tests changed alongside them"
+is useful signal rather than noise.
 
 Pass `--exclude-tests` to opt into the previous behavior: test symbols
 are detected per language (Go's `*_test.go`, Python's
@@ -387,36 +550,31 @@ summarized instead as a per-file count under a `## Tests` section:
 
 Under `--exclude-tests`, `TagsResolver`'s repo-wide dependency index
 applies the same exclusion, so a changed production symbol's "Depends
-on:" cannot resolve to a same-named test helper or fixture elsewhere in
-the repo (ADR 0009).
+on:" cannot resolve to a same-named test helper or fixture elsewhere
+in the repo (ADR 0009).
 
 ### `--include-generated`
 
-By default, rinkaku skips generated files two ways, both controlled by this
-one flag:
+By default, rinkaku skips generated files two ways, both controlled by
+this one flag:
 
-- **`.gitattributes`** (see [ADR 0010](docs/adr/0010-skip-files-marked-no-diff-or-generated-in-gitattributes.md)):
-  resolves each changed file's `diff`/`linguist-generated` attributes via
-  `git check-attr` and skips files marked `-diff` or `linguist-generated`.
-  Only applies when a local git repository is available (`--base`, `--pr`,
-  or stdin piped inside a repository); outside a repository, this check
-  does not run.
-- **Content markers** (see [ADR 0011](docs/adr/0011-detect-generated-files-by-content-markers.md)):
-  independent of `.gitattributes`, and doesn't require a git repository —
-  skips a file whose first 5 lines contain a linguist-compatible marker: a
-  `@generated` comment, or a line with both `Code generated` and
-  `DO NOT EDIT` (Go tooling/protobuf's
+- **`.gitattributes`** ([ADR 0010](docs/adr/0010-skip-files-marked-no-diff-or-generated-in-gitattributes.md)):
+  resolves each changed file's `diff`/`linguist-generated` attributes
+  via `git check-attr` and skips files marked `-diff` or
+  `linguist-generated`. Only applies when a local git repository is
+  available.
+- **Content markers** ([ADR 0011](docs/adr/0011-detect-generated-files-by-content-markers.md)):
+  skips a file whose first 5 lines contain a linguist-compatible
+  marker: a `@generated` comment, or a line with both `Code generated`
+  and `DO NOT EDIT` (Go tooling/protobuf's
   `// Code generated by <tool>. DO NOT EDIT.` convention, matched
-  regardless of the comment syntax a language uses). This is what catches
-  generated code in repositories that never configured `.gitattributes` at
-  all and rely on GitHub linguist's own content-based detection instead.
+  regardless of the comment syntax a language uses). Doesn't require a
+  git repository.
 
-Either way, skipped files (lockfiles, generated code — content already
-declared uninteresting to diff-review) are dropped from Markdown output
-silently: they do **not** appear under "Skipped files" at all, since
-listing them as something rinkaku "didn't look at" would just be noise on
-top of what's already known about them. A diff that touches nothing but
-generated files renders as empty Markdown output.
+Either way, skipped files (lockfiles, generated code) are dropped from
+Markdown output silently: they do **not** appear under "Skipped files"
+at all. A diff that touches nothing but generated files renders as
+empty Markdown output.
 
 They do still appear in `--format json`'s `skipped` array, with reason
 `"generated"`, for consumers that want the full picture:
@@ -433,249 +591,65 @@ $ rinkaku --base main --format json | jq '.skipped'
 ```
 
 Pass `--include-generated` to restore the previous behavior (generated
-files — by either detection method — are analyzed like any other file, in
-both output formats).
+files — by either detection method — are analyzed like any other file,
+in both output formats).
 
 ### `--entry <path>`
 
-By default, "Change graph"/"Repository graph" is rooted at auto-detected
-entry points (ADR 0008): symbols nothing else in the graph depends on.
-`--entry <path>` re-roots the tree at a chosen path instead (ADR 0019) —
-entry points become the symbols under `path` that nothing else *under that
-same path* depends on, and dependency trees still expand outward through
-the whole graph as usual. This is a change of vantage point, not a filter:
-symbols outside `path` are neither hidden nor excluded from analysis, only
-no longer eligible to be roots themselves. Useful for carving a reviewable
-viewpoint out of a large or whole-repo graph — e.g. "what does this change
-look like from the API layer":
+By default, "Change graph"/"Repository graph" is rooted at
+auto-detected entry points (ADR 0008): symbols nothing else in the
+graph depends on. `--entry <path>` re-roots the tree at a chosen path
+instead ([ADR 0019](docs/adr/0019-entry-path-pivot-view.md)) — entry
+points become the symbols under `path` that nothing else *under that
+same path* depends on, and dependency trees still expand outward
+through the whole graph as usual. This is a change of vantage point,
+not a filter: symbols outside `path` are neither hidden nor excluded
+from analysis, only no longer eligible to be roots themselves.
 
 ```sh
 rinkaku --base main --entry src/api
 ```
 
-Works with every input mode (stdin / `--base` / `--pr` / whole-repo) and
-combines with `--tui`: the TUI opens with the cursor already on the tree
-row matching `path` and the right-hand pane already showing its Blast
-radius (the `R` binding below) — the interactive session starts exactly
-where `--entry` would have rooted the Markdown/JSON tree, rather than
-requiring you to locate the row and press `R` yourself. If no tree row's
-path matches `path` exactly, the TUI opens normally (cursor on the first
-row, Detail pane) with a status-line note instead.
+Combines with `--tui`: the TUI opens with the cursor already on the
+tree row matching `path` and the right-hand pane already showing its
+Blast radius (the `R` binding). If no tree row's path matches exactly,
+the TUI opens normally with a status-line note instead.
 
-Prints `note: no symbols under <path>` to stderr and renders an empty tree
-when no symbol's path falls under `path`. Fan-in counts (Hotspots, and the
-TUI tree's `^N` badge) stay whole-analysis under `--entry`/the TUI blast-
-radius pane — re-rooting the tree changes the vantage point (which symbols
-count as entry points), not the direction fan-in itself measures, so
-scoping it to the re-rooted subset would misreport how much the rest of
-the repository actually depends on a symbol (see
-[ADR 0019](docs/adr/0019-entry-path-pivot-view.md)'s Consequences; the TUI
-naming itself is [ADR 0023](docs/adr/0023-tui-blast-radius-naming.md)).
+Prints `note: no symbols under <path>` to stderr and renders an empty
+tree when no symbol's path falls under `path`. Fan-in counts remain
+whole-analysis under `--entry` / the TUI blast-radius pane —
+re-rooting the tree changes the vantage point, not the direction
+fan-in itself measures (see
+[ADR 0019](docs/adr/0019-entry-path-pivot-view.md)'s Consequences).
 
-## Interactive TUI
+## Advanced: using rinkaku with LLM reviewers
 
-Markdown/JSON stay optimized for LLMs and CI ([ADR 0015](docs/adr/0015-tui-for-humans-markdown-for-machines.md));
-for a human reviewing a change in a terminal, pass `--tui` instead of
-`--format` to open an interactive terminal UI ([ADR 0016](docs/adr/0016-tui-crate-and-stack.md)),
-built with [ratatui](https://ratatui.rs):
+rinkaku's output can also be handed to an LLM as a "map" before it
+reads a diff. Ten rounds of a paired-arm experiment (see
+[`docs/experiments/0001-map-assisted-llm-review/`](docs/experiments/0001-map-assisted-llm-review/README.md))
+found that the map is a **complement, not a substitute** for a plain
+diff review, and that its measurable value shows up as
+**attention allocation** (routing toward integration seams,
+self-consistency defects, and coverage boundaries) rather than as
+token savings. Neither pass produced a superset of the other's
+findings, and dynamic verification (building and executing the
+changed code, especially against hostile/edge-case inputs) remained
+the strongest single predictor of finding real behavioral defects.
 
-```sh
-rinkaku --base main --tui
-```
+If you still want to run it, the recipe below reflects those
+constraints:
 
-`--tui` takes the same input flow as every other mode (stdin / `--base` /
-`--pr`) and only changes the output stage, so it conflicts with `--format`
-rather than combining with it. Bare `rinkaku`, run on an interactive
-terminal with no `--base`/`--pr`, opens the TUI automatically on a
-whole-repo outline instead of a diff ([ADR 0017](docs/adr/0017-whole-repo-outline-as-default-input-mode.md));
-the diff pane (the default right-hand pane, [ADR 0020](docs/adr/0020-tui-interaction-model-v2.md))
-has nothing to show in that case and renders a placeholder — press `d` to
-switch to the detail pane instead.
-
-The TUI also opens correctly when the diff itself comes from a pipe (e.g.
-`gh pr diff 123 | rinkaku` on a terminal, or the same with `--tui`
-explicit): keyboard input is read from the controlling terminal
-independently of whatever stdin is being used for ([ADR 0016](docs/adr/0016-tui-crate-and-stack.md)'s
-addendum), so a piped diff and interactive navigation are not mutually
-exclusive.
-
-### Interaction model
-
-The interface follows a **focus** model ([ADR 0020](docs/adr/0020-tui-interaction-model-v2.md)),
-similar to neovim's window/pane idioms: at any moment, either the tree
-(left pane) or the right-hand pane has focus, and `j`/`k` act on whichever
-one does. `enter` on a file/symbol row moves focus to the right pane;
-`h`/`esc` moves it back to the tree. `gd`/`gr` jump to a callee/caller of
-the selected symbol and `ctrl-o`/`ctrl-i` move back/forward through a
-jumplist of those jumps, both borrowed from neovim too
-([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md), see
-[Jump navigation](#jump-navigation-gd--gr) below). Press `?` any time for
-an in-app overlay listing every key and a short glossary (order modes,
-blast radius, cycle, jumplist).
-
-### What it shows
-
-- **Entry pane (left):** the directory tree of changed files, not the
-  call-graph tree — nesting depth mirrors your repository's layout.
-  Directories and files carry badges: `~N` changed symbols, `!N` contract
-  changes (added/removed/signature-changed), `^N` fan-in (hotspot
-  aggregate). A directory that participates in a dependency cycle is
-  marked `(cycle)`. By default, sibling directories are ordered
-  topologically — entry points (least depended-on) first, foundations
-  (most depended-on) last — the same shape the "Change graph" root-finding
-  uses in Markdown, condensed to the directory level; `o` toggles to plain
-  alphabetical order. Symbol rows show a kind abbreviation (`fn`, `struct`,
-  ...) and a classification marker: `+` added, `~` signature-changed, `x`
-  removed (dimmed and crossed out). A file rinkaku could not extract
-  symbols from (unsupported language, binary, deleted) still shows up as a
-  dimmed row marked `(skipped: <reason>)`, same reasons as `--format
-  json`'s `skipped[].reason` — the same as Markdown's own "Skipped files"
-  list, `SkipReason::Generated` entries are omitted by default (ADR
-  0010/0011). A file whose changed symbols were *all* test code (ADR 0009)
-  shows up too, marked `[test] (N symbols)`, instead of the pre-existing
-  gap where such a file had no row at all and was only summarized in
-  Markdown's "Tests" section.
-- **Diff pane (right, the default):** the raw unified-diff hunks touching
-  the selected row — "what changed" is what a reviewer wants to see first.
-  A symbol row clips to just its own line range; a file row groups hunks
-  under per-symbol section headers (each symbol's own signature line),
-  with hunks matching no symbol (e.g. import-only changes) collected under
-  a trailing `(module level)` section. When a symbol's signature itself
-  changed, a 2-line old/new header (`- <old>` / `+ <new>`) precedes its
-  hunks. A directory row has no single diff to show, since it spans
-  multiple files. Hunks in the four built-in languages are
-  syntax-highlighted (keywords, strings, types, ...); added/removed lines
-  keep their green/red diff signal as a background tint so it doesn't
-  compete with token colors, and any other file falls back to plain
-  green/red text. `d`/`D` toggles the right-hand pane to the detail view
-  instead.
-- **Detail pane (right):** what the cursor is on. A symbol row shows its
-  classification, signature (an old/new diff when the contract changed),
-  who depends on it ("used by"), and its callees. A file row shows every
-  symbol changed in that file with its classification marker and fan-in —
-  or, for a skipped file, why rinkaku didn't analyze it; or, for a
-  whole-test file, the changed test-symbol count. A directory row shows
-  its badge breakdown and top fan-in symbols, plus — when it participates
-  in a dependency cycle — exactly which other directories it cycles with
-  and the concrete symbol-to-symbol edges forming that cycle.
-- **Blast radius pane (right):** `r`/`R` toggles the right-hand pane to an
-  entry-tree view rooted at the directory or file row under the cursor —
-  "if this changes, what does it reach" ([ADR 0019](docs/adr/0019-entry-path-pivot-view.md)
-  for the re-rooting algorithm, [ADR 0023](docs/adr/0023-tui-blast-radius-naming.md)
-  for the naming) — the interactive equivalent of `--entry <path>`. The
-  tree follows the cursor: move to a different directory/file row while
-  the pane is active and it re-renders rooted at the new row's path; a
-  symbol row shows a placeholder instead, since measuring blast radius
-  only makes sense on a directory/file scope. Nodes reached only by
-  expanding a dependency edge outward past the selected path are dimmed
-  so you can tell "the layer I'm measuring from" from "what it reaches
-  into". A repeated node is marked `(see above)` rather than expanded
-  again, and a dependency loop back to an ancestor already on screen is
-  marked `(cycle)` — you've seen it, no need to expand further. Press `r`
-  again, or `d`, to leave the blast-radius pane.
-- **Scrolling the right-hand pane:** move focus to the right pane
-  (`enter` on a file/symbol row) and use `j`/`k` to scroll the
-  Detail/Diff/Blast-radius pane down/up by one line when its content is
-  too long to fit — the pane's title grows a `(first-last/total)` suffix
-  (e.g. `Detail (1-17/43)`) whenever there's more to see, so a long
-  cycle-edge list or a large file's diff doesn't quietly get cut off.
-  While viewing the Diff pane specifically, `]`/`[` jump straight to the
-  next/previous hunk. The scroll position resets to the top whenever the
-  underlying content could have changed: moving the cursor, toggling
-  between the detail/diff/blast-radius views, or returning from the
-  source view.
-- **Source view:** `s` on a symbol row opens that file, scrolled to and
-  highlighting the symbol's line range; `esc`/`q` returns to the entry
-  view. Reads the working tree directly (not the historical commit a
-  `--base`/`--pr` diff was computed against), so it always shows the
-  file's current content — note that the highlighted line range itself is
-  from analysis time, so it can drift (or, if the file has since shrunk,
-  get clamped to the end of the file) if you edit the file after opening
-  the TUI.
-
-### Key bindings
-
-Press `?` in the TUI for the always-up-to-date version of this table,
-grouped by focus.
-
-**Tree focus (default):**
-
-| Key(s) | Action |
-| --- | --- |
-| `j` / `k` / `↓` / `↑` | Move the cursor |
-| `enter` | Expand/collapse a directory row, or open a file/symbol row (moves focus right) |
-| `space` | Expand or collapse a directory/file row (never moves focus) |
-| `e` / `E` | Expand every row |
-| `c` / `C` | Collapse every row |
-
-**Right focus (Detail/Diff/Blast-radius pane):**
-
-| Key(s) | Action |
-| --- | --- |
-| `j` / `k` / `↓` / `↑` | Scroll the pane by one line |
-| `h` / `esc` | Return focus to the tree |
-| `]` | Jump to the next hunk (Diff pane only) |
-| `[` | Jump to the previous hunk (Diff pane only) |
-
-**Global (any focus):**
-
-| Key(s) | Action |
-| --- | --- |
-| `o` / `O` | Toggle topological / alphabetical ordering |
-| `d` / `D` | Toggle the right-hand pane between diff and detail |
-| `r` / `R` | Toggle the right-hand pane to the blast radius of the selected directory/file |
-| `s` / `S` | Open the source view for the symbol under the cursor |
-| `gd` | Jump to a callee of the symbol under the cursor ([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md)) |
-| `gr` | Jump to a caller of the symbol under the cursor |
-| `ctrl-o` | Jump back to the previous jumplist location |
-| `ctrl-i` | Jump forward to the next jumplist location |
-| `?` | Toggle the help overlay (keymap + glossary) |
-| `esc` / `q` | Return to the entry view (from the source view) |
-| `q` / `ctrl-c` | Quit (from the entry view) |
-
-Glyphs are plain ASCII (`~`/`!`/`^`/`+`/`x`, `v`/`>` for expand state)
-rather than Unicode/emoji, for compatibility with plainer terminal
-configurations.
-
-### Jump navigation (`gd` / `gr`)
-
-While reading a diff or its detail, `gd` jumps toward a callee of the
-symbol under the cursor and `gr` jumps toward a caller — a two-key
-sequence (press `g` then `d`/`r`), mirroring neovim's own "go to
-definition"/"go to references" idiom
-([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md)). Works
-regardless of focus, but only when the cursor sits on a symbol row: zero
-candidates shows a status-line note, one candidate jumps immediately, and
-more than one opens a popup (`j`/`k` to choose, `enter` to jump, `esc` to
-cancel). A jump moves the tree cursor to the target symbol — expanding any
-collapsed ancestor directories along the way — and shows its Diff, without
-moving focus off the right pane, so you keep reading rather than switching
-back to tree browsing.
-
-Every jump is recorded in a jumplist: `ctrl-o` returns to where you jumped
-from, and `ctrl-i` moves forward again after a `ctrl-o` — the same
-back/forward history neovim's own jumplist keeps. Jumping to a new
-location from the middle of that history discards whatever forward
-entries existed, the same way neovim's does.
-
-## Using rinkaku with LLM reviewers
-
-rinkaku's output works well as a "map" handed to an LLM before it reads a
-diff: the hotspots, contract markers (added/removed/signature-changed),
-and entry-point trees let the reviewer allocate deep-reading attention
-instead of reconstructing the change's structure itself.
-
-1. Generate the map from a **trusted checkout** — a clean `main` build,
-   never the branch under review, so a malicious or buggy diff can't tamper
-   with the tool inspecting it:
+1. Generate the map from a **trusted checkout** — a clean `main`
+   build, never the branch under review, so a malicious or buggy diff
+   can't tamper with the tool inspecting it:
 
    ```sh
    rinkaku --pr 123 --format md > map.md
    # or: rinkaku --base main --format md > map.md
    ```
 
-2. Paste `map.md` at the top of the reviewer's prompt, followed by the
-   actual diff, with instructions along these lines:
+2. Paste `map.md` at the top of the reviewer's prompt, followed by
+   the actual diff, with instructions along these lines:
 
    ```
    Here is a structural map of this change (hotspots, contract markers,
@@ -685,89 +659,26 @@ instead of reconstructing the change's structure itself.
    is safe to skip. Then review the diff below.
    ```
 
-3. Run an **independent pass without the map** alongside the map-assisted
-   one. Across repeated trials, the two passes consistently surface
-   different findings rather than one being a superset of the other — see
-   [`docs/experiments/0001-map-assisted-llm-review/`](docs/experiments/0001-map-assisted-llm-review/README.md).
+3. Run an **independent pass without the map** alongside the
+   map-assisted one; the two consistently surface different findings.
 
-4. Whichever pass(es) you run, always add a **dynamic verification**
-   step: build and actually execute the changed code, including
-   failure-mode invocations (non-TTY stdin, empty input, missing files).
-   Behavioral bugs don't show up on the signature surface the map draws
-   from, and the experiment's own rounds found real defects (a non-TTY
-   panic) only by running the binary.
-
-## GitHub Action
-
-This repository ships a composite [`action.yaml`](action.yaml) that runs
-rinkaku against a pull request's diff and posts (or updates) a sticky PR
-comment: a [`--format mermaid`](#usage) call/dependency graph up front —
-rendered natively by GitHub in the comment — with the full Markdown
-outline collapsed underneath for anyone who wants signature-level detail.
-
-```yaml
-name: rinkaku PR report
-
-on:
-  pull_request:
-    branches: [main]
-
-permissions:
-  pull-requests: write
-  contents: read
-
-jobs:
-  report:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}
-
-      - uses: hiro-o918/rinkaku@main
-        with:
-          github-token: ${{ github.token }}
-```
-
-Inputs: `version` (a release tag to download, default `latest`), `binary`
-(path to an already-built rinkaku binary, skipping the download entirely),
-`repo-path` (the checkout rinkaku should analyze; defaults to the current
-directory), `base` (defaults to the PR's base ref), `github-token`
-(defaults to `github.token`), and `comment` (set `false` to skip posting
-and just get the `mermaid-path`/`markdown-path` outputs).
-
-**Trusted-base posture**: the snippet above is the simple case (a pinned
-release binary, `permissions: pull-requests: write` scoped to only what
-posting a comment needs). If you build rinkaku yourself instead of using a
-release binary, build it from the PR's **base** ref, not the PR head —
-same rule this repository's own [dogfooding
-workflow](.github/workflows/rinkaku-report.yaml) follows, and for the
-same reason the [LLM-review recipe](#using-rinkaku-with-llm-reviewers)
-above always builds its map from a trusted checkout: a PR is exactly the
-input an attacker controls, and this job runs with a write token before
-anyone has reviewed it. That workflow checks out the PR's base ref at the
-job's default location (so `uses: ./` resolves *its own action code* —
-not just the binary — from the trusted checkout too) and checks out the
-PR head into a subdirectory purely as data, passed to this action via
-`repo-path`. **Fork PRs** get a read-only token from the `pull_request`
-trigger regardless of `permissions:` — this action detects that and falls
-back to writing the report into the job's step summary instead of
-posting a comment, so a fork PR's run still succeeds (exit 0) rather than
-failing on a 403.
+4. Add a **dynamic verification** step: build and actually execute
+   the changed code, including failure-mode invocations (non-TTY
+   stdin, empty input, missing files). Behavioral bugs don't show up
+   on the signature surface the map draws from.
 
 ## Development
 
-Requires a Rust toolchain (pinned in [`rust-toolchain.toml`](rust-toolchain.toml);
-`rustup` will install it automatically).
+Requires a Rust toolchain (pinned in
+[`rust-toolchain.toml`](rust-toolchain.toml); `rustup` will install it
+automatically).
 
-The workspace has three crates: `rinkaku-core` (the pure diff-condensation
-library, published standalone so it can be embedded in other tools),
-`rinkaku-tui` (the interactive terminal UI's view-models and `ratatui`
-rendering, depending on `rinkaku-core`; see [ADR 0016](docs/adr/0016-tui-crate-and-stack.md)),
-and `rinkaku` (the thin CLI binary, depending on both).
+The workspace has three crates: `rinkaku-core` (the pure
+diff-condensation library, published standalone so it can be embedded
+in other tools), `rinkaku-tui` (the interactive terminal UI's
+view-models and `ratatui` rendering, depending on `rinkaku-core`; see
+[ADR 0016](docs/adr/0016-tui-crate-and-stack.md)), and `rinkaku` (the
+thin CLI binary, depending on both).
 
 ```sh
 make test    # cargo test --all-features
@@ -781,100 +692,93 @@ CI runs the same `make` targets on every pull request (see
 
 ### Architecture
 
-Lightweight ports & adapters: core extraction logic in `rinkaku-core` is
-pure (no IO, no clock, no env), with tree-sitter parsing and future
+Lightweight ports & adapters: core extraction logic in `rinkaku-core`
+is pure (no IO, no clock, no env), with tree-sitter parsing and future
 LSP/process boundaries isolated behind traits (`LanguageSupport`,
-`Resolver`) defined on the consumer side. See [`CLAUDE.md`](CLAUDE.md) and
-[`docs/adr/`](docs/adr) for details.
+`Resolver`) defined on the consumer side. See
+[`CLAUDE.md`](CLAUDE.md) and [`docs/adr/`](docs/adr) for details.
 
 ### Known limitations
 
 **Mitigated in [#9](https://github.com/hiro-o918/rinkaku/pull/9):** the
-original QA pass (see below) found name-only matching noise and slow
-`--deps 1` indexing severe enough to block merging. Both are improved,
-though not eliminated — v1's resolver is still name-only (see "still
-open" below).
+original QA pass found name-only matching noise and slow `--deps 1`
+indexing severe enough to block merging. Both are improved, though not
+eliminated — v1's resolver is still name-only (see "still open" below).
 
-- **Same-name matches are ranked and capped, not resolved.** When several
-  definitions share a referenced name, they are ranked by path proximity
-  to the referencing file (same file > same directory > shared path
-  prefix depth > other) and only the top 3 ([`MAX_MATCHES_PER_NAME`]) are
-  shown; the rest are reported as a count (`(+N more definitions matched
-  by name)` in Markdown, `omitted_matches` in JSON) rather than silently
-  dropped or listed in full — see "When same-name matches are capped"
-  above for a real example. This bounds "Depends on" noise but does not
-  guarantee the top 3 include the actually-referenced definition, since
-  ranking is a proximity heuristic, not type-aware resolution.
-- **`_` and single-character identifiers are never resolved.** They are
-  filtered out of referenced names entirely, since under name-only
+- **Same-name matches are ranked and capped, not resolved.** When
+  several definitions share a referenced name, they are ranked by path
+  proximity to the referencing file (same file > same directory >
+  shared path prefix depth > other) and only the top 3
+  ([`MAX_MATCHES_PER_NAME`]) are shown; the rest are reported as a
+  count (`(+N more definitions matched by name)` in Markdown,
+  `omitted_matches` in JSON). This bounds "Depends on" noise but does
+  not guarantee the top 3 include the actually-referenced definition,
+  since ranking is a proximity heuristic, not type-aware resolution.
+- **`_` and single-character identifiers are never resolved.** They
+  are filtered out of referenced names entirely, since under name-only
   resolution they match too many unrelated definitions to be useful
-  (Python's `_` placeholder convention was the main offender found in
-  QA — see below).
+  (Python's `_` placeholder convention was the main offender).
 - **The `--deps 1` indexing prefilter has limited effect when a diff
-  references common standard-library-style names.** `TagsResolver::new`
-  skips parsing files whose content cannot contain any referenced name at
-  all (measured ~88% fewer files parsed, ~8x faster indexing on a
-  same-language-only reference set — see PR #9's description for the full
-  numbers). But a name like `Vec`, `Option`, `String`, `Some`, or `Ok`
-  appears in nearly every Rust file in a real codebase, so a diff whose
-  referenced names include several of these sees a smaller reduction (on
-  the ruff `6237ecb4d` diff used above, `--deps 1` dropped from ~9.5s
-  pre-#9 to ~6.5s post-#9 — better, not solved). The prefilter is a
-  substring match over raw file content, not scoped to actual
-  definitions, so it cannot distinguish "defines `Vec`" from "mentions
-  `Vec`" without also risking false negatives (see `deps.rs`'s
-  `should_parse_file` doc comment) — narrowing this further is left for a
-  future iteration. The dominant cost in `--base` mode remains the
-  per-file `git show` subprocess invocation for reading tracked files
-  (unrelated to this prefilter, and unaddressed — see `deps.rs`'s
-  performance doc comment).
+  references common standard-library-style names.**
+  `TagsResolver::new` skips parsing files whose content cannot contain
+  any referenced name at all (measured ~88% fewer files parsed, ~8x
+  faster indexing on a same-language-only reference set — see PR #9
+  for the full numbers). But a name like `Vec`, `Option`, `String`,
+  `Some`, or `Ok` appears in nearly every Rust file in a real
+  codebase, so a diff whose referenced names include several of these
+  sees a smaller reduction. The prefilter is a substring match over
+  raw file content, not scoped to actual definitions, so it cannot
+  distinguish "defines `Vec`" from "mentions `Vec`" without also
+  risking false negatives. The dominant cost in `--base` mode remains
+  the per-file `git show` subprocess invocation for reading tracked
+  files (unaddressed).
 
 **Still open — no type resolution (by design, ADR 0003):** dependency
 resolution matches referenced names against definitions by name alone,
 with no type information — it cannot disambiguate overloads, shadowed
 names, or same-named symbols in unrelated modules. The ranking and cap
 above reduce the resulting noise but do not fix the underlying
-imprecision (e.g. an unrelated same-named Python test fixture class can
-still outrank a real dependency once same-file/same-directory candidates
-are exhausted — see the `Inner` example above). A future `Resolver`
-implementation backed by an LSP server (pyright, gopls, rust-analyzer,
-...) is planned as a higher-precision, opt-in alternative for v2+; see
-the Roadmap below.
+imprecision. A future `Resolver` implementation backed by an LSP
+server (pyright, gopls, rust-analyzer, ...) is planned as a
+higher-precision, opt-in alternative for v2+; see the Roadmap below.
 
 [`MAX_MATCHES_PER_NAME`]: rinkaku-core/src/deps.rs
 
 ### Roadmap / not yet done
 
-- LSP-backed `Resolver` implementations (pyright, gopls, rust-analyzer,
-  ...) as a higher-precision, opt-in alternative to the v1 tags-based
-  `Resolver`.
+- LSP-backed `Resolver` implementations (pyright, gopls,
+  rust-analyzer, ...) as a higher-precision, opt-in alternative to
+  the v1 tags-based `Resolver`.
+- A TUI screenshot/GIF in this README — deferred to a follow-up (the
+  recording tooling needs a controlling TTY that this repository's
+  development environment doesn't always provide).
 
 ## Release
 
 `rinkaku` and `rinkaku-core` are versioned independently by
 [release-please](https://github.com/googleapis/release-please) (no
-`linked-versions` grouping): each crate only bumps when a commit touches
-its own path, so it's normal for them to be on different versions (e.g.
-`rinkaku` 0.2.0 depending on `rinkaku-core` 0.1.0). Only `rinkaku`'s
-release tag (`v{version}`, no component prefix) triggers
-`build-and-publish.yaml`; `rinkaku-core`'s tag is prefixed
-(`rinkaku-core-v{version}`) so a `rinkaku-core`-only release doesn't spin
-up the binary build/publish pipeline.
+`linked-versions` grouping): each crate only bumps when a commit
+touches its own path, so it's normal for them to be on different
+versions (e.g. `rinkaku` 0.2.0 depending on `rinkaku-core` 0.1.0).
+Only `rinkaku`'s release tag (`v{version}`, no component prefix)
+triggers `build-and-publish.yaml`; `rinkaku-core`'s tag is prefixed
+(`rinkaku-core-v{version}`) so a `rinkaku-core`-only release doesn't
+spin up the binary build/publish pipeline.
 
 `separate-pull-requests: true` is set for a reason that isn't obvious
-from the config alone: with more than one non-root `packages` entry (no
-`.` path), release-please's PR-merging step can't find a "root" release
-candidate to base the combined PR's title on, and falls back to a title
-that omits the version entirely (`chore: release main`). That title
-doesn't match what the *next* run expects when looking up the
-already-merged PR to tag, so tagging silently finds nothing to do and
-`release-main.yaml` aborts with "untagged, merged release PRs
+from the config alone: with more than one non-root `packages` entry
+(no `.` path), release-please's PR-merging step can't find a "root"
+release candidate to base the combined PR's title on, and falls back
+to a title that omits the version entirely (`chore: release main`).
+That title doesn't match what the *next* run expects when looking up
+the already-merged PR to tag, so tagging silently finds nothing to do
+and `release-main.yaml` aborts with "untagged, merged release PRs
 outstanding" -- this bit us for both the v0.2.0 and v0.3.0 releases,
 each requiring a manual `gh release create` + relabeling the PR
-`autorelease: tagged` to recover. `separate-pull-requests: true` sidesteps
-this entirely: each package gets its own PR (and its own title, correctly
-including that package's version), so there's no combined-PR title to
-compute in the first place.
+`autorelease: tagged` to recover. `separate-pull-requests: true`
+sidesteps this entirely: each package gets its own PR (and its own
+title, correctly including that package's version), so there's no
+combined-PR title to compute in the first place.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,783 +2,97 @@
 
 > rinkaku (輪郭, "outline" in Japanese)
 
-**A map of what a PR changes** — browse it interactively in your terminal,
-or read it inline in the PR itself as a mermaid graph.
+**See the shape of a PR before you read it.**
 
-For any pull request rinkaku picks out the *changed symbols* (and their
-1-hop dependencies), turns them into a compact call/dependency graph, and
-renders that graph two ways:
+rinkaku takes any pull request (yours, a teammate's, an OSS one you
+just found on GitHub) and shows you *what actually changed* — the
+functions and types touched, what they call, what depends on them —
+without making you scroll through the diff.
 
-1. **[Interactive TUI](#interactive-tui-recommended)** — a terminal-native
-   viewer with a directory tree, a diff pane, and a "blast radius" pane
-   for asking "if this changes, what does it reach?" Built for humans
-   reading a PR before diving into files.
-2. **[GitHub Action](#github-action)** — a composite action that posts (or
-   updates) a sticky PR comment with a mermaid graph rendered natively by
-   GitHub, plus the full signature outline collapsed underneath.
+Two ways to look at it:
 
-Both are backed by the same core: tree-sitter-based extraction of changed
-symbols, 1-hop dependency expansion, and structural summarizers
-(hotspots, contract markers, entry-point trees, blast radius). Rust, Go,
-Python, and TypeScript are supported out of the box.
+- 🖥️  **In your terminal** — an interactive TUI with a directory tree,
+  a syntax-highlighted diff pane, and a *blast radius* view for
+  *"if this changes, what does it reach?"*
+  → [`docs/tui.md`](docs/tui.md)
+- 🤖 **On the PR itself** — a GitHub Action that posts a sticky comment
+  with a mermaid graph GitHub renders natively.
+  → [`docs/action.md`](docs/action.md)
 
-## Status
+Both share one engine: tree-sitter extraction of changed symbols, 1-hop
+dependency expansion, hotspot / contract-change / entry-point
+summarizers. Rust, Go, Python, and TypeScript out of the box.
 
-Early development. Diff parsing, tree-sitter extraction, the CLI
-(stdin/`--base`/`--pr` input, Markdown/JSON/Mermaid output), 1-hop
-dependency expansion (`--deps`, the tags-based `Resolver`), the
-interactive TUI (`--tui`), and the GitHub Action are all implemented.
-
-## Installation
-
-### Homebrew
+## Try it in 30 seconds
 
 ```sh
+# 1. Install
 brew install hiro-o918/tap/rinkaku
-```
-
-### Install script
-
-```sh
+# or:
 curl -fsSL https://raw.githubusercontent.com/hiro-o918/rinkaku/main/install.sh | bash
+
+# 2. Point it at any GitHub PR — a local clone is optional
+rinkaku --pr https://github.com/owner/repo/pull/123
+
+# ...or the branch you're about to review
+rinkaku --base main
 ```
 
-You can also specify a version or install directory:
+Either command opens the TUI. Press `?` in the TUI for the keymap;
+`q` to quit.
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/hiro-o918/rinkaku/main/install.sh | VERSION=v0.1.0 bash
-curl -fsSL https://raw.githubusercontent.com/hiro-o918/rinkaku/main/install.sh | INSTALL_DIR=~/.local/bin bash
-```
+Prefer plain output? Pass `--format md`, `--format json`, or
+`--format mermaid` — see [`docs/cli.md`](docs/cli.md).
+Setting up CI so every PR gets a mermaid graph in a comment?
+[`docs/action.md`](docs/action.md).
+Feeding it to an LLM reviewer? Read
+[`docs/llm-review.md`](docs/llm-review.md) first — it's an attention
+aid, not a verifier, and we have the experiment rounds to prove it.
 
-### From source (cargo install)
+## Install
 
-```sh
-cargo install rinkaku
-```
-
-### GitHub Releases (manual)
-
-Download the tarball for your platform from the
-[latest release](https://github.com/hiro-o918/rinkaku/releases/latest),
-extract it, and place the `rinkaku` binary on your `PATH`:
-
-```sh
-tar xzf rinkaku-<target>.tar.gz
-mv rinkaku-<target>/rinkaku /usr/local/bin/
-```
-
-Where `<target>` is one of `x86_64-unknown-linux-gnu`,
-`aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, or
-`aarch64-apple-darwin`.
-
-### Updating
-
-```sh
-rinkaku self-update
-```
-
-Downloads and installs the latest GitHub release for your platform,
-replacing the running binary in place. If you installed via Homebrew or
-`cargo install`, prefer `brew upgrade` or `cargo install rinkaku` instead
-so your package manager's bookkeeping stays in sync — `self-update` works
-either way, but it bypasses those managers.
-
-By default this prompts for confirmation before installing. Pass `--yes`
-(or `-y`) to skip the prompt and proceed non-interactively:
-
-```sh
-rinkaku self-update --yes
-```
-
-When stdin is not a terminal (e.g. run from a script or CI) and `--yes`
-is not given, `self-update` refuses to run rather than silently
-proceeding.
-
-## Interactive TUI (recommended)
-
-The TUI is the intended path for humans reading a PR
-([ADR 0015](docs/adr/0015-tui-for-humans-markdown-for-machines.md));
-it's built with [ratatui](https://ratatui.rs)
-([ADR 0016](docs/adr/0016-tui-crate-and-stack.md)) and follows a
-neovim-style focus model
-([ADR 0020](docs/adr/0020-tui-interaction-model-v2.md)).
-
-```sh
-# Whole-repo outline — bare invocation opens the TUI on an interactive
-# terminal (ADR 0017), useful for onboarding or architecture review
-rinkaku
-
-# A PR by number (inside a local clone of the target repository)
-rinkaku --pr 123 --tui
-
-# A PR from any directory (URL form; auto-picks an existing ghq clone or
-# auto-clones a blobless copy into a cache — see ADR 0005/0006)
-rinkaku --pr https://github.com/octocat/hello-world/pull/123 --tui
-
-# A local git diff against a base branch
-rinkaku --base main --tui
-
-# Diff piped in from anywhere (keyboard input is read from the
-# controlling terminal independently of stdin — ADR 0016)
-gh pr diff 123 | rinkaku --tui
-```
-
-`--tui` replaces `--format`, so the two conflict rather than combining.
-
-### Layout
-
-The screen is split into a **tree pane** on the left and one of three
-**right-hand panes**:
-
-- **Tree pane** — a directory tree of *changed files* (not the call
-  graph), so nesting mirrors your repository layout. Rows carry badges:
-  `~N` changed symbols, `!N` contract changes (added/removed/signature-
-  changed), `^N` fan-in (hotspot aggregate). Directories that
-  participate in a dependency cycle are marked `(cycle)`. Sibling
-  directories default to topological order — entry points (least
-  depended-on) first, foundations last — with `o` to toggle plain
-  alphabetical order. Symbol rows show a kind abbreviation (`fn`,
-  `struct`, ...) and a classification marker: `+` added, `~`
-  signature-changed, `x` removed (dimmed, crossed out). Files rinkaku
-  couldn't analyze (unsupported language, binary, deleted) still
-  appear, dimmed and marked `(skipped: <reason>)`; a file whose changes
-  were entirely test code shows up as `[test] (N symbols)` (ADR 0009).
-- **Diff pane (default right pane)** — the raw unified-diff hunks
-  touching the selected row. Symbol rows clip to that symbol's line
-  range; file rows group hunks under per-symbol section headers, with
-  import-only hunks collected under a trailing `(module level)`
-  section. When a symbol's signature itself changed, a 2-line old/new
-  header (`- <old>` / `+ <new>`) precedes its hunks. Hunks in the four
-  built-in languages are syntax-highlighted
-  ([ADR 0018](docs/adr/0018-syntax-highlight-tui-diff-pane.md));
-  added/removed lines keep their green/red diff signal as a background
-  tint so it doesn't compete with token colors. Any other file falls
-  back to plain green/red text.
-- **Detail pane** (`d`) — what the cursor is on. A symbol row shows its
-  classification, signature (an old/new diff when the contract
-  changed), who depends on it ("used by"), and its callees. A file row
-  shows every symbol changed in that file. A directory row shows its
-  badge breakdown, top fan-in symbols, and — when it participates in a
-  dependency cycle — exactly which other directories it cycles with and
-  the concrete symbol-to-symbol edges forming that cycle.
-- **Blast radius pane** (`r`) — an entry-tree view rooted at the
-  directory or file row under the cursor: *"if this changes, what does
-  it reach?"* The interactive equivalent of the CLI's `--entry <path>`
-  ([ADR 0019](docs/adr/0019-entry-path-pivot-view.md), named per
-  [ADR 0023](docs/adr/0023-tui-blast-radius-naming.md)). The tree
-  follows the cursor: move to a different row and it re-renders rooted
-  at the new path. Nodes reached only past the selected path are
-  dimmed, repeated nodes are marked `(see above)` instead of expanded
-  again, and cycles are marked `(cycle)`.
-
-### Key bindings
-
-Press `?` in the TUI for the always-up-to-date version, grouped by
-focus.
-
-**Tree focus (default):**
-
-| Key(s) | Action |
+| Method | Command |
 | --- | --- |
-| `j` / `k` / `↓` / `↑` | Move the cursor |
-| `enter` | Expand/collapse a directory row, or open a file/symbol row (moves focus right) |
-| `space` | Expand or collapse a directory/file row (never moves focus) |
-| `e` / `E` | Expand every row |
-| `c` / `C` | Collapse every row |
-
-**Right focus (Detail/Diff/Blast-radius pane):**
-
-| Key(s) | Action |
-| --- | --- |
-| `j` / `k` / `↓` / `↑` | Scroll the pane by one line |
-| `h` / `esc` | Return focus to the tree |
-| `]` | Jump to the next hunk (Diff pane only) |
-| `[` | Jump to the previous hunk (Diff pane only) |
-
-**Global (any focus):**
-
-| Key(s) | Action |
-| --- | --- |
-| `o` / `O` | Toggle topological / alphabetical ordering |
-| `d` / `D` | Toggle the right-hand pane between diff and detail |
-| `r` / `R` | Toggle the right-hand pane to the blast radius of the selected directory/file |
-| `s` / `S` | Open the source view for the symbol under the cursor |
-| `gd` | Jump to a callee of the symbol under the cursor ([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md)) |
-| `gr` | Jump to a caller of the symbol under the cursor |
-| `ctrl-o` | Jump back to the previous jumplist location |
-| `ctrl-i` | Jump forward to the next jumplist location |
-| `?` | Toggle the help overlay (keymap + glossary) |
-| `esc` / `q` | Return to the entry view (from the source view) |
-| `q` / `ctrl-c` | Quit (from the entry view) |
-
-Glyphs are plain ASCII (`~`/`!`/`^`/`+`/`x`, `v`/`>` for expand state)
-rather than Unicode/emoji, for compatibility with plainer terminal
-configurations.
-
-### Jump navigation (`gd` / `gr`)
-
-While reading a diff or its detail, `gd` jumps toward a callee of the
-symbol under the cursor and `gr` jumps toward a caller — a two-key
-sequence (press `g` then `d`/`r`), mirroring neovim's own "go to
-definition"/"go to references" idiom
-([ADR 0022](docs/adr/0022-jump-navigation-and-jumplist.md)). Zero
-candidates shows a status-line note, one candidate jumps immediately,
-and more than one opens a popup (`j`/`k` to choose, `enter` to jump,
-`esc` to cancel). A jump moves the tree cursor to the target symbol —
-expanding any collapsed ancestor directories along the way — and shows
-its Diff, without moving focus off the right pane.
-
-Every jump is recorded in a jumplist: `ctrl-o` returns to where you
-jumped from, and `ctrl-i` moves forward again after a `ctrl-o` — the
-same back/forward history neovim's own jumplist keeps. Jumping to a new
-location from the middle of that history discards whatever forward
-entries existed.
-
-### Source view
-
-`s` on a symbol row opens the file, scrolled to and highlighting the
-symbol's line range; `esc`/`q` returns to the entry view. Reads the
-working tree directly (not the historical commit a `--base`/`--pr`
-diff was computed against), so it always shows the file's current
-content — note that the highlighted line range itself is from analysis
-time, so it can drift (or, if the file has since shrunk, get clamped to
-the end of the file) if you edit the file after opening the TUI.
-
-## GitHub Action
-
-The composite [`action.yaml`](action.yaml) runs rinkaku against a pull
-request's diff and posts (or updates) a sticky PR comment: a
-[`--format mermaid`](#format-mermaid-graph-for-pr-comments)
-call/dependency graph up front — rendered natively by GitHub in the
-comment — with the full Markdown outline collapsed underneath for
-anyone who wants signature-level detail.
-
-```yaml
-name: rinkaku PR report
-
-on:
-  pull_request:
-    branches: [main]
-
-permissions:
-  pull-requests: write
-  contents: read
-
-jobs:
-  report:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}
-
-      - uses: hiro-o918/rinkaku@main
-        with:
-          github-token: ${{ github.token }}
-```
-
-Inputs: `version` (a release tag to download, default `latest`),
-`binary` (path to an already-built rinkaku binary, skipping the
-download entirely), `repo-path` (the checkout rinkaku should analyze;
-defaults to the current directory), `base` (defaults to the PR's base
-ref), `github-token` (defaults to `github.token`), and `comment` (set
-`false` to skip posting and just get the `mermaid-path`/`markdown-path`
-outputs).
-
-### Trusted-base posture
-
-The snippet above is the simple case (a pinned release binary,
-`permissions: pull-requests: write` scoped to only what posting a
-comment needs). If you build rinkaku yourself instead of using a
-release binary, **build it from the PR's base ref, not the PR head** —
-same rule this repository's own [dogfooding
-workflow](.github/workflows/rinkaku-report.yaml) follows, and for the
-same reason the [LLM-review recipe](#advanced-using-rinkaku-with-llm-reviewers)
-below always builds its map from a trusted checkout: a PR is exactly
-the input an attacker controls, and this job runs with a write token
-before anyone has reviewed it. That workflow checks out the PR's base
-ref at the job's default location (so `uses: ./` resolves *its own
-action code* — not just the binary — from the trusted checkout too)
-and checks out the PR head into a subdirectory purely as data, passed
-to this action via `repo-path`.
-
-**Fork PRs** get a read-only token from the `pull_request` trigger
-regardless of `permissions:` — this action detects that and falls back
-to writing the report into the job's step summary instead of posting a
-comment, so a fork PR's run still succeeds (exit 0) rather than
-failing on a 403.
-
-## CLI reference
-
-The TUI and Action are the recommended entry points, but the same
-analysis is available as plain CLI output — useful for scripting, CI
-gates, custom tooling, or feeding downstream processors.
-
-### Input modes
-
-- **stdin**: `gh pr diff 123 | rinkaku` — file contents are read off
-  the working tree, which assumes the piped diff is consistent with
-  the current working tree (e.g. it was just produced by `git diff`
-  or already applied). A stale or unrelated diff piped via stdin can
-  produce misaligned line numbers.
-- **`--base <ref>`**: `rinkaku --base main` — runs `git diff`
-  internally and reads file contents via `git show <head>:<path>`, so
-  extraction always matches the diffed commit regardless of the
-  working tree's state.
-- **`--pr <number-or-url>`**: `rinkaku --pr 123` or
-  `rinkaku --pr https://github.com/owner/repo/pull/123` — resolves
-  the PR's base and head via `gh pr view`, fetches both, and reuses
-  the same `git show`-backed read strategy as `--base`
-  ([ADR 0004](docs/adr/0004-pr-input-mode-via-gh-in-local-clone.md)).
-  A bare PR number requires running inside a local clone of the
-  target repository; a URL also works from any directory, preferring
-  an existing [ghq](https://github.com/x-motemen/ghq)-managed clone
-  when one matches and otherwise auto-cloning a blobless copy into a
-  cache ([ADR 0005](docs/adr/0005-auto-clone-into-cache-for-pr-urls.md),
-  [ADR 0006](docs/adr/0006-prefer-ghq-managed-clones-over-cache.md)).
-  `gh` must be installed and authenticated. Private repos also need
-  `gh auth setup-git` so later `git fetch`s can authenticate.
-- **Whole-repo (no diff)**: bare `rinkaku` run inside a repository,
-  with stdout piped anywhere — no diff involved, produces an outline
-  of every symbol and its dependency structure
-  ([ADR 0017](docs/adr/0017-whole-repo-outline-as-default-input-mode.md)).
-  On an interactive terminal, bare `rinkaku` opens the TUI instead
-  (same whole-repo outline); pass `--format md` to force Markdown
-  even on a TTY.
-
-### Output formats (`--format`)
-
-```sh
-# Markdown (default when stdout is not a TTY) — designed to be fed to
-# an LLM or read by a human reviewer
-rinkaku --base main --format md
-
-# JSON — structured data for another tool
-rinkaku --base main --format json
-
-# Mermaid — a call/dependency flowchart for pasting into a PR
-# comment/description (ADR 0021), where GitHub renders it natively
-rinkaku --base main --format mermaid
-```
-
-`--tui` is not a `--format` value; it replaces the output stage
-entirely and conflicts with `--format`.
-
-### Markdown output example
-
-Running `rinkaku` on
-[a real rinkaku commit](https://github.com/hiro-o918/rinkaku/commit/aa7ca34)
-(a 35-line diff adding stderr progress logging to `main.rs`) produces:
-
-```sh
-$ git show aa7ca34 --format="" | rinkaku --deps 0
-```
-
-````markdown
-## Change graph
-
-4 changed symbols in 1 file
-
-- fn main (rinkaku/src/main.rs)
-  - fn build_resolver (rinkaku/src/main.rs)
-  - fn resolve_pr_workdir (rinkaku/src/main.rs)
-  - fn run_base_pipeline (rinkaku/src/main.rs)
-    - fn build_resolver (rinkaku/src/main.rs) (see above)
-
-## Definitions
-
-### fn main (rinkaku/src/main.rs)
-
-```
-fn main() -> anyhow::Result<()>
-```
-
-### fn build_resolver (rinkaku/src/main.rs)
-
-```
-fn build_resolver( cli: &Cli, diff_text: &str, diff_read_file: impl Fn(&str) -> std::io::Result<String>, head: Option<&str>, cwd: Option<&std::path::Path>, ) -> anyhow::Result<Option<TagsResolver>>
-```
-
-### fn resolve_pr_workdir (rinkaku/src/main.rs)
-
-```
-fn resolve_pr_workdir(parsed: &PrArg) -> anyhow::Result<Option<std::path::PathBuf>>
-```
-
-### fn run_base_pipeline (rinkaku/src/main.rs)
-
-```
-fn run_base_pipeline( cli: &Cli, base: &str, head: &str, cwd: Option<&std::path::Path>, ) -> anyhow::Result<rinkaku_core::render::Report>
-```
-
-````
-
-The line under the heading summarizes the shape of the change — how
-many symbols changed, across how many files, and (for multi-file
-diffs) which file concentrates most of them, e.g.
-`16 changed symbols in 3 files — most in store/items.go (11)` — so a
-reviewer sees the epicenter before reading a single tree line.
-
-"Change graph" reads top-down in call-hierarchy order
-([ADR 0008](docs/adr/0008-entry-point-tree-rendering-for-changed-symbols.md)):
-`main` is the only entry point, and every function it reaches is
-nested beneath it. `build_resolver` is reachable from both `main` and
-`run_base_pipeline`; it is rendered in full once, under `main` (the
-first place it's reached), and referenced by name only (`(see above)`)
-the second time — so a reviewer never sees the same signature twice.
-When two changed symbols depend on each other (a mutual-recursion
-cycle), the edge that closes the loop is marked
-`⚠️ ... — dependency cycle, see above` instead of being walked into
-again.
-
-Two more condensations
-([ADR 0012](docs/adr/0012-condense-change-graph-rendering.md)) keep
-request/response-style diffs readable. Changed **data-carrier types**
-(structs/enums/type aliases with no outgoing edges of their own) don't
-get tree lines; they're folded into the line of each symbol that
-references them as a `— uses:` annotation, with their full signatures
-still listed under "Definitions". And an **interface/trait declaration
-is linked to its changed methods** by method-spec name, so the methods
-nest under the interface instead of duplicating it at top level. A Go
-diff adding an `ItemStore` interface, two receiver-method
-implementations, and four request/response structs — 8 changed symbols
-— renders as just three tree lines:
-
-```markdown
-## Change graph
-
-8 changed symbols in 1 file
-
-- interface ItemStore (store.go) — uses: ListItemsRequest, ListItemsResponse, SaveItemRequest, SaveItemResponse
-  - fn ListItems (store.go) — uses: ListItemsRequest, ListItemsResponse, itemStore
-  - fn SaveItem (store.go) — uses: SaveItemRequest, SaveItemResponse, itemStore
-```
-
-Unchanged 1-hop dependencies (ADR 0003) — functions/types the diff
-touches but did not itself change — show up as a `Depends on:` list
-under each definition; they're omitted from the example above
-(`--deps 0`) to keep it focused on the tree shape.
-
-### JSON output
-
-`--format json` renders the same data as structured JSON
-(`{"files": [...], "skipped": [...], "graph": {"nodes", "edges", "roots"}}`),
-for piping into `jq` or another tool. The `graph` field is the same
-call-graph data "Change graph" renders as a tree, so JSON consumers
-don't need to recompute it from `referenced_names`:
-
-```sh
-$ git show aa7ca34 --format="" | rinkaku --format json --deps 0 | jq '.graph'
-```
-
-```json
-{
-  "nodes": [
-    { "id": "rinkaku/src/main.rs::main", "path": "rinkaku/src/main.rs", "name": "main" },
-    { "id": "rinkaku/src/main.rs::resolve_pr_workdir", "path": "rinkaku/src/main.rs", "name": "resolve_pr_workdir" },
-    { "id": "rinkaku/src/main.rs::run_base_pipeline", "path": "rinkaku/src/main.rs", "name": "run_base_pipeline" },
-    { "id": "rinkaku/src/main.rs::build_resolver", "path": "rinkaku/src/main.rs", "name": "build_resolver" }
-  ],
-  "edges": [
-    { "from": "rinkaku/src/main.rs::main", "to": "rinkaku/src/main.rs::build_resolver", "is_cycle": false },
-    { "from": "rinkaku/src/main.rs::main", "to": "rinkaku/src/main.rs::resolve_pr_workdir", "is_cycle": false },
-    { "from": "rinkaku/src/main.rs::main", "to": "rinkaku/src/main.rs::run_base_pipeline", "is_cycle": false },
-    { "from": "rinkaku/src/main.rs::run_base_pipeline", "to": "rinkaku/src/main.rs::build_resolver", "is_cycle": false }
-  ],
-  "roots": ["rinkaku/src/main.rs::main"]
-}
-```
-
-Each symbol in `files[].symbols` also carries an `id` field matching
-its `graph` node's `id`, so a consumer can join a symbol's full
-signature back to its position in the graph without recomputing the
-`{path}::{name}` id scheme itself.
-
-The top-level JSON report also carries `"tests": [{"path", "symbol_count"}]`
-(ADR 0009's per-file test-symbol counts, empty unless the diff touched
-any) and `skipped[].reason` can be `"generated"` (ADR 0010
-attribute-based detection, or ADR 0011 content-marker detection — both
-report the same reason value) alongside the existing
-`"unsupported_language"`/`"binary"`/`"deleted"` values.
-
-### `--format mermaid` (graph for PR comments)
-
-`--format mermaid` emits the same call/dependency graph as a mermaid
-flowchart
-([ADR 0021](docs/adr/0021-mermaid-output-format.md)), designed for
-pasting into a GitHub PR comment or description where mermaid renders
-natively. This is the format the [GitHub Action](#github-action) uses
-for the top of its sticky comment.
-
-### `--deps`
-
-`--deps 1` (the default) resolves each changed symbol's 1-hop
-dependencies by indexing every file `git ls-files` tracks in the
-repository — this makes the output more useful (you see what a changed
-function calls) but costs an up-front repo-wide scan. On a large
-diff/repo, `--deps 1` can take several seconds versus ~50ms for
-`--deps 0`. Prefer `--deps 0` for quick iteration or CI checks where
-the dependency context isn't needed. See
-[Known limitations](#known-limitations) for the resolver's precision
-caveats.
-
-### `--exclude-tests`
-
-By default ([ADR 0025](docs/adr/0025-default-to-including-tests.md)),
-test symbols appear in "Change graph"/"Definitions" alongside
-production symbols, and the `## Tests` summary section is omitted —
-this shape is designed for LLM consumers of the Markdown/JSON output,
-for which "which contracts have which tests changed alongside them"
-is useful signal rather than noise.
-
-Pass `--exclude-tests` to opt into the previous behavior: test symbols
-are detected per language (Go's `*_test.go`, Python's
-`test_*.py`/`*_test.py` and `tests/` directories, TypeScript's
-`*.test.ts(x)`/`*.spec.ts(x)` and `__tests__/`, and Rust's `tests/`
-directory plus `#[cfg(test)]` modules and
-`#[test]`/`#[rstest]`/`#[tokio::test]`-attributed functions) and
-summarized instead as a per-file count under a `## Tests` section:
-
-```markdown
-## Tests
-
-- rinkaku-core/src/pipeline.rs: 3 changed test symbols
-```
-
-Under `--exclude-tests`, `TagsResolver`'s repo-wide dependency index
-applies the same exclusion, so a changed production symbol's "Depends
-on:" cannot resolve to a same-named test helper or fixture elsewhere
-in the repo (ADR 0009).
-
-### `--include-generated`
-
-By default, rinkaku skips generated files two ways, both controlled by
-this one flag:
-
-- **`.gitattributes`** ([ADR 0010](docs/adr/0010-skip-files-marked-no-diff-or-generated-in-gitattributes.md)):
-  resolves each changed file's `diff`/`linguist-generated` attributes
-  via `git check-attr` and skips files marked `-diff` or
-  `linguist-generated`. Only applies when a local git repository is
-  available.
-- **Content markers** ([ADR 0011](docs/adr/0011-detect-generated-files-by-content-markers.md)):
-  skips a file whose first 5 lines contain a linguist-compatible
-  marker: a `@generated` comment, or a line with both `Code generated`
-  and `DO NOT EDIT` (Go tooling/protobuf's
-  `// Code generated by <tool>. DO NOT EDIT.` convention, matched
-  regardless of the comment syntax a language uses). Doesn't require a
-  git repository.
-
-Either way, skipped files (lockfiles, generated code) are dropped from
-Markdown output silently: they do **not** appear under "Skipped files"
-at all. A diff that touches nothing but generated files renders as
-empty Markdown output.
-
-They do still appear in `--format json`'s `skipped` array, with reason
-`"generated"`, for consumers that want the full picture:
-
-```sh
-$ rinkaku --base main --format json | jq '.skipped'
-```
-
-```json
-[
-  { "path": "Cargo.lock", "reason": "generated" },
-  { "path": "models/user.go", "reason": "generated" }
-]
-```
-
-Pass `--include-generated` to restore the previous behavior (generated
-files — by either detection method — are analyzed like any other file,
-in both output formats).
-
-### `--entry <path>`
-
-By default, "Change graph"/"Repository graph" is rooted at
-auto-detected entry points (ADR 0008): symbols nothing else in the
-graph depends on. `--entry <path>` re-roots the tree at a chosen path
-instead ([ADR 0019](docs/adr/0019-entry-path-pivot-view.md)) — entry
-points become the symbols under `path` that nothing else *under that
-same path* depends on, and dependency trees still expand outward
-through the whole graph as usual. This is a change of vantage point,
-not a filter: symbols outside `path` are neither hidden nor excluded
-from analysis, only no longer eligible to be roots themselves.
-
-```sh
-rinkaku --base main --entry src/api
-```
-
-Combines with `--tui`: the TUI opens with the cursor already on the
-tree row matching `path` and the right-hand pane already showing its
-Blast radius (the `R` binding). If no tree row's path matches exactly,
-the TUI opens normally with a status-line note instead.
-
-Prints `note: no symbols under <path>` to stderr and renders an empty
-tree when no symbol's path falls under `path`. Fan-in counts remain
-whole-analysis under `--entry` / the TUI blast-radius pane —
-re-rooting the tree changes the vantage point, not the direction
-fan-in itself measures (see
-[ADR 0019](docs/adr/0019-entry-path-pivot-view.md)'s Consequences).
-
-## Advanced: using rinkaku with LLM reviewers
-
-rinkaku's output can also be handed to an LLM as a "map" before it
-reads a diff. Ten rounds of a paired-arm experiment (see
-[`docs/experiments/0001-map-assisted-llm-review/`](docs/experiments/0001-map-assisted-llm-review/README.md))
-found that the map is a **complement, not a substitute** for a plain
-diff review, and that its measurable value shows up as
-**attention allocation** (routing toward integration seams,
-self-consistency defects, and coverage boundaries) rather than as
-token savings. Neither pass produced a superset of the other's
-findings, and dynamic verification (building and executing the
-changed code, especially against hostile/edge-case inputs) remained
-the strongest single predictor of finding real behavioral defects.
-
-If you still want to run it, the recipe below reflects those
-constraints:
-
-1. Generate the map from a **trusted checkout** — a clean `main`
-   build, never the branch under review, so a malicious or buggy diff
-   can't tamper with the tool inspecting it:
-
-   ```sh
-   rinkaku --pr 123 --format md > map.md
-   # or: rinkaku --base main --format md > map.md
-   ```
-
-2. Paste `map.md` at the top of the reviewer's prompt, followed by
-   the actual diff, with instructions along these lines:
-
-   ```
-   Here is a structural map of this change (hotspots, contract markers,
-   entry-point trees). Use it to decide where to read deeply first, but
-   it is an attention-allocation aid, not a verifier: read the full
-   implementation of anything it flags, and don't assume unflagged code
-   is safe to skip. Then review the diff below.
-   ```
-
-3. Run an **independent pass without the map** alongside the
-   map-assisted one; the two consistently surface different findings.
-
-4. Add a **dynamic verification** step: build and actually execute
-   the changed code, including failure-mode invocations (non-TTY
-   stdin, empty input, missing files). Behavioral bugs don't show up
-   on the signature surface the map draws from.
-
-## Development
+| Homebrew | `brew install hiro-o918/tap/rinkaku` |
+| Install script | `curl -fsSL https://raw.githubusercontent.com/hiro-o918/rinkaku/main/install.sh \| bash` |
+| From source | `cargo install rinkaku` |
+| Manual | Grab a tarball from the [latest release](https://github.com/hiro-o918/rinkaku/releases/latest) and put `rinkaku` on your `PATH`. Targets: `{x86_64,aarch64}-{unknown-linux-gnu,apple-darwin}`. |
+
+Update with `rinkaku self-update` (see
+[`docs/cli.md#self-update`](docs/cli.md#self-update) for the
+interactive / `--yes` / non-TTY behavior).
+
+## Docs
+
+- [`docs/tui.md`](docs/tui.md) — TUI layout, key bindings, navigation
+- [`docs/action.md`](docs/action.md) — GitHub Action setup and
+  trusted-base posture
+- [`docs/cli.md`](docs/cli.md) — Every input mode, output format, and
+  flag
+- [`docs/llm-review.md`](docs/llm-review.md) — Recipe and honest
+  caveats for LLM reviewers
+- [`docs/adr/`](docs/adr) — Design decisions
+- [`docs/experiments/`](docs/experiments) — Multi-round experiments
+  (what actually worked, what didn't)
+
+## Contributing
 
 Requires a Rust toolchain (pinned in
-[`rust-toolchain.toml`](rust-toolchain.toml); `rustup` will install it
+[`rust-toolchain.toml`](rust-toolchain.toml); `rustup` installs it
 automatically).
-
-The workspace has three crates: `rinkaku-core` (the pure
-diff-condensation library, published standalone so it can be embedded
-in other tools), `rinkaku-tui` (the interactive terminal UI's
-view-models and `ratatui` rendering, depending on `rinkaku-core`; see
-[ADR 0016](docs/adr/0016-tui-crate-and-stack.md)), and `rinkaku` (the
-thin CLI binary, depending on both).
 
 ```sh
 make test    # cargo test --all-features
 make lint    # cargo fmt --check + cargo clippy --all-targets --all-features -- -D warnings
 make format  # cargo fmt --all
-make help    # list available targets
 ```
 
-CI runs the same `make` targets on every pull request (see
-[`.github/workflows/`](.github/workflows)).
-
-### Architecture
-
-Lightweight ports & adapters: core extraction logic in `rinkaku-core`
-is pure (no IO, no clock, no env), with tree-sitter parsing and future
-LSP/process boundaries isolated behind traits (`LanguageSupport`,
-`Resolver`) defined on the consumer side. See
-[`CLAUDE.md`](CLAUDE.md) and [`docs/adr/`](docs/adr) for details.
-
-### Known limitations
-
-**Mitigated in [#9](https://github.com/hiro-o918/rinkaku/pull/9):** the
-original QA pass found name-only matching noise and slow `--deps 1`
-indexing severe enough to block merging. Both are improved, though not
-eliminated — v1's resolver is still name-only (see "still open" below).
-
-- **Same-name matches are ranked and capped, not resolved.** When
-  several definitions share a referenced name, they are ranked by path
-  proximity to the referencing file (same file > same directory >
-  shared path prefix depth > other) and only the top 3
-  ([`MAX_MATCHES_PER_NAME`]) are shown; the rest are reported as a
-  count (`(+N more definitions matched by name)` in Markdown,
-  `omitted_matches` in JSON). This bounds "Depends on" noise but does
-  not guarantee the top 3 include the actually-referenced definition,
-  since ranking is a proximity heuristic, not type-aware resolution.
-- **`_` and single-character identifiers are never resolved.** They
-  are filtered out of referenced names entirely, since under name-only
-  resolution they match too many unrelated definitions to be useful
-  (Python's `_` placeholder convention was the main offender).
-- **The `--deps 1` indexing prefilter has limited effect when a diff
-  references common standard-library-style names.**
-  `TagsResolver::new` skips parsing files whose content cannot contain
-  any referenced name at all (measured ~88% fewer files parsed, ~8x
-  faster indexing on a same-language-only reference set — see PR #9
-  for the full numbers). But a name like `Vec`, `Option`, `String`,
-  `Some`, or `Ok` appears in nearly every Rust file in a real
-  codebase, so a diff whose referenced names include several of these
-  sees a smaller reduction. The prefilter is a substring match over
-  raw file content, not scoped to actual definitions, so it cannot
-  distinguish "defines `Vec`" from "mentions `Vec`" without also
-  risking false negatives. The dominant cost in `--base` mode remains
-  the per-file `git show` subprocess invocation for reading tracked
-  files (unaddressed).
-
-**Still open — no type resolution (by design, ADR 0003):** dependency
-resolution matches referenced names against definitions by name alone,
-with no type information — it cannot disambiguate overloads, shadowed
-names, or same-named symbols in unrelated modules. The ranking and cap
-above reduce the resulting noise but do not fix the underlying
-imprecision. A future `Resolver` implementation backed by an LSP
-server (pyright, gopls, rust-analyzer, ...) is planned as a
-higher-precision, opt-in alternative for v2+; see the Roadmap below.
-
-[`MAX_MATCHES_PER_NAME`]: rinkaku-core/src/deps.rs
-
-### Roadmap / not yet done
-
-- LSP-backed `Resolver` implementations (pyright, gopls,
-  rust-analyzer, ...) as a higher-precision, opt-in alternative to
-  the v1 tags-based `Resolver`.
-- A TUI screenshot/GIF in this README — deferred to a follow-up (the
-  recording tooling needs a controlling TTY that this repository's
-  development environment doesn't always provide).
-
-## Release
-
-`rinkaku` and `rinkaku-core` are versioned independently by
-[release-please](https://github.com/googleapis/release-please) (no
-`linked-versions` grouping): each crate only bumps when a commit
-touches its own path, so it's normal for them to be on different
-versions (e.g. `rinkaku` 0.2.0 depending on `rinkaku-core` 0.1.0).
-Only `rinkaku`'s release tag (`v{version}`, no component prefix)
-triggers `build-and-publish.yaml`; `rinkaku-core`'s tag is prefixed
-(`rinkaku-core-v{version}`) so a `rinkaku-core`-only release doesn't
-spin up the binary build/publish pipeline.
-
-`separate-pull-requests: true` is set for a reason that isn't obvious
-from the config alone: with more than one non-root `packages` entry
-(no `.` path), release-please's PR-merging step can't find a "root"
-release candidate to base the combined PR's title on, and falls back
-to a title that omits the version entirely (`chore: release main`).
-That title doesn't match what the *next* run expects when looking up
-the already-merged PR to tag, so tagging silently finds nothing to do
-and `release-main.yaml` aborts with "untagged, merged release PRs
-outstanding" -- this bit us for both the v0.2.0 and v0.3.0 releases,
-each requiring a manual `gh release create` + relabeling the PR
-`autorelease: tagged` to recover. `separate-pull-requests: true`
-sidesteps this entirely: each package gets its own PR (and its own
-title, correctly including that package's version), so there's no
-combined-PR title to compute in the first place.
+The workspace has three crates: `rinkaku-core` (pure library —
+extraction and rendering; embeddable), `rinkaku-tui` (TUI view-models
+and ratatui rendering), and `rinkaku` (the CLI). Core stays pure — no
+IO, no clock, no env — with tree-sitter and future LSP boundaries
+isolated behind consumer-side traits. See [`CLAUDE.md`](CLAUDE.md) and
+[`docs/adr/`](docs/adr) for the reasoning.
 
 ## License
 

--- a/docs/action.md
+++ b/docs/action.md
@@ -1,0 +1,81 @@
+# GitHub Action
+
+The composite [`action.yaml`](../action.yaml) runs rinkaku against a
+pull request's diff and posts (or updates) a **sticky PR comment**: a
+[`--format mermaid`](cli.md#format-mermaid) call/dependency graph up
+front — rendered natively by GitHub in the comment — with the full
+Markdown outline collapsed underneath for anyone who wants
+signature-level detail.
+
+## Minimal workflow
+
+```yaml
+name: rinkaku PR report
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      - uses: hiro-o918/rinkaku@main
+        with:
+          github-token: ${{ github.token }}
+```
+
+## Inputs
+
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `version` | `latest` | Release tag to download |
+| `binary` | *(none)* | Path to a pre-built rinkaku binary; skips download |
+| `repo-path` | `.` | The checkout rinkaku should analyze |
+| `base` | PR's base ref | Base ref to diff against |
+| `github-token` | `${{ github.token }}` | Token used to post/update the comment |
+| `comment` | `true` | Set `false` to skip posting; only emit outputs |
+
+Outputs: `mermaid-path`, `markdown-path` (paths to the generated
+report files, whether or not `comment: true`).
+
+## Trusted-base posture
+
+The snippet above is the simple case (a pinned release binary,
+`permissions: pull-requests: write` scoped to only what posting a
+comment needs). If you build rinkaku yourself instead of using a
+release binary, **build it from the PR's base ref, not the PR head** —
+a PR is exactly the input an attacker controls, and this job runs
+with a write token before anyone has reviewed it.
+
+The pattern this repository's own [dogfooding
+workflow](../.github/workflows/rinkaku-report.yaml) uses:
+
+1. Check out the PR's **base** ref at the job's default location, so
+   `uses: ./` resolves *the action code itself* — not just the binary
+   — from a trusted checkout.
+2. Check out the PR head into a subdirectory purely as data, and pass
+   it to this action via `repo-path`.
+
+The same rationale applies to the [LLM-review recipe](llm-review.md):
+always build the map from a trusted checkout, never from the branch
+under review.
+
+## Fork PRs
+
+Fork PRs get a read-only token from the `pull_request` trigger
+regardless of `permissions:`. The action detects this and falls back
+to writing the report into the job's step summary instead of posting a
+comment, so a fork PR's run still succeeds (exit 0) rather than
+failing on a 403.

--- a/docs/action.md
+++ b/docs/action.md
@@ -1,13 +1,33 @@
 # GitHub Action
 
-The composite [`action.yaml`](../action.yaml) runs rinkaku against a
-pull request's diff and posts (or updates) a **sticky PR comment**: a
-[`--format mermaid`](cli.md#format-mermaid) call/dependency graph up
-front — rendered natively by GitHub in the comment — with the full
-Markdown outline collapsed underneath for anyone who wants
-signature-level detail.
+This repository ships a
+[composite action](../action.yaml) that runs rinkaku against a pull
+request's diff and posts (or updates) a **sticky PR comment**. This
+page is a setup guide for wiring it into a **different** repository's
+workflow. For the output format itself, see
+[CLI reference](cli.md).
 
-## Minimal workflow
+## What it does
+
+On each pull request, the action:
+
+1. **Resolves a rinkaku binary** — downloads a GitHub Release asset by
+   default, or uses a caller-provided binary (see [Inputs](#inputs)).
+2. **Runs it against the PR's diff**, producing a Markdown report and
+   (when the resolved binary supports it) a `--format mermaid` graph.
+3. **Composes both into a single comment body** — the mermaid graph up
+   front (rendered natively by GitHub), the full Markdown outline
+   collapsed underneath — and posts or updates a **sticky** comment on
+   the PR: every run on the same PR edits the same comment (matched by
+   an HTML marker) instead of piling up a new one per push.
+
+On a fork PR the run still succeeds (exit 0) — see
+[Fork PR fallback](#fork-pr-fallback) below.
+
+## Quick start
+
+Add a workflow like this to the target repository, e.g.
+`.github/workflows/rinkaku-report.yaml`:
 
 ```yaml
 name: rinkaku PR report
@@ -36,46 +56,95 @@ jobs:
           github-token: ${{ github.token }}
 ```
 
+`fetch-depth: 0` and the explicit `git fetch` of the base branch are
+both needed so rinkaku's internal `--base "origin/<base-ref>"` diff
+has the base commit available locally.
+
+Pin `hiro-o918/rinkaku@main` to a release tag or commit SHA once
+you've verified the action works for your repository — the same
+"don't trust a moving ref" reasoning as any other third-party action.
+
+## Getting a rinkaku binary
+
+The action resolves the binary it runs in one of two ways, controlled
+by the `binary` input:
+
+- **Default — download a release**: leave `binary` unset. The action
+  downloads the `version` release tag (default `latest`) from
+  [GitHub Releases](https://github.com/hiro-o918/rinkaku/releases) for
+  the runner's platform (`x86_64`/`aarch64`, Linux/macOS) and uses
+  that. Right choice for the vast majority of external callers — the
+  Quick start above uses it.
+- **Caller-provided binary**: set `binary` to the path of an
+  already-built rinkaku binary; the download is skipped entirely.
+  This exists for callers building rinkaku themselves — most notably
+  to preserve the [trust boundary](#trust-boundary) below — and is
+  what this repository's own [dogfooding
+  workflow](../.github/workflows/rinkaku-report.yaml) does
+  (`cargo build --release -p rinkaku` from a trusted checkout, then
+  `binary: ${{ github.workspace }}/target/release/rinkaku`).
+
 ## Inputs
 
-| Input | Default | Purpose |
-| --- | --- | --- |
-| `version` | `latest` | Release tag to download |
-| `binary` | *(none)* | Path to a pre-built rinkaku binary; skips download |
-| `repo-path` | `.` | The checkout rinkaku should analyze |
-| `base` | PR's base ref | Base ref to diff against |
-| `github-token` | `${{ github.token }}` | Token used to post/update the comment |
-| `comment` | `true` | Set `false` to skip posting; only emit outputs |
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `version` | No | `"latest"` | Release tag to download, e.g. `"v0.4.1"`. Ignored when `binary` is set. |
+| `binary` | No | `""` | Path to an already-built rinkaku binary to use instead of downloading a release asset. |
+| `repo-path` | No | `"."` | Path to the git checkout rinkaku should analyze. Defaults to the current directory, which is only correct when the action's own steps run inside that checkout. |
+| `base` | No | `${{ github.event.pull_request.base.ref }}` | Base ref to diff against, passed through to `rinkaku --base`. |
+| `github-token` | No | `${{ github.token }}` | Token used to read/write the PR comment. Read-only on a fork PR regardless — see [below](#fork-pr-fallback). |
+| `comment` | No | `"true"` | Whether to post/update a sticky PR comment. When `false`, only the report files exposed via outputs are produced (for callers composing their own comment). |
 
-Outputs: `mermaid-path`, `markdown-path` (paths to the generated
-report files, whether or not `comment: true`).
+## Outputs
 
-## Trusted-base posture
+| Output | Description |
+| --- | --- |
+| `mermaid-path` | Path to the generated mermaid report file. Empty when the resolved rinkaku binary predates `--format mermaid` (see `markdown-only`). |
+| `markdown-path` | Path to the generated Markdown report file. |
+| `markdown-only` | `"true"` when the resolved rinkaku binary predates `--format mermaid` and the run fell back to a Markdown-only report. |
 
-The snippet above is the simple case (a pinned release binary,
-`permissions: pull-requests: write` scoped to only what posting a
-comment needs). If you build rinkaku yourself instead of using a
-release binary, **build it from the PR's base ref, not the PR head** —
-a PR is exactly the input an attacker controls, and this job runs
-with a write token before anyone has reviewed it.
+## Trust boundary
 
-The pattern this repository's own [dogfooding
-workflow](../.github/workflows/rinkaku-report.yaml) uses:
+A pull request is exactly the input an attacker controls, and this
+job runs with `pull-requests: write` before anyone has reviewed the
+PR. The **binary** that inspects the diff must not itself come from
+the diff it is inspecting.
 
-1. Check out the PR's **base** ref at the job's default location, so
-   `uses: ./` resolves *the action code itself* — not just the binary
-   — from a trusted checkout.
-2. Check out the PR head into a subdirectory purely as data, and pass
-   it to this action via `repo-path`.
+As an **external caller** using `uses: hiro-o918/rinkaku@<pinned>`,
+you already get half of this for free: the action code itself comes
+from the pinned ref of this repository, not from the calling PR.
+What's left in your hands is the **binary**:
 
-The same rationale applies to the [LLM-review recipe](llm-review.md):
-always build the map from a trusted checkout, never from the branch
-under review.
+- The default (downloading a tagged release) is a reasonable choice
+  for most repositories — the binary comes from this repository's own
+  release pipeline, not from the PR under review.
+- If you build rinkaku yourself instead (the `binary` input), build
+  it from the PR's **base** ref, not the PR head, for the same
+  reason: letting a PR supply the very tool that inspects it defeats
+  the point of running that tool with a write token.
 
-## Fork PRs
+This repository's own [dogfooding
+workflow](../.github/workflows/rinkaku-report.yaml) enforces a
+stronger version of this rule than most external callers need,
+because it also has to protect the **orchestration code**
+(`action.yaml` and `compose_and_post_comment.sh` at `uses: ./`): it
+checks out the PR's base ref at the job's default location (so
+`uses: ./` resolves the action from that trusted checkout) and
+checks out the PR head into a subdirectory purely as data, passed to
+the action via `repo-path`.
 
-Fork PRs get a read-only token from the `pull_request` trigger
-regardless of `permissions:`. The action detects this and falls back
-to writing the report into the job's step summary instead of posting a
-comment, so a fork PR's run still succeeds (exit 0) rather than
-failing on a 403.
+The same reasoning applies to the
+[LLM-review recipe](llm-review.md) — always build the map from a
+trusted checkout, never from the branch under review.
+
+## Fork PR fallback
+
+A `pull_request`-triggered workflow against a fork PR receives a
+read-only `GITHUB_TOKEN` from GitHub, no matter what the workflow's
+`permissions:` block declares. The action detects this
+(`github.event.pull_request.head.repo.fork`) and skips the
+comment-post attempt entirely, writing the composed report to
+`$GITHUB_STEP_SUMMARY` instead — the job still succeeds rather than
+failing on a 403. The same fallback also covers any other unexpected
+403 when posting (e.g. an org policy further restricting
+`GITHUB_TOKEN`), not just the fork case.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,219 @@
+# CLI reference
+
+The [TUI](tui.md) and [GitHub Action](action.md) are the recommended
+entry points, but the same analysis is available as plain CLI output —
+useful for scripting, CI gates, custom tooling, or feeding downstream
+processors.
+
+## Input modes
+
+| Mode | Reads files from | Notes |
+| --- | --- | --- |
+| **stdin** — `gh pr diff 123 \| rinkaku` | working tree | Assumes the piped diff matches the working tree. A stale/unrelated piped diff will misalign line numbers. |
+| **`--base <ref>`** — `rinkaku --base main` | `git show <head>:<path>` | Runs `git diff` internally; extraction always matches the diffed commit. |
+| **`--pr <number>`** — inside a local clone | `git show`-backed | Requires `gh` installed and authenticated ([ADR 0004](adr/0004-pr-input-mode-via-gh-in-local-clone.md)). |
+| **`--pr <url>`** — from any directory | `git show`-backed | Prefers an existing [ghq](https://github.com/x-motemen/ghq) clone; otherwise auto-clones blobless into a cache ([ADR 0005](adr/0005-auto-clone-into-cache-for-pr-urls.md) / [ADR 0006](adr/0006-prefer-ghq-managed-clones-over-cache.md)). Private repos need `gh auth setup-git`. |
+| **Whole-repo** — bare `rinkaku` | working tree | No diff involved; outlines every symbol and its dependency structure ([ADR 0017](adr/0017-whole-repo-outline-as-default-input-mode.md)). Default on a TTY is the TUI. |
+
+## Output formats (`--format`)
+
+```sh
+rinkaku --base main --format md        # Markdown (default when stdout is not a TTY)
+rinkaku --base main --format json      # Structured JSON for tooling
+rinkaku --base main --format mermaid   # A flowchart for pasting into a PR comment
+```
+
+`--tui` replaces the output stage entirely and conflicts with
+`--format`.
+
+## Markdown example
+
+Running rinkaku on
+[commit aa7ca34](https://github.com/hiro-o918/rinkaku/commit/aa7ca34)
+(a 35-line diff adding stderr progress logging to `main.rs`):
+
+```sh
+$ git show aa7ca34 --format="" | rinkaku --deps 0
+```
+
+````markdown
+## Change graph
+
+4 changed symbols in 1 file
+
+- fn main (rinkaku/src/main.rs)
+  - fn build_resolver (rinkaku/src/main.rs)
+  - fn resolve_pr_workdir (rinkaku/src/main.rs)
+  - fn run_base_pipeline (rinkaku/src/main.rs)
+    - fn build_resolver (rinkaku/src/main.rs) (see above)
+
+## Definitions
+
+### fn main (rinkaku/src/main.rs)
+
+```
+fn main() -> anyhow::Result<()>
+```
+
+...
+````
+
+The line under the heading summarizes the shape of the change (symbol
+count, file count, and — for multi-file diffs — the file with the
+epicenter, e.g. `16 changed symbols in 3 files — most in
+store/items.go (11)`).
+
+**"Change graph"** reads top-down in call-hierarchy order
+([ADR 0008](adr/0008-entry-point-tree-rendering-for-changed-symbols.md)):
+entry points at the top, callees nested. A symbol reachable from more
+than one place is rendered fully once and marked `(see above)` on
+repeats. Mutual-recursion cycles are marked
+`⚠️ ... — dependency cycle, see above`.
+
+Two condensations
+([ADR 0012](adr/0012-condense-change-graph-rendering.md)) keep
+request/response-style diffs readable: **data-carrier types** (structs
+/ enums / type aliases with no outgoing edges) fold into `— uses:`
+annotations on their referencer's line, and **interface/trait methods
+nest under their declaration** by method-spec name.
+
+Unchanged 1-hop dependencies (ADR 0003) show up as a `Depends on:` list
+under each definition.
+
+## JSON output
+
+`--format json` renders the same data as
+`{"files": [...], "skipped": [...], "graph": {"nodes", "edges", "roots"}}`,
+plus a `"tests": [{"path", "symbol_count"}]` array (ADR 0009's per-file
+test-symbol counts, non-empty only under `--exclude-tests` or when the
+diff touched test symbols under the default).
+
+The `graph` field is the same call-graph "Change graph" renders as a
+tree, so JSON consumers don't need to recompute it. Each entry in
+`files[].symbols` carries an `id` matching its `graph` node's `id`.
+
+`skipped[].reason` can be `"generated"` (ADR 0010 attribute-based
+detection, or ADR 0011 content-marker detection — both report the same
+reason) alongside `"unsupported_language"` / `"binary"` / `"deleted"`.
+
+## `--format mermaid`
+
+Emits the same call/dependency graph as a mermaid flowchart
+([ADR 0021](adr/0021-mermaid-output-format.md)), designed for pasting
+into a GitHub PR comment or description where mermaid renders
+natively. This is the format the [GitHub Action](action.md) uses for
+the top of its sticky comment.
+
+## Flags
+
+### `--deps <N>`
+
+`--deps 1` (default) resolves each changed symbol's 1-hop
+dependencies by indexing every file `git ls-files` tracks — richer
+output at the cost of an up-front repo-wide scan. `--deps 0` skips
+resolution entirely (no `Depends on:` sections, no repo scan) and is
+dramatically faster; use it for quick iteration or CI checks that
+don't need dependency context. See
+[Known limitations](#known-limitations) for precision caveats.
+
+### `--exclude-tests`
+
+By default ([ADR 0025](adr/0025-default-to-including-tests.md)), test
+symbols appear alongside production symbols and the `## Tests` section
+is omitted — this shape is designed for LLM consumers, for which
+"which contracts have which tests changed alongside them" is signal
+rather than noise.
+
+Pass `--exclude-tests` to opt into the previous behavior: test symbols
+(Go's `*_test.go`, Python's `test_*.py`/`*_test.py` and `tests/`,
+TypeScript's `*.test.ts(x)`/`*.spec.ts(x)` and `__tests__/`, Rust's
+`tests/` plus `#[cfg(test)]` and `#[test]`/`#[rstest]`/`#[tokio::test]`)
+are summarized as per-file counts under `## Tests` instead, and
+`TagsResolver`'s dependency index applies the same exclusion (ADR
+0009).
+
+### `--include-generated`
+
+By default, rinkaku skips generated files two ways:
+
+- **`.gitattributes`** ([ADR 0010](adr/0010-skip-files-marked-no-diff-or-generated-in-gitattributes.md)):
+  skips files marked `-diff` or `linguist-generated` (via
+  `git check-attr`; only when a git repository is available).
+- **Content markers** ([ADR 0011](adr/0011-detect-generated-files-by-content-markers.md)):
+  skips a file whose first 5 lines contain a linguist-compatible
+  marker (`@generated`, or a `Code generated ... DO NOT EDIT` line
+  regardless of comment syntax).
+
+Skipped generated files are dropped from Markdown silently (a diff
+that touches only generated files renders as empty Markdown) but do
+appear in `--format json`'s `skipped` array with reason `"generated"`.
+
+Pass `--include-generated` to disable both detections.
+
+### `--entry <path>`
+
+Re-roots "Change graph"/"Repository graph" at `path`
+([ADR 0019](adr/0019-entry-path-pivot-view.md)) — entry points become
+the symbols under `path` that nothing else *under that same path*
+depends on. Symbols outside `path` are neither hidden nor excluded
+from analysis, only no longer eligible to be roots.
+
+```sh
+rinkaku --base main --entry src/api
+```
+
+Combines with `--tui`: opens with the cursor on the row matching
+`path` and the Blast-radius pane already active. Prints
+`note: no symbols under <path>` to stderr and renders an empty tree
+when nothing matches. Fan-in counts remain whole-analysis (see
+[ADR 0019](adr/0019-entry-path-pivot-view.md)'s Consequences).
+
+## `self-update`
+
+```sh
+rinkaku self-update            # prompts before installing
+rinkaku self-update --yes      # non-interactive
+```
+
+Downloads the latest release for your platform and replaces the
+running binary in place. If you installed via Homebrew or
+`cargo install`, prefer `brew upgrade` / `cargo install rinkaku` so
+your package manager's bookkeeping stays in sync. When stdin is not a
+terminal and `--yes` is not given, `self-update` refuses to run rather
+than silently proceeding.
+
+## Known limitations
+
+**Mitigated in [#9](https://github.com/hiro-o918/rinkaku/pull/9):** the
+original QA pass found name-only matching noise and slow `--deps 1`
+indexing severe enough to block merging. Both are improved, though
+not eliminated — v1's resolver is still name-only.
+
+- **Same-name matches are ranked and capped, not resolved.** When
+  several definitions share a referenced name, they are ranked by path
+  proximity (same file > same directory > shared prefix depth > other)
+  and only the top 3 ([`MAX_MATCHES_PER_NAME`]) are shown; the rest
+  are reported as a count. Bounds noise but doesn't guarantee the top
+  3 include the actually-referenced definition — ranking is a
+  proximity heuristic, not type-aware resolution.
+- **`_` and single-character identifiers are never resolved.**
+  Filtered out entirely; under name-only resolution they match too
+  many unrelated definitions to be useful.
+- **The `--deps 1` indexing prefilter has limited effect on
+  standard-library-style names.** `TagsResolver::new` skips parsing
+  files whose content cannot contain any referenced name at all
+  (measured ~88% fewer files parsed, ~8x faster indexing on a
+  same-language-only reference set — see PR #9). But a name like
+  `Vec`, `Option`, `String`, `Some`, or `Ok` appears in nearly every
+  Rust file, so a diff referencing several of these sees a smaller
+  reduction. The dominant cost in `--base` mode remains the per-file
+  `git show` subprocess for reading tracked files (unaddressed).
+
+**Still open — no type resolution (by design, ADR 0003):** dependency
+resolution matches referenced names against definitions by name alone
+— it cannot disambiguate overloads, shadowed names, or same-named
+symbols in unrelated modules. A future `Resolver` backed by an LSP
+server (pyright, gopls, rust-analyzer, ...) is planned as a
+higher-precision, opt-in alternative for v2+.
+
+[`MAX_MATCHES_PER_NAME`]: ../rinkaku-core/src/deps.rs

--- a/docs/llm-review.md
+++ b/docs/llm-review.md
@@ -1,0 +1,51 @@
+# Using rinkaku with LLM reviewers
+
+rinkaku's Markdown output can be handed to an LLM as a "map" before it
+reads a diff. Ten rounds of a paired-arm experiment (see
+[`experiments/0001-map-assisted-llm-review/`](experiments/0001-map-assisted-llm-review/README.md))
+established what to expect and what not to:
+
+- The map is a **complement, not a substitute** for a plain diff
+  review. Across ten rounds, neither pass produced a superset of the
+  other's findings — running both remains the defensible default.
+- Its measurable value is **attention allocation** (routing toward
+  integration seams, self-consistency defects, coverage boundaries),
+  not token savings.
+- **Dynamic verification** (building and executing the changed code
+  against hostile / edge-case inputs) is the strongest single
+  predictor of finding real behavioral defects. It has caught bugs
+  the map cannot see by design: regressions in unchanged code, wrong
+  values on data-flow wires, and anything outside language coverage.
+
+The map does not verify anything. Treat it as an attention-allocation
+aid.
+
+## Recipe
+
+1. **Generate the map from a trusted checkout** — a clean `main`
+   build, never the branch under review, so a malicious or buggy diff
+   can't tamper with the tool inspecting it:
+
+   ```sh
+   rinkaku --pr 123 --format md > map.md
+   # or: rinkaku --base main --format md > map.md
+   ```
+
+2. **Paste `map.md` at the top of the reviewer's prompt**, followed
+   by the actual diff, with instructions along these lines:
+
+   ```
+   Here is a structural map of this change (hotspots, contract markers,
+   entry-point trees). Use it to decide where to read deeply first, but
+   it is an attention-allocation aid, not a verifier: read the full
+   implementation of anything it flags, and don't assume unflagged code
+   is safe to skip. Then review the diff below.
+   ```
+
+3. **Run an independent pass without the map** alongside the
+   map-assisted one; the two consistently surface different findings.
+
+4. **Add a dynamic verification step** — build and actually execute
+   the changed code, including failure-mode invocations (non-TTY
+   stdin, empty input, missing files). Behavioral bugs don't show up
+   on the signature surface the map draws from.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -1,0 +1,115 @@
+# Interactive TUI
+
+The TUI is the intended path for humans reading a PR
+([ADR 0015](adr/0015-tui-for-humans-markdown-for-machines.md)), built
+with [ratatui](https://ratatui.rs)
+([ADR 0016](adr/0016-tui-crate-and-stack.md)) on a neovim-style focus
+model ([ADR 0020](adr/0020-tui-interaction-model-v2.md)).
+
+On an interactive terminal, TUI is the **default output**: bare
+`rinkaku` opens the TUI on a whole-repo outline
+([ADR 0017](adr/0017-whole-repo-outline-as-default-input-mode.md)), and
+so do `rinkaku --pr 123`, `rinkaku --base main`, etc. The `--tui` flag
+only becomes load-bearing when the output would otherwise not be TUI
+(stdout is not a TTY, e.g. a diff piped in). It conflicts with
+`--format`.
+
+## Layout
+
+- **Tree pane (left)** — a directory tree of *changed files*, mirroring
+  your repository layout. Rows carry badges: `~N` changed symbols, `!N`
+  contract changes (added / removed / signature-changed), `^N` fan-in
+  (hotspot aggregate); directories in a dependency cycle are marked
+  `(cycle)`. Symbol rows show a kind abbreviation (`fn`, `struct`, ...)
+  and a classification marker: `+` added, `~` signature-changed, `x`
+  removed. Files rinkaku couldn't analyze appear dimmed as
+  `(skipped: <reason>)`; whole-test files as `[test] (N symbols)`.
+- **Diff pane (right, default)** — the raw unified-diff hunks touching
+  the selected row, syntax-highlighted for the four built-in languages
+  ([ADR 0018](adr/0018-syntax-highlight-diff-pane-via-tree-sitter.md)).
+- **Detail pane (right)** — what the cursor is on: classification,
+  signature (with an old/new diff on contract change), used-by, callees;
+  or, for a directory, its badge breakdown and cycle members.
+- **Blast radius pane (right)** — an entry-tree rooted at the cursor's
+  directory/file: *"if this changes, what does it reach?"* The
+  interactive equivalent of `--entry <path>`
+  ([ADR 0019](adr/0019-entry-path-pivot-view.md), named per
+  [ADR 0023](adr/0023-tui-blast-radius-naming.md)).
+
+## Key bindings
+
+Press `?` in the TUI for the always-up-to-date table.
+
+**Tree focus (default):**
+
+| Key(s) | Action |
+| --- | --- |
+| `j` / `k` / `↓` / `↑` | Move the cursor |
+| `enter` | Expand/collapse a directory, or open a file/symbol row (moves focus right) |
+| `space` | Expand or collapse (never moves focus) |
+| `e` / `E` | Expand every row |
+| `c` / `C` | Collapse every row |
+
+**Right focus (Detail / Diff / Blast-radius pane):**
+
+| Key(s) | Action |
+| --- | --- |
+| `j` / `k` / `↓` / `↑` | Scroll by one line |
+| `ctrl-d` / `ctrl-u` | Half-page scroll |
+| `gg` / `G` | Jump to top / bottom |
+| `h` / `esc` | Return focus to the tree |
+| `]` / `[` | Next / previous hunk (Diff pane only) |
+
+**Global (any focus):**
+
+| Key(s) | Action |
+| --- | --- |
+| `o` / `O` | Toggle topological / alphabetical ordering |
+| `d` / `D` | Toggle right pane between diff and detail |
+| `r` / `R` | Toggle right pane to blast radius |
+| `s` / `S` | Open the source view for the symbol under the cursor |
+| `gd` / `gr` | Jump to a callee / caller ([ADR 0022](adr/0022-jump-navigation-and-jumplist.md)) |
+| `ctrl-o` / `ctrl-i` | Jump back / forward through the jumplist |
+| `?` | Toggle the help overlay |
+| `q` / `ctrl-c` | Quit (from the entry view); `esc`/`q` also returns from the source view |
+
+Glyphs are plain ASCII (`~`/`!`/`^`/`+`/`x`, `v`/`>` for expand state).
+
+## Jump navigation (`gd` / `gr`)
+
+`gd` jumps toward a callee of the symbol under the cursor, `gr`
+toward a caller — a two-key sequence, mirroring neovim's own idiom
+([ADR 0022](adr/0022-jump-navigation-and-jumplist.md)). Zero candidates
+shows a status-line note, one candidate jumps immediately, more than
+one opens a popup (`j`/`k` to choose, `enter` to jump, `esc` to
+cancel). Every jump is recorded in a jumplist; `ctrl-o` / `ctrl-i`
+move back / forward, and a new jump from mid-history discards forward
+entries — same behavior as neovim's jumplist.
+
+## Source view
+
+`s` on a symbol row opens the file scrolled to and highlighting its
+line range. Reads the working tree (not the historical commit
+`--base`/`--pr` compared against), so the highlighted range can drift
+if you edit the file after opening the TUI. `esc`/`q` returns.
+
+## Combining with `--entry`
+
+`--entry <path>` combined with the TUI opens with the cursor already on
+the tree row matching `path` and the Blast-radius pane already active
+(the `R` binding) — the interactive session starts exactly where
+`--entry` would have rooted the Markdown/JSON tree. If no row's path
+matches exactly, the TUI opens normally with a status-line note.
+
+## Piped stdin + TUI
+
+Keyboard input is read from the controlling terminal independently of
+stdin ([ADR 0016](adr/0016-tui-crate-and-stack.md)'s addendum), so a
+piped diff and interactive navigation coexist:
+
+```sh
+gh pr diff 123 | rinkaku --tui
+```
+
+Here `--tui` is required because stdout may not be a TTY under the pipe
+composition.


### PR DESCRIPTION
## Summary

- Restructure the README so the interactive TUI (`--tui`) and the GitHub
  Action (mermaid sticky comment) are the two front-matter sections —
  those are the paths people actually reach for a PR through in
  practice.
- Preserve every CLI capability the prior README documented under a
  single "CLI reference" section (stdin, `--base`, `--pr`, `--format
  md/json/mermaid`, `--deps`, `--exclude-tests`, `--include-generated`,
  `--entry`), for scripting and CI use.
- Demote the LLM-review recipe to an "Advanced" section that leads
  with what `docs/experiments/0001-map-assisted-llm-review/` actually
  concluded: the map is a **complement, not a substitute** for a plain
  diff review; its measurable value is attention allocation, not token
  savings; dynamic verification remains the strongest predictor of
  finding real behavioral defects. This aligns the README's framing
  with the experimental result rather than overselling the LLM use
  case.

Only README content changed; no code, no ADRs, no other docs.

## What was cut

Nothing capability-wise. The rewrite consolidates duplicated prose
(the same-name-cap example, the ruff-6237ecb4d timing anecdote,
several restated caveats) rather than removing any feature or flag
from the docs.

## Deferred

A TUI screenshot / GIF at the top of the "Interactive TUI" section.
`vhs` on this machine failed against ttyd, and this session's shell
environment could not allocate a controlling TTY, so recording the
TUI is left for a follow-up. The Roadmap section notes it explicitly.

## Test plan

- [ ] Render `README.md` on GitHub and confirm the two new front-matter
      sections read clearly and the anchor links (`#interactive-tui-
      recommended`, `#github-action`, `#format-mermaid-graph-for-pr-
      comments`, `#advanced-using-rinkaku-with-llm-reviewers`, etc.)
      resolve.
- [ ] Sanity-check the "Interactive TUI" section against the current
      TUI behavior (key bindings, panes, `--tui` flag interactions).
- [ ] Sanity-check the "GitHub Action" section against
      `.github/workflows/rinkaku-report.yaml` and `action.yaml` (input
      names, trusted-base wording, fork-PR fallback).