### PR TITLE
feat(tui): support mouse wheel scrolling

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/020.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/020.md
@@ -1,0 +1,144 @@
+# Round 20
+
+- Subject: PR #84 — mouse wheel scroll support for the TUI. `run` now
+  enables/disables `crossterm` mouse capture (with its own panic-hook
+  layer chained before `ratatui::try_init`'s, so mouse capture is
+  disabled on panic too), and a new pure `translate_mouse_event` maps
+  `MouseEventKind::ScrollUp`/`ScrollDown` onto the existing
+  `InputKey::Up`/`Down` variants rather than introducing dedicated
+  scroll variants. The event loop's key-read `if let` chain became a
+  `match` on `Event::Key`/`Event::Mouse`/`_` to make room for the new
+  arm. Single-file change (`rinkaku-tui/src/lib.rs`).
+- Map-assisted pass: `rinkaku --base main` (trusted `main` checkout)
+  reported 10 changed symbols, all in `rinkaku-tui/src/lib.rs` — `run`
+  and `run_app` (body-modified) plus `translate_mouse_event` and its 7
+  unit tests. The map's one hotspot line was exactly on target:
+  `fn translate_mouse_event ... used by 8: run_app,
+  should_translate_click_to_none, should_translate_drag_to_none, ...` —
+  one new pure function fanning out to 7 tests plus its single
+  production caller, correctly flagging it as the deep-read target.
+  `removed: []` (no contract-marker equivalent fired) correctly signaled
+  no breaking signature change; `run`'s own signature is unchanged, and
+  the map (scoped to the diff) doesn't show `main.rs`'s call site at
+  `rinkaku/src/main.rs:353`, which a follow-up grep confirmed is
+  untouched and unaffected. The map cannot see behavior — it correctly
+  routed attention to `translate_mouse_event`'s logic but flagged the
+  panic-hook chaining, the event-loop `match` refactor, and the
+  popup/mouse integration as needing verification it cannot itself
+  provide.
+- Independent pass: read the diff without the map. Traced every exit
+  path of `run` by hand against `ratatui::try_init`'s actual source
+  (`ratatui-0.30.2/src/init.rs`): `try_init` installs a panic hook via
+  `set_panic_hook` *and* leaves raw mode/alternate screen active as
+  soon as `enable_raw_mode()?`/`EnterAlternateScreen` succeed — before
+  `Terminal::new` even runs. This exposed a real gap the diff as
+  submitted did not cover: `execute!(stdout(), EnableMouseCapture)?`
+  immediately after `try_init()?` propagated its `Err` with a bare `?`,
+  which skips straight past the `ratatui::restore()` call later in the
+  function. An `EnableMouseCapture` IO failure is a plain `Err`, not a
+  panic, so the just-installed panic-hook layer (this PR's own, and
+  `try_init`'s wrapped one) never fires either — the caller's terminal
+  would be left in raw mode + alternate screen with **no** cleanup path
+  at all, a strictly worse outcome than the panic case this PR was
+  otherwise careful to cover symmetrically. Also verified: `run_app`'s
+  internal `return Ok(())` on `app.should_quit()` returns from
+  `run_app` only, flows back into `run`'s `result` binding, and still
+  passes through the unconditional `DisableMouseCapture`/`restore()` at
+  the end of `run` — no leak on the ordinary quit path. Checked
+  `is_scroll_input_key`/`dispatch_non_source_key`/`App::handle_key`:
+  `InputKey::Up`/`Down` (what `translate_mouse_event` produces) is not
+  one of the four ADR-0026 scroll variants, so it always falls through
+  to `app.handle_key(input_key)`, which itself dispatches to
+  `handle_key_with_popup_open` whenever `jump_popup.is_some()` —
+  confirming by static trace (later reproduced dynamically) that wheel
+  scroll reaches the jump-popup cursor, not just the tree/right pane.
+  No `unwrap`/`expect` added to library code; comments are why-only and
+  match the surrounding file's density; English throughout; the 6 new
+  `translate_mouse_event` tests are fully qualified single-value
+  `assert_eq!` calls consistent with the rest of the file's convention.
+- Dynamic verification: built the worktree binary (`cargo build
+  --release`, `make test` — 472 passed — and `make lint`, both clean
+  pre-fix). Drove the real TUI in tmux via raw SGR mouse escape
+  sequences (`\x1b[<65;COL;ROWM` scroll-down, `\x1b[<64;COL;ROWM`
+  scroll-up), against `rinkaku --base main --tui` run from the worktree
+  itself:
+  - Right pane (`Focus::Right`, diff pane open on `fn run`): 3×
+    scroll-down moved the visible range from `1-51/248` to `4-54/248`
+    (1 line/tick, matching `InputKey::Down`'s single-line-scroll
+    semantics for `Focus::Right`); 2× scroll-up moved it back to
+    `2-52/248`.
+  - Tree pane (`Focus::Tree`): scroll-down moved the tree cursor down
+    one row (confirmed via the reverse-video `ESC[7m` marker in a
+    color-preserving `tmux capture-pane -e`) and the diff pane
+    auto-followed to the newly selected symbol, matching keyboard
+    `j`'s behavior.
+  - Jump popup open (`gr` on `translate_mouse_event`, 8 candidates):
+    scroll-down moved the popup's highlighted candidate from `run_app`
+    to `should_translate_scroll_up_to_input_key_up` (confirmed via the
+    `ESC[1;7m` reversed+bold marker on the candidate line); scroll-up
+    moved it back, clamping at the first candidate rather than
+    wrapping — exactly `handle_key_with_popup_open`'s documented
+    `saturating_sub`/`.min(...)` clamp behavior. This directly confirms
+    the review brief's open question: wheel input during the popup
+    does reach the popup cursor via the ordinary `InputKey` dispatch
+    path, not a separate/parallel one.
+  - Exit paths: `q` and Ctrl-C both exited with code 0 and returned the
+    shell to a normal, working prompt (no residual raw mode — verified
+    the shell accepted a plain `echo` immediately after), matching the
+    unconditional `DisableMouseCapture`/`restore()` at the end of `run`.
+  - Non-TTY stdin (`--tui < /dev/null`): exits 1 with `Error: Device
+    not configured (os error 6)`, no panic, no raw-terminal artifacts —
+    this is `try_init()?`'s own early return (before `EnableMouseCapture`
+    is ever reached), unaffected by the gap found above.
+  - A first attempt at this same tmux sequence produced what looked
+    like a `j`-key double-step (one keypress appearing to move the
+    cursor two tree rows); side-by-side replay against a `main`-only
+    binary displaying the same PR diff (via `--pr <url>`) showed
+    identical single-step behavior on both, and a slower, deliberately
+    paced re-run on the PR binary also showed single-step — the
+    apparent double-step was TUI-startup keystroke loss from an
+    insufficient `sleep` before the first `send-keys`, not a PR defect.
+    Recorded here per round 15/18's standing lesson: don't trust a
+    single observation of tmux-captured output without a same-binary,
+    same-timing re-run.
+- Fix applied this round: `run`'s `EnableMouseCapture` call now checks
+  its `Result` explicitly and calls `ratatui::restore()` before
+  returning the error, instead of relying on `?` to propagate past the
+  unconditional restore later in the function. Doc comments on `run`
+  and at the call site explain why this path needs an explicit restore
+  (the failure is a plain `Err`, not a panic, so neither panic-hook
+  layer installed just above fires). No new unit test added: this is a
+  real-terminal IO failure path with no pure transformation to extract
+  (consistent with `run`/`run_app` being intentionally outside this
+  crate's unit-test surface per CLAUDE.md's IO-boundary policy) — the
+  fix's correctness was instead checked by re-running the non-TTY
+  dynamic-verification case, which still exits 1 cleanly, and by
+  `make test`/`make lint` staying clean (472 passed, no new warnings).
+- Severity summary: one **should-fix** (terminal left in raw
+  mode/alternate screen with no restore path if `EnableMouseCapture`
+  itself fails post-`try_init` — fixed this round) and no blocking
+  findings. Every dynamically-checked behavior in the review brief
+  (wheel scroll in the diff/tree panes, wheel scroll reaching the jump
+  popup, clean mouse-capture teardown on `q`/Ctrl-C, non-TTY failure
+  mode) matched the PR's own design intent exactly.
+- Takeaway: the map correctly pointed at `translate_mouse_event` as the
+  one new logic surface worth a deep read, but the actual defect found
+  this round lived one level up, in `run`'s IO-failure control flow —
+  exactly the kind of integration-seam bug map fan-in counts cannot see
+  (a hotspot count answers "what's referenced a lot", not "does every
+  `?` in this function still hit the cleanup path"). Finding it required
+  reading the vendored `ratatui::try_init` source directly rather than
+  trusting the PR's own doc comment's paraphrase of it — the comment's
+  claim ("restored on return and on panic") was accurate for the
+  pre-existing raw-mode/alternate-screen guarantee but silently did not
+  extend to the new `EnableMouseCapture` call added right after it,
+  which is exactly the kind of claim multi-source verification (reading
+  the dependency's actual source, not just the wrapping code's comment
+  about it) is supposed to catch per this repo's own
+  "複数情報源による事実確認" discipline. Confirming the popup/mouse
+  interaction required real SGR escape sequences over tmux, not a
+  keyboard-only repro — no test in the PR's own suite exercises that
+  path, since it is a live-terminal integration behavior by
+  construction (consistent with round 8/18's pattern that scroll/
+  overflow/input-routing behavior needs a driven TUI, not just unit
+  tests, to verify).

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -72,7 +72,14 @@ use std::time::Duration;
 /// this one and both run on panic — see `try_init`'s own doc comment: "set
 /// a panic hook that restores the terminal") to disable mouse capture on
 /// panic too, mirroring the guarantee `try_init` already gives raw mode/
-/// alternate screen.
+/// alternate screen. `EnableMouseCapture` failing outright (as opposed to
+/// panicking) is handled the same way: `try_init` has already put the
+/// terminal into raw mode/the alternate screen by that point, so this
+/// function calls `ratatui::restore()` itself on that path before
+/// propagating the error, rather than relying on `?` to skip straight to
+/// the caller (which would strand the terminal mid-setup, since that
+/// particular failure is a plain `Err`, not a panic the installed hook
+/// would catch).
 ///
 /// This is the only function in the crate that touches a real terminal or
 /// blocks on input; everything it calls into (`App`, `row_view`, `ui`,
@@ -124,7 +131,17 @@ pub fn run(
     }));
 
     let mut terminal = ratatui::try_init()?;
-    execute!(std::io::stdout(), event::EnableMouseCapture)?;
+    // Restore explicitly on this `?`'s early-return path (rather than
+    // letting `?` skip straight past the `ratatui::restore()` call below):
+    // `try_init` above already left raw mode/the alternate screen active,
+    // and a plain `EnableMouseCapture` IO failure is not a panic, so the
+    // panic-hook layer just installed does not run either — without this,
+    // that combination would strand the caller's terminal in raw mode/
+    // alternate screen with no cleanup at all.
+    if let Err(err) = execute!(std::io::stdout(), event::EnableMouseCapture) {
+        ratatui::restore();
+        return Err(err);
+    }
     let result = run_app(&mut terminal, report, diff_text, entry_path, repo_root);
     let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
     ratatui::restore();

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -44,6 +44,7 @@ pub mod ui;
 
 use app::{App, BlastRadiusSelection, InputKey, Screen};
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use ratatui::crossterm::execute;
 use rinkaku_core::render::Report;
 use std::time::Duration;
 
@@ -59,6 +60,19 @@ use std::time::Duration;
 /// `anyhow` path to print cleanly and exit 1, instead of `ratatui::init`'s
 /// own `.expect(...)` panicking with a raw Rust panic message and exit
 /// code 101.
+///
+/// Also enables mouse capture (`EnableMouseCapture`) so the wheel/trackpad
+/// scroll support below can receive `Event::Mouse` at all — without it, a
+/// scroll gesture is intercepted by the terminal emulator itself (moving
+/// its own scrollback) and never reaches this process. `ratatui::try_init`/
+/// `restore` do not touch mouse capture (mouse support is opt-in, unlike
+/// raw mode/alternate screen which every TUI needs), so this function
+/// enables and disables it itself, and installs its own panic-hook layer
+/// (chained *before* calling `try_init`, so `try_init`'s own hook wraps
+/// this one and both run on panic — see `try_init`'s own doc comment: "set
+/// a panic hook that restores the terminal") to disable mouse capture on
+/// panic too, mirroring the guarantee `try_init` already gives raw mode/
+/// alternate screen.
 ///
 /// This is the only function in the crate that touches a real terminal or
 /// blocks on input; everything it calls into (`App`, `row_view`, `ui`,
@@ -97,8 +111,22 @@ pub fn run(
     entry_path: Option<&str>,
     repo_root: &std::path::Path,
 ) -> std::io::Result<()> {
+    // Chained *before* `ratatui::try_init`'s own `set_panic_hook` call
+    // below, so the hook `try_init` installs wraps this one: on panic,
+    // `try_init`'s hook runs `ratatui::restore()` (raw mode/alternate
+    // screen) and then this crate's hook (disable mouse capture), rather
+    // than mouse capture silently staying enabled in the panicking
+    // caller's terminal.
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
+        previous_hook(info);
+    }));
+
     let mut terminal = ratatui::try_init()?;
+    execute!(std::io::stdout(), event::EnableMouseCapture)?;
     let result = run_app(&mut terminal, report, diff_text, entry_path, repo_root);
+    let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
     ratatui::restore();
     result
 }
@@ -249,11 +277,28 @@ fn run_app(
         // this loop might grow to check in the future (kept short as a
         // resize/redraw responsiveness margin, not a correctness
         // requirement of the key-handling itself).
-        if event::poll(Duration::from_millis(100))?
-            && let Event::Key(key_event) = event::read()?
-            && key_event.kind == KeyEventKind::Press
-            && let Some(input_key) = translate_key(key_event.code, key_event.modifiers, &app)
-        {
+        //
+        // Both a keyboard press and a mouse wheel tick resolve to the same
+        // `Option<InputKey>` here (`translate_key`/`translate_mouse_event`
+        // respectively) and share every downstream dispatch branch below —
+        // a wheel scroll is just another way to produce `InputKey::Up`/
+        // `Down`, not a second, parallel handling path. Every other
+        // `Event` variant (`FocusGained`/`FocusLost`/`Paste`/`Resize`, and
+        // click/drag/move mouse events `translate_mouse_event` maps to
+        // `None`) falls through to `None` and the loop simply redraws.
+        let translated_input_key = if event::poll(Duration::from_millis(100))? {
+            match event::read()? {
+                Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
+                    translate_key(key_event.code, key_event.modifiers, &app)
+                }
+                Event::Mouse(mouse_event) => translate_mouse_event(mouse_event.kind),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        if let Some(input_key) = translated_input_key {
             if let InputKey::Source = input_key {
                 app = app.handle_key(input_key);
                 if let Screen::Source { symbol_id, .. } = app.screen().clone()
@@ -899,6 +944,37 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         KeyCode::Esc if on_source_screen => Some(InputKey::Back),
         KeyCode::Char('q') if on_source_screen => Some(InputKey::Back),
         KeyCode::Char('q') => Some(InputKey::Quit),
+        _ => None,
+    }
+}
+
+/// Translates a raw `crossterm` mouse event into an [`InputKey`], the same
+/// boundary role [`translate_key`] plays for keyboard input — a pure
+/// function so the mapping is unit-testable without a live terminal.
+///
+/// Only `ScrollUp`/`ScrollDown` (wheel/trackpad) are mapped, and they are
+/// mapped onto the *existing* [`InputKey::Up`]/[`InputKey::Down`] variants
+/// rather than a dedicated pair of scroll variants: `App::handle_key`
+/// already gives `Up`/`Down` the right contextual meaning everywhere a
+/// wheel scroll should act — the tree cursor while [`app::Focus::Tree`],
+/// [`app::App::right_pane_scroll`] by one line while [`app::Focus::Right`]
+/// (ADR 0020), and [`app::Screen::Source`]'s `scroll_top` on the source
+/// screen (ADR 0026) — so reusing them is a strict simplification (no new
+/// state-machine surface) rather than introducing a second, parallel
+/// motion concept the app would have to keep in sync with the first.
+///
+/// `MouseEventKind::ScrollLeft`/`ScrollRight` (horizontal wheel/trackpad)
+/// and every click/drag/move variant are deliberately unmapped (`None`):
+/// this crate has no horizontally-scrollable pane, and no pane targeting by
+/// click position — the row/column the event occurred at is intentionally
+/// not consulted here. Wheel input always acts on whichever pane already
+/// has focus, exactly like a keyboard `j`/`k` press would; teaching the
+/// wheel to also *change* focus by clicking a pane is future scope, not
+/// attempted by this function.
+fn translate_mouse_event(kind: event::MouseEventKind) -> Option<InputKey> {
+    match kind {
+        event::MouseEventKind::ScrollUp => Some(InputKey::Up),
+        event::MouseEventKind::ScrollDown => Some(InputKey::Down),
         _ => None,
     }
 }
@@ -2107,5 +2183,60 @@ mod tests {
             app.right_pane_scroll(),
             "jumping back must restore the scroll offset recorded when gd was pressed, not 0"
         );
+    }
+
+    // translate_mouse_event tests (mouse wheel scroll support).
+
+    #[test]
+    fn should_translate_scroll_up_to_input_key_up() {
+        let actual = translate_mouse_event(event::MouseEventKind::ScrollUp);
+
+        assert_eq!(Some(InputKey::Up), actual);
+    }
+
+    #[test]
+    fn should_translate_scroll_down_to_input_key_down() {
+        let actual = translate_mouse_event(event::MouseEventKind::ScrollDown);
+
+        assert_eq!(Some(InputKey::Down), actual);
+    }
+
+    #[test]
+    fn should_translate_scroll_left_to_none() {
+        // Horizontal wheel/trackpad input has no mapping — this crate has
+        // no horizontally-scrollable pane (this function's own doc comment).
+        let actual = translate_mouse_event(event::MouseEventKind::ScrollLeft);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_translate_scroll_right_to_none() {
+        let actual = translate_mouse_event(event::MouseEventKind::ScrollRight);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_translate_click_to_none() {
+        // Clicks/drags/moves are deliberately out of scope (no pane
+        // targeting by click position) — this function's own doc comment.
+        let actual = translate_mouse_event(event::MouseEventKind::Down(event::MouseButton::Left));
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_translate_drag_to_none() {
+        let actual = translate_mouse_event(event::MouseEventKind::Drag(event::MouseButton::Left));
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_translate_mouse_moved_to_none() {
+        let actual = translate_mouse_event(event::MouseEventKind::Moved);
+
+        assert_eq!(None, actual);
     }
 }


### PR DESCRIPTION
## Summary

- Enables mouse capture around the TUI's terminal session so wheel/trackpad
  scroll events reach the app instead of moving the terminal emulator's own
  scrollback (`crossterm::event::EnableMouseCapture`/`DisableMouseCapture`
  around `ratatui::try_init`/`restore`, since those two helpers do not touch
  mouse capture themselves).
- Adds a pure `translate_mouse_event` function (mirroring the existing
  `translate_key`) that maps `MouseEventKind::ScrollUp`/`ScrollDown` onto the
  *existing* `InputKey::Up`/`Down` variants, rather than introducing a
  dedicated pair of scroll `InputKey` variants.
- Installs an additional panic-hook layer (chained before
  `ratatui::try_init`'s own hook) so a panic mid-session still disables mouse
  capture before unwinding — mirroring the guarantee `try_init` already gives
  raw mode/the alternate screen.

## Why reuse `InputKey::Up`/`Down` instead of new variants

`App::handle_key` already gives `Up`/`Down` the right contextual meaning
everywhere a wheel scroll should act:

- tree cursor movement while `Focus::Tree`,
- `right_pane_scroll` by one line while `Focus::Right` (ADR 0020),
- `Screen::Source`'s `scroll_top` on the source screen (ADR 0026).

Mapping the wheel onto these instead of a new variant pair is a strict
simplification — no new state-machine surface, and the wheel automatically
gets every future refinement to `Up`/`Down`'s semantics for free.

## Scope

In scope:
- Vertical wheel scroll (`ScrollUp`/`ScrollDown`), one `InputKey` per tick,
  acting on whichever pane/screen currently has focus (same target `j`/`k`
  would act on).

Explicitly out of scope (left unmapped, documented in
`translate_mouse_event`'s doc comment):
- Horizontal wheel/trackpad scroll (`ScrollLeft`/`ScrollRight`) — no
  horizontally-scrollable pane exists today.
- Click/drag/move mouse events, including click-to-focus-a-pane. The wheel
  acts on whatever already has focus; teaching a click to *change* focus is
  future scope, not attempted here.
- The `?` help overlay's keymap listing is not updated — mouse wheel reuses
  `j`/`k`'s existing entries there rather than adding a new row, and help
  overlay scrolling itself is being handled in a separate, already in-flight
  PR per repo convention.

## QA

- `make test` (472 passed, 7 new) and `make lint` (fmt + clippy
  `-D warnings`) both pass.
- Dynamic verification against the real release binary in a live terminal
  (tmux, sending raw SGR mouse escape sequences to simulate wheel ticks —
  a real trackpad/mouse was not available in this environment, but the
  terminal-protocol-level input is identical):
  - Ran `rinkaku --base main~1 --head main --tui` against this repo's own
    history, opened the Diff pane on a changed symbol (`Focus::Right`),
    and confirmed simulated wheel-down/wheel-up ticks move
    `right_pane_scroll` by exactly one line per tick, matching plain `j`/`k`
    keyboard scrolling pixel-for-pixel (pane header went `1-51` -> `6-56`
    across 5 down-ticks, matching 5 `j` presses; then `6-56` -> `3-53`
    across 3 up-ticks).
  - Repeated on `Screen::Source` (opened via `s`): a single wheel-down tick
    moved `scroll_top` from line 100 to 101, confirming the same mapping
    works there too.
  - Sent a raw mouse left-click (`MouseEventKind::Down`) and confirmed it is
    a no-op (scroll position and status line unchanged, no crash).
  - Confirmed `q` still exits cleanly back to the shell prompt with no
    leftover raw-mode/mouse-capture terminal corruption.
  - Confirmed non-TTY invocation (`--tui < /dev/null`) still fails the same
    way it did before this change (`Error: Device not configured`, exit 0
    from the CLI's own error path) — verified against an unmodified build
    from the same commit to rule out a regression, since this change touches
    the same `run()` terminal-setup function that failure path goes through.