### PR TITLE
feat(tui): make help overlay scrollable

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/019.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/019.md
@@ -1,0 +1,129 @@
+# Round 19
+
+- Subject: draft PR #85 — the `?` help overlay becomes scrollable,
+  reusing ADR 0026's generic scroll machinery (`handle_scroll_key`,
+  `DrawOutcome`'s viewport-height plumbing, `render_scrollable_pane`)
+  as a third scrollable surface alongside the source screen and the
+  entry-view right pane. `App` gains `help_scroll`; `translate_key`'s
+  help-open gate maps `j`/`k`/`Ctrl-d`/`Ctrl-u`/`gg`/`G`; `DrawOutcome`
+  gains `clamped_help_scroll`/`help_scroll_viewport_height`. Side fix:
+  `App::handle_scroll_key` previously had no `help_open` guard, so a
+  `Ctrl-d`/`Ctrl-u`/`gg`/`G` press while the overlay was open silently
+  scrolled the right pane *behind* it. 6 files, ~650 lines changed
+  (`rinkaku-tui/src/{app/mod.rs,app/tests.rs,lib.rs,ui/mod.rs,
+  ui/overlay.rs,ui/source_screen.rs}`).
+- Protocol note: single-reviewer session covering all three angles
+  (map-assisted, independent, dynamic verification), not a harness-
+  timed A/B pair — recorded in the same per-round format as prior
+  rounds for continuity, per round 17's precedent.
+- **Map-assisted pass**: built `rinkaku` from a trusted `main` checkout
+  (worktree unaffected) and ran the PR diff through it. Hotspots
+  correctly concentrated attention on `struct App` (used by 4 changed
+  call sites), `fn draw` (used by 4 changed tests), `fn translate_key`
+  (used by `run_app` plus 2 changed tests), and `struct DrawOutcome` —
+  exactly the four seams this PR actually touches to wire a third
+  scrollable surface through. This routed deep reading straight to
+  `App::handle_key`/`handle_scroll_key`'s two `help_open` branches, the
+  `ui::draw` fold-back of the overlay's own `(clamped, viewport_height)`
+  pair into `DrawOutcome`, and `translate_key`'s help-open early return
+  — the exact integration seams where a fold-back or priority-ordering
+  bug would live. No hotspot pointed at a defect; the map's value here
+  was confirming coverage of the intended seams, not finding something
+  wrong with them.
+- **Independent pass** (map-free re-read of the diff): checked the
+  specific risks flagged going in.
+  - `help_scroll` reset on close: confirmed both `ToggleHelp` arms in
+    `App::handle_key` (open and close) reset `help_scroll = 0`, and a
+    dedicated test (`should_reset_help_scroll_when_overlay_reopens_
+    after_a_previous_scroll`) pins re-open-after-scroll starts at 0.
+  - `DrawOutcome` field mix-up risk: `clamped_help_scroll`/
+    `help_scroll_viewport_height` are a genuinely separate pair from
+    `clamped_right_pane_scroll`/`scroll_viewport_height`, each set
+    independently in `ui::draw` and folded back via two distinct
+    `run_app` helpers (`clamp_right_pane_scroll_after_draw` vs.
+    `clamp_help_scroll_after_draw`) — no cross-wiring found.
+  - Clamp timing / one-frame skew: the overlay follows the exact
+    already-shipped `right_pane_scroll` pattern (`App` holds an
+    unclamped "requested" value; `render_scrollable_pane` clamps at
+    draw time; the clamped value is folded back after the frame) —
+    same design, same risk profile as code already in production since
+    ADR 0026, not a new source of flicker.
+  - `translate_key`'s help-open gate vs. jump-popup gate ordering:
+    checked whether both can be open simultaneously. They cannot —
+    `GotoDefinition`/`GotoReferences` (the only path to
+    `open_jump_popup`) require the `gd`/`gr` sequence, and
+    `translate_key`'s help-open branch maps `g` only to `PendingGoto`
+    (arming the prefix) or, with a pending prefix already set, to
+    `ScrollToTop` (`gg`) — never to `d`/`r` resolution. So a jump popup
+    cannot open while help is open, and the ordering question is moot
+    by construction rather than by priority. Confirmed this isn't
+    accidental: the doc comment on `translate_key` states the ordering
+    explicitly.
+  - Two changed pre-existing tests: `should_ignore_navigation_keys_
+    while_help_overlay_is_open` was renamed and now asserts
+    `help_scroll == 1` after `Down` (previously asserted `Down` was a
+    no-op) — correct, since scrolling is exactly what this PR adds;
+    the tree-cursor invariant it originally pinned is preserved
+    unchanged. `should_translate_arbitrary_key_to_none_when_overlay_
+    is_open` switched its example key from `'j'` to `'z'` with a
+    comment explaining why `'j'` no longer proves "arbitrary keys are
+    swallowed" — both changes are justified, not silently weakened.
+  - Convention check: fully qualified `assert_eq!`/`assert!` throughout
+    (no partial-field assertions), `should_<behavior>_when_<condition>`
+    naming, comments explain *why* (e.g. why `clamped_help_scroll` is
+    a separate field rather than reusing the right-pane pair), no
+    `unwrap`/`expect` outside test code (`grep` confirmed every
+    `.expect(...)` added by this diff is in `#[cfg(test)]` scope).
+  - No ADR added for this PR — judged correct: this extends an
+    existing mechanism (ADR 0026) to a third consumer rather than
+    introducing a new layer, shared abstraction, or external
+    dependency: it does not meet this repo's own ADR trigger bar.
+- **Dynamic verification** (built the worktree binary, drove it via
+  `tmux` in a 60x15 real terminal — small enough to force overflow):
+  - `?` opened the overlay with a `(1-11/68)` overflow indicator.
+  - `j` moved it to `(2-12/68)` (exact 1-line step); `k` returned it to
+    `(1-11/68)`.
+  - `Ctrl-d` moved it to `(6-16/68)` (5-line half-page step against an
+    11-row inner height); `Ctrl-u` returned it to `(1-11/68)`.
+  - `G` jumped to `(58-68/68)`, revealing the Glossary's last entry
+    ("jumplist"); `gg` returned to `(1-11/68)`.
+  - Background-scroll regression check (the bug this PR's own
+    description calls out): opened a symbol's Diff pane, focused it,
+    and scrolled it to `(7-18/317)` with `Ctrl-d`. Opened the overlay
+    on top (`(1-11/68)`) and pressed `Ctrl-d` twice plus `j` three
+    times — the overlay's own indicator advanced through `(11-21/68)`
+    to `(14-24/68)` while the Diff pane underneath stayed pinned at
+    `(7-18/317)` for every single frame captured. Confirms the
+    `help_open` guard in `handle_scroll_key` actually closes the gap
+    the PR describes, not just in the unit tests but in a real
+    terminal with a real underlying scroll state to leak into.
+  - Closed with `?`, reopened: indicator reset to `(1-11/68)` while the
+    Diff pane stayed at `(7-18/317)` — confirms the reset is scoped to
+    the overlay's own state only.
+  - `Esc` also closed the overlay without quitting (`pane_dead 0`
+    confirmed via `tmux list-panes`).
+  - Non-TTY failure mode: `echo "" | rinkaku --tui < /dev/null` fails
+    with `Error: Device not configured (os error 6)` on both the
+    worktree binary and a `main`-built binary — identical output,
+    confirming this PR did not change or worsen that pre-existing gap
+    (tracked separately per round 8/17's own note on non-TTY-adjacent
+    findings not being this PR's to fix).
+- **No findings above Nit.** The one Nit-level observation:
+  `draw_help_overlay`'s new `(usize, usize)` return tuple
+  (`clamped_scroll`, `inner_height`) carries its field meaning only in
+  the call site's comment, not in the type itself — consistent with
+  how `ui::draw`'s other draw functions already return bare `Option<usize>`
+  in this crate, so left as a style note rather than a requested change.
+- Takeaway: this round is the mirror image of round 17 — here the map's
+  hotspot list pointed exactly at the seams that mattered (a mechanism-
+  extension PR touching a genuine fan-in point, `struct App`/`fn draw`/
+  `fn translate_key`), and both the independent pass and dynamic
+  verification confirmed the map's routing rather than surfacing
+  anything it missed. The PR's own most valuable single piece of
+  verification — proving the background-pane leak is actually fixed,
+  not just guarded in a unit test — required constructing a real
+  scrolled-and-focused Diff pane state and watching it *not* move
+  across real keypresses in a live terminal; no static read of the
+  `help_open` guard placement could have distinguished "the guard
+  exists" from "the guard is checked before the state it protects is
+  ever mutated by the offending path."

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -284,6 +284,16 @@ pub struct App {
     /// free by construction: nothing else about `App`'s state changes while
     /// the overlay is open.
     help_open: bool,
+    /// The `?` help overlay's own scroll offset (lines), unclamped in the
+    /// same "requested, not authoritative" sense as [`Self::right_pane_scroll`]
+    /// — `App` has no notion of the overlay's rendered height, so clamping
+    /// is `crate::ui`'s job at draw time (`crate::ui::overlay::draw_help_overlay`,
+    /// reusing [`crate::ui::scroll::render_scrollable_pane`]'s clamp).
+    /// Reset to 0 whenever the overlay opens or closes ([`Self::handle_key`]'s
+    /// `ToggleHelp` arms), so re-opening the overlay after scrolling always
+    /// starts from the top rather than resuming a stale offset the reviewer
+    /// has no way to see coming back.
+    help_scroll: usize,
     /// A `g`-prefixed sequence's first key, awaiting its second (ADR 0022) —
     /// `None` outside that one-key window. Set by `g` and cleared by
     /// *every* subsequent key regardless of what it is (`crate::lib::
@@ -335,6 +345,7 @@ impl App {
             right_pane_scroll: 0,
             focus: Focus::default(),
             help_open: false,
+            help_scroll: 0,
             pending_prefix: None,
             jump_popup: None,
             jump_back: Vec::new(),
@@ -413,6 +424,12 @@ impl App {
     /// own doc comment.
     pub fn focus(&self) -> Focus {
         self.focus
+    }
+
+    /// The `?` help overlay's requested scroll offset (lines) — see
+    /// [`Self::help_scroll`]'s own doc comment on why this is unclamped.
+    pub fn help_scroll(&self) -> usize {
+        self.help_scroll
     }
 
     /// Whether the `?` help overlay (ADR 0020) is currently open.
@@ -692,14 +709,21 @@ impl App {
     /// active) and is otherwise unused.
     ///
     /// The `?` help overlay (ADR 0020) is handled first and takes over the
-    /// whole key space while open: `ToggleHelp` closes it and every other
-    /// key is swallowed as a no-op (deliberately, including `Quit` — the
-    /// overlay's whole point is a safe, low-stakes "let me check the keys"
-    /// action that cannot be short-circuited by an accidental app exit; see
-    /// `Self::help_open`'s own doc comment). This must run before the
-    /// screen/focus dispatch below, not as another arm inside it, so no
-    /// future `InputKey` variant can accidentally bypass the overlay by
-    /// being handled in a screen-specific branch first.
+    /// whole key space while open: `ToggleHelp` closes it, `Up`/`Down` move
+    /// [`Self::help_scroll`] by one line (the content can run longer than
+    /// the overlay's own box — ADR 0026's follow-up, this struct's own
+    /// `help_scroll` doc comment), `ScrollHalfPageDown`/`ScrollHalfPageUp`/
+    /// `ScrollToTop`/`ScrollToBottom` are let through unmodified for
+    /// [`Self::handle_scroll_key`] to apply (mirroring ADR 0026's existing
+    /// two-step dispatch for the source screen/right pane — see that
+    /// method's own doc comment), and every other key is swallowed as a
+    /// no-op (deliberately, including `Quit` — the overlay's whole point is
+    /// a safe, low-stakes "let me check the keys" action that cannot be
+    /// short-circuited by an accidental app exit; see `Self::help_open`'s
+    /// own doc comment). This must run before the screen/focus dispatch
+    /// below, not as another arm inside it, so no future `InputKey` variant
+    /// can accidentally bypass the overlay by being handled in a
+    /// screen-specific branch first.
     ///
     /// `right_pane_scroll` is reset to 0 by every key *except* `Up`/`Down`
     /// while [`Focus::Right`] on [`Screen::Entry`] (ADR 0020: scrolling
@@ -750,13 +774,35 @@ impl App {
         };
 
         if self.help_open {
-            if key == InputKey::ToggleHelp {
-                self.help_open = false;
+            match key {
+                InputKey::ToggleHelp => {
+                    self.help_open = false;
+                    self.help_scroll = 0;
+                }
+                InputKey::Down => {
+                    self.help_scroll = self.help_scroll.saturating_add(1);
+                }
+                InputKey::Up => {
+                    self.help_scroll = self.help_scroll.saturating_sub(1);
+                }
+                // The four ADR 0026 scroll variants are deliberately not
+                // handled here: their step size depends on the overlay's
+                // rendered height, which only `Self::handle_scroll_key`
+                // receives (`crate::run_app`'s two-step dispatch) — passed
+                // through as a no-op here so that call still runs (matching
+                // every other scroll key's own `handle_key` arm, ADR 0026's
+                // `is_scroll_input_key` doc comment).
+                InputKey::ScrollHalfPageDown
+                | InputKey::ScrollHalfPageUp
+                | InputKey::ScrollToTop
+                | InputKey::ScrollToBottom => {}
+                _ => {}
             }
             return self;
         }
         if key == InputKey::ToggleHelp {
             self.help_open = true;
+            self.help_scroll = 0;
             return self;
         }
 
@@ -1277,6 +1323,19 @@ impl App {
         self
     }
 
+    /// Overwrites the `?` help overlay's scroll offset directly to `scroll`
+    /// — used by `crate::run_app` to fold the actually-clamped, actually-
+    /// rendered offset back into `App` after every draw
+    /// (`crate::ui::DrawOutcome`'s own doc comment on why this fold-back
+    /// exists: without it, repeated scrolling past the overlay's own end
+    /// would keep incrementing this unclamped request with no visible
+    /// effect, the same overshoot [`Self::with_right_pane_scroll`] already
+    /// guards against for the right pane).
+    pub fn with_help_scroll(mut self, scroll: usize) -> Self {
+        self.help_scroll = scroll;
+        self
+    }
+
     /// Overwrites [`Screen::Source`]'s `scroll_top` to `scroll_top` —
     /// used by `crate::run_app` right after the `s` key transitions to
     /// [`Screen::Source`], to back-fill the centered starting position
@@ -1327,8 +1386,36 @@ impl App {
     /// ([`InputKey::ScrollToBottom`]'s doc comment): the clamp-at-draw
     /// step folds it down to `total_lines - viewport_height` cleanly,
     /// so no per-pane bottom sentinel is needed here.
+    /// While the `?` help overlay is open, these four variants act on
+    /// [`Self::help_scroll`] instead of whatever `self.screen`/`self.focus`
+    /// would otherwise imply, checked before the screen/focus match below —
+    /// same priority [`Self::handle_key`] already gives the overlay, and
+    /// for the same reason: without this, `crate::run_app`'s unconditional
+    /// second-step call to this method (ADR 0026's two-step dispatch;
+    /// `Self::handle_key`'s own arms for these variants are deliberate
+    /// no-ops) would fall through to the ordinary `Screen::Entry` +
+    /// `Focus::Right` branch and silently scroll the right pane *behind*
+    /// the overlay while it looked closed to the reviewer.
     pub fn handle_scroll_key(mut self, key: InputKey, viewport_height: usize) -> Self {
         let step = viewport_height / 2;
+        if self.help_open {
+            match key {
+                InputKey::ScrollHalfPageDown => {
+                    self.help_scroll = self.help_scroll.saturating_add(step);
+                }
+                InputKey::ScrollHalfPageUp => {
+                    self.help_scroll = self.help_scroll.saturating_sub(step);
+                }
+                InputKey::ScrollToTop => {
+                    self.help_scroll = 0;
+                }
+                InputKey::ScrollToBottom => {
+                    self.help_scroll = usize::MAX;
+                }
+                _ => {}
+            }
+            return self;
+        }
         match (&self.screen, self.focus, key) {
             (
                 Screen::Source {

--- a/rinkaku-tui/src/app/tests.rs
+++ b/rinkaku-tui/src/app/tests.rs
@@ -1017,7 +1017,11 @@ fn should_ignore_quit_while_help_overlay_is_open() {
 }
 
 #[test]
-fn should_ignore_navigation_keys_while_help_overlay_is_open() {
+fn should_scroll_help_overlay_instead_of_moving_tree_cursor_when_down_is_pressed_while_open() {
+    // `Down` used to be ignored outright while the overlay was open; it now
+    // scrolls the overlay's own content instead (this feature) — the tree
+    // cursor underneath must still stay untouched either way, since the
+    // overlay composites on top of it rather than replacing it.
     let report = report_with_one_symbol();
     let app = App::new(&report).handle_key(InputKey::ToggleHelp);
     let cursor_before = app.nav().cursor();
@@ -1026,6 +1030,7 @@ fn should_ignore_navigation_keys_while_help_overlay_is_open() {
 
     assert_eq!(cursor_before, app.nav().cursor());
     assert_eq!(true, app.help_open());
+    assert_eq!(1, app.help_scroll());
 }
 
 #[test]
@@ -1044,6 +1049,166 @@ fn should_leave_other_state_untouched_when_help_overlay_opens() {
 
     assert_eq!(right_pane_before, app.right_pane());
     assert_eq!(cursor_before, app.nav().cursor());
+}
+
+#[test]
+fn should_start_with_zero_help_scroll() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    assert_eq!(0, app.help_scroll());
+}
+
+#[test]
+fn should_scroll_help_overlay_down_by_one_line_when_down_is_pressed_while_open() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    let app = app.handle_key(InputKey::Down);
+
+    assert_eq!(1, app.help_scroll());
+}
+
+#[test]
+fn should_scroll_help_overlay_up_by_one_line_when_up_is_pressed_while_open() {
+    let report = empty_report();
+    let app = App::new(&report)
+        .handle_key(InputKey::ToggleHelp)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Down);
+    assert_eq!(2, app.help_scroll());
+
+    let app = app.handle_key(InputKey::Up);
+
+    assert_eq!(1, app.help_scroll());
+}
+
+#[test]
+fn should_not_underflow_help_scroll_when_up_is_pressed_at_the_top() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+    assert_eq!(0, app.help_scroll());
+
+    let app = app.handle_key(InputKey::Up);
+
+    assert_eq!(0, app.help_scroll());
+}
+
+#[test]
+fn should_reset_help_scroll_when_overlay_closes() {
+    let report = empty_report();
+    let app = App::new(&report)
+        .handle_key(InputKey::ToggleHelp)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Down);
+    assert_eq!(2, app.help_scroll());
+
+    let app = app.handle_key(InputKey::ToggleHelp);
+
+    assert_eq!(0, app.help_scroll());
+}
+
+#[test]
+fn should_reset_help_scroll_when_overlay_reopens_after_a_previous_scroll() {
+    // Re-opening after a previous scrolled session must start from the top
+    // again (this struct's own `help_scroll` doc comment: "a reviewer has
+    // no way to see coming back" otherwise), not resume the stale offset.
+    let report = empty_report();
+    let app = App::new(&report)
+        .handle_key(InputKey::ToggleHelp)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::ToggleHelp);
+    assert_eq!(0, app.help_scroll());
+
+    let app = app.handle_key(InputKey::ToggleHelp);
+
+    assert_eq!(true, app.help_open());
+    assert_eq!(0, app.help_scroll());
+}
+
+#[test]
+fn should_scroll_help_overlay_half_page_down_via_handle_scroll_key_when_open() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, 20);
+
+    assert_eq!(10, app.help_scroll());
+}
+
+#[test]
+fn should_scroll_help_overlay_half_page_up_via_handle_scroll_key_when_open() {
+    let report = empty_report();
+    let app = App::new(&report)
+        .handle_key(InputKey::ToggleHelp)
+        .handle_scroll_key(InputKey::ScrollHalfPageDown, 20);
+    assert_eq!(10, app.help_scroll());
+
+    let app = app.handle_scroll_key(InputKey::ScrollHalfPageUp, 20);
+
+    assert_eq!(0, app.help_scroll());
+}
+
+#[test]
+fn should_scroll_help_overlay_to_top_via_handle_scroll_key_when_open() {
+    let report = empty_report();
+    let app = App::new(&report)
+        .handle_key(InputKey::ToggleHelp)
+        .handle_scroll_key(InputKey::ScrollHalfPageDown, 20);
+    assert_eq!(10, app.help_scroll());
+
+    let app = app.handle_scroll_key(InputKey::ScrollToTop, 20);
+
+    assert_eq!(0, app.help_scroll());
+}
+
+#[test]
+fn should_scroll_help_overlay_to_bottom_sentinel_via_handle_scroll_key_when_open() {
+    // `usize::MAX` is the same "scroll to bottom" sentinel ADR 0026 already
+    // uses for `right_pane_scroll`/`Screen::Source::scroll_top` — folded
+    // down to the real max at draw time by `render_scrollable_pane`'s own
+    // clamp, so no per-pane bottom sentinel is needed here either.
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    let app = app.handle_scroll_key(InputKey::ScrollToBottom, 20);
+
+    assert_eq!(usize::MAX, app.help_scroll());
+}
+
+#[test]
+fn should_not_scroll_right_pane_via_handle_scroll_key_when_help_overlay_is_open() {
+    // Regression guard for the latent bug this feature's own implementation
+    // found: without the `help_open` check at the top of `handle_scroll_key`,
+    // `crate::run_app`'s unconditional two-step dispatch (`handle_key` then
+    // `handle_scroll_key`) would fall through to the ordinary
+    // `Screen::Entry` + `Focus::Right` branch and scroll the right pane
+    // *behind* the overlay while it looked closed to the reviewer.
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(InputKey::Open)
+        .handle_key(InputKey::ToggleHelp);
+    let right_pane_scroll_before = app.right_pane_scroll();
+
+    let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, 20);
+
+    assert_eq!(right_pane_scroll_before, app.right_pane_scroll());
+    assert_eq!(10, app.help_scroll());
+}
+
+#[test]
+fn should_leave_help_scroll_untouched_when_with_help_scroll_is_called_on_a_closed_overlay() {
+    // `App::with_help_scroll` is a plain setter with no `help_open` guard
+    // (mirroring `with_right_pane_scroll`'s own unconditional write) — this
+    // pins that `crate::run_app`'s post-draw fold-back is itself gated by
+    // `DrawOutcome::clamped_help_scroll` being `None` while closed
+    // (`ui::draw`'s own doc comment), not by this setter refusing the call.
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let app = app.with_help_scroll(5);
+
+    assert_eq!(5, app.help_scroll());
 }
 
 #[test]

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -202,6 +202,14 @@ fn run_app(
     // near-impossible edge case, but guarded rather than defaulting to a
     // zero step) falls back to [`DEFAULT_SCROLL_VIEWPORT_HEIGHT`].
     let mut last_scroll_viewport_height: Option<usize> = None;
+    // The `?` help overlay's own last-drawn inner height, tracked
+    // separately from `last_scroll_viewport_height` above: the overlay can
+    // be open on top of either screen, and its box is a different size
+    // than whichever pane sits underneath it — sizing a `Ctrl-d` press
+    // while the overlay is open against the *underlying* pane's height
+    // would produce a step that does not match what the reviewer is
+    // actually looking at.
+    let mut last_help_scroll_viewport_height: Option<usize> = None;
 
     loop {
         // `ui::draw`'s return value (`DrawOutcome`, `ui::draw`'s own doc
@@ -224,6 +232,10 @@ fn run_app(
         app = clamp_right_pane_scroll_after_draw(app, outcome.clamped_right_pane_scroll);
         if outcome.scroll_viewport_height.is_some() {
             last_scroll_viewport_height = outcome.scroll_viewport_height;
+        }
+        app = clamp_help_scroll_after_draw(app, outcome.clamped_help_scroll);
+        if outcome.help_scroll_viewport_height.is_some() {
+            last_help_scroll_viewport_height = outcome.help_scroll_viewport_height;
         }
 
         if app.should_quit() {
@@ -299,9 +311,19 @@ fn run_app(
                 // mutation. `handle_key`'s own arm for these four
                 // variants is deliberately a no-op; the state change
                 // lives here.
+                //
+                // While the help overlay is open, both steps size against
+                // and act on the overlay's own scroll state instead of
+                // whichever pane is underneath it (`App::handle_key`/
+                // `App::handle_scroll_key`'s own `help_open` branches) —
+                // `last_help_scroll_viewport_height` is this loop's mirror
+                // of `last_scroll_viewport_height` for that surface.
                 app = app.handle_key(input_key);
-                let viewport_height =
-                    last_scroll_viewport_height.unwrap_or(DEFAULT_SCROLL_VIEWPORT_HEIGHT);
+                let viewport_height = if app.help_open() {
+                    last_help_scroll_viewport_height.unwrap_or(DEFAULT_SCROLL_VIEWPORT_HEIGHT)
+                } else {
+                    last_scroll_viewport_height.unwrap_or(DEFAULT_SCROLL_VIEWPORT_HEIGHT)
+                };
                 app = app.handle_scroll_key(input_key, viewport_height);
             } else {
                 // Every non-`Source` key's dispatch is pure (no IO), so it
@@ -415,6 +437,18 @@ fn is_scroll_input_key(input_key: InputKey) -> bool {
 fn clamp_right_pane_scroll_after_draw(app: App, clamped: Option<usize>) -> App {
     match clamped {
         Some(scroll) => app.with_right_pane_scroll(scroll),
+        None => app,
+    }
+}
+
+/// The `?` help overlay's own version of [`clamp_right_pane_scroll_after_draw`]
+/// — folds `ui::DrawOutcome::clamped_help_scroll` back into `App` after every
+/// draw so an overshot request (repeated `j` past the overlay's own last
+/// line) never survives past the frame that visibly clamped it, mirroring
+/// that function's own reasoning for the right pane.
+fn clamp_help_scroll_after_draw(app: App, clamped: Option<usize>) -> App {
+    match clamped {
+        Some(scroll) => app.with_help_scroll(scroll),
         None => app,
     }
 }
@@ -724,8 +758,33 @@ fn should_recompute_blast_radius_selection(app: &App) -> bool {
 /// unwind on any key that is not `d`/`r`.
 fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<InputKey> {
     if app.help_open() {
+        // The overlay's own content can run longer than its box (this
+        // feature's whole reason for existing) — `j`/`k`/`Ctrl-d`/`Ctrl-u`/
+        // `G` scroll it, mirroring the plain-key mapping each already has
+        // outside the overlay so a reviewer does not have to learn a
+        // second gesture just because the overlay is open. `gg`'s
+        // second-`g` resolution still goes through the `pending_prefix`
+        // branch below (this early return only covers `?`/Esc/`q`/`Ctrl-d`/
+        // `Ctrl-u`/`G` and the bare `j`/`k`/arrow keys; a first `g` press
+        // is deliberately *not* matched here so it falls through to the
+        // ordinary `PendingGoto` arm at the bottom of this function, which
+        // works identically whether the overlay is open or not since it
+        // only touches `app.pending_prefix()`).
         return match code {
             KeyCode::Char('?') | KeyCode::Esc | KeyCode::Char('q') => Some(InputKey::ToggleHelp),
+            KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
+            KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
+            KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
+                Some(InputKey::ScrollHalfPageDown)
+            }
+            KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
+                Some(InputKey::ScrollHalfPageUp)
+            }
+            KeyCode::Char('G') => Some(InputKey::ScrollToBottom),
+            KeyCode::Char('g') if app.pending_prefix() == Some(app::PendingPrefix::G) => {
+                Some(InputKey::ScrollToTop)
+            }
+            KeyCode::Char('g') => Some(InputKey::PendingGoto),
             _ => None,
         };
     }
@@ -1030,13 +1089,85 @@ mod tests {
     }
 
     #[test]
-    fn should_translate_arbitrary_key_to_none_when_overlay_is_open() {
+    fn should_translate_unbound_key_to_none_when_overlay_is_open() {
+        // `'j'` used to be this test's example key, back when the overlay
+        // had no scroll gestures of its own and swallowed every key but
+        // `?`/Esc/`q` (`should_ignore_navigation_keys_while_help_overlay_is_open`'s
+        // own App-level counterpart). Scrolling the overlay now maps `'j'`
+        // to `InputKey::Down` even while it is open — see
+        // `should_translate_j_to_down_for_overlay_scroll_when_overlay_is_open`
+        // below — so this test switched to `'z'`, a key with no meaning
+        // anywhere in the keymap, to keep pinning "arbitrary keys are
+        // swallowed" without asserting something that is no longer true.
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+        let actual = translate_key(KeyCode::Char('z'), KeyModifiers::NONE, &app);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_translate_j_to_down_for_overlay_scroll_when_overlay_is_open() {
         let report = empty_report();
         let app = App::new(&report).handle_key(InputKey::ToggleHelp);
 
         let actual = translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app);
 
-        assert_eq!(None, actual);
+        assert_eq!(Some(InputKey::Down), actual);
+    }
+
+    #[test]
+    fn should_translate_k_to_up_for_overlay_scroll_when_overlay_is_open() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+        let actual = translate_key(KeyCode::Char('k'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::Up), actual);
+    }
+
+    #[test]
+    fn should_translate_ctrl_d_to_scroll_half_page_down_when_overlay_is_open() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+        let actual = translate_key(KeyCode::Char('d'), KeyModifiers::CONTROL, &app);
+
+        assert_eq!(Some(InputKey::ScrollHalfPageDown), actual);
+    }
+
+    #[test]
+    fn should_translate_ctrl_u_to_scroll_half_page_up_when_overlay_is_open() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+        let actual = translate_key(KeyCode::Char('u'), KeyModifiers::CONTROL, &app);
+
+        assert_eq!(Some(InputKey::ScrollHalfPageUp), actual);
+    }
+
+    #[test]
+    fn should_translate_uppercase_g_to_scroll_to_bottom_when_overlay_is_open() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+        let actual = translate_key(KeyCode::Char('G'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ScrollToBottom), actual);
+    }
+
+    #[test]
+    fn should_translate_double_g_to_scroll_to_top_when_overlay_is_open() {
+        let report = empty_report();
+        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+        let first_g = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
+        assert_eq!(Some(InputKey::PendingGoto), first_g);
+        let app = app.handle_key(first_g.expect("first g translates"));
+
+        let actual = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
+
+        assert_eq!(Some(InputKey::ScrollToTop), actual);
     }
 
     #[test]
@@ -1407,6 +1538,57 @@ mod tests {
         let app = clamp_right_pane_scroll_after_draw(app, None);
 
         assert_eq!(3, app.right_pane_scroll());
+    }
+
+    // --- clamp_help_scroll_after_draw ---
+    //
+    // Same fold-back discipline as `clamp_right_pane_scroll_after_draw`
+    // above, applied to the `?` help overlay's own independent scroll
+    // state (this feature).
+
+    #[test]
+    fn should_overwrite_help_scroll_with_the_clamped_value_when_some() {
+        let report = empty_report();
+        let app = App::new(&report).with_help_scroll(999);
+
+        let app = clamp_help_scroll_after_draw(app, Some(4));
+
+        assert_eq!(4, app.help_scroll());
+    }
+
+    #[test]
+    fn should_leave_help_scroll_untouched_when_none() {
+        let report = empty_report();
+        let app = App::new(&report).with_help_scroll(2);
+
+        let app = clamp_help_scroll_after_draw(app, None);
+
+        assert_eq!(2, app.help_scroll());
+    }
+
+    // --- is_scroll_input_key ---
+
+    #[test]
+    fn should_treat_the_four_adr_0026_scroll_variants_as_scroll_input_keys() {
+        for key in [
+            InputKey::ScrollHalfPageDown,
+            InputKey::ScrollHalfPageUp,
+            InputKey::ScrollToTop,
+            InputKey::ScrollToBottom,
+        ] {
+            assert!(is_scroll_input_key(key), "{key:?} should be a scroll key");
+        }
+    }
+
+    #[test]
+    fn should_not_treat_up_or_down_as_scroll_input_keys() {
+        // `Up`/`Down` scroll the help overlay too, but through the ordinary
+        // `dispatch_non_source_key` path (`App::handle_key`'s own
+        // `help_open` branch), not the two-step `handle_scroll_key`
+        // dispatch reserved for the four ADR 0026 variants — this pins
+        // that boundary stays where `run_app`'s own dispatch expects it.
+        assert!(!is_scroll_input_key(InputKey::Up));
+        assert!(!is_scroll_input_key(InputKey::Down));
     }
 
     // g-prefix and jump-popup translate_key tests (ADR 0022).

--- a/rinkaku-tui/src/ui/mod.rs
+++ b/rinkaku-tui/src/ui/mod.rs
@@ -35,13 +35,16 @@ use status::draw_status_line;
 /// request never survives past the visible clamp) and the inner height of
 /// the currently-scrolling pane (so the next `Ctrl-d`/`Ctrl-u` half-page
 /// step, ADR 0026, can be sized against the real viewport rather than a
-/// magic constant).
+/// magic constant) — plus the same pair again for the `?` help overlay,
+/// which can be open and scrolling independently of whichever screen is
+/// showing underneath it.
 ///
-/// Both fields are `Option<usize>` because a given frame may not have
+/// Every field is `Option<usize>` because a given frame may not have
 /// anything to fold back at all — no right pane on [`Screen::Source`],
-/// no scrolling pane at all when the tree has focus, etc. `crate::run_app`
-/// treats each `None` as "nothing to update on that seam this frame",
-/// mirroring the pre-existing single-`Option<usize>` return this replaces.
+/// no scrolling pane at all when the tree has focus, the overlay closed,
+/// etc. `crate::run_app` treats each `None` as "nothing to update on that
+/// seam this frame", mirroring the pre-existing single-`Option<usize>`
+/// return this replaces.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct DrawOutcome {
     /// The right-hand pane's scroll offset as actually clamped and
@@ -66,6 +69,23 @@ pub struct DrawOutcome {
     /// half-page (ADR 0026) key arrives, so the step size scales with
     /// the actual pane rather than a magic constant.
     pub scroll_viewport_height: Option<usize>,
+    /// The `?` help overlay's own scroll offset as actually clamped and
+    /// rendered this frame (`None` while the overlay is closed) — kept
+    /// separate from [`Self::clamped_right_pane_scroll`] rather than reusing
+    /// it, since the overlay composites *on top of* whichever screen was
+    /// already showing (`crate::app::App::help_open`'s own doc comment) and
+    /// can be open while that underlying screen still has its own scroll
+    /// state to fold back independently; collapsing the two into one field
+    /// would make one clobber the other the moment both are scrollable in
+    /// the same frame. `crate::run_app` feeds this back via
+    /// `App::with_help_scroll`, mirroring the right-pane fold-back.
+    pub clamped_help_scroll: Option<usize>,
+    /// The help overlay's own inner height (borders excluded) this frame,
+    /// `None` while closed — `crate::run_app` remembers this the same way
+    /// it does [`Self::scroll_viewport_height`], so a `Ctrl-d`/`Ctrl-u`
+    /// half-page press while the overlay is open sizes its step against the
+    /// overlay's own box, not whatever pane happens to be underneath it.
+    pub help_scroll_viewport_height: Option<usize>,
 }
 
 /// Draws one full frame: the entry view (tree + right pane split) or the
@@ -93,7 +113,13 @@ pub struct DrawOutcome {
 /// `Screen`/`crate::app::RightPane` themselves draw (`App::help_open`'s own doc
 /// comment), so the underlying frame is built exactly the same way whether
 /// the overlay is open or not, and the overlay is simply composited over
-/// it as a final step.
+/// it as a final step. Its own clamped scroll offset and inner height
+/// (scrolling, added after the overlay's content outgrew a single fixed
+/// box) are folded into `outcome` after the base match above, rather than
+/// as another arm of it, since the overlay is orthogonal to which `Screen`
+/// is underneath — `outcome`'s `clamped_right_pane_scroll`/
+/// `scroll_viewport_height` pair (whichever screen set it) is left
+/// untouched by this step.
 pub fn draw(
     frame: &mut Frame,
     app: &App,
@@ -107,7 +133,7 @@ pub fn draw(
     let [body, status_area] =
         Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(area);
 
-    let outcome = match app.screen() {
+    let mut outcome = match app.screen() {
         Screen::Entry => {
             let clamped = draw_entry_screen(
                 frame,
@@ -133,6 +159,8 @@ pub fn draw(
             DrawOutcome {
                 clamped_right_pane_scroll: clamped,
                 scroll_viewport_height,
+                clamped_help_scroll: None,
+                help_scroll_viewport_height: None,
             }
         }
         Screen::Source {
@@ -144,6 +172,8 @@ pub fn draw(
             DrawOutcome {
                 clamped_right_pane_scroll: None,
                 scroll_viewport_height: Some(inner_height),
+                clamped_help_scroll: None,
+                help_scroll_viewport_height: None,
             }
         }
     };
@@ -151,7 +181,10 @@ pub fn draw(
     draw_status_line(frame, app, status_area);
 
     if app.help_open() {
-        draw_help_overlay(frame, area);
+        let (clamped_help_scroll, help_scroll_viewport_height) =
+            draw_help_overlay(frame, area, app.help_scroll());
+        outcome.clamped_help_scroll = Some(clamped_help_scroll);
+        outcome.help_scroll_viewport_height = Some(help_scroll_viewport_height);
     }
     if let Some(popup) = app.jump_popup() {
         draw_jump_popup(frame, popup, area);

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -2,24 +2,18 @@
 //! composited on top of whatever screen was already rendered underneath,
 //! after the pane split has drawn everything else.
 
-use super::scroll::{truncate_to_width, windowed_rows_with_indicators};
+use super::scroll::{render_scrollable_pane, truncate_to_width, windowed_rows_with_indicators};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Clear, Paragraph};
 
-/// Draws the `?` help overlay (ADR 0020) centered over `full_area`: a
-/// bordered box roughly 70% of the frame's width/height (capped so it
-/// never claims more than the frame itself on a small terminal), listing
-/// every [`crate::help::HELP_CONTENT`] keymap group followed by the
-/// glossary. [`Clear`] is rendered first so the overlay's background is
-/// opaque rather than letting the underlying frame's glyphs show through
-/// gaps in the overlay's own text.
-pub(crate) fn draw_help_overlay(frame: &mut Frame, full_area: Rect) {
-    let overlay_area = centered_rect(full_area, 80, 90);
-    frame.render_widget(Clear, overlay_area);
-
+/// The `?` help overlay's content laid out once, independent of the pane's
+/// rendered size — extracted from [`draw_help_overlay`] so tests can pin
+/// its shape without a live `Frame`, mirroring how `crate::help::HELP_CONTENT`
+/// itself is already plain data rather than something computed at draw time.
+fn help_overlay_lines() -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> = Vec::new();
     for group in crate::help::HELP_CONTENT.keymap_groups {
         lines.push(Line::styled(
@@ -44,12 +38,50 @@ pub(crate) fn draw_help_overlay(frame: &mut Frame, full_area: Rect) {
             entry.term, entry.explanation
         )));
     }
+    lines
+}
 
-    let block = Block::bordered().title(" Help (? to close) ");
-    let paragraph = Paragraph::new(lines)
-        .block(block)
-        .wrap(ratatui::widgets::Wrap { trim: false });
-    frame.render_widget(paragraph, overlay_area);
+/// Draws the `?` help overlay (ADR 0020, scrolling added post-hoc once the
+/// keymap grew past what always fit on screen — ADR 0026's own "Source
+/// view" group plus the `gd`/`gr`/jumplist entries pushed the pre-glossary
+/// content past a typical terminal's height) centered over `full_area`: a
+/// bordered box roughly 80%/90% of the frame's width/height (capped so it
+/// never claims more than the frame itself on a small terminal), listing
+/// every [`crate::help::HELP_CONTENT`] keymap group followed by the
+/// glossary. [`Clear`] is rendered first so the overlay's background is
+/// opaque rather than letting the underlying frame's glyphs show through
+/// gaps in the overlay's own text.
+///
+/// Scrolled via [`render_scrollable_pane`] — the same clamp/indicator/
+/// `Paragraph::scroll` machinery the Detail and Diff panes already share
+/// (`crate::ui::scroll`'s own module doc comment), rather than a bespoke
+/// mechanism just for this overlay: a terminal short enough that the
+/// keymap + glossary overflow the box now scrolls via `j`/`k`/`Ctrl-d`/
+/// `Ctrl-u`/`gg`/`G` (`App::handle_key`/`App::handle_scroll_key`'s own
+/// `help_open` branches) instead of silently clipping the bottom of the
+/// content with no way to reach it.
+///
+/// Returns the actually-clamped scroll offset and the overlay's own inner
+/// height, for `crate::ui::draw` to fold into [`crate::ui::DrawOutcome`]
+/// the same way every other scrollable pane's draw call already does.
+pub(crate) fn draw_help_overlay(
+    frame: &mut Frame,
+    full_area: Rect,
+    requested_scroll: usize,
+) -> (usize, usize) {
+    let overlay_area = centered_rect(full_area, 80, 90);
+    frame.render_widget(Clear, overlay_area);
+
+    let lines = help_overlay_lines();
+    let inner_height = overlay_area.height.saturating_sub(2) as usize;
+    let scroll = render_scrollable_pane(
+        frame,
+        " Help (? to close) ",
+        &lines,
+        requested_scroll,
+        overlay_area,
+    );
+    (scroll, inner_height)
 }
 
 /// A `Rect` centered within `area`, `percent_width`/`percent_height` of
@@ -255,6 +287,114 @@ mod tests {
         assert!(text.contains("Global"));
         assert!(text.contains("Glossary"));
         assert!(text.contains("blast radius"));
+    }
+
+    #[test]
+    fn should_not_show_glossary_when_terminal_is_too_short_to_fit_the_whole_keymap_and_scroll_is_zero()
+     {
+        // A small terminal (30 rows) whose overlay box cannot fit every
+        // keymap group *and* the trailing Glossary section at once — the
+        // gap this feature exists to close (previously: the unscrolled
+        // `Paragraph` simply clipped the bottom of the content with no way
+        // to reach it, `draw_help_overlay`'s pre-scroll doc comment).
+        // Pinning that the Glossary is *not* visible at scroll 0 here, and
+        // *is* visible after scrolling in the next test, is what proves
+        // scrolling actually moves the rendered content rather than the
+        // box merely being tall enough by coincidence.
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleHelp);
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    None,
+                );
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Tree focus"));
+        assert!(!text.contains("Glossary"), "Glossary should not fit yet");
+    }
+
+    #[test]
+    fn should_reveal_glossary_after_scrolling_down_when_terminal_is_too_short_to_fit_the_whole_keymap()
+     {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(crate::app::InputKey::ToggleHelp);
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
+
+        // Scroll well past every keymap group — `handle_scroll_key`'s own
+        // clamp-free "requested" semantics mean this overshoots on
+        // purpose; `render_scrollable_pane`'s clamp inside `draw` below is
+        // what brings it back in bounds, mirroring how every other
+        // scrollable pane in this crate is exercised in its own tests.
+        let app = app.handle_scroll_key(crate::app::InputKey::ScrollToBottom, 20);
+
+        let mut actual_outcome = crate::ui::DrawOutcome::default();
+        terminal
+            .draw(|frame| {
+                actual_outcome = draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    None,
+                );
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(
+            text.contains("Glossary"),
+            "Glossary should be visible after scrolling to the bottom"
+        );
+        assert!(
+            text.contains("jumplist"),
+            "the last glossary entry should be visible at the bottom"
+        );
+        // The scroll actually applied must be reported back (`DrawOutcome`'s
+        // own doc comment on why `crate::run_app` needs this to fold the
+        // overshot request back down) rather than staying at the
+        // unclamped `usize::MAX` sentinel `ScrollToBottom` set.
+        assert!(actual_outcome.clamped_help_scroll.is_some());
+        assert_ne!(Some(usize::MAX), actual_outcome.clamped_help_scroll);
+        assert!(actual_outcome.help_scroll_viewport_height.is_some());
+    }
+
+    #[test]
+    fn should_report_none_clamped_help_scroll_and_none_viewport_height_when_help_overlay_is_closed()
+    {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
+
+        let mut actual_outcome = crate::ui::DrawOutcome::default();
+        terminal
+            .draw(|frame| {
+                actual_outcome = draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    None,
+                );
+            })
+            .expect("draw");
+
+        assert_eq!(None, actual_outcome.clamped_help_scroll);
+        assert_eq!(None, actual_outcome.help_scroll_viewport_height);
     }
 
     #[test]

--- a/rinkaku-tui/src/ui/source_screen.rs
+++ b/rinkaku-tui/src/ui/source_screen.rs
@@ -483,6 +483,8 @@ mod tests {
         let mut actual = DrawOutcome {
             clamped_right_pane_scroll: Some(999),
             scroll_viewport_height: None,
+            clamped_help_scroll: None,
+            help_scroll_viewport_height: None,
         };
         terminal
             .draw(|frame| {


### PR DESCRIPTION
## Summary

The `?` help overlay's content (keymap groups + glossary) has grown
past what fits in a typical terminal — ADR 0026 alone added a "Source
view" keymap group and several new bindings — but the overlay drew as
a fixed, unscrolled `Paragraph`: content past the bottom of the box
was silently clipped with no way to reach it.

This adds scrolling to the overlay, reusing the scroll machinery ADR
0026 already established for the source screen and entry-view right
pane, rather than inventing a third parallel mechanism:

- `App::help_scroll`, an unclamped "requested" offset mirroring
  `right_pane_scroll`'s own design.
- `j`/`k` scroll by one line while the overlay is open; `Ctrl-d`/
  `Ctrl-u` scroll by half a page; `gg`/`G` jump to top/bottom — the
  same four `InputKey` variants and `App::handle_scroll_key` entry
  point ADR 0026 introduced, extended to a third scrollable surface.
- `draw_help_overlay` now renders through `render_scrollable_pane`,
  the same clamp + `(first-last/total)` overflow-indicator helper the
  Detail and Diff panes already share, instead of an unscrolled
  `Paragraph`.
- `DrawOutcome` gains `clamped_help_scroll`/`help_scroll_viewport_height`,
  folded back into `App` after every draw the same way the right
  pane's own scroll already is — kept as separate fields (not reused
  from the right-pane pair) since the overlay composites on top of
  whichever screen is showing underneath it and can be scrolling
  independently of that screen's own scroll state.

## Bug found along the way

While wiring this up, `App::handle_scroll_key` turned out to have no
`help_open` guard: `crate::run_app`'s two-step dispatch
(`handle_key` then `handle_scroll_key` for the four ADR 0026
variants) calls `handle_scroll_key` unconditionally, and without the
guard a `Ctrl-d`/`Ctrl-u`/`gg`/`G` press while the overlay was open
would fall through to the ordinary `Screen::Entry` + `Focus::Right`
branch and silently scroll the right pane *behind* the overlay while
it looked closed to the reviewer. Fixed by checking `help_open` first
in `handle_scroll_key`, mirroring the priority `handle_key` already
gives the overlay — and this same guard is what makes the overlay's
own scrolling correct in the first place.

## QA

- `make test` / `make lint`: both pass (490 tests).
- New unit tests: `App::help_scroll` state transitions
  (`rinkaku-tui/src/app/tests.rs`), `translate_key` mapping scroll
  keys while the overlay is open (`rinkaku-tui/src/lib.rs`), and a
  `TestBackend`-driven UI test proving the Glossary section — invisible
  at scroll 0 in a short terminal — becomes visible after scrolling to
  the bottom (`rinkaku-tui/src/ui/overlay.rs`).
- Dynamic verification: built the binary and drove it interactively
  through `tmux` in a 20-row terminal (real terminal, not just
  `TestBackend`):
  - `?` opens the overlay with a `(1-16/45)` overflow indicator in
    the title.
  - `j` × 15 moves the indicator to `(16-31/45)` (exact 1:1 line
    match).
  - `G` jumps to `(30-45/45)`, revealing the Glossary's last entry
    ("jumplist").
  - `gg` returns to `(1-16/45)`.
  - `Ctrl-d` moves to `(9-24/45)` — an 8-line half-page step sized
    against the overlay's own 16-row inner height, not whatever pane
    is underneath it.
  - `q` closes the overlay (confirmed via `tmux capture-pane`) without
    quitting the app (`pane_dead 0`); `Esc` also closes it.
  - Re-opening after a scroll starts back at `(1-16/45)` (scroll
    resets, not resumed).

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] Manual verification against the built binary via tmux (see QA
      section above)