### PR TITLE
fix(release): single-tag scheme + versioned PR title + publish rinkaku-tui

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -4,6 +4,7 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "separate-pull-requests": false,
+  "pull-request-title-pattern": "chore${scope}: release v${version}",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
@@ -45,12 +46,10 @@
   ],
   "packages": {
     "rinkaku-core": {
-      "component": "rinkaku-core",
-      "include-component-in-tag": true
+      "component": "rinkaku-core"
     },
     "rinkaku-tui": {
-      "component": "rinkaku-tui",
-      "include-component-in-tag": true
+      "component": "rinkaku-tui"
     },
     "rinkaku": {
       "component": "rinkaku"

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -177,10 +177,36 @@ jobs:
         run: cargo publish -p rinkaku-core --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
 
       # crates.io needs a short window to index rinkaku-core before
-      # rinkaku's publish can resolve it as a dependency. Only needed
+      # rinkaku-tui's publish can resolve it as a dependency. Only needed
       # right after an actual publish, not when we skipped above.
       - name: Wait for rinkaku-core to be indexed
         if: steps.check-core.outputs.already_published == 'false'
+        run: sleep 30
+
+      # rinkaku-tui must publish before rinkaku for the same reason
+      # rinkaku-core does: rinkaku depends on rinkaku-tui by version, and
+      # crates.io resolves that dependency from the registry, not from
+      # the workspace path. Same check-then-publish-then-wait pattern as
+      # rinkaku-core above.
+      - name: Check whether rinkaku-tui is already published
+        id: check-tui
+        run: |
+          version=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "rinkaku-tui") | .version')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if curl -sf "https://index.crates.io/ri/nk/rinkaku-tui" \
+              | grep -q "\"vers\":\"${version}\""; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish rinkaku-tui
+        if: steps.check-tui.outputs.already_published == 'false'
+        run: cargo publish -p rinkaku-tui --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+
+      - name: Wait for rinkaku-tui to be indexed
+        if: steps.check-tui.outputs.already_published == 'false'
         run: sleep 30
 
       - name: Check whether rinkaku is already published


### PR DESCRIPTION
## Summary

Finish the CI/CD unification started in #73. Three defects that
surfaced during v0.5.0/v0.5.1 all share one root — release-please
was configured as if each crate shipped independently, when in
practice rinkaku is one product with one release:

1. **Wrong component tags.** \`rinkaku-core-v0.5.1\` (actual 0.2.1)
   and \`rinkaku-tui-v0.5.1\` (actual 0.2.0) generated by
   release-please, and \`v*\` on build-and-publish matched all three
   so the workflow fired three times per release.
2. **Empty PR title.** \`chore(main): release\` (v0.5.1 needed a
   manual title edit before merge).
3. **\`publish-crates\` always fails.** rinkaku-tui is never
   uploaded to crates.io, so \`cargo publish rinkaku\` cannot
   resolve its own dependency.

## Changes

- \`.github/release-please/config.json\`:
  - Drop \`include-component-in-tag: true\` from \`rinkaku-core\` and
    \`rinkaku-tui\` — the top-level \`include-component-in-tag: false\`
    now applies uniformly, so no component tags are generated.
  - Add \`pull-request-title-pattern: \"chore\${scope}: release v\${version}\"\`
    so the PR title always includes the version.
- \`.github/workflows/build-and-publish.yaml\`:
  - Mirror the existing rinkaku-core publish block (check → publish → sleep)
    for rinkaku-tui, inserted between rinkaku-core and rinkaku so all
    three publish in dependency order.

Component-per-crate changelogs are preserved via the \`component\` field
on each package.

## Verification (self-verifies via the next release)

- [ ] CI passes on this PR (rust-test 3 platforms).
- [ ] Merge this PR normally.
- [ ] release-please opens a PR titled **\`chore(main): release v0.5.2\`**
      (title contains the version, no manual edit needed).
- [ ] Merge the release PR normally.
- [ ] release-please creates **exactly one** tag \`v0.5.2\`
      (no \`rinkaku-core-v0.5.2\` / \`rinkaku-tui-v0.5.2\`).
- [ ] \`build-and-publish\` runs **exactly once** for \`v0.5.2\` (no
      triple trigger from component tags).
- [ ] \`publish-crates\` succeeds: rinkaku-core → rinkaku-tui →
      rinkaku all uploaded.
- [ ] \`cargo search rinkaku\` shows \`rinkaku = \"0.5.2\"\` and
      \`cargo install rinkaku\` resolves.

Once these pass, releases going forward are hands-off.