### PR TITLE
fix: unify release-please into a single-PR release cycle

### DIFF
--- a/.github/release-please/.manifest.json
+++ b/.github/release-please/.manifest.json
@@ -1,1 +1,1 @@
-{"rinkaku":"0.5.0","rinkaku-core":"0.2.0"}
+{"rinkaku":"0.5.0","rinkaku-core":"0.2.0","rinkaku-tui":"0.1.0"}

--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -3,7 +3,7 @@
   "release-type": "rust",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
@@ -48,6 +48,10 @@
       "component": "rinkaku-core",
       "include-component-in-tag": true
     },
+    "rinkaku-tui": {
+      "component": "rinkaku-tui",
+      "include-component-in-tag": true
+    },
     "rinkaku": {
       "component": "rinkaku"
     }
@@ -55,7 +59,7 @@
   "plugins": [
     {
       "type": "cargo-workspace",
-      "merge": false
+      "merge": true
     }
   ]
 }

--- a/rinkaku-core/Cargo.toml
+++ b/rinkaku-core/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Core diff-condensation engine for rinkaku: parses unified diffs and slices out changed symbols with their signatures and dependencies"
+documentation = "https://docs.rs/rinkaku-core"
 readme = "../README.md"
 keywords = ["diff", "tree-sitter", "code-review", "llm"]
 categories = ["development-tools"]

--- a/rinkaku-tui/Cargo.toml
+++ b/rinkaku-tui/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Interactive terminal UI view-models for rinkaku (ADR 0015/0016): directory tree, navigation, and detail views over a Report"
+documentation = "https://docs.rs/rinkaku-tui"
 readme = "../README.md"
 keywords = ["diff", "tui", "code-review"]
 categories = ["development-tools"]

--- a/rinkaku/Cargo.toml
+++ b/rinkaku/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Condense PR diffs into signatures and their dependencies for LLM-friendly review"
+documentation = "https://docs.rs/rinkaku"
 readme = "../README.md"
 keywords = ["diff", "tree-sitter", "code-review", "llm"]
 categories = ["command-line-utilities", "development-tools"]


### PR DESCRIPTION
## Summary

Fix two structural release-please gaps that surfaced during the v0.5.0 release:

1. **rinkaku-tui was never on crates.io.** It was added to the workspace when the TUI landed but never registered in \`.github/release-please/config.json\`'s \`packages\`, so \`cargo publish rinkaku\` at v0.5.0 failed with \`no matching package named `rinkaku-tui` found\` and \`cargo install rinkaku\` cannot resolve 0.5.0. Only crates.io was broken — the GitHub Release, Homebrew tap, install.sh, and self-update all shipped fine.
2. **Sibling dependency requirements were not updated atomically.** \`separate-pull-requests: true\` + \`cargo-workspace merge: false\` split each crate into its own release PR, so PR #37 merging rinkaku-core 0.2.0 left \`rinkaku/Cargo.toml\` and \`rinkaku-tui/Cargo.toml\` requesting \`rinkaku-core = \"0.1.0\"\` — main stopped building until PR #72 hand-wrote the bump. Scaling that dance to three crates every release is not sustainable.

## Change

- \`separate-pull-requests: false\` → all releasable crates roll into a **single** release PR.
- \`cargo-workspace\` plugin: \`merge: true\` (explicit; the plugin default). Rewrites sibling deps in the same PR.
- Adds \`rinkaku-tui\` to \`packages\` and to the manifest at its current \`0.1.0\` baseline.
- Adds an explicit \`documentation = \"https://docs.rs/...\"\` field to each crate's \`Cargo.toml\` — a minor crate-affecting change so release-please's path-based detection sees a bump for every crate this release.

Expected next release: **v0.5.1** / rinkaku-tui **0.1.1** / rinkaku-core **0.2.1**, all in one PR, one CI run, one normal merge.

## Historical caveat

The prior config was set to \`separate-pull-requests: true\` on purpose — README used to explain that \`false\` triggered an empty-title bug on the release-please PR that broke tagging (manually recovered on v0.2.0/v0.3.0). The bug was in an older release-please version; \`googleapis/release-please-action@16a9c90\` (v4.4.0) may have fixed it. This PR is that verification. If it recurs, the fallback is the same known manual \`gh release create\` + \`autorelease: tagged\` relabel.

## Test plan

- [x] \`cargo check --all-features\` passes locally with the new \`documentation\` fields
- [ ] CI passes on this PR
- [ ] After merge, release-please creates a **single** PR that bumps all three crates and updates sibling \`Cargo.toml\` requirements together
- [ ] After that PR merges, \`publish-crates\` succeeds for all three crates (rinkaku-tui 0.1.1 lands on crates.io, and \`cargo install rinkaku\` resolves v0.5.1)

Fixes Task #7 (see the referenced issue/task list).