### PR TITLE
fix(tui): keep jump popup candidates one row each so the window math holds

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/018.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/018.md
@@ -1,0 +1,93 @@
+# Round 18
+
+- Subject: PR #83 — the jump-target popup (`gd`/`gr`, ADR 0022) could
+  push its own highlighted candidate off-screen with no visual feedback
+  when a candidate label (`"{name} ({path})"`) was longer than the
+  popup's inner width, because `windowed_rows_with_indicators`'s window
+  math assumes one candidate is one rendered row while the popup used to
+  hand labels to `Paragraph::wrap`, which silently turned an overlong
+  label into 2-3 physical rows. Fix: a new `truncate_to_width` helper
+  (unicode-width aware, single trailing `…`) truncates each label to the
+  popup's inner width instead of wrapping it, restoring the one-row-per-
+  candidate invariant the window math relies on.
+- Map-assisted pass: `git diff main...HEAD | rinkaku` (built from a
+  trusted `main` checkout, not the branch under review) surfaced exactly
+  the 5 changed symbols across the two touched files, with
+  `draw_jump_popup` depending on `windowed_rows_with_indicators` shown
+  explicitly — correctly routing attention to the one integration seam
+  that matters (does the new truncation call sit *before* the window
+  math runs, or does it still let a label reach `Paragraph` unbounded?).
+  The map's contract markers were otherwise unremarkable for a same-file
+  bug fix (no cross-crate fan-in, no removed symbols) — its value here
+  was confirming the dependency edge, not surfacing a hidden risk.
+- Independent pass: read the diff without the map. Confirmed
+  `viewport_width = overlay_area.width.saturating_sub(2)` matches the
+  `saturating_sub(2)` convention already used by
+  `render_scrollable_pane`, `draw_entry_screen`, and `source_screen.rs`
+  for a bordered pane's inner width — no ad hoc constant introduced.
+  Checked comment discipline (why, not what; body-final rationale
+  matches CLAUDE.md), no `unwrap`/`expect` added to library code, and
+  English throughout. Ran the `truncate_to_width` boundary logic through
+  a standalone probe crate (same `unicode-width` version pinned in
+  `Cargo.toml`) for `width` in `0..=5` plus a CJK-leading case: the
+  `width == 0` short-circuit and the `budget = width - 1` arithmetic
+  compose correctly at every value, including `width == 1` (returns just
+  `"…"`, itself exactly 1 column) — but the test suite as submitted
+  covered `width == 0` and `width >= 4` only, leaving `width == 1`
+  unverified in-tree despite the doc comment explicitly describing it as
+  a boundary ("even when `width == 0`"). Flagged as a should-fix test
+  gap, not a logic bug.
+- Dynamic verification: built the worktree binary
+  (`cargo build --release -p rinkaku`); `make test` (472 passed) and
+  `make lint` clean pre-fix-to-this-round. Non-TTY stdin with an empty
+  diff exits 0 with `note: diff is empty, nothing to analyze`, no panic.
+  `--base <ref> --tui` piped through stdin still hits the pre-existing,
+  out-of-scope stdin-consumption/`--tui` startup failure tracked in the
+  experiment README's backlog (round 8) — confirmed unrelated to this
+  PR by reproducing it against a pre-PR-83 build too.
+  Drove the actual TUI in tmux against a synthetic repo built for this
+  round specifically (the real PR #83 diff only touches 2 files with no
+  jump candidates deep enough to force window scrolling): a hotspot
+  function referenced by 25 callers whose names mix long ASCII with
+  embedded Japanese characters, opened via `gr`. First tmux attempt used
+  a session sized 80x24 that macOS tmux silently reported back as
+  188x54 (no attached client), which made an initial reading of the
+  captured pane look like truncation wasn't firing — re-verified against
+  the actual reported window size and, separately, against a standalone
+  Rust probe using the exact `truncate_to_width` body and the exact
+  `unicode-width` crate version, before concluding the pane, not the
+  code, was the source of the mismatch. Re-ran the same repro; with the
+  real (188-wide) popup width the `…` marker appears correctly on every
+  overflowing label, `j`-ing the cursor down to the last of 25
+  candidates keeps it visible and highlighted (`ESC[1;7m` reversed+bold
+  in the raw ANSI capture) with a correct `… 6 more above` indicator, no
+  candidate pushed out of frame at any step — matching the PR's own
+  20-candidate/80x24 regression test at a different window size and
+  script/data shape.
+- Fix applied this round: added two unit tests for the `width == 1`
+  boundary flagged above (`truncate_to_width` returning just the marker,
+  both for a plain-ASCII input and one starting with a double-width CJK
+  character, so the budget-exhaustion guard and the double-width guard
+  are shown to compose rather than one masking a bug in the other).
+  `make test` (474 passed, +2) and `make lint` clean after the fix.
+- No blocking findings. The only gap found (missing `width == 1` test)
+  was a coverage gap in an otherwise-correct implementation, not a
+  behavioral defect — fixed in this round rather than left as a report-
+  only item.
+- Takeaway: this round's near-miss was self-inflicted tooling noise, not
+  a code defect — a detached tmux session silently ignoring `-x`/`-y`
+  produced a pane capture that, read carelessly, looked exactly like the
+  truncation bug the PR was fixing having regressed. The save was
+  routine for this experiment's method (round 15's lesson repeated):
+  don't trust a single observation of rendered/captured output — cross-
+  check window/pane dimensions independently (`tmux list-windows`) and
+  reproduce the same computation in an isolated probe before concluding
+  a mismatch is in the code under review rather than in the harness
+  observing it. A second, complementary lesson specific to *this* PR's
+  shape: the PR's own diff doesn't contain data dense enough (only 5
+  symbols, 2 files) to exercise the window-scroll interaction its fix
+  claims to guarantee — dynamic verification for a scroll/overflow fix
+  needs a purpose-built fixture with enough candidates and long-enough
+  labels to force scrolling, not just the PR's own small diff, echoing
+  round 5's and round 8's pattern of purpose-built repros catching what
+  the PR's own diff is too small to exercise.

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -2,7 +2,7 @@
 //! composited on top of whatever screen was already rendered underneath,
 //! after the pane split has drawn everything else.
 
-use super::scroll::windowed_rows_with_indicators;
+use super::scroll::{truncate_to_width, windowed_rows_with_indicators};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
@@ -93,13 +93,27 @@ pub(crate) fn centered_rect(area: Rect, percent_width: u16, percent_height: u16)
 /// all) — the same cursor-follow scroll `draw_tree_pane` uses, plus dim
 /// "… N more above/below" lines inside the box when the window does not
 /// reach an edge of the candidate list.
+///
+/// Candidate labels are [`truncate_to_width`]-ed to the popup's own inner
+/// width rather than wrapped (a second bug found while fixing the first:
+/// `windowed_rows_with_indicators`'s window math assumes one candidate is
+/// one rendered row, but this used to render with `Paragraph::wrap`
+/// enabled — a `"{name} ({path})"` label longer than the box's inner width
+/// wrapped onto 2-3 physical rows, so the window's row-count budget
+/// silently undercounted and pushed later candidates, including the
+/// cursor row, off the bottom of the popup with no visual feedback,
+/// exactly the failure mode the windowing fix above exists to prevent).
+/// Truncating instead of wrapping restores the "one candidate, one row"
+/// invariant the window math relies on.
 pub(crate) fn draw_jump_popup(frame: &mut Frame, popup: &crate::app::JumpPopup, full_area: Rect) {
     let overlay_area = centered_rect(full_area, 60, 40);
     frame.render_widget(Clear, overlay_area);
 
-    // 2 rows for the top/bottom border, matching `render_scrollable_pane`'s
-    // own `saturating_sub(2)` convention for a bordered pane's inner height.
+    // 2 rows/columns for the top/bottom and left/right border, matching
+    // `render_scrollable_pane`'s own `saturating_sub(2)` convention for a
+    // bordered pane's inner height/width.
     let viewport_height = overlay_area.height.saturating_sub(2) as usize;
+    let viewport_width = overlay_area.width.saturating_sub(2) as usize;
     let (start, end, above, below) =
         windowed_rows_with_indicators(popup.candidates.len(), popup.cursor, viewport_height);
 
@@ -115,7 +129,10 @@ pub(crate) fn draw_jump_popup(frame: &mut Frame, popup: &crate::app::JumpPopup, 
             .iter()
             .enumerate()
             .map(|(offset, candidate)| {
-                let text = format!("{} ({})", candidate.name, candidate.path);
+                let text = truncate_to_width(
+                    &format!("{} ({})", candidate.name, candidate.path),
+                    viewport_width,
+                );
                 if start + offset == popup.cursor {
                     Line::styled(
                         text,
@@ -136,9 +153,7 @@ pub(crate) fn draw_jump_popup(frame: &mut Frame, popup: &crate::app::JumpPopup, 
     }
 
     let block = Block::bordered().title(" Jump to (enter: go, esc: cancel) ");
-    let paragraph = Paragraph::new(lines)
-        .block(block)
-        .wrap(ratatui::widgets::Wrap { trim: false });
+    let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, overlay_area);
 }
 
@@ -347,6 +362,64 @@ mod tests {
         // it must not be rendered, and an overflow indicator must say so.
         assert!(!text.contains("sym0 ("), "sym0 should have scrolled off");
         assert!(text.contains("more above"));
+    }
+
+    #[test]
+    fn should_keep_highlighted_candidate_visible_when_labels_wrap_across_multiple_rows() {
+        // Regression test for the bug this change fixes:
+        // `windowed_rows_with_indicators` computes its window assuming one
+        // candidate = one rendered row, but `draw_jump_popup` used to hand
+        // its lines to `Paragraph` with `Wrap { trim: false }` enabled — a
+        // candidate label (`"{name} ({path})"`) longer than the popup's
+        // inner width wrapped onto 2-3 physical rows, so the window's
+        // row-count math silently undercounted and pushed later
+        // candidates, including the cursor row, off the bottom of the
+        // popup with no visual feedback at all. An 80x24 terminal (a
+        // common real-world size, smaller than every other test in this
+        // file's 100-wide terminals) with 40-90 character paths reproduces
+        // it: the popup's 60%-width box is nowhere near wide enough to fit
+        // "name (path)" on one row unwrapped.
+        let report = report_with_one_symbol();
+        let candidates: Vec<crate::app::JumpCandidate> = (0..20)
+            .map(|i| crate::app::JumpCandidate {
+                id: format!("lib.rs::sym{i}"),
+                name: format!("very_long_symbol_name_number_{i}"),
+                path: format!(
+                    "src/very/deeply/nested/module/path/number_{i}/that/is/quite/long/file.rs"
+                ),
+            })
+            .collect();
+        let mut app = App::new(&report).open_jump_popup(candidates);
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
+
+        // Move the cursor one step at a time, checking after *every* step
+        // (not just at the end) that the highlighted candidate is visible —
+        // the bug manifested at intermediate cursor positions too, not only
+        // at the very last candidate.
+        for step in 0..19 {
+            app = app.handle_key(crate::app::InputKey::Down);
+            terminal
+                .draw(|frame| {
+                    draw(
+                        frame,
+                        &app,
+                        &report,
+                        &crate::diff_shape::DiffPaneContent::Empty,
+                        &[],
+                        &BlastRadiusSelection::NotApplicable,
+                        None,
+                    );
+                })
+                .expect("draw");
+
+            let text = buffer_text(&terminal);
+            let expected_marker = format!("very_long_symbol_name_number_{}", step + 1);
+            assert!(
+                text.contains(&expected_marker),
+                "cursor candidate {expected_marker} not visible after {} Down presses:\n{text}",
+                step + 1
+            );
+        }
     }
 
     #[test]

--- a/rinkaku-tui/src/ui/scroll.rs
+++ b/rinkaku-tui/src/ui/scroll.rs
@@ -1,10 +1,10 @@
 //! Pure scroll/wrap helpers shared by the panes in this module — extracted so
 //! `clamp_scroll`, `scroll_indicator`, `visible_index_window`,
-//! `window_overflow_indicators`, `windowed_rows_with_indicators`, and
-//! `wrap_lines`/`wrap_one_line` stay unit-testable without a live
-//! `ratatui::backend::TestBackend`, and so [`render_scrollable_pane`] itself
-//! (the one non-pure helper here) has a single home shared by every pane
-//! that scrolls.
+//! `window_overflow_indicators`, `windowed_rows_with_indicators`,
+//! `wrap_lines`/`wrap_one_line`, and `truncate_to_width` stay unit-testable
+//! without a live `ratatui::backend::TestBackend`, and so
+//! [`render_scrollable_pane`] itself (the one non-pure helper here) has a
+//! single home shared by every pane that scrolls.
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -161,6 +161,53 @@ pub(crate) fn wrap_one_line(line: &Line<'static>, width: usize) -> Vec<Line<'sta
 
     result_lines.push(Line::from(current_spans).style(line.style));
     result_lines
+}
+
+/// Truncates `text` to fit within `width` display columns, replacing the
+/// tail with a single `…` (1 column) when it does not fit — unlike
+/// [`wrap_lines`], which turns overflow into *more rows*, this turns
+/// overflow into a shorter *single* row, for callers whose windowing math
+/// (e.g. [`windowed_rows_with_indicators`]) has already committed to
+/// "one logical item = one rendered row" and would desync if a row were
+/// allowed to wrap (`draw_jump_popup`'s own fix for exactly that: a
+/// `Paragraph::wrap`-ed candidate label taller than one row pushed later
+/// candidates, including the cursor row, out of the popup's viewport with
+/// no visual feedback, defeating `windowed_rows_with_indicators`'s own
+/// "cursor always inside the window" contract).
+///
+/// Width is measured with [`UnicodeWidthChar::width`] (same fallback-to-1
+/// convention as [`wrap_one_line`]) so a wide (e.g. CJK) character is never
+/// sliced in half — if the last character that would fit is wide and only
+/// one column of room remains, it is dropped along with the rest of the
+/// tail rather than emitted half-width.
+///
+/// `text` already fitting within `width` (including exactly, or when
+/// `width == 0`) is returned unchanged/empty respectively without adding
+/// the `…` marker — nothing was actually cut off.
+pub(crate) fn truncate_to_width(text: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let text_width: usize = text.chars().map(|ch| ch.width().unwrap_or(1)).sum();
+    if text_width <= width {
+        return text.to_string();
+    }
+
+    // Reserve 1 column for the trailing `…` marker, then greedily take
+    // characters until the next one would overflow the remaining budget.
+    let budget = width - 1;
+    let mut result = String::new();
+    let mut used = 0usize;
+    for ch in text.chars() {
+        let char_width = ch.width().unwrap_or(1);
+        if used + char_width > budget {
+            break;
+        }
+        result.push(ch);
+        used += char_width;
+    }
+    result.push('…');
+    result
 }
 
 /// Clamps a requested scroll offset (lines) to `[0, content_len -
@@ -646,5 +693,54 @@ mod tests {
             vec![Line::raw("abcd"), Line::raw("ef"), Line::raw("xy")],
             actual
         );
+    }
+
+    // --- truncate_to_width (pure helper, jump popup one-row-per-candidate fix) ---
+
+    #[test]
+    fn should_return_text_unchanged_when_it_fits_exactly_within_width() {
+        let actual = truncate_to_width("abcde", 5);
+
+        assert_eq!("abcde".to_string(), actual);
+    }
+
+    #[test]
+    fn should_return_text_unchanged_when_it_is_shorter_than_width() {
+        let actual = truncate_to_width("abc", 10);
+
+        assert_eq!("abc".to_string(), actual);
+    }
+
+    #[test]
+    fn should_return_empty_string_when_width_is_zero() {
+        let actual = truncate_to_width("abcdef", 0);
+
+        assert_eq!("".to_string(), actual);
+    }
+
+    #[test]
+    fn should_truncate_long_ascii_text_with_trailing_marker_when_it_overflows_width() {
+        // width=5 -> 4 chars of budget + 1 column for the trailing "…".
+        let actual = truncate_to_width("abcdefgh", 5);
+
+        assert_eq!("abcd…".to_string(), actual);
+    }
+
+    #[test]
+    fn should_not_split_a_double_width_character_when_truncating() {
+        // "あ" is 2 columns; a width-4 budget after reserving 1 column for
+        // "…" leaves 3 columns, which fits "a" (1) + "あ" (2) exactly but
+        // not a second "あ" (would need 5) — so the second "あ" and
+        // everything after it is dropped rather than sliced in half.
+        let actual = truncate_to_width("aああb", 4);
+
+        assert_eq!("aあ…".to_string(), actual);
+    }
+
+    #[test]
+    fn should_truncate_mixed_cjk_and_ascii_label_when_it_overflows_width() {
+        let actual = truncate_to_width("シンボル名 (path/to/very/long/file.rs)", 10);
+
+        assert_eq!("シンボル…".to_string(), actual);
     }
 }

--- a/rinkaku-tui/src/ui/scroll.rs
+++ b/rinkaku-tui/src/ui/scroll.rs
@@ -743,4 +743,28 @@ mod tests {
 
         assert_eq!("シンボル…".to_string(), actual);
     }
+
+    #[test]
+    fn should_return_only_the_marker_when_width_is_one() {
+        // width=1 leaves a budget of 0 after reserving 1 column for "…", so
+        // every character of the input is dropped and only the marker
+        // itself remains — the narrowest width at which truncation still
+        // produces non-empty output (width=0 is the separate empty-string
+        // case covered above).
+        let actual = truncate_to_width("abcdef", 1);
+
+        assert_eq!("…".to_string(), actual);
+    }
+
+    #[test]
+    fn should_return_only_the_marker_when_width_is_one_and_first_char_is_double_width() {
+        // Same width=1 boundary, but the first character of the input is a
+        // 2-column CJK character that would not fit in the 0-column budget
+        // either — makes sure the double-width guard and the width=1
+        // budget-exhaustion guard compose correctly instead of one
+        // masking a bug in the other.
+        let actual = truncate_to_width("あいう", 1);
+
+        assert_eq!("…".to_string(), actual);
+    }
 }


### PR DESCRIPTION
## Summary

The jump-target popup (ADR 0022) could highlight a candidate that was
scrolled off-screen with zero visual feedback, on real-world terminal
sizes with long file paths.

## Root cause

`windowed_rows_with_indicators` (`rinkaku-tui/src/ui/scroll.rs`) computes
the popup's scroll window under the assumption that **one candidate is
one rendered row**. `draw_jump_popup` (`rinkaku-tui/src/ui/overlay.rs`)
built each candidate's label as `"{name} ({path})"` and rendered it
through `Paragraph::new(lines).wrap(Wrap { trim: false })`.

Once a label was longer than the popup's inner width (very likely with
realistic symbol names + file paths, especially in narrower terminals),
`Wrap` split it across 2-3 physical rows at draw time — a fact the window
math had no way to know about, since it only counts logical candidates.
The window would decide "N candidates fit", but the wrapped rows actually
consumed more vertical space than the box had, silently pushing later
candidates — including, in the worst case, the highlighted cursor row —
below the visible area.

Reproduced on an 80x24 terminal with 40-90 character paths; confirmed
with a new regression test that steps the cursor through 20 long-path
candidates and asserts the highlighted one is visible at every step.

## Fix

- Added `truncate_to_width` (`rinkaku-tui/src/ui/scroll.rs`): a pure,
  unicode-width-aware helper that truncates a label to fit a given
  column budget, appending a single `…` marker when it cuts something
  off. CJK/full-width characters are never sliced in half (mirrors the
  existing `wrap_one_line` width convention).
- `draw_jump_popup` now truncates each candidate label to the popup's
  inner width instead of wrapping it, and the `Paragraph::wrap(...)` call
  is removed. This restores the "one candidate = one row" invariant
  `windowed_rows_with_indicators` already relies on, so its window
  calculation is correct again.

## Alternatives considered

- **Keep wrapping, but make the window math wrap-aware** (pre-wrap the
  labels first, like `render_scrollable_pane` already does for the
  Detail/Diff panes, then window over physical rows instead of logical
  candidates): rejected for this popup specifically because a
  multi-row-wrapped candidate would also need multi-row highlighting
  (every wrapped row of the selected candidate reversed/bold), which is
  more rendering complexity for a popup whose only job is "pick one
  short-ish item from a list" — truncation keeps the one-row-per-item
  mental model simple and matches how similar pickers (e.g. fuzzy
  finders) typically handle overlong entries anyway.

## QA

- `make test` — 472 passed (up from 465 baseline: +6 unit tests for
  `truncate_to_width` covering ASCII truncation, no-op when it already
  fits, zero width, and CJK/mixed-width boundaries; +1 regression test
  reproducing the original bug on an 80x24 terminal).
- `make lint` — clean (`cargo fmt --all --check` + `cargo clippy
  --all-targets --all-features -- -D warnings`).
- `cargo build -p rinkaku` — builds cleanly end-to-end.
- Regression test confirmed **red** against the pre-fix code (panicked
  with the highlighted candidate missing from the rendered buffer after
  3 `Down` presses), then **green** after the fix, before running the
  full suite.

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] `cargo build -p rinkaku`
- [x] Regression test reproduces the bug pre-fix, passes post-fix