### PR TITLE
feat(cli): drop timestamp and module path from stderr logs

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/017.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/017.md
@@ -1,0 +1,62 @@
+# Round 17
+
+- Subject: PR #79 — `rinkaku/src/main.rs`'s `env_logger::Builder` gains
+  `.format_timestamp(None)` and `.format_target(false)`, so stderr log
+  lines drop the timestamp and module-path prefix. A one-hunk,
+  single-symbol change (`fn main`); no test file touched.
+- Protocol note: this round was not run as a harness-timed A/B pair
+  (no token/tool-call/wall-clock metrics were collected); it records
+  the same two-pass-plus-dynamic-verification review this PR actually
+  received before merge, in the same per-round format as prior rounds
+  for continuity of the record.
+- **Map-assisted pass**: `gh pr diff 79 | rinkaku` (built from a
+  trusted `main` checkout) showed exactly 1 changed symbol (`fn main`),
+  no hotspots, and no signature-change markers — correctly silent,
+  because this PR's entire risk surface (the rendered *text* of a
+  stderr log line) lives outside rinkaku's symbol/signature
+  representational model entirely; there is no signature to diff. With
+  the map offering nothing to route on, the reviewer fell back to
+  manually tracing "who reads this output": confirmed `action.yaml`,
+  `.github/workflows/rinkaku-report.yaml`, and
+  `compose_and_post_comment.sh` all capture **stdout** only, that the
+  mermaid-availability probe parses `--help` (unaffected by logging
+  format), that stderr is discarded in every consumer, and that no
+  doc anywhere embeds a timestamped log sample that would go stale.
+  No findings.
+- **Independent pass**: map-free reading of the diff and its
+  surrounding context, verdict Approve. Comment discipline (the new
+  comment explains *why* — short-lived CLI, single-crate binary — not
+  *what*), commit message conformance, and the no-`unwrap`/`expect`-in-
+  library-code rule all check out. Judged the missing unit test
+  acceptable rather than a gap: `env_logger`'s `Builder::init()` sets a
+  process-global logger and panics on double-init, so the standard
+  in-module `#[cfg(test)]` pattern this repo otherwise requires isn't
+  available here — dynamic verification is the correct tool for this
+  specific symbol, not a test gap to flag.
+- **Dynamic verification**: `--base main` renders `[INFO ] ...` with no
+  timestamp and no module-path segment; empty non-TTY stdin still
+  exits 0 without panicking; `RUST_LOG=warn` correctly suppresses the
+  `INFO`-level startup line (confirming `Builder::from_env` precedence
+  is untouched); `--base nonexistent-branch` exits 1 through the
+  existing `anyhow` `Error:` path, unaffected; clap's own usage-error
+  path is likewise untouched. The two `log::warn!` call sites in the
+  codebase weren't organically reachable through CLI flags in a quick
+  pass, so the reviewer isolated the exact `Builder` configuration in
+  a throwaway crate and drove it directly, confirming uniform
+  formatting (no timestamp, no target) across `DEBUG`/`INFO`/`WARN`/
+  `ERROR` levels with level-label alignment preserved.
+- **No findings from either pass.** Both explicitly checked for the
+  failure shape rounds 1-16 established as the map's blind spot at
+  this scale (non-signature body-only diffs) rather than treating
+  silence as evidence of nothing-to-check.
+- Takeaway, echoing round 10's lesson from the opposite direction: on a
+  diff entirely outside the map's representational model (here, a
+  one-line formatter-config change whose entire risk is in rendered
+  text, not in any type or signature), the map's correct move is to
+  stay silent rather than manufacture a hotspot or marker that would
+  mislead. The absence of map markers must not be read as "nothing to
+  check" by the reviewer — it was the trigger for the independent
+  pass's manual consumer trace (does anything parse or archive this
+  stderr text?) and for dynamic verification isolating the exact
+  render behavior a symbol-level diff cannot show. A clean map on a
+  body-only diff is a blind-spot signal, not a clearance.

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -194,7 +194,14 @@ fn main() -> anyhow::Result<()> {
     // below — gave no feedback at all while running). `RUST_LOG` still
     // overrides this, same as any other `env_logger::Builder::from_env`
     // setup.
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    //
+    // Timestamp and module path are dropped: this is a short-lived
+    // one-shot CLI, so there is nothing to correlate a timestamp against,
+    // and the binary is a single crate, making the module path redundant.
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format_timestamp(None)
+        .format_target(false)
+        .init();
     let cli = Cli::parse();
 
     if let Some(Command::SelfUpdate { yes }) = cli.command {


### PR DESCRIPTION
## Summary
- Drop the timestamp and module path from `env_logger`'s stderr format via `.format_timestamp(None)` and `.format_target(false)`, keeping only the level prefix.
- rinkaku is a short-lived one-shot CLI, so a wall-clock timestamp has nothing to correlate against, and the binary is a single crate, so the module path (always `rinkaku`) is redundant noise.
- The level prefix is kept so warnings/errors stay visually distinguishable from info lines.

## QA

Built and ran the binary directly (not just unit tests), per the repo's mandatory dynamic-verification policy.

**Before** (built from `main` at `f581058`, unchanged `main.rs`):
```
$ ./target/debug/rinkaku --base main
[2026-07-13T07:07:25Z INFO  rinkaku] diffing main...HEAD
[2026-07-13T07:07:25Z INFO  rinkaku] building dependency index over 100 tracked files
[2026-07-13T07:07:25Z INFO  rinkaku] analyzing diff
```

**After** (this branch):
```
$ ./target/debug/rinkaku --base main
[INFO ] diffing main...HEAD
[INFO ] building dependency index over 100 tracked files
[INFO ] analyzing diff
```

**Non-TTY empty stdin** (no panic, exit code 0):
```
$ printf '' | ./target/debug/rinkaku
note: diff is empty, nothing to analyze
[INFO ] building dependency index over 100 tracked files
[INFO ] analyzing diff
```

**`RUST_LOG=debug`** (confirms the format applies uniformly across levels — `format_timestamp`/`format_target` are level-agnostic formatter settings, not conditional per level; no `debug!` call happens to fire on the `--base main` path, but the INFO lines shown use the same minimal formatter):
```
$ RUST_LOG=debug ./target/debug/rinkaku --base main
[INFO ] diffing main...HEAD
[INFO ] building dependency index over 100 tracked files
[INFO ] analyzing diff
```

- `make lint`: pass (`cargo fmt --all --check` + `cargo clippy --all-targets --all-features -- -D warnings`)
- `make test`: pass (161 + 336 + 460 = 957 tests, 0 failed, across `rinkaku-core`, `rinkaku-tui`, `rinkaku`)
