### PR TITLE
fix: bump rinkaku-core dep to 0.2.0 in rinkaku and rinkaku-tui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "rinkaku-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/rinkaku-tui/Cargo.toml
+++ b/rinkaku-tui/Cargo.toml
@@ -17,7 +17,7 @@ name = "rinkaku_tui"
 path = "src/lib.rs"
 
 [dependencies]
-rinkaku-core = { path = "../rinkaku-core", version = "0.1.0" }
+rinkaku-core = { path = "../rinkaku-core", version = "0.2.0" }
 ratatui = { workspace = true }
 # Declared directly (unlike most crossterm usage, which goes through
 # ratatui's own `ratatui::crossterm` re-export — see that re-export's use

--- a/rinkaku/Cargo.toml
+++ b/rinkaku/Cargo.toml
@@ -17,7 +17,7 @@ name = "rinkaku"
 path = "src/main.rs"
 
 [dependencies]
-rinkaku-core = { path = "../rinkaku-core", version = "0.1.0" }
+rinkaku-core = { path = "../rinkaku-core", version = "0.2.0" }
 rinkaku-tui = { path = "../rinkaku-tui", version = "0.1.0" }
 clap = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
## Summary

Main is currently broken: after PR #37 merged rinkaku-core 0.2.0,
`rinkaku/Cargo.toml` and `rinkaku-tui/Cargo.toml` still request
`rinkaku-core = "0.1.0"`, so \`cargo check --all-features\` fails with
\`failed to select a version for the requirement rinkaku-core = ^0.1.0\`.

release-please's cargo-workspace plugin (\`merge: false\`, per
[.github/release-please/config.json](.github/release-please/config.json))
does not rewrite dependency requirements in sibling packages when a
package is released standalone. That's the underlying misbehaviour;
this PR is the immediate hotfix.

This also unblocks the pending rinkaku 0.5.0 release PR (#36),
whose CI is failing for the same reason.

## Follow-up

Collapsing the workspace's release-please configuration to a
unified tag / PR scheme (so the two-step rinkaku-core / rinkaku
release dance is not needed) is a separate task — this hotfix does
not change the release configuration itself.

## Test plan

- [x] \`cargo check --all-features\` passes locally after the bump
- [ ] CI passes on this PR