### PR TITLE
feat(tui): diff pane follows symbol selection with auto-scroll

### DIFF
--- a/docs/adr/0027-diff-pane-follows-symbol-selection.md
+++ b/docs/adr/0027-diff-pane-follows-symbol-selection.md
@@ -1,0 +1,190 @@
+# 0027. Diff pane follows symbol selection: always render the whole file, auto-scroll to the selected symbol's section
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+ADR 0020 decision 4 split the diff pane's selection-scope semantics
+into two shapes: **symbol selected** clipped the pane to that symbol's
+own hunks, hiding sibling symbols; **file selected** grouped every
+hunk in the file under per-symbol section headers. This shipped and
+matched the ADR's "orient before reading" framing at the individual
+symbol level.
+
+Dogfooding surfaced a specific complaint: moving the left-pane cursor
+between symbols in the same file does not visibly "follow" on the
+right — the diff pane's content swaps out entirely (from symbol A's
+clipped hunks to symbol B's) and the scroll offset resets to 0. There
+is nothing to *scroll* through, so `j`/`k` on `Focus::Right` is
+useless while a symbol is selected, `]c`/`[c` only walks the one
+symbol's own hunks, and the reader loses the surrounding-file context
+they had while any file row was selected. It reads as "the diff pane
+is not connected to the symbol I just moved to", even though the pane
+is technically showing exactly that symbol's hunks — because the
+motion produced no visible motion.
+
+Two closely related properties fell out of the same clip-on-symbol
+rule that the user noticed together:
+
+- The reviewer cannot see, from a symbol row, the hunks of adjacent
+  symbols in the same file. Those adjacent hunks are frequently the
+  reason a change under the cursor was made — a caller a few symbols
+  above, a helper a few symbols below — and today reaching them means
+  moving the cursor off the symbol first, defeating "keep reading on
+  this symbol".
+- `]c`/`[c` (`InputKey::NextHunk`/`PrevHunk`) can only walk within one
+  symbol's hunks while that symbol is selected, so a common "sweep
+  every hunk in this file in order" gesture requires an extra
+  intermediate step (pick the file row first, then bracket-walk).
+
+These are all facets of the same underlying design choice — the diff
+pane treats a symbol selection as a *filter* rather than as a
+*focus point*. This ADR flips that.
+
+## Decision
+
+**1. The diff pane always renders the whole selected file.** Remove
+`DiffPaneContent::Symbol(section)`; both file-row and symbol-row
+selections now produce `DiffPaneContent::File(sections)` from
+`crate::diff_shape::build_diff_pane_content`. The per-symbol section
+grouping, module-level bucket, and contract headers established by
+ADR 0020 decision 4 all stay exactly as they are for a file
+selection — they just now also apply when a symbol row is selected.
+
+**2. A symbol selection auto-scrolls to that symbol's section.**
+When `App::selected_diff_target` resolves to a symbol row, the diff
+pane's `right_pane_scroll` is set to the logical-line offset where
+that symbol's section header starts within the shaped content, using
+`crate::diff_shape::hunk_start_lines`' existing offset table. The
+scroll offset is a normal `right_pane_scroll` value: `j`/`k`,
+`Ctrl-d`/`Ctrl-u`, `gg`/`G`, and `]c`/`[c` all continue to work from
+there, and the clamp-at-draw-time discipline
+(`crate::ui::clamp_scroll`, folded back via
+`clamp_right_pane_scroll_after_draw`) is unchanged.
+
+**3. Section start, not first hunk start.** The auto-scroll target is
+the section's *header* line (its signature line, and the contract
+header above it if present) — not the first hunk's `@@` line. The
+reviewer wants to see the section title / contract change first;
+starting mid-header would hide exactly the outline-level fact ADR 0020
+decision 4's contract header was added to surface.
+
+**4. `run_app` owns the auto-scroll.** The offset is written to
+`right_pane_scroll` in `crate::run_app`'s existing "recompute diff
+pane content on selection change" step
+(`should_recompute_diff_pane_content`), the same seam that already
+rebuilds the shaped content and the highlight cache when the
+selection changes. This keeps the auto-scroll rule in one place, next
+to the state it derives from, and out of `App::handle_key` — which
+has no access to `report` in the general case (that access is exactly
+what forced `NextHunk`/`PrevHunk`'s own scroll computation to live in
+`run_app` rather than `App`).
+
+**5. Symbol-move preserves auto-scroll, not the manual scroll
+offset.** `App::handle_key`'s blanket "reset `right_pane_scroll` to 0
+on every key except `Up`/`Down` on `Focus::Right`" rule still runs;
+the auto-scroll simply writes a fresh non-zero value right after,
+based on the new selection. A reviewer who scrolled by hand within
+one symbol's section and then moves the cursor to a sibling symbol
+gets the sibling's section start — not their prior manual offset
+translated onto the new section. This is the same "cursor motion
+retargets the pane" principle every other right-pane content follows;
+the alternative (preserve manual scroll across selection changes)
+would have to invent a per-symbol scroll memory the rest of the pane
+model does not have.
+
+**6. `]c`/`[c` now walks every hunk in the file.** With the pane
+always showing the whole file, `NextHunk`/`PrevHunk` naturally sweep
+across every symbol's hunks in source order, from any row selection.
+No change to `jump_scroll_target` itself — it already walks
+`hunk_start_lines`, which now covers the whole file regardless of
+selection kind.
+
+**7. Removed-symbol / directory rows are unchanged.** A directory
+row still shows the placeholder (`DiffTarget::None`), and a removed
+symbol row still shows nothing (no line range to derive a scroll
+target from). Only the *present* symbol row's semantics change.
+
+## Alternatives
+
+- **Keep the symbol-clip default and add a keybinding to expand to
+  the whole file.** Rejected: this preserves the exact "moving the
+  cursor does nothing visible" complaint that motivated the ADR, and
+  adds a mode toggle on top. The default should already do the right
+  thing.
+- **Auto-scroll to the first *hunk* of the section instead of the
+  section header.** Rejected: ADR 0020 decision 4 added the
+  contract-change header specifically so the outline fact appears
+  before the hunks; landing past it hides exactly what that header
+  exists to show. Only applies when a contract header is present, but
+  handling the two cases differently would put a per-section
+  conditional into the auto-scroll rule for one line's saving.
+- **Preserve `right_pane_scroll` across symbol moves (translate the
+  offset onto the new section).** Rejected: introduces per-symbol
+  scroll memory the rest of the right pane does not have, and would
+  need a well-defined rule for "what does a scroll offset mean when
+  moving from a 3-line symbol to a 30-line one" — a design surface
+  bigger than the auto-scroll rule this ADR chose instead.
+- **Cache one shaped `DiffPaneContent::File` per file and update only
+  the scroll offset on symbol moves within the same file.** Rejected
+  as a premature optimization: `build_diff_pane_content` on a file
+  runs once per handled key on the currently selected file only,
+  operates over already-parsed `FileHunks`, and is comfortably fast
+  enough that the caching complexity is not justified. Can be revisited
+  if profiling ever shows this recompute as a real cost.
+- **Keep `DiffPaneContent::Symbol` around as dead code for potential
+  future use.** Rejected: an unreferenced variant is a maintenance
+  liability (every match on `DiffPaneContent` still has to handle it)
+  for no current caller. Delete it; if a future feature needs a
+  symbol-clipped view, add it back with a specific requirement to
+  point at.
+- **A dedicated "symbol focus" scroll indicator in the diff pane title
+  (e.g. `Diff — fn foo`).** Considered as a way to make the auto-scroll
+  visible even when the section is already fully on screen (no scroll
+  motion). Deferred: not needed to fix the reported complaint, and
+  ADR 0020 decision 4 already puts the symbol's signature at the top
+  of its section as the header — that *is* the "you are focused
+  here" indicator, right where the reviewer is reading. If dogfooding
+  finds this insufficient a follow-up ADR can add a title suffix.
+
+## Consequences
+
+- The complaint the ADR was written to fix ("symbol 移動しても diff の
+  scroll が連携しない") is fixed by construction: moving the left-pane
+  cursor between symbols in the same file now visibly scrolls the
+  right pane to the new symbol's section. Moving to a symbol in a
+  different file rebuilds the shaped content for that file and lands
+  the scroll at the new symbol's section start — same rule, different
+  file.
+- `DiffPaneContent::Symbol` and `build_symbol_content` are removed.
+  Any test asserting a `DiffPaneContent::Symbol(_)` shape is rewritten
+  to assert the corresponding `DiffPaneContent::File(vec![...])` shape
+  (which was already the file-row expected value, so the
+  post-migration expected values mostly already exist elsewhere in the
+  same test module).
+- `App::selected_diff_target` for a symbol row now returns
+  `DiffTarget::File { path }` plus a separate "focus symbol id"
+  channel (either as a second field on `DiffTarget`, or via a
+  companion `selected_diff_focus` accessor — the implementation
+  chooses the smaller change). Either way, the returned enum stays
+  the shape `build_diff_pane_content` already accepts; the focus id
+  is consumed by `run_app`'s auto-scroll step, not by the shaping
+  function.
+- Hunk-jump keys (`]c`/`[c`) become file-wide instead of symbol-scoped
+  when a symbol is selected. This is a strict expansion — the same
+  keys still work, they just walk more hunks. `should_apply_hunk_jump`
+  is unchanged (still gated on `Focus::Right` + `RightPane::Diff`).
+- `App::handle_key`'s existing scroll-reset-on-every-key rule needs no
+  change: the reset still fires, then `run_app` re-derives the correct
+  offset from the new selection. This keeps the reset rule uniform (no
+  new "preserve scroll for symbol move" carve-out) and the auto-scroll
+  rule in one place.
+- No backward compatibility concern: the TUI has never shipped a
+  release (ADR 0015/0016), so this replaces the ADR 0020 semantics
+  in place rather than migrating between them.
+- ADR 0020 decision 4's file-selection sub-rules (per-symbol section
+  headers, module-level bucket for hunks intersecting no symbol,
+  first-match attribution for overlapping symbols, contract header
+  above signature-changed sections) all continue to apply — this ADR
+  extends them to symbol selections rather than replacing them.

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -1015,6 +1015,22 @@ impl App {
             // is a real pane switch to Diff and must still fall through to
             // the blanket reset below.
             (Screen::Entry, Focus::Right, RightPane::Diff, InputKey::Open)
+                // ADR 0027 dogfooding finding: Enter from Tree focus onto a
+                // file/symbol row already showing Diff does not visibly
+                // change the pane's content (Diff was already the current
+                // right pane, and the auto-scroll for the row already ran
+                // when the cursor first landed on it) — it just moves
+                // focus. Resetting `right_pane_scroll` to 0 here would
+                // wipe both the auto-scroll offset and any subsequent
+                // manual scrolling the reviewer did before pressing Enter,
+                // dropping them back at the top of the file instead of
+                // the section they were reading. The other `Focus::Tree,
+                // Open` cases — a directory row (expand/collapse only, no
+                // focus change, dispatched via `Action::ToggleExpand`
+                // below) and the Detail/BlastRadius→Diff swap — do change
+                // the pane's content and must still fall through to the
+                // reset.
+                | (Screen::Entry, Focus::Tree, RightPane::Diff, InputKey::Open)
         );
         // Set by the `JumpBack`/`JumpForward` arms below when they actually
         // restore a jumplist entry's own scroll offset — that restored
@@ -2641,6 +2657,35 @@ mod tests {
         let app = app.handle_key(InputKey::ToggleDiff);
 
         assert_eq!(0, app.right_pane_scroll());
+    }
+
+    #[test]
+    fn should_preserve_right_pane_scroll_when_open_pressed_from_tree_focus_on_diff_pane() {
+        // ADR 0027 dogfooding finding: pressing Enter from Tree focus onto
+        // a file/symbol row that is already showing on the Diff pane must
+        // not wipe `right_pane_scroll` — the pane's content is not
+        // changing, only the focus is, so the reviewer's reading position
+        // (whether set by the previous auto-scroll to the section start,
+        // or by any manual `j`/`k` they did after that) must survive the
+        // focus swap. Without this, `run_app`'s "only auto-scroll on focus
+        // change" rule leaves nothing to re-derive the scroll from and the
+        // pane snaps back to line 0.
+        let report = report_with_one_symbol();
+        // Start on Diff pane (the default per ADR 0020), cursor on the
+        // symbol row, focus Right. Manually seed a nonzero scroll to
+        // represent an auto-scroll offset or a manual `j` press.
+        let app = App::new(&report)
+            .handle_key(InputKey::Down) // cursor -> the symbol row
+            .with_right_pane_scroll(4);
+        assert_eq!(Focus::Tree, app.focus());
+        assert_eq!(RightPane::Diff, app.right_pane());
+        assert_eq!(4, app.right_pane_scroll());
+
+        let app = app.handle_key(InputKey::Open);
+
+        assert_eq!(Focus::Right, app.focus());
+        assert_eq!(RightPane::Diff, app.right_pane());
+        assert_eq!(4, app.right_pane_scroll());
     }
 
     #[test]

--- a/rinkaku-tui/src/app.rs
+++ b/rinkaku-tui/src/app.rs
@@ -314,19 +314,37 @@ pub enum SelectedDetail {
 }
 
 /// What [`App::selected_diff_target`] resolved the cursor's row to — plain
-/// data describing which file (and, for a symbol, which 1-based inclusive
-/// line range) the diff pane should slice hunks from; `crate::ui` combines
-/// this with the raw diff text (via `crate::diff_view`) at draw time.
+/// data describing which file the diff pane should slice hunks from;
+/// `crate::ui` combines this with the raw diff text (via
+/// `crate::diff_view`) at draw time.
+///
+/// Per ADR 0027 this always resolves to a file-scoped target, even for
+/// symbol rows — the "which symbol is focused" information is carried by
+/// [`App::selected_diff_focus`] on a separate accessor and applied by
+/// `crate::run_app` as an auto-scroll offset, not by branching the diff
+/// pane's shape here. The old `DiffTarget::Symbol` variant is gone.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiffTarget {
-    Symbol {
-        path: String,
-        range_start: usize,
-        range_end: usize,
-    },
-    File {
-        path: String,
-    },
+    File { path: String },
+}
+
+/// Which symbol (if any) the tree cursor is currently on for the diff
+/// pane's benefit (ADR 0027 decision 2 + Consequences): `crate::run_app`
+/// looks up this symbol's shaped section
+/// (`crate::diff_shape::section_start_line_for_symbol`) and auto-scrolls
+/// [`App::right_pane_scroll`] to that section's start whenever a new
+/// selection triggers a diff-pane recompute. `None` on file/directory
+/// rows and on removed symbol rows — those either have no symbol to
+/// focus, or no line-range/graph identity to derive a section from.
+///
+/// `path` is redundant with [`DiffTarget::File`]'s own `path` (both come
+/// from the same tree row), but is kept here so a caller with only a
+/// `DiffFocus` in hand does not need to also thread a `DiffTarget`
+/// through to know which file the focus belongs to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffFocus {
+    pub path: String,
+    pub symbol_id: String,
 }
 
 /// What [`App::selected_blast_radius_view`] resolved the cursor's row to
@@ -651,40 +669,71 @@ impl App {
 
     /// What the diff pane (TUI iteration 2, [`RightPane::Diff`]) should
     /// slice out of the raw diff text for the row currently under the
-    /// cursor: a symbol row scopes to just its own line range (looked up
-    /// from `report`, since `crate::tree::SymbolRef` itself carries no line
-    /// range — only `id`/`name`/`kind`/`classification`/`removed`), a file
-    /// row to the whole file, and a directory row has nothing diff-specific
-    /// to show (a directory spans multiple files with no single line range
-    /// to highlight — showing "every hunk under this directory" was
-    /// considered and deferred, since it would just be the concatenation
-    /// of every file's own diff, better browsed file by file). `None` when
-    /// there are no rows at all, the cursor sits on a removed symbol (no
-    /// line range to scope to, same as `selected_detail`'s handling), or
-    /// (defensively) `report` no longer contains the selected symbol.
-    pub fn selected_diff_target(&self, report: &Report) -> Option<DiffTarget> {
+    /// cursor: a file-scoped [`DiffTarget::File`] on both file rows and
+    /// symbol rows (ADR 0027 decision 1 — the diff pane always renders the
+    /// whole file, and "which symbol is focused" is carried on
+    /// [`Self::selected_diff_focus`] alongside), or `None` on a directory
+    /// row (a directory spans multiple files with no single diff to show —
+    /// showing "every hunk under this directory" was considered and
+    /// deferred, since it would just be the concatenation of every file's
+    /// own diff, better browsed file by file). `None` also when there are
+    /// no rows at all.
+    ///
+    /// `_report` is unused now that resolution needs only the tree row's
+    /// own path (previously the symbol variant needed the line range from
+    /// `report.files[..].symbols` — ADR 0027 folded that lookup into
+    /// `crate::diff_shape` instead). Kept in the signature so the
+    /// symmetry with [`Self::selected_detail`]/[`Self::selected_diff_focus`]
+    /// stays intact for call sites that already thread `report` through.
+    pub fn selected_diff_target(&self, _report: &Report) -> Option<DiffTarget> {
         let rows = self.nav.rows(&self.tree);
         let row = rows.get(self.nav.cursor())?;
         match &row.node.kind {
-            NodeKind::Symbol(symbol_ref) if !symbol_ref.removed => {
-                let range = report
-                    .files
-                    .iter()
-                    .find(|file| file.path == row.node.path)
-                    .and_then(|file| file.symbols.iter().find(|s| s.id == symbol_ref.id))
-                    .map(|s| s.range)?;
-                Some(DiffTarget::Symbol {
-                    path: row.node.path.clone(),
-                    range_start: range.start,
-                    range_end: range.end,
-                })
-            }
+            NodeKind::Symbol(symbol_ref) if !symbol_ref.removed => Some(DiffTarget::File {
+                path: row.node.path.clone(),
+            }),
             NodeKind::Symbol(_) => None,
             NodeKind::File => Some(DiffTarget::File {
                 path: row.node.path.clone(),
             }),
             NodeKind::Dir => None,
         }
+    }
+
+    /// Which symbol the tree cursor currently focuses for the diff pane's
+    /// auto-scroll (ADR 0027 decision 2 + Consequences): [`DiffFocus`] on a
+    /// present symbol row, `None` on file/directory rows, on removed symbol
+    /// rows (no graph identity to look up), or when there are no rows at
+    /// all. `report` is threaded through only defensively — the focus id
+    /// itself lives on the tree row already, but a caller wiring the focus
+    /// into the shaped diff content must still know whether the id exists
+    /// in `report.files[..].symbols`; when it does not (a mismatch between
+    /// tree and report, "should not happen" but not enforceable at compile
+    /// time), returning `None` here matches
+    /// [`crate::diff_shape::section_start_line_for_symbol`]'s own "no
+    /// section found" behavior so the diff pane simply does not auto-scroll
+    /// rather than jumping to a stale offset.
+    pub fn selected_diff_focus(&self, report: &Report) -> Option<DiffFocus> {
+        let rows = self.nav.rows(&self.tree);
+        let row = rows.get(self.nav.cursor())?;
+        let NodeKind::Symbol(symbol_ref) = &row.node.kind else {
+            return None;
+        };
+        if symbol_ref.removed {
+            return None;
+        }
+        let known = report
+            .files
+            .iter()
+            .find(|file| file.path == row.node.path)
+            .is_some_and(|file| file.symbols.iter().any(|s| s.id == symbol_ref.id));
+        if !known {
+            return None;
+        }
+        Some(DiffFocus {
+            path: row.node.path.clone(),
+            symbol_id: symbol_ref.id.clone(),
+        })
     }
 
     /// What the blast-radius pane ([`RightPane::BlastRadius`], ADR 0019/0023)
@@ -2141,7 +2190,10 @@ mod tests {
     }
 
     #[test]
-    fn should_return_symbol_diff_target_with_line_range_when_cursor_is_on_a_symbol_row() {
+    fn should_return_file_diff_target_when_cursor_is_on_a_symbol_row() {
+        // ADR 0027 decision 1: even on a symbol row the diff pane resolves
+        // to a file-scoped target — "which symbol is focused" is carried by
+        // `selected_diff_focus` on a separate accessor instead.
         let report = Report {
             origin: rinkaku_core::render::ReportOrigin::Diff,
             files: vec![FileReport {
@@ -2158,13 +2210,56 @@ mod tests {
         let actual = app.selected_diff_target(&report);
 
         assert_eq!(
-            Some(DiffTarget::Symbol {
+            Some(DiffTarget::File {
                 path: "lib.rs".to_string(),
-                range_start: 3,
-                range_end: 7,
             }),
             actual
         );
+    }
+
+    #[test]
+    fn should_return_diff_focus_when_cursor_is_on_a_present_symbol_row() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    range: LineRange { start: 3, end: 7 },
+                    ..symbol("lib.rs::foo", "foo")
+                }],
+            }],
+            ..empty_report()
+        };
+        let app = App::new(&report).handle_key(InputKey::Down);
+
+        let actual = app.selected_diff_focus(&report);
+
+        assert_eq!(
+            Some(DiffFocus {
+                path: "lib.rs".to_string(),
+                symbol_id: "lib.rs::foo".to_string(),
+            }),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_return_no_diff_focus_when_cursor_is_on_a_file_row() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo")],
+            }],
+            ..empty_report()
+        };
+        // App::new lands the cursor on the first row, which is the file row
+        // (the tree only has one path so no directory row collapses in).
+        let app = App::new(&report);
+
+        let actual = app.selected_diff_focus(&report);
+
+        assert_eq!(None, actual);
     }
 
     #[test]

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -1,11 +1,16 @@
-//! Diff-pane content shaping (ADR 0020): given the row currently selected
-//! in the entry view (a symbol or a file) plus the already-parsed diff
-//! hunks (`crate::diff_view`), decides how the diff pane groups and
-//! annotates that content — a symbol selection clips to its own hunks
-//! (unchanged from before this ADR), while a file selection now groups
-//! hunks under per-symbol section headers instead of listing them
-//! undifferentiated, and either selection gets a 2-line old/new signature
-//! header up front when the symbol's contract changed.
+//! Diff-pane content shaping (ADR 0020, ADR 0027): given the row currently
+//! selected in the entry view (a symbol or a file) plus the already-parsed
+//! diff hunks (`crate::diff_view`), decides how the diff pane groups and
+//! annotates that content. Per ADR 0027, both symbol-row and file-row
+//! selections now produce the same file-scoped shape: hunks grouped under
+//! per-symbol section headers (unchanged from ADR 0020's file-selection
+//! semantics), with each section carrying an optional `symbol_id` so
+//! `crate::run_app` can look up the selected symbol's section start and
+//! auto-scroll to it. The old `DiffPaneContent::Symbol` clip variant is gone
+//! (ADR 0027 decision 1).
+//!
+//! Each section whose symbol's contract changed gets a 2-line old/new
+//! signature header up front.
 //!
 //! Pure and free of `ratatui` types, mirroring every other view-model in
 //! this crate (`crate::tree`/`crate::nav`/`crate::detail`/`crate::blast_radius`):
@@ -57,6 +62,16 @@ pub struct DiffSection {
     /// fixed `"(module level)"` label for hunks intersecting no symbol at
     /// all (import-only changes, module-level `use` statements).
     pub title: String,
+    /// The extracted symbol's id (matches
+    /// [`rinkaku_core::extract::ExtractedSymbol::id`] for symbol sections,
+    /// `None` for the module-level bucket) — used by `crate::run_app` to
+    /// find "which section is the selected symbol's" and auto-scroll the
+    /// diff pane's `right_pane_scroll` to that section's start (ADR 0027
+    /// decision 2). Kept as an `Option` rather than a separate lookup on
+    /// `Report` so the lookup stays a plain `iter().find()` over already-
+    /// shaped sections, and so the module-level bucket cannot accidentally
+    /// match any real symbol id.
+    pub symbol_id: Option<String>,
     pub contract_header: Option<ContractHeader>,
     pub hunks: Vec<AttributedHunk>,
 }
@@ -64,16 +79,17 @@ pub struct DiffSection {
 /// The diff pane's fully shaped content for the current selection —
 /// what `crate::ui::draw_diff_pane` renders, computed once by
 /// `crate::run_app` and handed in rather than recomputed per draw.
+///
+/// Per ADR 0027 decision 1 the old `Symbol(DiffSection)` clip variant was
+/// removed: both symbol-row and file-row selections now produce `File(..)`,
+/// and a symbol selection is expressed as an auto-scroll target (see
+/// [`section_start_line_for_symbol`]) rather than a distinct pane shape.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiffPaneContent {
     /// Nothing to show: no row selected, a directory row (no diff-specific
     /// content of its own — `App::selected_diff_target`'s own doc comment),
     /// or (defensively) a mismatch between `report` and the diff text.
     Empty,
-    /// A single symbol's hunks, clipped to its own line range — unchanged
-    /// scoping from before this ADR, just wrapped in the same
-    /// `DiffPaneContent` shape a file selection now also produces.
-    Symbol(DiffSection),
     /// A file's hunks, grouped into one [`DiffSection`] per symbol in
     /// `report.files[..].symbols` order, plus a trailing `"(module level)"`
     /// section for hunks intersecting no symbol at all — omitted (not an
@@ -102,35 +118,80 @@ pub const MODULE_LEVEL_TITLE: &str = "(module level)";
 /// same trade `crate::order`'s own doc comment already accepts for its
 /// deliberately duplicated Tarjan SCC implementation.
 pub fn hunk_start_lines(content: &DiffPaneContent) -> Vec<usize> {
-    let (sections, show_section_headers): (Vec<&DiffSection>, bool) = match content {
-        DiffPaneContent::Empty => return Vec::new(),
-        DiffPaneContent::Symbol(section) => (vec![section], false),
-        DiffPaneContent::File(sections) => (sections.iter().collect(), true),
+    let mut starts = Vec::new();
+    for (_, _, _, hunk_starts) in walk_sections(content) {
+        starts.extend(hunk_starts);
+    }
+    starts
+}
+
+/// The logical-line offset (same "requested-scroll unit"
+/// [`hunk_start_lines`] uses) where the section whose `symbol_id` matches
+/// `symbol_id` starts, in the exact order [`crate::ui::draw_diff_pane`]
+/// renders sections. Returns `None` when `content` is
+/// [`DiffPaneContent::Empty`] or no section matches (the selected symbol
+/// contributed no hunks of its own, e.g. a `BodyOnly` classification whose
+/// diff lines all fell inside another symbol's range — same rule as
+/// [`build_diff_pane_content`]'s "drop empty sections" step).
+///
+/// Points at the *start of the section*, including its title line — not at
+/// the first hunk's `@@` header (ADR 0027 decision 3): a reviewer moving
+/// between symbols wants to see the section title (and its contract header,
+/// when present) first, before the hunks that follow.
+///
+/// Used by `crate::run_app` to write the auto-scroll target into
+/// `App::right_pane_scroll` right after `build_diff_pane_content` rebuilds
+/// the shaped content for a new selection.
+pub fn section_start_line_for_symbol(content: &DiffPaneContent, symbol_id: &str) -> Option<usize> {
+    walk_sections(content)
+        .find(|(_, section, _, _)| section.symbol_id.as_deref() == Some(symbol_id))
+        .map(|(_, _, section_start, _)| section_start)
+}
+
+/// One entry per section for line-counting consumers ([`hunk_start_lines`]
+/// and [`section_start_line_for_symbol`] both need the exact same layout
+/// walk, kept in one place so a change to
+/// [`crate::ui::diff_pane_lines`]'s rendered layout only has to be mirrored
+/// once here — the same trade [`hunk_start_lines`]'s own doc comment already
+/// accepts for the mirroring itself). Yields `(section_index, &section,
+/// section_start_line, hunk_start_lines)` — `section_start_line` is where
+/// the section's title (or its very first line, when nothing precedes it)
+/// begins.
+fn walk_sections(
+    content: &DiffPaneContent,
+) -> impl Iterator<Item = (usize, &DiffSection, usize, Vec<usize>)> {
+    let sections: &[DiffSection] = match content {
+        DiffPaneContent::Empty => &[],
+        DiffPaneContent::File(sections) => sections,
     };
 
-    let mut starts = Vec::new();
     let mut line = 0usize;
+    let mut out = Vec::with_capacity(sections.len());
     for (section_index, section) in sections.iter().enumerate() {
         if section_index > 0 {
             line += 1; // blank line between sections
         }
-        if show_section_headers {
-            line += 1; // section title line
-        }
+        let section_start = line;
+        line += 1; // section title line (always shown now — ADR 0027)
         if section.contract_header.is_some() {
             line += 2; // "- previous" / "+ current" lines
         }
 
-        for (hunk_index, attributed) in section.hunks.iter().enumerate() {
-            if hunk_index > 0 || show_section_headers || section.contract_header.is_some() {
-                line += 1; // blank line before this hunk's own header
-            }
-            starts.push(line);
+        let mut hunk_starts = Vec::with_capacity(section.hunks.len());
+        for attributed in &section.hunks {
+            // Blank line before every hunk header: the section title is
+            // always shown (ADR 0027 collapsed the two former
+            // `show_section_headers` cases into one), so every hunk —
+            // including a section's first — has *something* on the line
+            // above it and needs the visual separator.
+            line += 1;
+            hunk_starts.push(line);
             line += 1; // the hunk header line itself
             line += attributed.hunk.lines.len();
         }
+        out.push((section_index, section, section_start, hunk_starts));
     }
-    starts
+    out.into_iter()
 }
 
 /// Builds the diff pane's shaped content for `target` (`None` mirrors
@@ -138,6 +199,12 @@ pub fn hunk_start_lines(content: &DiffPaneContent) -> Vec<usize> {
 /// directory row). `diff_files` is the whole diff already parsed once by
 /// `crate::run_app` (`crate::diff_view::parse_diff_hunks`), not re-parsed
 /// here.
+///
+/// Per ADR 0027 both symbol-row and file-row selections produce the same
+/// file-scoped shape; a symbol selection is expressed by
+/// `App::selected_diff_focus` (a separate accessor) and applied by
+/// `crate::run_app` as an auto-scroll target, not by returning a different
+/// `DiffPaneContent` variant here.
 pub fn build_diff_pane_content(
     report: &Report,
     diff_files: &[FileHunks],
@@ -145,56 +212,8 @@ pub fn build_diff_pane_content(
 ) -> DiffPaneContent {
     match target {
         None => DiffPaneContent::Empty,
-        Some(DiffTarget::Symbol {
-            path,
-            range_start,
-            range_end,
-        }) => build_symbol_content(report, diff_files, path, *range_start, *range_end),
         Some(DiffTarget::File { path }) => build_file_content(report, diff_files, path),
     }
-}
-
-fn build_symbol_content(
-    report: &Report,
-    diff_files: &[FileHunks],
-    path: &str,
-    range_start: usize,
-    range_end: usize,
-) -> DiffPaneContent {
-    let Some(file_hunks) = file_hunks(diff_files, path) else {
-        return DiffPaneContent::Empty;
-    };
-    let hunks: Vec<AttributedHunk> = file_hunks
-        .hunks
-        .iter()
-        .enumerate()
-        .filter(|(_, hunk)| crate::diff_view::hunk_intersects(hunk, range_start, range_end))
-        .map(|(source_index, hunk)| AttributedHunk {
-            source_index,
-            hunk: hunk.clone(),
-        })
-        .collect();
-    if hunks.is_empty() {
-        return DiffPaneContent::Empty;
-    }
-
-    let symbol = report
-        .files
-        .iter()
-        .find(|file| file.path == path)
-        .and_then(|file| {
-            file.symbols
-                .iter()
-                .find(|s| s.range.start == range_start && s.range.end == range_end)
-        });
-    let title = symbol.map(|s| s.signature.clone()).unwrap_or_default();
-    let contract_header = symbol.and_then(contract_header_for_symbol);
-
-    DiffPaneContent::Symbol(DiffSection {
-        title,
-        contract_header,
-        hunks,
-    })
 }
 
 fn build_file_content(report: &Report, diff_files: &[FileHunks], path: &str) -> DiffPaneContent {
@@ -216,6 +235,7 @@ fn build_file_content(report: &Report, diff_files: &[FileHunks], path: &str) -> 
         .iter()
         .map(|symbol| DiffSection {
             title: symbol.signature.clone(),
+            symbol_id: Some(symbol.id.clone()),
             contract_header: contract_header_for_symbol(symbol),
             hunks: Vec::new(),
         })
@@ -252,6 +272,7 @@ fn build_file_content(report: &Report, diff_files: &[FileHunks], path: &str) -> 
     if !module_level_hunks.is_empty() {
         sections.push(DiffSection {
             title: MODULE_LEVEL_TITLE.to_string(),
+            symbol_id: None,
             contract_header: None,
             hunks: module_level_hunks,
         });
@@ -355,154 +376,6 @@ mod tests {
     }
 
     #[test]
-    fn should_return_empty_when_symbol_file_has_no_matching_diff_hunks() {
-        let report = Report {
-            files: vec![FileReport {
-                path: "lib.rs".to_string(),
-                symbols: vec![symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 1 })],
-            }],
-            ..empty_report()
-        };
-        let target = DiffTarget::Symbol {
-            path: "lib.rs".to_string(),
-            range_start: 1,
-            range_end: 1,
-        };
-
-        let actual = build_diff_pane_content(&report, &[], Some(&target));
-
-        assert_eq!(DiffPaneContent::Empty, actual);
-    }
-
-    #[test]
-    fn should_clip_symbol_selection_to_its_own_hunks() {
-        let report = Report {
-            files: vec![FileReport {
-                path: "lib.rs".to_string(),
-                symbols: vec![
-                    symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 2 }),
-                    symbol("lib.rs::bar", "bar", LineRange { start: 10, end: 11 }),
-                ],
-            }],
-            ..empty_report()
-        };
-        let diff_files = vec![FileHunks {
-            path: "lib.rs".to_string(),
-            hunks: vec![
-                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
-                hunk("@@ -10,1 +10,2 @@", Some((10, 11)), vec!["fn bar() {}"]),
-            ],
-        }];
-        let target = DiffTarget::Symbol {
-            path: "lib.rs".to_string(),
-            range_start: 1,
-            range_end: 2,
-        };
-
-        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
-
-        let expected = DiffPaneContent::Symbol(DiffSection {
-            title: "fn foo()".to_string(),
-            contract_header: None,
-            hunks: vec![attributed(
-                0,
-                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
-            )],
-        });
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_include_pure_deletion_hunk_in_symbol_selection_when_it_intersects_the_symbol() {
-        // Finding-2 regression: a pure-deletion hunk (`new_range` a
-        // zero-width position, `crate::diff_view::Hunk`'s own doc comment)
-        // used to always report `hunk_intersects == false`, so it silently
-        // vanished from a symbol-scoped diff view entirely instead of
-        // showing the deleted lines under the symbol they were removed
-        // from.
-        let report = Report {
-            files: vec![FileReport {
-                path: "lib.rs".to_string(),
-                symbols: vec![symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 4 })],
-            }],
-            ..empty_report()
-        };
-        let diff_files = vec![FileHunks {
-            path: "lib.rs".to_string(),
-            hunks: vec![hunk(
-                "@@ -4 +3,0 @@",
-                Some((3, 2)),
-                vec!["println!(\"removed\");"],
-            )],
-        }];
-        let target = DiffTarget::Symbol {
-            path: "lib.rs".to_string(),
-            range_start: 1,
-            range_end: 4,
-        };
-
-        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
-
-        let expected = DiffPaneContent::Symbol(DiffSection {
-            title: "fn foo()".to_string(),
-            contract_header: None,
-            hunks: vec![attributed(
-                0,
-                hunk(
-                    "@@ -4 +3,0 @@",
-                    Some((3, 2)),
-                    vec!["println!(\"removed\");"],
-                ),
-            )],
-        });
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_include_contract_header_when_symbol_selection_signature_changed() {
-        let report = Report {
-            files: vec![FileReport {
-                path: "lib.rs".to_string(),
-                symbols: vec![ExtractedSymbol {
-                    classification: Some(Classification::SignatureChanged),
-                    previous_signature: Some("fn foo(a: i32)".to_string()),
-                    signature: "fn foo(a: i32, b: i32)".to_string(),
-                    ..symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 2 })
-                }],
-            }],
-            ..empty_report()
-        };
-        let diff_files = vec![FileHunks {
-            path: "lib.rs".to_string(),
-            hunks: vec![hunk(
-                "@@ -1,1 +1,2 @@",
-                Some((1, 2)),
-                vec!["fn foo(a, b) {}"],
-            )],
-        }];
-        let target = DiffTarget::Symbol {
-            path: "lib.rs".to_string(),
-            range_start: 1,
-            range_end: 2,
-        };
-
-        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
-
-        let expected = DiffPaneContent::Symbol(DiffSection {
-            title: "fn foo(a: i32, b: i32)".to_string(),
-            contract_header: Some(ContractHeader {
-                previous_signature: "fn foo(a: i32)".to_string(),
-                signature: "fn foo(a: i32, b: i32)".to_string(),
-            }),
-            hunks: vec![attributed(
-                0,
-                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo(a, b) {}"]),
-            )],
-        });
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
     fn should_group_file_selection_hunks_under_per_symbol_sections() {
         let report = Report {
             files: vec![FileReport {
@@ -530,6 +403,7 @@ mod tests {
         let expected = DiffPaneContent::File(vec![
             DiffSection {
                 title: "fn foo()".to_string(),
+                symbol_id: Some("lib.rs::foo".to_string()),
                 contract_header: None,
                 hunks: vec![attributed(
                     0,
@@ -538,6 +412,7 @@ mod tests {
             },
             DiffSection {
                 title: "fn bar()".to_string(),
+                symbol_id: Some("lib.rs::bar".to_string()),
                 contract_header: None,
                 hunks: vec![attributed(
                     1,
@@ -578,6 +453,7 @@ mod tests {
 
         let expected = DiffPaneContent::File(vec![DiffSection {
             title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
             contract_header: None,
             hunks: vec![attributed(
                 0,
@@ -620,6 +496,7 @@ mod tests {
         let expected = DiffPaneContent::File(vec![
             DiffSection {
                 title: "fn foo()".to_string(),
+                symbol_id: Some("lib.rs::foo".to_string()),
                 contract_header: None,
                 hunks: vec![attributed(
                     1,
@@ -628,6 +505,7 @@ mod tests {
             },
             DiffSection {
                 title: MODULE_LEVEL_TITLE.to_string(),
+                symbol_id: None,
                 contract_header: None,
                 hunks: vec![attributed(
                     0,
@@ -659,6 +537,7 @@ mod tests {
 
         let expected = DiffPaneContent::File(vec![DiffSection {
             title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
             contract_header: None,
             hunks: vec![attributed(
                 0,
@@ -698,6 +577,7 @@ mod tests {
 
         let expected = DiffPaneContent::File(vec![DiffSection {
             title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
             contract_header: None,
             hunks: vec![attributed(
                 0,
@@ -737,6 +617,7 @@ mod tests {
 
         let expected = DiffPaneContent::File(vec![DiffSection {
             title: "fn foo(a: i32, b: i32)".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
             contract_header: Some(ContractHeader {
                 previous_signature: "fn foo(a: i32)".to_string(),
                 signature: "fn foo(a: i32, b: i32)".to_string(),
@@ -777,6 +658,7 @@ mod tests {
 
         let expected = DiffPaneContent::File(vec![DiffSection {
             title: MODULE_LEVEL_TITLE.to_string(),
+            symbol_id: None,
             contract_header: None,
             hunks: vec![attributed(
                 0,
@@ -860,13 +742,15 @@ mod tests {
     }
 
     #[test]
-    fn should_start_first_hunk_at_line_zero_for_a_single_section_symbol_selection_with_no_contract_header()
+    fn should_offset_first_hunk_start_by_title_and_blank_when_file_has_a_single_section_without_contract_header()
      {
-        // No section header shown for a symbol selection (`diff_pane_lines`'s
-        // own `show_section_headers` rule) and no contract header here, so
-        // the hunk's own header line is the very first line.
-        let content = DiffPaneContent::Symbol(DiffSection {
+        // ADR 0027 unified layout: the section title is always shown, and
+        // every hunk (including the section's first) gets a blank line
+        // before its header. So: title(0), blank(1), header(2) — the hunk
+        // starts at line 2.
+        let content = DiffPaneContent::File(vec![DiffSection {
             title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
             contract_header: None,
             hunks: vec![attributed(
                 0,
@@ -876,18 +760,20 @@ mod tests {
                     vec!["fn a() {}", "fn foo() {}"],
                 ),
             )],
-        });
+        }]);
 
         let actual = hunk_start_lines(&content);
 
-        assert_eq!(vec![0], actual);
+        assert_eq!(vec![2], actual);
     }
 
     #[test]
-    fn should_offset_hunk_start_by_contract_header_lines_when_symbol_selection_has_one() {
-        // 2 contract-header lines precede the hunk's own header line.
-        let content = DiffPaneContent::Symbol(DiffSection {
+    fn should_offset_hunk_start_by_contract_header_lines_when_section_has_one() {
+        // Title(0), 2 contract-header lines (1, 2), blank before the hunk (3),
+        // hunk header (4) — hunk starts at line 4.
+        let content = DiffPaneContent::File(vec![DiffSection {
             title: "fn foo(a, b)".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
             contract_header: Some(ContractHeader {
                 previous_signature: "fn foo(a)".to_string(),
                 signature: "fn foo(a, b)".to_string(),
@@ -896,19 +782,20 @@ mod tests {
                 0,
                 hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo(a, b) {}"]),
             )],
-        });
+        }]);
 
         let actual = hunk_start_lines(&content);
 
-        assert_eq!(vec![3], actual);
+        assert_eq!(vec![4], actual);
     }
 
     #[test]
     fn should_offset_second_hunk_start_by_first_hunk_header_and_body_length() {
-        // First hunk: header (1 line) + 2 body lines = 3 lines, then 1 blank
-        // separator line before the second hunk's own header.
-        let content = DiffPaneContent::Symbol(DiffSection {
+        // Section title(0), blank(1), first hunk header(2), 2 body lines(3,4),
+        // blank before second hunk(5), second hunk header(6) — starts at 2, 6.
+        let content = DiffPaneContent::File(vec![DiffSection {
             title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
             contract_header: None,
             hunks: vec![
                 attributed(
@@ -924,23 +811,22 @@ mod tests {
                     hunk("@@ -10,1 +11,1 @@", Some((11, 11)), vec!["fn c() {}"]),
                 ),
             ],
-        });
+        }]);
 
         let actual = hunk_start_lines(&content);
 
-        assert_eq!(vec![0, 4], actual);
+        assert_eq!(vec![2, 6], actual);
     }
 
     #[test]
     fn should_offset_hunk_start_by_section_header_and_separator_lines_for_a_file_selection() {
-        // Section 0 (file selection: `show_section_headers` is always true,
-        // so the blank-before-hunk rule fires even for the section's first
-        // hunk): title(0), blank(1), header(2), 1 body line(3) — hunk starts
-        // at line 2. Section 1: blank separator between sections(4),
+        // Section 0: title(0), blank(1), header(2), 1 body line(3) — hunk
+        // starts at line 2. Section 1: blank separator between sections(4),
         // title(5), blank before its hunk(6), header(7) — hunk starts at 7.
         let content = DiffPaneContent::File(vec![
             DiffSection {
                 title: "fn foo()".to_string(),
+                symbol_id: Some("lib.rs::foo".to_string()),
                 contract_header: None,
                 hunks: vec![attributed(
                     0,
@@ -949,6 +835,7 @@ mod tests {
             },
             DiffSection {
                 title: "fn bar()".to_string(),
+                symbol_id: Some("lib.rs::bar".to_string()),
                 contract_header: None,
                 hunks: vec![attributed(
                     1,
@@ -960,5 +847,138 @@ mod tests {
         let actual = hunk_start_lines(&content);
 
         assert_eq!(vec![2, 7], actual);
+    }
+
+    // --- section_start_line_for_symbol ---
+
+    #[test]
+    fn should_return_none_for_symbol_start_when_content_is_empty() {
+        let actual = section_start_line_for_symbol(&DiffPaneContent::Empty, "lib.rs::foo");
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_return_zero_for_symbol_start_when_content_has_a_single_matching_section() {
+        // Only section: its title is at line 0, so the section starts at 0.
+        let content = DiffPaneContent::File(vec![DiffSection {
+            title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+            )],
+        }]);
+
+        let actual = section_start_line_for_symbol(&content, "lib.rs::foo");
+
+        assert_eq!(Some(0), actual);
+    }
+
+    #[test]
+    fn should_return_second_section_start_when_symbol_id_matches_the_second_section() {
+        // Section 0 layout: title(0), blank(1), header(2), body(3) — 4 lines.
+        // Blank separator between sections at line 4, so section 1 starts at 5.
+        let content = DiffPaneContent::File(vec![
+            DiffSection {
+                title: "fn foo()".to_string(),
+                symbol_id: Some("lib.rs::foo".to_string()),
+                contract_header: None,
+                hunks: vec![attributed(
+                    0,
+                    hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+                )],
+            },
+            DiffSection {
+                title: "fn bar()".to_string(),
+                symbol_id: Some("lib.rs::bar".to_string()),
+                contract_header: None,
+                hunks: vec![attributed(
+                    1,
+                    hunk("@@ -10,1 +10,2 @@", Some((10, 11)), vec!["fn bar() {}"]),
+                )],
+            },
+        ]);
+
+        let actual = section_start_line_for_symbol(&content, "lib.rs::bar");
+
+        assert_eq!(Some(5), actual);
+    }
+
+    #[test]
+    fn should_point_at_section_title_line_when_section_has_a_contract_header() {
+        // The section start is the title line, *before* the contract header —
+        // ADR 0027 decision 3: the reviewer wants the section title and its
+        // contract change first, not the hunks below them.
+        // Section 0: title(0), body(1), 2 contract-header lines(2,3), blank
+        // before hunk(4), hunk header(5) — 6 lines. Blank between sections at
+        // line 6, section 1 title at line 7.
+        let content = DiffPaneContent::File(vec![
+            DiffSection {
+                title: "fn foo(a, b)".to_string(),
+                symbol_id: Some("lib.rs::foo".to_string()),
+                contract_header: Some(ContractHeader {
+                    previous_signature: "fn foo(a)".to_string(),
+                    signature: "fn foo(a, b)".to_string(),
+                }),
+                hunks: vec![attributed(
+                    0,
+                    hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo(a, b) {}"]),
+                )],
+            },
+            DiffSection {
+                title: "fn bar()".to_string(),
+                symbol_id: Some("lib.rs::bar".to_string()),
+                contract_header: None,
+                hunks: vec![attributed(
+                    1,
+                    hunk("@@ -10,1 +10,2 @@", Some((10, 11)), vec!["fn bar() {}"]),
+                )],
+            },
+        ]);
+
+        let actual = section_start_line_for_symbol(&content, "lib.rs::bar");
+
+        assert_eq!(Some(7), actual);
+    }
+
+    #[test]
+    fn should_return_none_for_module_level_bucket_when_asked_by_any_symbol_id() {
+        // The module-level bucket has `symbol_id: None`, so no real symbol id
+        // lookup can accidentally match it. Even passing the literal
+        // `MODULE_LEVEL_TITLE` as a symbol id (which is not a valid symbol id
+        // shape but is the closest a caller could get to "aim at the bucket")
+        // must not match.
+        let content = DiffPaneContent::File(vec![DiffSection {
+            title: MODULE_LEVEL_TITLE.to_string(),
+            symbol_id: None,
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["use foo::bar;"]),
+            )],
+        }]);
+
+        let actual = section_start_line_for_symbol(&content, MODULE_LEVEL_TITLE);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_return_none_when_symbol_id_matches_no_section() {
+        let content = DiffPaneContent::File(vec![DiffSection {
+            title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+            )],
+        }]);
+
+        let actual = section_start_line_for_symbol(&content, "lib.rs::nonexistent");
+
+        assert_eq!(None, actual);
     }
 }

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -166,10 +166,11 @@ fn run_app(
         diff_shape::DiffPaneContent::Empty
     };
     // ADR 0027 decision 2: apply the same "auto-scroll to the focused
-    // symbol's section" rule the loop below runs after every diff-content
-    // recompute, so `--tui` startup on a symbol row (e.g. `App::new`'s
-    // default cursor when the first row happens to be a symbol) already
-    // opens with the correct scroll offset rather than an unrelated 0.
+    // symbol's section" rule the loop below runs on selection change, so
+    // `--tui` startup on a symbol row (e.g. `App::new`'s default cursor
+    // when the first row happens to be a symbol) already opens with the
+    // correct scroll offset rather than an unrelated 0.
+    let mut last_diff_focus: Option<app::DiffFocus> = app.selected_diff_focus(report);
     if let Some(target_scroll) = auto_scroll_for_diff_focus(&app, report, &diff_pane_content) {
         app = app.with_right_pane_scroll(target_scroll);
     }
@@ -319,19 +320,26 @@ fn run_app(
                     &diff_hunks,
                     app.selected_diff_target(report).as_ref(),
                 );
-                // ADR 0027 decision 2: after the shaped content is rebuilt
-                // for the new selection, auto-scroll the diff pane to the
-                // focused symbol's section start (if any). `App::handle_key`
-                // has already reset `right_pane_scroll` to 0 as part of its
-                // blanket rule (see that method's `preserve_scroll`
-                // exception list) — this override runs after that, so the
-                // reset-then-retarget order matches every other
-                // selection-derived recompute in this loop (blast radius,
-                // diff content).
-                if let Some(target_scroll) =
-                    auto_scroll_for_diff_focus(&app, report, &diff_pane_content)
-                {
-                    app = app.with_right_pane_scroll(target_scroll);
+                // ADR 0027 decision 2: auto-scroll to the focused symbol's
+                // section start only when the focus *actually changed* since
+                // the previous key. `should_recompute_diff_pane_content` is
+                // `true` on every key while Diff is showing (it just gates
+                // the cache rebuild, not a selection-change signal), so
+                // firing auto-scroll unconditionally here would overwrite
+                // the reviewer's own `j`/`k`/`Ctrl-d` scrolling immediately
+                // after they pressed it (dogfooding finding: Enter into
+                // Focus::Right + subsequent `j`/`k` had no visible effect
+                // because this override snapped back to the section start
+                // every keystroke). Only when the tree cursor lands on a
+                // different symbol do we retarget the pane.
+                let next_focus = app.selected_diff_focus(report);
+                if next_focus != last_diff_focus {
+                    last_diff_focus = next_focus;
+                    if let Some(target_scroll) =
+                        auto_scroll_for_diff_focus(&app, report, &diff_pane_content)
+                    {
+                        app = app.with_right_pane_scroll(target_scroll);
+                    }
                 }
             }
         }

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -165,6 +165,14 @@ fn run_app(
     } else {
         diff_shape::DiffPaneContent::Empty
     };
+    // ADR 0027 decision 2: apply the same "auto-scroll to the focused
+    // symbol's section" rule the loop below runs after every diff-content
+    // recompute, so `--tui` startup on a symbol row (e.g. `App::new`'s
+    // default cursor when the first row happens to be a symbol) already
+    // opens with the correct scroll offset rather than an unrelated 0.
+    if let Some(target_scroll) = auto_scroll_for_diff_focus(&app, report, &diff_pane_content) {
+        app = app.with_right_pane_scroll(target_scroll);
+    }
     // The source screen's (`s` key) file read + syntax highlight, computed
     // once when `Screen::Source` is entered (the `InputKey::Source` arm
     // below) and cached here across every subsequent draw — including the
@@ -311,6 +319,20 @@ fn run_app(
                     &diff_hunks,
                     app.selected_diff_target(report).as_ref(),
                 );
+                // ADR 0027 decision 2: after the shaped content is rebuilt
+                // for the new selection, auto-scroll the diff pane to the
+                // focused symbol's section start (if any). `App::handle_key`
+                // has already reset `right_pane_scroll` to 0 as part of its
+                // blanket rule (see that method's `preserve_scroll`
+                // exception list) — this override runs after that, so the
+                // reset-then-retarget order matches every other
+                // selection-derived recompute in this loop (blast radius,
+                // diff content).
+                if let Some(target_scroll) =
+                    auto_scroll_for_diff_focus(&app, report, &diff_pane_content)
+                {
+                    app = app.with_right_pane_scroll(target_scroll);
+                }
             }
         }
     }
@@ -479,6 +501,28 @@ fn dispatch_non_source_key(
 /// reasoning, just for [`RightPane::Diff`] instead of `RightPane::BlastRadius`.
 fn should_recompute_diff_pane_content(app: &App) -> bool {
     matches!(app.screen(), Screen::Entry) && app.right_pane() == app::RightPane::Diff
+}
+
+/// The auto-scroll target for the diff pane (ADR 0027 decision 2 + 4):
+/// [`crate::diff_shape::section_start_line_for_symbol`] on the currently
+/// focused symbol's section, or `None` when there is nothing to auto-scroll
+/// to — a file/directory row has no `DiffFocus`, and a symbol whose id
+/// contributed no section (e.g. its hunks were absorbed into an adjacent
+/// symbol's section via first-match attribution, or the file has no diff
+/// hunks at all) has no section start to jump to.
+///
+/// Extracted as its own pure function (mirroring
+/// [`jump_scroll_target`]/[`should_apply_hunk_jump`]'s own precedent) so this
+/// rule stays unit-testable without a live `ratatui::DefaultTerminal`, and
+/// so the "when do we auto-scroll?" gate is in one obvious place rather than
+/// scattered through `run_app`'s loop body.
+fn auto_scroll_for_diff_focus(
+    app: &App,
+    report: &Report,
+    diff_pane_content: &diff_shape::DiffPaneContent,
+) -> Option<usize> {
+    let focus = app.selected_diff_focus(report)?;
+    diff_shape::section_start_line_for_symbol(diff_pane_content, &focus.symbol_id)
 }
 
 /// Whether `crate::run_app`'s [`InputKey::Source`] arm should re-run

--- a/rinkaku-tui/src/ui.rs
+++ b/rinkaku-tui/src/ui.rs
@@ -480,7 +480,7 @@ fn draw_diff_pane(
 
     let target = app.selected_diff_target(report);
     let path: &str = match &target {
-        Some(DiffTarget::Symbol { path, .. }) | Some(DiffTarget::File { path }) => path.as_str(),
+        Some(DiffTarget::File { path }) => path.as_str(),
         None => "",
     };
 
@@ -497,13 +497,16 @@ fn draw_diff_pane(
             frame.render_widget(paragraph, area);
             return None;
         }
-        DiffPaneContent::Symbol(section) => vec![section],
         DiffPaneContent::File(sections) => sections.iter().collect(),
     };
 
     let highlighted_file = highlight::highlighted_file(diff_highlights, path);
-    let is_file_selection = matches!(diff_content, DiffPaneContent::File(_));
-    let lines = diff_pane_lines(&sections, is_file_selection, highlighted_file);
+    // ADR 0027: `DiffPaneContent` no longer has a symbol-clip variant, so
+    // the diff pane always renders with section headers on. `diff_pane_lines`'s
+    // `show_section_headers` parameter is now always `true` at this call
+    // site, kept as a parameter to leave that layout knob visible in one
+    // place rather than hard-coding it inside `diff_pane_lines`.
+    let lines = diff_pane_lines(&sections, true, highlighted_file);
     Some(render_scrollable_pane(
         frame,
         " Diff ",


### PR DESCRIPTION
## Summary

Per [ADR 0027](docs/adr/0027-diff-pane-follows-symbol-selection.md), the diff pane now always renders the whole selected file and auto-scrolls to the focused symbol's section start whenever the tree cursor moves.

Fixes the dogfooding complaint: moving between symbols in the same file used to produce no visible motion on the right pane, because the diff was clipped to only that symbol's hunks and the scroll offset was reset to 0.

## Behavior change

- **Before**: symbol row selection → diff pane shows only that symbol's hunks (`DiffPaneContent::Symbol`), scroll = 0.
- **After**: any selection → diff pane shows the whole file grouped into per-symbol sections; a symbol selection auto-scrolls `right_pane_scroll` to that section's title line.
- `]c` / `[c` now walks every hunk in the file (not just the selected symbol's), as a strict consequence.

## Implementation

- Remove `DiffPaneContent::Symbol` and `DiffTarget::Symbol` variants.
- `DiffSection` grows `symbol_id: Option<String>` (`None` for the module-level bucket).
- New `App::selected_diff_focus` returns `DiffFocus { path, symbol_id }` on present symbol rows.
- New `diff_shape::section_start_line_for_symbol` computes the auto-scroll target.
- `run_app` writes the target into `App::right_pane_scroll` right after `build_diff_pane_content` rebuilds the shaped content (both up-front and inside the event loop).

## Test plan

- [x] `make test` — 464 pass (added 6 new tests for `section_start_line_for_symbol` and 2 for `selected_diff_focus`; adapted existing `DiffTarget::Symbol` / `DiffPaneContent::Symbol` tests to the new file-scoped shape)
- [x] `make lint` clean (fmt + clippy \`-D warnings\`)
- [ ] **Manual QA (TUI)**: build and pipe a diff into \`rinkaku --tui\`; verify
  - moving the tree cursor between symbols in the same file scrolls the diff pane to the target symbol's section header
  - moving to a symbol whose section is already fully on screen keeps working (scroll offset just changes)
  - \`]c\` / \`[c\` on a symbol row walks across every hunk in the file, not just the selected symbol's
  - startup with the cursor on a symbol row shows that symbol's section from the top (first frame is not scrolled to 0)