### PR TITLE
chore(ci): bump release-please-action from v4.4.0 to v5.0.0

### DIFF
--- a/.github/workflows/release-main.yaml
+++ b/.github/workflows/release-main.yaml
@@ -38,7 +38,7 @@ jobs:
           repositories: >-
             ["${{ github.event.repository.name }}"]
 
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ steps.gh_pr_token.outputs.token }}


### PR DESCRIPTION
Pull nine months of release-please improvements. Core version
bundled with the action moves from **17.1.3** (2025-10-06) to
**17.6.0** (2026-04-13); action wrapper moves to node24.

## Impact

- BREAKING between v4.4.0 → v5.0.0 is only the action's own node
  runtime (node20 → node24). ubuntu-latest already provides
  node24, so no change on our side.
- No release-please config changes needed.

## What it might fix

Scan of the release-please changelog between 17.1.3 and 17.6.0 did
not surface a specific fix for the empty-version PR title problem
we still see with \`separate-pull-requests: false\` + no root
package. Bumping is worthwhile anyway for the accumulated bugfix
and dep-bump surface.

## Verify

Merge → the next release-please run against main uses v5.0.0 →
verify that (a) the run itself succeeds, and (b) whether the
subsequent release PR's title now contains a version or is still
`chore: release main`.