### PR TITLE
feat: surface file-size warnings in rinkaku output (ADR 0028)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,37 @@ CI (`.github/workflows/lint-and-test.yaml` → `wc-rust-test.yaml`) runs the
 exact same `cargo` commands as the Makefile — never add a check to CI that
 isn't also runnable locally via `make`.
 
+## File size discipline
+
+Files grow by drift, not by design — see ADR 0028 for the rationale.
+Keep source files small enough that a reviewer can hold the outline in
+one context window.
+
+- **Thresholds** (mirror the `pub const`s in `rinkaku-core/src/file_size.rs`;
+  changing them is an ADR amendment):
+  - ≤ 1000 lines — normal, no action.
+  - 1000–1500 lines — watch; a follow-up split is on the horizon.
+  - > 1500 lines — warn; start planning the split now.
+  - > 2000 lines — split it, or write down in the PR body why not.
+- **Co-locate tests, but move them out when they push the file over.**
+  Default to `#[cfg(test)] mod tests { ... }` in the same file. When
+  production + test lines together exceed a threshold, switch to
+  `#[cfg(test)] #[path = "tests.rs"] mod tests;` so the counted file
+  stays under threshold without hiding the tests. Canonical example:
+  PR #82's `rinkaku-tui/src/app/{mod,input_key,tests}.rs`.
+- **Split along responsibility, not line count.** If a file is over
+  threshold, look for an independent responsibility to extract before
+  reaching for a mechanical top/bottom cut. Canonical example: PR #82's
+  `rinkaku-core/src/render/` split Markdown, Mermaid, and JSON
+  rendering into sibling modules because each is an independent output
+  format, not because the numbers demanded three parts.
+- **rinkaku's own warning is authoritative.** When
+  `rinkaku --base main` (from a trusted `main` build, per the
+  dogfooding rule above) prints a `## File size warnings` entry for a
+  file this PR touches, treat it as a review-blocker hint: either
+  perform the split in the same PR, or justify the continued growth
+  in the PR body. Do not merge past the warning silently.
+
 ## Conventions
 
 - **English only**: code comments, documentation, ADRs, and commit

--- a/docs/adr/0013-hotspots-fan-in-section.md
+++ b/docs/adr/0013-hotspots-fan-in-section.md
@@ -103,3 +103,23 @@ already there.
   concepts (file-level symbol density vs. per-symbol fan-in) living in
   the same output, so naming or wording may need a follow-up pass if
   this reads as ambiguous in practice.
+
+## Amendment (2026-07-13, feat/file-size-warnings)
+
+The tree pane badge originally rendered `~N` for changed symbols and `^N`
+for fan-in aggregate (ADR 0015/0016). During work on ADR 0028 (file-size
+warnings, which added `lines:N` and `warn:N split:M` badges alongside),
+the terse single-glyph prefixes proved illegible to first-time
+reviewers: `~` and `^` conveyed no semantic hint by themselves.
+
+Change: the tree pane badges are relabeled as `chg:N` (changed symbols)
+and `ref:N` (references, i.e. fan-in aggregate) — text prefixes matching
+the file-size badges' `lines:` / `warn:` / `split:` convention. Number
+coloring is unchanged; only the label prefix is replaced. `Badges`
+struct field names (`Badges.fan_in`, etc.) are left as-is — the change
+is purely presentational.
+
+This is a breaking change to the TUI's badge presentation, but has never
+shipped a release (per ADR 0015/0016), so no compatibility path is
+needed. Consumers of `Report` (Markdown / JSON / Mermaid) are
+untouched.

--- a/docs/adr/0028-file-size-warnings.md
+++ b/docs/adr/0028-file-size-warnings.md
@@ -1,0 +1,198 @@
+# 0028. File size warnings as a first-class attention dimension in rinkaku's output
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+Today's session started with a symbol-follow scroll bug in the TUI
+(PR #80) and ended with a 12000-line mechanical refactor (PR #82) that
+split three files — `render.rs` (4837 lines), `ui.rs` (4154 lines), and
+`app.rs` (3475 lines) — into module directories. None of those files
+was designed to be that large. Each grew by 100–300 lines per PR over
+many merges, with no single PR ever presenting a "this file is now
+huge" moment for a reviewer to react to. By the time the size became
+obvious, the split was much more expensive than an incremental split
+along the way would have been.
+
+This is the standard mode of failure for oversized files in a codebase
+this size: they don't grow by design, they grow by drift. A code-review
+process that only looks at "what changed in this PR" cannot catch a
+file that grew from 3000 to 3300 lines in a single acceptable diff.
+Rinkaku's whole reason to exist is to allocate reviewer attention
+across signals a plain diff hides — this is exactly one of those
+signals.
+
+Related prior art: ADR 0013 already introduced `## Hotspots` for a
+different attention dimension (fan-in / blast-radius). The section
+header framing in ADR 0013 — "here is a list of nodes that deserve
+extra scrutiny, computed once and shown when non-empty" — is exactly
+the shape file-size warnings need.
+
+Related self-critique: PR #82 had to happen at all because rinkaku's
+own output was silent about the three files it was about to reshape.
+The tool telling *itself* to split its own source is the direct
+motivation for this ADR.
+
+## Decision
+
+**1. Add a distinct `FileSizeWarning` type to `Report`.** New module
+`rinkaku-core/src/file_size.rs`:
+
+```rust
+pub struct FileSizeWarning {
+    pub path: String,
+    pub line_count: usize,
+    pub severity: FileSizeSeverity,
+}
+
+pub enum FileSizeSeverity { Warn, Split }
+```
+
+Both derive `Serialize` so the JSON output is additive. Stored on
+`Report` as a new field `pub file_size_warnings: Vec<FileSizeWarning>`.
+
+**2. Two thresholds, empirical from PR #82.** As `pub const` on the
+same module:
+
+- `WARN_LINE_THRESHOLD: usize = 1500` — over this, the file is
+  reported as `FileSizeSeverity::Warn` ("start planning the split")
+- `SPLIT_LINE_THRESHOLD: usize = 2000` — over this,
+  `FileSizeSeverity::Split` ("this needs to be split, or the PR body
+  must justify the growth")
+
+A file at exactly 1500 lines is not warned (the check is strictly
+greater); a file at exactly 2000 lines is `Warn`. The rationale for
+these particular numbers is the observed pain point: at ~1500 lines a
+reviewer can still hold the file's outline in one context window, at
+~2000 they cannot, at ≥3000 (the PR #82 files) any change requires a
+grep-first workflow that itself hides drift.
+
+Changing these constants is a spec change and must be an ADR amendment
+— consumers (LLM reviewers, human review policy, potential future CI
+integration) rely on them as stable.
+
+**3. Line counting happens inside `pipeline.rs`.** `analyze_diff` and
+`analyze_repo` already call the `read_file` port and hold each
+changed/scanned file's content in scope during tree-sitter parse.
+Count lines (`content.lines().count()`) there, collect `(path,
+line_count)` pairs, then call the pure
+`compute_file_size_warnings(&pairs) -> Vec<FileSizeWarning>` right
+after `compute_hotspots(&graph)`. Skipped files (binary, generated,
+deleted, unsupported-language) are not measured — they either have no
+content or are outside rinkaku's concern.
+
+**4. Markdown surface.** New `## File size warnings` section, placed
+immediately after `## Hotspots` and before `## Definitions` — both are
+attention allocators, and a reviewer scanning the output top-to-bottom
+should see the fan-in and file-size dimensions consecutively rather
+than one below the definitions body. Skipped entirely when the vec is
+empty (mirrors ADR 0013's "Hotspots is skipped when empty" rule).
+Format:
+
+```markdown
+## File size warnings
+
+- ⚠ `path/to/file.rs` (1734 lines) — over the 1500-line watch threshold; consider splitting
+- 🚨 `path/to/big.rs` (4837 lines) — over the 2000-line split threshold
+```
+
+The `⚠` / `🚨` glyphs match ADR 0014's marker convention (single
+high-contrast glyph, colored consistently). Ordering: `Split` before
+`Warn`, then within each severity, `line_count DESC` then `path ASC`
+for stability.
+
+**5. JSON surface.** `file_size_warnings` becomes a top-level field on
+the `Report` JSON, always present (empty array when nothing warns),
+mirroring how `hotspots` is always present. `FileSizeSeverity`
+serializes as `"warn"` / `"split"` (`#[serde(rename_all =
+"snake_case")]`).
+
+**6. TUI surface (two touch points, no new pane).**
+
+- **Status line** (`ui/status.rs`): when
+  `report.file_size_warnings` is non-empty, append `"⚠ N file-size
+  warnings"` to the status line so the reviewer sees the total at a
+  glance from any pane.
+- **Detail pane on a file row** (`build_file_detail` +
+  `ui/detail_pane.rs`): when the cursor lands on a file row whose path
+  matches a warning, show one line "⚠ 1734 lines — consider splitting
+  (>1500 watch)" in the Detail pane, positioned above the file's
+  own symbol listing (same layout position `top_fan_in` uses on
+  `DirDetail`).
+- **No new pane, no new keybinding.** Reviewers already have Enter →
+  Detail. Adding a dedicated File-size pane would violate ADR 0020's
+  one-pane-per-attention-dimension ratio for a feature that fits
+  entirely into an existing pane's slot.
+
+**7. Mermaid: no rendering.** Mermaid (ADR 0021) is a graph view of
+symbol edges. File size is not a graph property (it belongs to a
+node's file, not its incoming/outgoing edges). Rendering file-size on
+Mermaid would either require faking an edge (misleading) or bolting a
+sidebar into a diagram format that has no place for one. Explicit
+non-goal.
+
+**8. Tests are not deducted from the line count.** rinkaku counts
+whatever content `read_file` returned, no test-block heuristic. The
+CLAUDE.md guideline separately tells authors to use `#[cfg(test)]
+#[path = "tests.rs"] mod tests;` (the PR #82 `app/` pattern) when
+test weight is what tipped a file over — that keeps the counted file
+naturally under threshold, so the tool and the guideline reinforce
+each other without either silently working around the other.
+
+## Alternatives
+
+- **Widen `Hotspot` into an enum with a `FileSize` variant** —
+  rejected. `Hotspot` today is fan-in-specific (`id: NodeId`, `used_by:
+  Vec<String>`); every Mermaid class-assignment (`hotspot_ids`
+  collection, `render/mermaid.rs`) and TUI `Badges.fan_in` sum
+  (`tree.rs`) reads that shape directly. An enum widening forces every
+  consumer to variant-match forever and breaks the existing JSON
+  schema. ADR 0013 itself notes the "hotspot" word is informally
+  overloaded already; solidifying `Hotspot` as fan-in-only and
+  introducing `FileSizeWarning` as a sibling is cleaner than merging
+  two concepts under one name.
+- **Enforce thresholds in CI** (fail the build over `SPLIT_LINE_THRESHOLD`)
+  — rejected here, deferred to `.github/workflows/`. Rinkaku's job is
+  attention allocation; enforcement is separate policy. Doing both in
+  the same PR would tangle the map-vs-verifier split ADR 0015 and
+  0026 both maintain.
+- **CLI flag `--file-size-warn=<N> --file-size-split=<N>`** — deferred.
+  The two constants ARE the spec; if a downstream repo needs different
+  numbers they can fork the tool or submit a follow-up ADR.
+  Configurability now would freeze the numbers as "one choice among
+  many", weakening the ADR-driven norm.
+- **Silently exclude the `mod tests { ... }` block from the count** —
+  rejected on principle: it turns the metric into
+  "production-code-only lines" which every reviewer would then have
+  to mentally reconcile against `wc -l`. The CLAUDE.md guideline
+  route is transparent (the author physically moves tests to
+  `tests.rs`) and works with any external tool, not just rinkaku.
+- **Report only the worst offender** (top 1 file, top 3 files) —
+  rejected. `## Hotspots` already reports every fan-in ≥ 2 rather
+  than "top N", and this ADR mirrors that "show every threshold
+  crossing" rule for consistency.
+
+## Consequences
+
+- Every `Report` fixture in existing tests grows a `file_size_warnings:
+  vec![]` line. This is mechanical, but touches a lot of test files —
+  the PR should call this out explicitly so a reviewer isn't surprised
+  by the diff volume.
+- Markdown and JSON output on any repository with a file ≥ 1500 lines
+  gains a new section / field. Downstream consumers (LLM reviewers
+  parsing the Markdown, machine consumers parsing the JSON) that pin
+  the schema will need to acknowledge one new field.
+- Mermaid output is unchanged. Any file-size dimension a Mermaid
+  viewer wants must come from the JSON alongside.
+- rinkaku on its own repo will start warning about
+  `rinkaku-core/src/render/markdown.rs` (3627 lines post-refactor —
+  already over `SPLIT_LINE_THRESHOLD`) at the first run. This is
+  correct: the PR #82 split lowered the top-level files, but the
+  Markdown submodule itself is still oversized and marked for follow-up.
+- Bumping the constants is an ADR amendment (this file's own decision
+  rule), so the numbers cannot silently drift the way the source
+  files themselves did.
+- CI enforcement, CLI configurability, and a dedicated Mermaid /
+  Change-graph annotation for file size are all out of scope; each
+  can arrive as its own ADR when there is concrete demand.

--- a/docs/adr/0028-file-size-warnings.md
+++ b/docs/adr/0028-file-size-warnings.md
@@ -108,18 +108,45 @@ mirroring how `hotspots` is always present. `FileSizeSeverity`
 serializes as `"warn"` / `"split"` (`#[serde(rename_all =
 "snake_case")]`).
 
-**6. TUI surface (two touch points, no new pane).**
+**6. TUI surface (three touch points, no new pane).**
+
+The TUI deliberately conveys severity through **text labels + color**
+(no emoji glyphs) everywhere it surfaces file-size warnings. Terminal
+emoji rendering width is inconsistent enough to distort the Tree pane's
+column layout — and once the Tree pane had to drop the glyph, the
+Status line and Detail pane were switched over too so the reviewer
+never has to reconcile two different legends for the same signal. The
+Markdown/JSON output keeps its `⚠` / `🚨` glyphs (rendered outside a
+terminal, no width problem).
 
 - **Status line** (`ui/status.rs`): when
-  `report.file_size_warnings` is non-empty, append `"⚠ N file-size
-  warnings"` to the status line so the reviewer sees the total at a
-  glance from any pane.
+  `report.file_size_warnings` is non-empty, append
+  `"warn:N split:M file-size"` to the status line so the reviewer sees
+  the per-severity totals at a glance from any pane. Either half is
+  dropped when its count is zero (so an all-Warn report reads
+  `"warn:N file-size"`, mirroring how the Tree badge omits a zero
+  half).
 - **Detail pane on a file row** (`build_file_detail` +
   `ui/detail_pane.rs`): when the cursor lands on a file row whose path
-  matches a warning, show one line "⚠ 1734 lines — consider splitting
-  (>1500 watch)" in the Detail pane, positioned above the file's
-  own symbol listing (same layout position `top_fan_in` uses on
-  `DirDetail`).
+  matches a warning, show one line
+  `"Warn: 1734 lines — consider splitting (>1500 watch)"` (yellow) or
+  `"Split: 4837 lines — over the 2000-line split threshold"` (red) in
+  the Detail pane, positioned above the file's own symbol listing (same
+  layout position `top_fan_in` uses on `DirDetail`). Whole-line severity
+  color (`Color::Yellow` / `Color::Red`) is applied at the caller so the
+  formatter itself stays a pure `String`.
+- **Tree pane badge** (`row_view::push_badge_spans`): file rows
+  carrying a warning render `lines:N` after the row label — the `lines:`
+  prefix stays uncolored, the numeric `N` picks up the severity color
+  (yellow for Warn, red for Split), so the eye lands on the number.
+  Directory rows aggregate their descendants as `warn:N split:N`, each
+  half's numeric portion colored by its own severity; a half whose
+  count is zero is omitted so a small subtree never gains a stray
+  `split:0`. This mirrors the existing `^N` fan-in badge aggregation
+  pattern (`Badges.fan_in`), lets the reviewer see "which files are
+  oversized" directly from the Tree browse without opening the Detail
+  pane, and — because severity is conveyed by color rather than a glyph
+  — reads correctly across every terminal that supports 8+ colors.
 - **No new pane, no new keybinding.** Reviewers already have Enter →
   Detail. Adding a dedicated File-size pane would violate ADR 0020's
   one-pane-per-attention-dimension ratio for a feature that fits

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -17,10 +17,10 @@ only becomes load-bearing when the output would otherwise not be TUI
 ## Layout
 
 - **Tree pane (left)** — a directory tree of *changed files*, mirroring
-  your repository layout. Rows carry badges: `~N` changed symbols, `!N`
-  contract changes (added / removed / signature-changed), `^N` fan-in
-  (hotspot aggregate); directories in a dependency cycle are marked
-  `(cycle)`. Symbol rows show a kind abbreviation (`fn`, `struct`, ...)
+  your repository layout. Rows carry badges: `chg:N` changed symbols,
+  `!N` contract changes (added / removed / signature-changed), `ref:N`
+  fan-in (hotspot aggregate); directories in a dependency cycle are
+  marked `(cycle)`. Symbol rows show a kind abbreviation (`fn`, `struct`, ...)
   and a classification marker: `+` added, `~` signature-changed, `x`
   removed. Files rinkaku couldn't analyze appear dimmed as
   `(skipped: <reason>)`; whole-test files as `[test] (N symbols)`.

--- a/rinkaku-core/src/file_size.rs
+++ b/rinkaku-core/src/file_size.rs
@@ -1,0 +1,250 @@
+//! File-size warnings (ADR 0028): flag source files that have grown past
+//! empirical readability thresholds, so a reviewer skimming rinkaku's
+//! output sees oversized files at a glance rather than discovering the
+//! drift only when a multi-thousand-line file finally needs a mechanical
+//! split.
+//!
+//! Pure over plain `(path, line_count)` pairs — [`crate::pipeline`]
+//! collects the pairs while it already holds each file's content in scope
+//! for parsing (skipped files — binary, generated, deleted,
+//! unsupported-language — are excluded there, not here), then this module
+//! turns them into [`FileSizeWarning`]s. Two thresholds
+//! ([`WARN_LINE_THRESHOLD`], [`SPLIT_LINE_THRESHOLD`]) are fixed by ADR
+//! 0028 as part of the spec: changing them is an ADR amendment, not a
+//! silent tune, so downstream consumers (LLM reviewers, human review
+//! policy) can rely on the meaning of "warn" vs "split" staying stable.
+
+use serde::Serialize;
+
+/// Line-count threshold above which a file is reported as
+/// [`FileSizeSeverity::Warn`] (ADR 0028). The check is strictly greater:
+/// a file at exactly [`WARN_LINE_THRESHOLD`] lines is not warned about.
+pub const WARN_LINE_THRESHOLD: usize = 1500;
+
+/// Line-count threshold above which a file is reported as
+/// [`FileSizeSeverity::Split`] (ADR 0028). Strictly greater, same as
+/// [`WARN_LINE_THRESHOLD`].
+pub const SPLIT_LINE_THRESHOLD: usize = 2000;
+
+/// Severity of a [`FileSizeWarning`] (ADR 0028): `Warn` = the file has
+/// crossed the "start planning the split" watch threshold, `Split` = the
+/// file has crossed the "this needs to be split, or the PR body must
+/// justify the growth" threshold. Serializes as `"warn"` / `"split"` for
+/// the JSON output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileSizeSeverity {
+    Warn,
+    Split,
+}
+
+/// One file's oversized-file warning (ADR 0028), reported on
+/// [`crate::render::Report::file_size_warnings`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FileSizeWarning {
+    pub path: String,
+    pub line_count: usize,
+    pub severity: FileSizeSeverity,
+}
+
+/// Computes the per-file size warnings for a `(path, line_count)` list,
+/// following ADR 0028's thresholds and ordering:
+///
+/// - `line_count > SPLIT_LINE_THRESHOLD` -> [`FileSizeSeverity::Split`]
+/// - `line_count > WARN_LINE_THRESHOLD` -> [`FileSizeSeverity::Warn`]
+/// - anything else is dropped (not included in the returned vec)
+///
+/// The returned vec is sorted so the most attention-worthy entries come
+/// first: severity descending (`Split` before `Warn`), then within one
+/// severity, `line_count` descending, then `path` ascending for a stable
+/// tiebreak. That order matches the Markdown surface's top-to-bottom
+/// reading, so both the JSON consumer and the Markdown renderer share one
+/// canonical ordering rather than each sorting on its own.
+pub fn compute_file_size_warnings(files: &[(String, usize)]) -> Vec<FileSizeWarning> {
+    let mut warnings: Vec<FileSizeWarning> = files
+        .iter()
+        .filter_map(|(path, line_count)| {
+            let severity = if *line_count > SPLIT_LINE_THRESHOLD {
+                FileSizeSeverity::Split
+            } else if *line_count > WARN_LINE_THRESHOLD {
+                FileSizeSeverity::Warn
+            } else {
+                return None;
+            };
+            Some(FileSizeWarning {
+                path: path.clone(),
+                line_count: *line_count,
+                severity,
+            })
+        })
+        .collect();
+
+    // Ordering rationale (matches ADR 0028's Markdown ordering):
+    //   1. severity descending (Split before Warn) via `severity_rank`
+    //   2. line_count descending
+    //   3. path ascending (stable tiebreak)
+    warnings.sort_by(|a, b| {
+        severity_rank(b.severity)
+            .cmp(&severity_rank(a.severity))
+            .then_with(|| b.line_count.cmp(&a.line_count))
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    warnings
+}
+
+/// Numeric weight used to sort [`FileSizeSeverity`] descending
+/// (`Split` > `Warn`) without depending on the enum's Rust-side
+/// `PartialOrd` derivation (which would leak into the public API).
+fn severity_rank(severity: FileSizeSeverity) -> u8 {
+    match severity {
+        FileSizeSeverity::Split => 1,
+        FileSizeSeverity::Warn => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_return_empty_when_no_files_are_over_threshold() {
+        let files = vec![
+            ("small.rs".to_string(), 10),
+            ("medium.rs".to_string(), WARN_LINE_THRESHOLD),
+            ("empty.rs".to_string(), 0),
+        ];
+
+        let expected: Vec<FileSizeWarning> = vec![];
+        let actual = compute_file_size_warnings(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_report_warn_when_line_count_is_above_warn_threshold() {
+        let files = vec![("watch.rs".to_string(), WARN_LINE_THRESHOLD + 1)];
+
+        let expected = vec![FileSizeWarning {
+            path: "watch.rs".to_string(),
+            line_count: WARN_LINE_THRESHOLD + 1,
+            severity: FileSizeSeverity::Warn,
+        }];
+        let actual = compute_file_size_warnings(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_report_split_when_line_count_is_above_split_threshold() {
+        let files = vec![("huge.rs".to_string(), SPLIT_LINE_THRESHOLD + 1)];
+
+        let expected = vec![FileSizeWarning {
+            path: "huge.rs".to_string(),
+            line_count: SPLIT_LINE_THRESHOLD + 1,
+            severity: FileSizeSeverity::Split,
+        }];
+        let actual = compute_file_size_warnings(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_not_report_when_line_count_equals_warn_threshold() {
+        // ADR 0028: the check is strictly greater. A file at exactly
+        // WARN_LINE_THRESHOLD is not warned about; only WARN + 1 crosses.
+        let files = vec![("edge.rs".to_string(), WARN_LINE_THRESHOLD)];
+
+        let expected: Vec<FileSizeWarning> = vec![];
+        let actual = compute_file_size_warnings(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_sort_split_before_warn() {
+        // A `Warn` file with a higher line count than a `Split` file must
+        // still sort after it: severity dominates line_count in the
+        // ordering (ADR 0028).
+        let files = vec![
+            ("small_warn.rs".to_string(), WARN_LINE_THRESHOLD + 100),
+            ("big_split.rs".to_string(), SPLIT_LINE_THRESHOLD + 1),
+        ];
+
+        let expected = vec![
+            FileSizeWarning {
+                path: "big_split.rs".to_string(),
+                line_count: SPLIT_LINE_THRESHOLD + 1,
+                severity: FileSizeSeverity::Split,
+            },
+            FileSizeWarning {
+                path: "small_warn.rs".to_string(),
+                line_count: WARN_LINE_THRESHOLD + 100,
+                severity: FileSizeSeverity::Warn,
+            },
+        ];
+        let actual = compute_file_size_warnings(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_sort_by_line_count_desc_within_same_severity() {
+        let files = vec![
+            ("smaller.rs".to_string(), WARN_LINE_THRESHOLD + 10),
+            ("bigger.rs".to_string(), WARN_LINE_THRESHOLD + 500),
+            ("mid.rs".to_string(), WARN_LINE_THRESHOLD + 100),
+        ];
+
+        let expected = vec![
+            FileSizeWarning {
+                path: "bigger.rs".to_string(),
+                line_count: WARN_LINE_THRESHOLD + 500,
+                severity: FileSizeSeverity::Warn,
+            },
+            FileSizeWarning {
+                path: "mid.rs".to_string(),
+                line_count: WARN_LINE_THRESHOLD + 100,
+                severity: FileSizeSeverity::Warn,
+            },
+            FileSizeWarning {
+                path: "smaller.rs".to_string(),
+                line_count: WARN_LINE_THRESHOLD + 10,
+                severity: FileSizeSeverity::Warn,
+            },
+        ];
+        let actual = compute_file_size_warnings(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_sort_by_path_asc_when_line_count_and_severity_match() {
+        let files = vec![
+            ("z.rs".to_string(), WARN_LINE_THRESHOLD + 42),
+            ("a.rs".to_string(), WARN_LINE_THRESHOLD + 42),
+            ("m.rs".to_string(), WARN_LINE_THRESHOLD + 42),
+        ];
+
+        let expected = vec![
+            FileSizeWarning {
+                path: "a.rs".to_string(),
+                line_count: WARN_LINE_THRESHOLD + 42,
+                severity: FileSizeSeverity::Warn,
+            },
+            FileSizeWarning {
+                path: "m.rs".to_string(),
+                line_count: WARN_LINE_THRESHOLD + 42,
+                severity: FileSizeSeverity::Warn,
+            },
+            FileSizeWarning {
+                path: "z.rs".to_string(),
+                line_count: WARN_LINE_THRESHOLD + 42,
+                severity: FileSizeSeverity::Warn,
+            },
+        ];
+        let actual = compute_file_size_warnings(&files);
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/rinkaku-core/src/lib.rs
+++ b/rinkaku-core/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod deps;
 pub mod diff;
 pub mod extract;
+pub mod file_size;
 pub mod graph;
 pub mod language;
 pub mod pipeline;

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -12,6 +12,7 @@ use crate::diff::{ChangeKind, parse_unified_diff};
 use crate::extract::{
     ExtractedSymbol, RemovedSymbol, classify_symbols, extract_all_symbols, extract_changed_symbols,
 };
+use crate::file_size::compute_file_size_warnings;
 use crate::graph::{build_graph, compute_hotspots, stamp_ids};
 use crate::language::{LanguageSupport, language_for_path};
 use crate::render::{FileReport, Report, ReportOrigin, SkipReason, SkippedFile, TestFileSummary};
@@ -141,6 +142,12 @@ pub fn analyze_diff(
     let mut files = Vec::new();
     let mut skipped = Vec::new();
     let mut removed = Vec::new();
+    // ADR 0028: `(path, line_count)` for every file the pipeline actually
+    // reads content for, collected here rather than at the render layer so
+    // skipped files (binary/generated/deleted/unsupported-language) are
+    // excluded by construction — they have no content to measure, or are
+    // explicitly outside rinkaku's concern.
+    let mut sized_files: Vec<(String, usize)> = Vec::new();
 
     for changed_file in changed_files {
         if changed_file.kind == ChangeKind::Deleted {
@@ -224,6 +231,10 @@ pub fn analyze_diff(
             });
             continue;
         }
+        // ADR 0028: measure line count once the file's content has cleared
+        // every skip check above. `str::lines()` returns a sensible count
+        // whether or not the final line ends in a newline.
+        sized_files.push((changed_file.path.clone(), source.lines().count()));
         let mut symbols = extract_changed_symbols(&source, lang, &changed_file.changed_ranges);
 
         // ADR 0014: classify each symbol's contract impact against the
@@ -268,6 +279,9 @@ pub fn analyze_diff(
     // hotspot's `used_by` names always match the stamped ids/nodes
     // (ADR 0013).
     let hotspots = compute_hotspots(&graph);
+    // ADR 0028: file-size warnings from the `(path, line_count)` pairs
+    // collected inline above during the per-file read loop.
+    let file_size_warnings = compute_file_size_warnings(&sized_files);
 
     Ok(Report {
         origin: ReportOrigin::Diff,
@@ -276,6 +290,7 @@ pub fn analyze_diff(
         graph,
         tests,
         hotspots,
+        file_size_warnings,
         removed,
     })
 }
@@ -359,6 +374,11 @@ pub fn analyze_repo(
     include_generated: bool,
 ) -> Report {
     let mut files = Vec::new();
+    // ADR 0028: same collection strategy as `analyze_diff` — record every
+    // file whose content actually got read past the per-file filters, so
+    // filtered-out files (unsupported language, test path, generated) are
+    // never measured.
+    let mut sized_files: Vec<(String, usize)> = Vec::new();
 
     for path in paths {
         let Some(lang) = language_for_path(path) else {
@@ -381,6 +401,7 @@ pub fn analyze_repo(
         if !include_generated && is_generated_content(&content) {
             continue;
         }
+        sized_files.push((path.clone(), content.lines().count()));
 
         let symbols: Vec<ExtractedSymbol> = extract_all_symbols(&content, lang)
             .into_iter()
@@ -399,6 +420,7 @@ pub fn analyze_repo(
     let graph = build_graph(&files);
     stamp_ids(&mut files, &graph);
     let hotspots = compute_hotspots(&graph);
+    let file_size_warnings = compute_file_size_warnings(&sized_files);
 
     Report {
         origin: ReportOrigin::RepoOutline,
@@ -407,6 +429,7 @@ pub fn analyze_repo(
         graph,
         tests: Vec::new(),
         hotspots,
+        file_size_warnings,
         removed: Vec::new(),
     }
 }
@@ -618,6 +641,7 @@ mod tests {
             graph: empty_graph(),
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         let actual = analyze_diff("", read_file, None, None, true, &HashSet::new(), true)
@@ -677,6 +701,7 @@ fn foo(a: i32) -> i32 {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
@@ -711,6 +736,7 @@ index 4b825dc..0000000
             graph: empty_graph(),
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
@@ -738,6 +764,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
             graph: empty_graph(),
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
@@ -773,6 +800,7 @@ index e69de29..4b825dc 100644
             graph: empty_graph(),
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
@@ -812,6 +840,7 @@ rename to src/new_name.rs
             graph: empty_graph(),
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
@@ -916,6 +945,7 @@ index e69de29..4b825dc 100644
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
@@ -1255,6 +1285,7 @@ fn should_add_two_numbers() {
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
@@ -1404,6 +1435,7 @@ mod tests {
                     symbol_count: 1,
                 }],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_diff(diff, read_file, None, None, false, &HashSet::new(), true)
@@ -1591,6 +1623,7 @@ func Foo() int { return 2 }
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
@@ -1650,6 +1683,7 @@ fn foo(a: i32) -> i32 {
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), false)
@@ -1719,6 +1753,7 @@ index e69de29..4b825dc 100644
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), false)
@@ -2422,6 +2457,7 @@ index e69de29..4b825dc 100644
                 graph: empty_graph(),
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_repo(&[], read_file, true, &HashSet::new(), true);
@@ -2504,6 +2540,7 @@ struct Point {
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
@@ -2544,6 +2581,7 @@ struct Point {
                 graph: empty_graph(),
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
@@ -2566,6 +2604,7 @@ struct Point {
                 graph: empty_graph(),
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
@@ -2592,6 +2631,7 @@ struct Point {
                 graph: empty_graph(),
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_repo(&paths, read_file, true, &generated_paths, true);
@@ -2613,6 +2653,7 @@ struct Point {
                 graph: empty_graph(),
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), false);
@@ -2651,6 +2692,7 @@ func TestFoo(t *testing.T) {
                 graph: empty_graph(),
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
             let actual = analyze_repo(&paths, read_file, false, &HashSet::new(), true);
@@ -2738,6 +2780,107 @@ fn caller_two() -> i32 {
                 used_by: vec!["caller_one".to_string(), "caller_two".to_string()],
             }];
             assert_eq!(expected, report.hotspots);
+        }
+    }
+
+    /// ADR 0028 integration tests: end-to-end wiring of `compute_file_size_warnings`
+    /// through both pipeline entry points. Unit-level ordering/threshold
+    /// behavior is already covered by `crate::file_size::tests`; these
+    /// tests only prove that the pipeline collects `(path, line_count)`
+    /// pairs correctly and threads them through to `Report::file_size_warnings`.
+    mod file_size_warnings_tests {
+        use super::*;
+        use crate::file_size::{FileSizeSeverity, FileSizeWarning, WARN_LINE_THRESHOLD};
+        use pretty_assertions::assert_eq;
+
+        /// Builds a Rust source string of roughly `line_count` lines whose
+        /// first line is a real function definition (so `analyze_diff` has
+        /// something to extract) padded to the requested line count by
+        /// trivial let-bindings on subsequent lines. The head function's
+        /// body-length itself is what pushes the file's total line count
+        /// over the threshold.
+        fn rust_source_with_line_count(line_count: usize) -> String {
+            let mut buf = String::from("fn touched() -> i32 {\n");
+            // Two lines already used (`fn touched() ... {` and the trailing
+            // `}`); the rest are body lines.
+            let filler_lines = line_count.saturating_sub(2);
+            for i in 0..filler_lines {
+                buf.push_str(&format!("    let _v{i} = {i};\n"));
+            }
+            buf.push_str("}\n");
+            buf
+        }
+
+        #[test]
+        fn should_include_warn_when_analyze_diff_reads_a_file_over_warn_threshold() {
+            let big_source = rust_source_with_line_count(WARN_LINE_THRESHOLD + 100);
+            let actual_line_count = big_source.lines().count();
+            // The diff itself only needs to touch one line for the file to
+            // enter the pipeline's per-file read loop — line-count
+            // measurement is on the read source, not on the diff hunks.
+            let diff = "\
+diff --git a/src/big.rs b/src/big.rs
+index e69de29..4b825dc 100644
+--- a/src/big.rs
++++ b/src/big.rs
+@@ -1,1 +1,1 @@
+-fn touched() -> i32 {
++fn touched() -> i32 {
+";
+            let read_file = fake_reader(HashMap::from([(
+                "src/big.rs",
+                Box::leak(big_source.into_boxed_str()) as &'static str,
+            )]));
+
+            let report = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
+                .expect("analyze should succeed");
+
+            let expected = vec![FileSizeWarning {
+                path: "src/big.rs".to_string(),
+                line_count: actual_line_count,
+                severity: FileSizeSeverity::Warn,
+            }];
+            assert_eq!(expected, report.file_size_warnings);
+        }
+
+        #[test]
+        fn should_exclude_skipped_files_from_file_size_warnings_when_analyze_diff_runs() {
+            // A binary file is skipped before any read happens, so it can
+            // never appear in `file_size_warnings` regardless of size — the
+            // (path, line_count) collection only records files whose
+            // content was actually read.
+            let diff = "\
+diff --git a/assets/logo.png b/assets/logo.png
+index e69de29..4b825dc 100644
+Binary files a/assets/logo.png and b/assets/logo.png differ
+";
+            let read_file = fake_reader(HashMap::new());
+
+            let report = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
+                .expect("analyze should succeed");
+
+            let expected: Vec<FileSizeWarning> = vec![];
+            assert_eq!(expected, report.file_size_warnings);
+        }
+
+        #[test]
+        fn should_include_warn_when_analyze_repo_reads_a_file_over_warn_threshold() {
+            let big_source = rust_source_with_line_count(WARN_LINE_THRESHOLD + 200);
+            let actual_line_count = big_source.lines().count();
+            let read_file = fake_reader(HashMap::from([(
+                "src/big.rs",
+                Box::leak(big_source.into_boxed_str()) as &'static str,
+            )]));
+            let paths = vec!["src/big.rs".to_string()];
+
+            let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+
+            let expected = vec![FileSizeWarning {
+                path: "src/big.rs".to_string(),
+                line_count: actual_line_count,
+                severity: FileSizeSeverity::Warn,
+            }];
+            assert_eq!(expected, report.file_size_warnings);
         }
     }
 }

--- a/rinkaku-core/src/render/markdown.rs
+++ b/rinkaku-core/src/render/markdown.rs
@@ -8,6 +8,9 @@
 //! each section shape.
 
 use crate::extract::{Classification, ExtractedSymbol, RemovedSymbol, SymbolKind};
+use crate::file_size::{
+    FileSizeSeverity, FileSizeWarning, SPLIT_LINE_THRESHOLD, WARN_LINE_THRESHOLD,
+};
 use crate::graph::{Hotspot, Node, NodeId, SymbolGraph};
 use crate::render::RenderError;
 use crate::render::report::{Report, ReportOrigin, SkipReason, SkippedFile, skip_reason_label};
@@ -98,6 +101,15 @@ pub(super) fn render_markdown(report: &Report) -> Result<String, RenderError> {
                     hotspot.used_by.len(),
                     hotspot.used_by.join(", ")
                 )?;
+            }
+            writeln!(out)?;
+        }
+
+        if !report.file_size_warnings.is_empty() {
+            writeln!(out, "## File size warnings")?;
+            writeln!(out)?;
+            for warning in &report.file_size_warnings {
+                writeln!(out, "- {}", file_size_warning_label(warning))?;
             }
             writeln!(out)?;
         }
@@ -516,6 +528,26 @@ fn hotspot_label(hotspot: &Hotspot, lookup: &SymbolLookup) -> String {
     }
 }
 
+/// Builds the "File size warnings" line label for a [`FileSizeWarning`]
+/// (ADR 0028): `⚠` for [`FileSizeSeverity::Warn`] / `🚨` for
+/// [`FileSizeSeverity::Split`], followed by the path (in `code span`), the
+/// line count, and a short explanation naming the threshold crossed. The
+/// threshold numbers are pulled from [`WARN_LINE_THRESHOLD`] and
+/// [`SPLIT_LINE_THRESHOLD`] rather than duplicated inline, so the Markdown
+/// text stays in sync with the file_size module's single source of truth.
+fn file_size_warning_label(warning: &FileSizeWarning) -> String {
+    match warning.severity {
+        FileSizeSeverity::Warn => format!(
+            "⚠ `{}` ({} lines) — over the {}-line watch threshold; consider splitting",
+            warning.path, warning.line_count, WARN_LINE_THRESHOLD,
+        ),
+        FileSizeSeverity::Split => format!(
+            "🚨 `{}` ({} lines) — over the {}-line split threshold",
+            warning.path, warning.line_count, SPLIT_LINE_THRESHOLD,
+        ),
+    }
+}
+
 /// Builds the "Removed symbols" line label for a [`RemovedSymbol`]:
 /// `{prefix} {name} ({path})`, the same form [`tree_label`] uses, minus the
 /// `:{start_line}` disambiguation suffix — `RemovedSymbol` carries no
@@ -766,6 +798,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -800,6 +833,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -846,6 +880,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -894,6 +929,7 @@ fn foo()
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -928,6 +964,7 @@ fn foo()
                 symbol_count: 1,
             }],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -959,6 +996,7 @@ fn foo()
                 symbol_count: 3,
             }],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -999,6 +1037,7 @@ fn foo()
                 symbol_count: 2,
             }],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1052,6 +1091,7 @@ fn foo()
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1086,6 +1126,7 @@ fn foo()
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1120,6 +1161,7 @@ fn foo()
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1173,6 +1215,7 @@ fn foo(a: i32) -> i32
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1223,6 +1266,7 @@ fn foo(a: i32) -> i32
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1260,6 +1304,7 @@ fn foo(a: i32) -> i32
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1305,6 +1350,7 @@ fn foo(a: i32) -> i32
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1370,6 +1416,7 @@ fn foo(a: i32) -> i32
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1442,6 +1489,7 @@ fn foo(a: i32, b: i32)
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1525,6 +1573,7 @@ fn resolve_pr_base_sha() -> Result<String>
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1614,6 +1663,7 @@ fn c()
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1683,6 +1733,7 @@ fn bar()
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1794,6 +1845,7 @@ fn resolve_pr_base_sha()
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -1908,6 +1960,7 @@ struct Config { path: String }
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2004,6 +2057,7 @@ type UpsertItemsResponse struct { Count int }
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2087,6 +2141,7 @@ struct Dup { b: i32 }
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2151,6 +2206,7 @@ fn bar()
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2228,6 +2284,7 @@ struct Config { path: String }
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2309,6 +2366,7 @@ struct Inner { x: i32 }
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2366,6 +2424,7 @@ struct Node { next: Option<Box<Node>> }
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2419,6 +2478,7 @@ fn bar(&self) -> i32
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2480,6 +2540,7 @@ Depends on:
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2537,6 +2598,7 @@ Depends on:
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2596,6 +2658,7 @@ Depends on:
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2648,6 +2711,7 @@ fn example_macro() { let s = \"```rust\\nfn f() {}\\n```\"; }
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2700,6 +2764,7 @@ fn bar(&self) -> i32
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2740,6 +2805,7 @@ fn bar(&self) -> i32
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2789,6 +2855,7 @@ fn foo()
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2884,6 +2951,7 @@ fn foo()
                 name: "UpsertItemsRequest".to_string(),
                 used_by: vec!["HandleBar".to_string(), "HandleFoo".to_string()],
             }],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2955,6 +3023,7 @@ func HandleBar(req UpsertItemsRequest) error
                 name: "ghost".to_string(),
                 used_by: vec!["a".to_string(), "b".to_string()],
             }],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -2973,6 +3042,284 @@ func HandleBar(req UpsertItemsRequest) error
 "
         .to_string();
         let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_render_file_size_warnings_section_when_warnings_are_present() {
+        // Two warnings across both severities: the `Split` entry must come
+        // first (ADR 0028 orders `Split` before `Warn`), each glyph and the
+        // threshold-numbered explanation pinned exactly as the ADR spec
+        // shows.
+        let report = Report {
+            origin: ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    SymbolKind::Function,
+                    "fn foo()",
+                )],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            file_size_warnings: vec![
+                crate::file_size::FileSizeWarning {
+                    path: "b.rs".to_string(),
+                    line_count: 2500,
+                    severity: crate::file_size::FileSizeSeverity::Split,
+                },
+                crate::file_size::FileSizeWarning {
+                    path: "a.rs".to_string(),
+                    line_count: 1600,
+                    severity: crate::file_size::FileSizeSeverity::Warn,
+                },
+            ],
+            removed: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+1 changed symbol in 1 file
+
+- fn foo (src/lib.rs)
+
+## File size warnings
+
+- 🚨 `b.rs` (2500 lines) — over the 2000-line split threshold
+- ⚠ `a.rs` (1600 lines) — over the 1500-line watch threshold; consider splitting
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo()
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_omit_file_size_warnings_section_when_report_has_no_warnings() {
+        // Empty `file_size_warnings` must drop the whole section — no bare
+        // "## File size warnings" heading with nothing under it.
+        let report = Report {
+            origin: ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    SymbolKind::Function,
+                    "fn foo()",
+                )],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::foo".to_string()],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            file_size_warnings: vec![],
+            removed: vec![],
+        };
+
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert!(!actual.contains("## File size warnings"));
+    }
+
+    #[test]
+    fn should_place_file_size_warnings_between_hotspots_and_definitions() {
+        // A report with both a hotspot and a file-size warning: the
+        // `## File size warnings` section must land after `## Hotspots` and
+        // before `## Definitions`, matching ADR 0028's placement decision.
+        let report = Report {
+            origin: ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "store/items.go".to_string(),
+                symbols: vec![
+                    symbol(
+                        "store/items.go::HandleFoo",
+                        "HandleFoo",
+                        SymbolKind::Function,
+                        "func HandleFoo(req UpsertItemsRequest) error",
+                    ),
+                    symbol(
+                        "store/items.go::HandleBar",
+                        "HandleBar",
+                        SymbolKind::Function,
+                        "func HandleBar(req UpsertItemsRequest) error",
+                    ),
+                    symbol(
+                        "store/items.go::UpsertItemsRequest",
+                        "UpsertItemsRequest",
+                        SymbolKind::Struct,
+                        "type UpsertItemsRequest struct { Items []Item }",
+                    ),
+                ],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![
+                    node("store/items.go::HandleFoo", "store/items.go", "HandleFoo"),
+                    node("store/items.go::HandleBar", "store/items.go", "HandleBar"),
+                    node(
+                        "store/items.go::UpsertItemsRequest",
+                        "store/items.go",
+                        "UpsertItemsRequest",
+                    ),
+                ],
+                edges: vec![
+                    Edge {
+                        from: "store/items.go::HandleFoo".to_string(),
+                        to: "store/items.go::UpsertItemsRequest".to_string(),
+                        is_cycle: false,
+                    },
+                    Edge {
+                        from: "store/items.go::HandleBar".to_string(),
+                        to: "store/items.go::UpsertItemsRequest".to_string(),
+                        is_cycle: false,
+                    },
+                ],
+                roots: vec![
+                    "store/items.go::HandleFoo".to_string(),
+                    "store/items.go::HandleBar".to_string(),
+                ],
+            },
+            tests: vec![],
+            hotspots: vec![Hotspot {
+                id: "store/items.go::UpsertItemsRequest".to_string(),
+                path: "store/items.go".to_string(),
+                name: "UpsertItemsRequest".to_string(),
+                used_by: vec!["HandleBar".to_string(), "HandleFoo".to_string()],
+            }],
+            file_size_warnings: vec![crate::file_size::FileSizeWarning {
+                path: "store/items.go".to_string(),
+                line_count: 2100,
+                severity: crate::file_size::FileSizeSeverity::Split,
+            }],
+            removed: vec![],
+        };
+
+        let expected = "\
+## Change graph
+
+3 changed symbols in 1 file
+
+- fn HandleFoo (store/items.go) — uses: UpsertItemsRequest
+- fn HandleBar (store/items.go) — uses: UpsertItemsRequest
+
+## Hotspots
+
+- struct UpsertItemsRequest (store/items.go) — used by 2: HandleBar, HandleFoo
+
+## File size warnings
+
+- 🚨 `store/items.go` (2100 lines) — over the 2000-line split threshold
+
+## Definitions
+
+### fn HandleFoo (store/items.go)
+
+```
+func HandleFoo(req UpsertItemsRequest) error
+```
+
+### struct UpsertItemsRequest (store/items.go)
+
+```
+type UpsertItemsRequest struct { Items []Item }
+```
+
+### fn HandleBar (store/items.go)
+
+```
+func HandleBar(req UpsertItemsRequest) error
+```
+
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    // ADR 0028: JSON output must always carry `file_size_warnings` as a
+    // top-level field, present-and-empty when nothing warns (mirroring how
+    // `hotspots` is always present). This pins that shape end-to-end via
+    // the same `render` entry point the Markdown tests above use.
+    #[test]
+    fn should_include_file_size_warnings_in_json_output() {
+        let report = Report {
+            origin: ReportOrigin::Diff,
+            files: vec![],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            hotspots: vec![],
+            file_size_warnings: vec![
+                crate::file_size::FileSizeWarning {
+                    path: "b.rs".to_string(),
+                    line_count: 2500,
+                    severity: crate::file_size::FileSizeSeverity::Split,
+                },
+                crate::file_size::FileSizeWarning {
+                    path: "a.rs".to_string(),
+                    line_count: 1600,
+                    severity: crate::file_size::FileSizeSeverity::Warn,
+                },
+            ],
+            removed: vec![],
+        };
+
+        let expected = "\
+{
+  \"files\": [],
+  \"skipped\": [],
+  \"graph\": {
+    \"nodes\": [],
+    \"edges\": [],
+    \"roots\": []
+  },
+  \"tests\": [],
+  \"hotspots\": [],
+  \"file_size_warnings\": [
+    {
+      \"path\": \"b.rs\",
+      \"line_count\": 2500,
+      \"severity\": \"split\"
+    },
+    {
+      \"path\": \"a.rs\",
+      \"line_count\": 1600,
+      \"severity\": \"warn\"
+    }
+  ],
+  \"removed\": []
+}"
+        .to_string();
+        let actual = render(&report, OutputFormat::Json).expect("json render succeeds");
 
         assert_eq!(expected, actual);
     }
@@ -3003,6 +3350,7 @@ func HandleBar(req UpsertItemsRequest) error
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -3038,6 +3386,7 @@ func HandleBar(req UpsertItemsRequest) error
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -3091,6 +3440,7 @@ func HandleBar(req UpsertItemsRequest) error
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -3140,6 +3490,7 @@ fn foo()
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
 
@@ -3189,6 +3540,7 @@ fn foo()
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
 
@@ -3245,6 +3597,7 @@ fn foo()
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
 
@@ -3299,6 +3652,7 @@ fn foo()
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
 
@@ -3353,6 +3707,7 @@ fn foo()
                     name: "shared".to_string(),
                     used_by: vec!["caller_one".to_string(), "caller_two".to_string()],
                 }],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
 
@@ -3399,6 +3754,7 @@ fn foo()
                     symbol_count: 1,
                 }],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![RemovedSymbol {
                     name: "old_helper".to_string(),
                     kind: SymbolKind::Function,
@@ -3457,6 +3813,7 @@ fn foo()
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![RemovedSymbol {
                     name: "old_helper".to_string(),
                     kind: SymbolKind::Function,
@@ -3497,6 +3854,7 @@ fn foo()
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![
                     RemovedSymbol {
                         name: "save".to_string(),
@@ -3557,6 +3915,7 @@ fn foo()
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
 
@@ -3598,6 +3957,7 @@ fn foo()
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
 

--- a/rinkaku-core/src/render/mermaid.rs
+++ b/rinkaku-core/src/render/mermaid.rs
@@ -316,6 +316,7 @@ mod tests {
             graph,
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }
@@ -551,6 +552,7 @@ flowchart LR
                 name: "shared".to_string(),
                 used_by: vec!["a".to_string(), "b".to_string()],
             }],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -603,6 +605,7 @@ flowchart LR
                 name: "new_helper".to_string(),
                 used_by: vec!["a".to_string(), "b".to_string()],
             }],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 

--- a/rinkaku-core/src/render/report.rs
+++ b/rinkaku-core/src/render/report.rs
@@ -49,6 +49,15 @@ pub struct Report {
     /// consumers get it without recomputing the aggregation themselves,
     /// matching how `graph` itself is already exposed alongside `files`.
     pub hotspots: Vec<Hotspot>,
+    /// File-size warnings (ADR 0028): source files whose line count crosses
+    /// the [`crate::file_size::WARN_LINE_THRESHOLD`] / [`crate::file_size::SPLIT_LINE_THRESHOLD`]
+    /// watch/split thresholds. Derived from the same per-file content
+    /// [`crate::pipeline::analyze_diff`] and [`crate::pipeline::analyze_repo`]
+    /// already read for parsing, via [`crate::file_size::compute_file_size_warnings`],
+    /// and stored on `Report` (rather than recomputed at render time) so JSON
+    /// consumers get it as an always-present top-level field, matching how
+    /// `hotspots` above is already exposed.
+    pub file_size_warnings: Vec<crate::file_size::FileSizeWarning>,
     /// Symbols present on the base side of a diff but absent from the head
     /// side entirely (ADR 0014's `removed` classification) — reported
     /// separately from `files` since a removed symbol has no head-side
@@ -197,6 +206,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -216,6 +226,7 @@ mod tests {
   },
   \"tests\": [],
   \"hotspots\": [],
+  \"file_size_warnings\": [],
   \"removed\": []
 }"
         .to_string();
@@ -244,6 +255,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -259,6 +271,7 @@ mod tests {
   },
   \"tests\": [],
   \"hotspots\": [],
+  \"file_size_warnings\": [],
   \"removed\": []
 }"
         .to_string();
@@ -291,6 +304,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
 
@@ -337,6 +351,7 @@ mod tests {
   },
   \"tests\": [],
   \"hotspots\": [],
+  \"file_size_warnings\": [],
   \"removed\": []
 }"
         .to_string();
@@ -369,6 +384,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![RemovedSymbol {
                 name: "old_helper".to_string(),
                 kind: SymbolKind::Function,
@@ -417,6 +433,7 @@ mod tests {
   },
   \"tests\": [],
   \"hotspots\": [],
+  \"file_size_warnings\": [],
   \"removed\": [
     {
       \"name\": \"old_helper\",

--- a/rinkaku-tui/src/app/tests.rs
+++ b/rinkaku-tui/src/app/tests.rs
@@ -35,6 +35,7 @@ fn empty_report() -> Report {
         },
         tests: vec![],
         hotspots: vec![],
+        file_size_warnings: vec![],
         removed: vec![],
     }
 }
@@ -203,6 +204,7 @@ fn should_return_file_detail_when_cursor_is_on_a_file_row() {
         }],
         skip_reason: None,
         test_symbol_count: None,
+        size_warning: None,
     });
     assert_eq!(Some(expected), actual);
 }

--- a/rinkaku-tui/src/app/tests.rs
+++ b/rinkaku-tui/src/app/tests.rs
@@ -242,6 +242,7 @@ fn should_return_dir_detail_when_cursor_is_on_a_directory_row() {
             changed_symbols: 1,
             contract_changes: 0,
             fan_in: 0,
+            ..crate::tree::Badges::default()
         },
         top_fan_in: vec![],
         cycle_partners: vec![],

--- a/rinkaku-tui/src/blast_radius.rs
+++ b/rinkaku-tui/src/blast_radius.rs
@@ -288,6 +288,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/detail.rs
+++ b/rinkaku-tui/src/detail.rs
@@ -289,6 +289,11 @@ pub struct FileDetail {
     pub symbols: Vec<FileSymbolSummary>,
     pub skip_reason: Option<rinkaku_core::render::SkipReason>,
     pub test_symbol_count: Option<usize>,
+    /// Oversized-file warning for this file (ADR 0028), when
+    /// `report.file_size_warnings` has an entry whose `path` matches this
+    /// file. `None` means the file is under the watch threshold — a
+    /// distinct signal from the aggregated total on the status line.
+    pub size_warning: Option<rinkaku_core::file_size::FileSizeWarning>,
 }
 
 /// Builds a [`DirDetail`] for the directory at `path` in `tree`, or `None`
@@ -370,11 +375,18 @@ pub fn build_file_detail(tree: &Tree, report: &Report, path: &str) -> Option<Fil
         })
         .collect();
 
+    let size_warning = report
+        .file_size_warnings
+        .iter()
+        .find(|warning| warning.path == node.path)
+        .cloned();
+
     Some(FileDetail {
         path: node.path.clone(),
         symbols,
         skip_reason: node.skip_reason,
         test_symbol_count: node.test_symbol_count,
+        size_warning,
     })
 }
 
@@ -474,6 +486,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }
@@ -1174,6 +1187,7 @@ mod tests {
             ],
             skip_reason: None,
             test_symbol_count: None,
+            size_warning: None,
         };
         assert_eq!(expected, actual);
     }
@@ -1206,6 +1220,7 @@ mod tests {
             }],
             skip_reason: None,
             test_symbol_count: None,
+            size_warning: None,
         };
         assert_eq!(expected, actual);
     }
@@ -1229,6 +1244,7 @@ mod tests {
             symbols: vec![],
             skip_reason: Some(rinkaku_core::render::SkipReason::Binary),
             test_symbol_count: None,
+            size_warning: None,
         };
         assert_eq!(expected, actual);
     }
@@ -1252,6 +1268,7 @@ mod tests {
             symbols: vec![],
             skip_reason: None,
             test_symbol_count: Some(4),
+            size_warning: None,
         };
         assert_eq!(expected, actual);
     }
@@ -1295,6 +1312,46 @@ mod tests {
             }],
             skip_reason: None,
             test_symbol_count: Some(5),
+            size_warning: None,
+        };
+        assert_eq!(expected, actual);
+    }
+
+    // ADR 0028: a file whose path shows up in `report.file_size_warnings`
+    // must carry the matching warning onto its `FileDetail` so the detail
+    // pane can render the "1734 lines — consider splitting" hint above
+    // the symbols listing without re-scanning the report itself.
+    #[test]
+    fn should_populate_size_warning_on_file_detail_when_report_has_warning_for_that_path() {
+        let warning = rinkaku_core::file_size::FileSizeWarning {
+            path: "src/big.rs".to_string(),
+            line_count: 1734,
+            severity: rinkaku_core::file_size::FileSizeSeverity::Warn,
+        };
+        let report = Report {
+            files: vec![FileReport {
+                path: "src/big.rs".to_string(),
+                symbols: vec![symbol("src/big.rs::foo", "foo")],
+            }],
+            file_size_warnings: vec![warning.clone()],
+            ..empty_report()
+        };
+        let tree = crate::tree::build_tree(&report);
+
+        let actual = build_file_detail(&tree, &report, "src/big.rs").expect("file found");
+
+        let expected = FileDetail {
+            path: "src/big.rs".to_string(),
+            symbols: vec![FileSymbolSummary {
+                name: "foo".to_string(),
+                kind: SymbolKind::Function,
+                classification: None,
+                removed: false,
+                fan_in: 0,
+            }],
+            skip_reason: None,
+            test_symbol_count: None,
+            size_warning: Some(warning),
         };
         assert_eq!(expected, actual);
     }

--- a/rinkaku-tui/src/detail.rs
+++ b/rinkaku-tui/src/detail.rs
@@ -962,6 +962,7 @@ mod tests {
                 changed_symbols: 1,
                 contract_changes: 1,
                 fan_in: 0,
+                ..crate::tree::Badges::default()
             },
             top_fan_in: vec![],
             cycle_partners: vec![],

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -340,6 +340,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -1013,6 +1013,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/order.rs
+++ b/rinkaku-tui/src/order.rs
@@ -677,6 +677,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -18,6 +18,7 @@ use crate::tree::{Badges, NodeKind, SymbolRef};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use rinkaku_core::extract::{Classification, SymbolKind};
+use rinkaku_core::file_size::FileSizeSeverity;
 use std::collections::HashMap;
 
 /// Indent width per tree depth level, in columns.
@@ -57,7 +58,7 @@ pub fn entry_row_line(
                 Style::default().add_modifier(Modifier::BOLD),
             ));
             spans.push(Span::raw(" "));
-            spans.push(badges_span(&row.node.badges));
+            push_badge_spans(&mut spans, &row.node.badges, BadgeContext::Dir);
             if in_cycle {
                 spans.push(Span::raw(" "));
                 spans.push(Span::styled(
@@ -72,7 +73,7 @@ pub fn entry_row_line(
             spans.push(Span::raw(format!("{} ", expand_marker(row))));
             spans.push(Span::styled(label.to_string(), file_label_style(row.node)));
             spans.push(Span::raw(" "));
-            spans.push(badges_span(&row.node.badges));
+            push_badge_spans(&mut spans, &row.node.badges, BadgeContext::File);
             // `skip_reason` is mutually exclusive with `test_symbol_count`
             // (`crate::tree::TreeNode::skip_reason`'s own doc comment: a
             // skipped file has no `FileReport`/`TestFileSummary` entry of
@@ -186,24 +187,106 @@ pub fn relative_labels(rows: &[Row<'_>]) -> Vec<String> {
         .collect()
 }
 
-/// The compact badge summary shared by `Dir`/`File` rows: changed-symbol
-/// count, contract-change count, and fan-in, each only shown when nonzero
-/// (an all-zero badge set renders as an empty span, keeping quiet rows
-/// quiet) — ASCII-only glyphs (`~`/`!`/`^`) chosen over Unicode/emoji for
-/// terminal-compatibility (this implementation's own decision, see the
-/// README's Interactive TUI section for the legend).
-fn badges_span(badges: &Badges) -> Span<'static> {
-    let mut parts = Vec::new();
+/// Which side of the tree a badge row is on — `Dir` rows render the
+/// aggregated file-size warning counts (`warn:N split:N`), `File` rows
+/// render this file's own `lines:N` instead. `NodeKind::Symbol` never
+/// reaches badge rendering (symbol rows have their own layout, no badge
+/// summary), so this only needs the two cases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BadgeContext {
+    Dir,
+    File,
+}
+
+/// Appends the compact badge summary for a `Dir`/`File` row to `spans`:
+/// changed-symbol count, contract-change count, fan-in, and (per
+/// `context`) either the file-size-warning aggregate (`warn:N split:N`
+/// on a directory) or this file's own line count (`lines:N` on a file
+/// row). Each badge is only emitted when its underlying counter is
+/// nonzero (an all-zero badge set adds nothing, keeping quiet rows
+/// quiet).
+///
+/// Badge encoding rationale:
+/// - The count/fan-in badges use ASCII-only glyphs (`~`/`!`/`^`), chosen
+///   over Unicode/emoji for terminal-compatibility (see the README's
+///   Interactive TUI section for the legend), and are all cyan.
+/// - The file-size warnings (ADR 0028) deliberately use **text labels
+///   plus color** rather than an emoji glyph (`⚠` / `🚨`): terminal
+///   emoji rendering width is inconsistent enough to distort the tree
+///   column layout, and the color already encodes severity. Only the
+///   numeric N portion is colored (yellow for Warn, red for Split); the
+///   `lines:` / `warn:` / `split:` label stays default so the eye lands
+///   on the number.
+fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: BadgeContext) {
+    let mut ascii_parts = Vec::new();
     if badges.changed_symbols > 0 {
-        parts.push(format!("~{}", badges.changed_symbols));
+        ascii_parts.push(format!("~{}", badges.changed_symbols));
     }
     if badges.contract_changes > 0 {
-        parts.push(format!("!{}", badges.contract_changes));
+        ascii_parts.push(format!("!{}", badges.contract_changes));
     }
     if badges.fan_in > 0 {
-        parts.push(format!("^{}", badges.fan_in));
+        ascii_parts.push(format!("^{}", badges.fan_in));
     }
-    Span::styled(parts.join(" "), Style::default().fg(Color::Cyan))
+    spans.push(Span::styled(
+        ascii_parts.join(" "),
+        Style::default().fg(Color::Cyan),
+    ));
+
+    // File-size warning badges (ADR 0028) — text label + color, no
+    // emoji. Rendered as separate spans so only the numeric N picks up
+    // the severity color.
+    match context {
+        BadgeContext::File => {
+            if let (Some(severity), Some(line_count)) =
+                (badges.own_file_size_severity, badges.own_file_line_count)
+            {
+                // Leading space only when the cyan span above wrote
+                // something — otherwise the row would gain a stray gap.
+                spans.push(Span::raw(if ascii_parts.is_empty() { "" } else { " " }));
+                spans.push(Span::raw("lines:"));
+                spans.push(Span::styled(
+                    line_count.to_string(),
+                    Style::default().fg(severity_color(severity)),
+                ));
+            }
+        }
+        BadgeContext::Dir => {
+            let has_warn = badges.file_size_warn_count > 0;
+            let has_split = badges.file_size_split_count > 0;
+            if has_warn || has_split {
+                spans.push(Span::raw(if ascii_parts.is_empty() { "" } else { " " }));
+            }
+            if has_warn {
+                spans.push(Span::raw("warn:"));
+                spans.push(Span::styled(
+                    badges.file_size_warn_count.to_string(),
+                    Style::default().fg(Color::Yellow),
+                ));
+            }
+            if has_warn && has_split {
+                spans.push(Span::raw(" "));
+            }
+            if has_split {
+                spans.push(Span::raw("split:"));
+                spans.push(Span::styled(
+                    badges.file_size_split_count.to_string(),
+                    Style::default().fg(Color::Red),
+                ));
+            }
+        }
+    }
+}
+
+/// Maps a [`FileSizeSeverity`] to its display color — yellow for `Warn`,
+/// red for `Split`. Shared by the file-row `lines:N` badge and the
+/// directory-row `warn:N` / `split:N` aggregates so both surfaces agree
+/// on the color legend.
+fn severity_color(severity: FileSizeSeverity) -> Color {
+    match severity {
+        FileSizeSeverity::Warn => Color::Yellow,
+        FileSizeSeverity::Split => Color::Red,
+    }
 }
 
 /// A `File` row's label style: dimmed for a skipped file (nothing was
@@ -398,6 +481,7 @@ mod tests {
                 changed_symbols: 2,
                 contract_changes: 1,
                 fan_in: 3,
+                ..Badges::default()
             },
             vec![file_node("src/a.rs", Badges::default())],
         );
@@ -783,5 +867,157 @@ mod tests {
             ],
             labels
         );
+    }
+
+    // File-size warning badges (ADR 0028): a file row carrying a warning
+    // renders `lines:{N}` with the numeric N colored by severity (yellow
+    // for Warn, red for Split), and a directory row aggregates the
+    // per-severity counts as `warn:N split:N` with the numbers colored
+    // the same way. No emoji glyphs — the color already conveys severity
+    // and emoji rendering width is inconsistent across terminals.
+
+    /// Locates the styled span whose visible text is `content` in `line`,
+    /// returning its foreground color (or `None` when the span exists but
+    /// has no explicit fg, matching ratatui's default). Panics when no
+    /// such span exists — a matching-span assertion is what the test
+    /// wanted, so a missing span is a test failure, not a `None`.
+    fn fg_of_span_with_content(line: &Line<'_>, content: &str) -> Option<Color> {
+        line.spans
+            .iter()
+            .find(|span| span.content.as_ref() == content)
+            .unwrap_or_else(|| {
+                panic!(
+                    "no span with content {content:?} found in line: {:?}",
+                    line_text(line)
+                )
+            })
+            .style
+            .fg
+    }
+
+    #[test]
+    fn should_render_lines_count_in_yellow_when_file_has_warn_severity() {
+        let node = TreeNode {
+            kind: NodeKind::File,
+            path: "src/big.rs".to_string(),
+            badges: Badges {
+                own_file_size_severity: Some(FileSizeSeverity::Warn),
+                own_file_line_count: Some(1734),
+                ..Badges::default()
+            },
+            children: vec![],
+            skip_reason: None,
+            test_symbol_count: None,
+        };
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "big.rs", &HashMap::new(), false);
+
+        assert_eq!("  big.rs lines:1734", line_text(&line));
+        // The numeric 1734 span carries the severity color; the leading
+        // "lines:" label stays uncolored so the eye lands on the number.
+        assert_eq!(Some(Color::Yellow), fg_of_span_with_content(&line, "1734"));
+        assert_eq!(None, fg_of_span_with_content(&line, "lines:"));
+    }
+
+    #[test]
+    fn should_render_lines_count_in_red_when_file_has_split_severity() {
+        let node = TreeNode {
+            kind: NodeKind::File,
+            path: "src/huge.rs".to_string(),
+            badges: Badges {
+                own_file_size_severity: Some(FileSizeSeverity::Split),
+                own_file_line_count: Some(4837),
+                ..Badges::default()
+            },
+            children: vec![],
+            skip_reason: None,
+            test_symbol_count: None,
+        };
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "huge.rs", &HashMap::new(), false);
+
+        assert_eq!("  huge.rs lines:4837", line_text(&line));
+        assert_eq!(Some(Color::Red), fg_of_span_with_content(&line, "4837"));
+    }
+
+    #[test]
+    fn should_render_warn_and_split_labels_side_by_side_on_dir_row() {
+        let node = dir_node(
+            "src",
+            Badges {
+                file_size_warn_count: 2,
+                file_size_split_count: 1,
+                ..Badges::default()
+            },
+            vec![file_node("src/a.rs", Badges::default())],
+        );
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: true,
+        };
+
+        let line = entry_row_line(&row, "src", &HashMap::new(), false);
+
+        assert_eq!("v src warn:2 split:1", line_text(&line));
+        // The numeric part of each half picks up its own severity color;
+        // the "warn:" / "split:" labels themselves stay uncolored so the
+        // eye lands on the counts.
+        assert_eq!(Some(Color::Yellow), fg_of_span_with_content(&line, "2"));
+        assert_eq!(Some(Color::Red), fg_of_span_with_content(&line, "1"));
+        assert_eq!(None, fg_of_span_with_content(&line, "warn:"));
+        assert_eq!(None, fg_of_span_with_content(&line, "split:"));
+    }
+
+    #[test]
+    fn should_not_render_file_size_badge_when_file_node_has_no_warning() {
+        let node = file_node("lib.rs", Badges::default());
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: false,
+        };
+
+        let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
+
+        let text = line_text(&line);
+        assert!(!text.contains("lines:"));
+        assert!(!text.contains("warn:"));
+        assert!(!text.contains("split:"));
+    }
+
+    #[test]
+    fn should_render_only_warn_label_on_dir_row_when_no_split_files() {
+        // When only one severity is present under a directory, only that
+        // half of the badge shows — the other half is omitted rather
+        // than rendered as "warn:0" or "split:0".
+        let node = dir_node(
+            "src",
+            Badges {
+                file_size_warn_count: 3,
+                file_size_split_count: 0,
+                ..Badges::default()
+            },
+            vec![file_node("src/a.rs", Badges::default())],
+        );
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: true,
+        };
+
+        let line = entry_row_line(&row, "src", &HashMap::new(), false);
+
+        assert_eq!("v src warn:3", line_text(&line));
     }
 }

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -207,9 +207,17 @@ enum BadgeContext {
 /// quiet).
 ///
 /// Badge encoding rationale:
-/// - The count/fan-in badges use ASCII-only glyphs (`~`/`!`/`^`), chosen
-///   over Unicode/emoji for terminal-compatibility (see the README's
-///   Interactive TUI section for the legend), and are all cyan.
+/// - The changed-symbol and fan-in badges use text labels
+///   (`chg:` / `ref:`) matching the file-size badges' `lines:` / `warn:`
+///   / `split:` convention (see ADR 0013 amendment 2026-07-13). The
+///   single-glyph prefixes they replaced (`~` for changed, `^` for
+///   fan-in) conveyed no semantic hint on their own to a first-time
+///   reviewer. Only the numeric N picks up cyan; the label stays
+///   default so the eye lands on the number, matching the file-size
+///   badges' split-span pattern.
+/// - `!{N}` (contract-change count) keeps its compact `!` glyph — the
+///   ADR 0013 amendment that added `chg:`/`ref:` explicitly scopes the
+///   rename to `~` and `^`, so `!N` is left untouched.
 /// - The file-size warnings (ADR 0028) deliberately use **text labels
 ///   plus color** rather than an emoji glyph (`⚠` / `🚨`): terminal
 ///   emoji rendering width is inconsistent enough to distort the tree
@@ -218,20 +226,28 @@ enum BadgeContext {
 ///   `lines:` / `warn:` / `split:` label stays default so the eye lands
 ///   on the number.
 fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: BadgeContext) {
-    let mut ascii_parts = Vec::new();
+    let cyan = Style::default().fg(Color::Cyan);
+    let mut wrote_any_ascii_badge = false;
     if badges.changed_symbols > 0 {
-        ascii_parts.push(format!("~{}", badges.changed_symbols));
+        spans.push(Span::raw("chg:"));
+        spans.push(Span::styled(badges.changed_symbols.to_string(), cyan));
+        wrote_any_ascii_badge = true;
     }
     if badges.contract_changes > 0 {
-        ascii_parts.push(format!("!{}", badges.contract_changes));
+        if wrote_any_ascii_badge {
+            spans.push(Span::raw(" "));
+        }
+        spans.push(Span::styled(format!("!{}", badges.contract_changes), cyan));
+        wrote_any_ascii_badge = true;
     }
     if badges.fan_in > 0 {
-        ascii_parts.push(format!("^{}", badges.fan_in));
+        if wrote_any_ascii_badge {
+            spans.push(Span::raw(" "));
+        }
+        spans.push(Span::raw("ref:"));
+        spans.push(Span::styled(badges.fan_in.to_string(), cyan));
+        wrote_any_ascii_badge = true;
     }
-    spans.push(Span::styled(
-        ascii_parts.join(" "),
-        Style::default().fg(Color::Cyan),
-    ));
 
     // File-size warning badges (ADR 0028) — text label + color, no
     // emoji. Rendered as separate spans so only the numeric N picks up
@@ -241,9 +257,11 @@ fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: Ba
             if let (Some(severity), Some(line_count)) =
                 (badges.own_file_size_severity, badges.own_file_line_count)
             {
-                // Leading space only when the cyan span above wrote
+                // Leading space only when a preceding badge wrote
                 // something — otherwise the row would gain a stray gap.
-                spans.push(Span::raw(if ascii_parts.is_empty() { "" } else { " " }));
+                if wrote_any_ascii_badge {
+                    spans.push(Span::raw(" "));
+                }
                 spans.push(Span::raw("lines:"));
                 spans.push(Span::styled(
                     line_count.to_string(),
@@ -254,8 +272,8 @@ fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: Ba
         BadgeContext::Dir => {
             let has_warn = badges.file_size_warn_count > 0;
             let has_split = badges.file_size_split_count > 0;
-            if has_warn || has_split {
-                spans.push(Span::raw(if ascii_parts.is_empty() { "" } else { " " }));
+            if (has_warn || has_split) && wrote_any_ascii_badge {
+                spans.push(Span::raw(" "));
             }
             if has_warn {
                 spans.push(Span::raw("warn:"));
@@ -474,7 +492,12 @@ mod tests {
     }
 
     #[test]
-    fn should_include_badge_glyphs_for_nonzero_badges_on_a_dir_row() {
+    fn should_include_badge_labels_for_nonzero_badges_on_a_dir_row() {
+        // ADR 0013 amendment (2026-07-13): the changed-symbol and fan-in
+        // badges use `chg:` / `ref:` text labels instead of the original
+        // `~` / `^` glyphs. `!{N}` (contract-change count) is
+        // intentionally left as a compact glyph — see `push_badge_spans`'
+        // doc comment for the scope split.
         let node = dir_node(
             "src",
             Badges {
@@ -493,7 +516,7 @@ mod tests {
 
         let line = entry_row_line(&row, "src", &HashMap::new(), false);
 
-        assert_eq!("v src ~2 !1 ^3", line_text(&line));
+        assert_eq!("v src chg:2 !1 ref:3", line_text(&line));
     }
 
     #[test]
@@ -1019,5 +1042,56 @@ mod tests {
         let line = entry_row_line(&row, "src", &HashMap::new(), false);
 
         assert_eq!("v src warn:3", line_text(&line));
+    }
+
+    // ADR 0013 amendment (2026-07-13): `chg:N` and `ref:N` badges split
+    // their label from their number across two spans so only the number
+    // picks up cyan — matching the file-size badges' split-span pattern
+    // (`lines:N`, `warn:N`, `split:N`). The label prefix reads at the
+    // default color to keep the eye on the numeric part.
+    #[test]
+    fn should_color_only_the_number_of_chg_badge_and_leave_label_uncolored() {
+        let node = dir_node(
+            "src",
+            Badges {
+                changed_symbols: 299,
+                ..Badges::default()
+            },
+            vec![file_node("src/a.rs", Badges::default())],
+        );
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: true,
+        };
+
+        let line = entry_row_line(&row, "src", &HashMap::new(), false);
+
+        assert_eq!("v src chg:299", line_text(&line));
+        assert_eq!(Some(Color::Cyan), fg_of_span_with_content(&line, "299"));
+        assert_eq!(None, fg_of_span_with_content(&line, "chg:"));
+    }
+
+    #[test]
+    fn should_color_only_the_number_of_ref_badge_and_leave_label_uncolored() {
+        let node = dir_node(
+            "src",
+            Badges {
+                fan_in: 1072,
+                ..Badges::default()
+            },
+            vec![file_node("src/a.rs", Badges::default())],
+        );
+        let row = Row {
+            node: &node,
+            depth: 0,
+            expanded: true,
+        };
+
+        let line = entry_row_line(&row, "src", &HashMap::new(), false);
+
+        assert_eq!("v src ref:1072", line_text(&line));
+        assert_eq!(Some(Color::Cyan), fg_of_span_with_content(&line, "1072"));
+        assert_eq!(None, fg_of_span_with_content(&line, "ref:"));
     }
 }

--- a/rinkaku-tui/src/source.rs
+++ b/rinkaku-tui/src/source.rs
@@ -325,6 +325,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/tree.rs
+++ b/rinkaku-tui/src/tree.rs
@@ -579,6 +579,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/tree.rs
+++ b/rinkaku-tui/src/tree.rs
@@ -7,6 +7,7 @@
 //! separate concern, see `crate::order`).
 
 use rinkaku_core::extract::{Classification, SymbolKind};
+use rinkaku_core::file_size::FileSizeSeverity;
 use rinkaku_core::render::{Report, SkipReason};
 use std::collections::{BTreeMap, HashMap};
 
@@ -83,11 +84,36 @@ pub enum NodeKind {
 ///   nothing to any ancestor directory's `fan_in` badge here — expected,
 ///   not a bug, since the badge's whole purpose is to flag hotspots
 ///   specifically, not fan-in in general.
+/// - `own_file_size_severity`: the severity of this file node's own
+///   [`FileSizeWarning`] (ADR 0028), or `None` when the file is under
+///   the watch threshold and for every non-file node. Paired with
+///   `own_file_line_count`. Deliberately **not** merged upward: a
+///   directory has no single severity of its own, only the aggregated
+///   counts below (which are split by severity, so a mixed subtree of
+///   `Warn` and `Split` files reads as `warn:N split:M` rather than
+///   collapsing into one meaningless total).
+/// - `own_file_line_count`: this file node's own line count, matching
+///   the [`FileSizeWarning`] it carries. `None` when the file is under
+///   the watch threshold and for every non-file node. Kept alongside
+///   `own_file_size_severity` so the file row can render `lines:{N}`
+///   without a second lookup back into the report.
+/// - `file_size_warn_count`: bottom-up **count** of file nodes in this
+///   subtree whose own severity is `FileSizeSeverity::Warn`. A directory
+///   row displays this as `warn:N` (colored yellow) when nonzero — same
+///   aggregation pattern as `fan_in` — and severity is kept split from
+///   `file_size_split_count` so the reader sees "how many yellow" and
+///   "how many red" separately.
+/// - `file_size_split_count`: same as above for `FileSizeSeverity::Split`;
+///   renders as `split:N` (colored red) on directory rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Badges {
     pub changed_symbols: usize,
     pub contract_changes: usize,
     pub fan_in: usize,
+    pub own_file_size_severity: Option<FileSizeSeverity>,
+    pub own_file_line_count: Option<usize>,
+    pub file_size_warn_count: usize,
+    pub file_size_split_count: usize,
 }
 
 impl Badges {
@@ -95,6 +121,12 @@ impl Badges {
         self.changed_symbols += other.changed_symbols;
         self.contract_changes += other.contract_changes;
         self.fan_in += other.fan_in;
+        self.file_size_warn_count += other.file_size_warn_count;
+        self.file_size_split_count += other.file_size_split_count;
+        // `own_file_size_severity` / `own_file_line_count` are per-file
+        // attributes, not aggregates — see this struct's doc comment.
+        // The aggregates live in `file_size_warn_count` /
+        // `file_size_split_count` above, split by severity.
     }
 }
 
@@ -202,7 +234,18 @@ pub fn build_tree(report: &Report) -> Tree {
         .map(|hotspot| (hotspot.id.as_str(), hotspot.used_by.len()))
         .collect();
 
-    let mut builder = TreeBuilder::new(fan_in_by_id);
+    let file_size_by_path: HashMap<&str, (FileSizeSeverity, usize)> = report
+        .file_size_warnings
+        .iter()
+        .map(|warning| {
+            (
+                warning.path.as_str(),
+                (warning.severity, warning.line_count),
+            )
+        })
+        .collect();
+
+    let mut builder = TreeBuilder::new(fan_in_by_id, file_size_by_path);
 
     for file in &report.files {
         builder.insert_file(&file.path, &file.symbols);
@@ -235,6 +278,14 @@ struct TreeBuilder<'a> {
     /// `report.files` — built once in `build_tree` rather than per-symbol,
     /// since `report.hotspots` doesn't change during one `build_tree` call.
     fan_in_by_id: HashMap<&'a str, usize>,
+    /// `report.file_size_warnings`, keyed by path — the value is
+    /// `(severity, line_count)` so a file node can populate both
+    /// `own_file_size_severity` and `own_file_line_count` (and its
+    /// per-severity contribution to the aggregate `file_size_warn_count` /
+    /// `file_size_split_count`) in one lookup, while walking every source
+    /// of file rows (`report.files`, `report.tests`, `report.skipped`).
+    /// Built once in `build_tree`, same reasoning as `fan_in_by_id`.
+    file_size_by_path: HashMap<&'a str, (FileSizeSeverity, usize)>,
 }
 
 #[derive(Default)]
@@ -259,10 +310,14 @@ struct FileBuilder {
 }
 
 impl<'a> TreeBuilder<'a> {
-    fn new(fan_in_by_id: HashMap<&'a str, usize>) -> Self {
+    fn new(
+        fan_in_by_id: HashMap<&'a str, usize>,
+        file_size_by_path: HashMap<&'a str, (FileSizeSeverity, usize)>,
+    ) -> Self {
         Self {
             root: DirBuilder::default(),
             fan_in_by_id,
+            file_size_by_path,
         }
     }
 
@@ -357,7 +412,9 @@ impl<'a> TreeBuilder<'a> {
 
     fn finish(self) -> Tree {
         Tree {
-            roots: self.root.into_nodes(String::new(), &self.fan_in_by_id),
+            roots: self
+                .root
+                .into_nodes(String::new(), &self.fan_in_by_id, &self.file_size_by_path),
         }
     }
 }
@@ -396,8 +453,16 @@ impl DirBuilder {
     /// order, applying single-child directory collapsing (see
     /// `build_tree`'s doc comment) and computing bottom-up [`Badges`] as it
     /// goes. `fan_in_by_id` is threaded through to leaf symbols unchanged —
-    /// see `symbol_badges`.
-    fn into_nodes(self, prefix: String, fan_in_by_id: &HashMap<&str, usize>) -> Vec<TreeNode> {
+    /// see `symbol_badges`. `file_size_by_path` is threaded to file nodes,
+    /// where a match seeds `own_file_size_severity` /
+    /// `own_file_line_count` and the per-severity contribution to the
+    /// aggregated `file_size_warn_count` / `file_size_split_count`.
+    fn into_nodes(
+        self,
+        prefix: String,
+        fan_in_by_id: &HashMap<&str, usize>,
+        file_size_by_path: &HashMap<&str, (FileSizeSeverity, usize)>,
+    ) -> Vec<TreeNode> {
         let DirBuilder {
             mut dirs,
             mut files,
@@ -413,6 +478,7 @@ impl DirBuilder {
                     &prefix,
                     child,
                     fan_in_by_id,
+                    file_size_by_path,
                 ));
             } else if let Some(file_name) = key.strip_prefix("f:") {
                 let file = files
@@ -423,6 +489,7 @@ impl DirBuilder {
                     &prefix,
                     file,
                     fan_in_by_id,
+                    file_size_by_path,
                 ));
             }
         }
@@ -442,6 +509,7 @@ fn build_dir_node(
     prefix: &str,
     mut dir: DirBuilder,
     fan_in_by_id: &HashMap<&str, usize>,
+    file_size_by_path: &HashMap<&str, (FileSizeSeverity, usize)>,
 ) -> TreeNode {
     let mut label = name;
     loop {
@@ -460,7 +528,7 @@ fn build_dir_node(
     }
 
     let path = join_path(prefix, &label);
-    let children = dir.into_nodes(path.clone(), fan_in_by_id);
+    let children = dir.into_nodes(path.clone(), fan_in_by_id, file_size_by_path);
     let mut badges = Badges::default();
     for child in &children {
         badges.merge(child.badges);
@@ -481,9 +549,34 @@ fn build_file_node(
     prefix: &str,
     file: FileBuilder,
     fan_in_by_id: &HashMap<&str, usize>,
+    file_size_by_path: &HashMap<&str, (FileSizeSeverity, usize)>,
 ) -> TreeNode {
     let path = join_path(prefix, &name);
-    let mut badges = Badges::default();
+    let (own_file_size_severity, own_file_line_count) = match file_size_by_path.get(path.as_str()) {
+        Some((severity, line_count)) => (Some(*severity), Some(*line_count)),
+        None => (None, None),
+    };
+    // A file with its own warning contributes 1 to the matching aggregate
+    // count so an ancestor directory's `Badges::merge` sums the correct
+    // per-severity totals (which `Badges::merge` does — the aggregate
+    // fields — while it deliberately does not merge
+    // `own_file_size_severity` / `own_file_line_count`, see `Badges`'
+    // doc comment).
+    let file_size_warn_count = usize::from(matches!(
+        own_file_size_severity,
+        Some(FileSizeSeverity::Warn)
+    ));
+    let file_size_split_count = usize::from(matches!(
+        own_file_size_severity,
+        Some(FileSizeSeverity::Split)
+    ));
+    let mut badges = Badges {
+        own_file_size_severity,
+        own_file_line_count,
+        file_size_warn_count,
+        file_size_split_count,
+        ..Badges::default()
+    };
     let children: Vec<TreeNode> = file
         .symbols
         .into_iter()
@@ -530,6 +623,13 @@ fn symbol_badges(symbol_ref: &SymbolRef, fan_in_by_id: &HashMap<&str, usize>) ->
             .get(symbol_ref.id.as_str())
             .copied()
             .unwrap_or(0),
+        // File-size warnings are a per-file attribute (ADR 0028), not a
+        // per-symbol one, so a symbol never contributes to any of the
+        // file-size fields.
+        own_file_size_severity: None,
+        own_file_line_count: None,
+        file_size_warn_count: 0,
+        file_size_split_count: 0,
     }
 }
 
@@ -613,6 +713,7 @@ mod tests {
                     changed_symbols: 1,
                     contract_changes: 0,
                     fan_in: 0,
+                    ..Badges::default()
                 },
                 children: vec![TreeNode {
                     kind: NodeKind::Symbol(SymbolRef {
@@ -627,6 +728,7 @@ mod tests {
                         changed_symbols: 1,
                         contract_changes: 0,
                         fan_in: 0,
+                        ..Badges::default()
                     },
                     children: vec![],
                     skip_reason: None,
@@ -804,6 +906,7 @@ mod tests {
             changed_symbols: 1,
             contract_changes: 1,
             fan_in: 0,
+            ..Badges::default()
         };
         let actual = tree.roots[0].badges;
 
@@ -830,6 +933,7 @@ mod tests {
             changed_symbols: 1,
             contract_changes: 0,
             fan_in: 0,
+            ..Badges::default()
         };
         let actual = tree.roots[0].badges;
 
@@ -858,6 +962,7 @@ mod tests {
                     changed_symbols: 0,
                     contract_changes: 1,
                     fan_in: 0,
+                    ..Badges::default()
                 },
                 children: vec![TreeNode {
                     kind: NodeKind::Symbol(SymbolRef {
@@ -872,6 +977,7 @@ mod tests {
                         changed_symbols: 0,
                         contract_changes: 1,
                         fan_in: 0,
+                        ..Badges::default()
                     },
                     children: vec![],
                     skip_reason: None,
@@ -914,6 +1020,7 @@ mod tests {
                     changed_symbols: 1,
                     contract_changes: 1,
                     fan_in: 0,
+                    ..Badges::default()
                 },
                 children: vec![
                     TreeNode {
@@ -929,6 +1036,7 @@ mod tests {
                             changed_symbols: 1,
                             contract_changes: 0,
                             fan_in: 0,
+                            ..Badges::default()
                         },
                         children: vec![],
                         skip_reason: None,
@@ -947,6 +1055,7 @@ mod tests {
                             changed_symbols: 0,
                             contract_changes: 1,
                             fan_in: 0,
+                            ..Badges::default()
                         },
                         children: vec![],
                         skip_reason: None,
@@ -999,6 +1108,7 @@ mod tests {
             changed_symbols: 2,
             contract_changes: 1,
             fan_in: 0,
+            ..Badges::default()
         };
         assert_eq!(expected, src.badges);
     }
@@ -1109,6 +1219,121 @@ mod tests {
         let tree = build_tree(&report);
 
         assert_eq!(0, tree.roots[0].badges.fan_in);
+    }
+
+    // File-size warning badge tests (ADR 0028): a file rinkaku measured as
+    // oversized must carry its own severity + line count on the file node,
+    // and its containing directories must aggregate the count split by
+    // severity so `row_view` can render the pair (`warn:N split:M`).
+
+    #[test]
+    fn should_populate_own_file_line_count_when_report_has_warning_for_that_path() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/big.rs".to_string(),
+                symbols: vec![],
+            }],
+            file_size_warnings: vec![rinkaku_core::file_size::FileSizeWarning {
+                path: "src/big.rs".to_string(),
+                line_count: 1734,
+                severity: FileSizeSeverity::Warn,
+            }],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        // Root is the "src" Dir; file node is its only child.
+        let file_node = &tree.roots[0].children[0];
+        let expected = Badges {
+            own_file_size_severity: Some(FileSizeSeverity::Warn),
+            own_file_line_count: Some(1734),
+            file_size_warn_count: 1,
+            file_size_split_count: 0,
+            ..Badges::default()
+        };
+        assert_eq!(expected, file_node.badges);
+    }
+
+    #[test]
+    fn should_aggregate_warn_and_split_counts_separately_on_parent_dir() {
+        // src/warn.rs = Warn, src/split.rs = Split, src/ok.rs = under
+        // threshold. The parent "src" dir must show warn_count=1,
+        // split_count=1 — kept split by severity so the row can render
+        // `warn:1 split:1` rather than merging into one meaningless total.
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![
+                FileReport {
+                    path: "src/warn.rs".to_string(),
+                    symbols: vec![],
+                },
+                FileReport {
+                    path: "src/split.rs".to_string(),
+                    symbols: vec![],
+                },
+                FileReport {
+                    path: "src/ok.rs".to_string(),
+                    symbols: vec![],
+                },
+            ],
+            file_size_warnings: vec![
+                rinkaku_core::file_size::FileSizeWarning {
+                    path: "src/warn.rs".to_string(),
+                    line_count: 1600,
+                    severity: FileSizeSeverity::Warn,
+                },
+                rinkaku_core::file_size::FileSizeWarning {
+                    path: "src/split.rs".to_string(),
+                    line_count: 2500,
+                    severity: FileSizeSeverity::Split,
+                },
+            ],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        // Root is the "src" Dir.
+        let expected = Badges {
+            file_size_warn_count: 1,
+            file_size_split_count: 1,
+            // Directories deliberately never carry per-node severity /
+            // line_count of their own — those live only on file rows.
+            own_file_size_severity: None,
+            own_file_line_count: None,
+            ..Badges::default()
+        };
+        assert_eq!(expected, tree.roots[0].badges);
+    }
+
+    #[test]
+    fn should_leave_own_file_size_severity_none_on_dir_node() {
+        // Even when a directory aggregates a nonzero warn/split count
+        // from below, its own_file_size_severity / own_file_line_count
+        // must stay None — those two fields are per-file attributes only.
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/big.rs".to_string(),
+                symbols: vec![],
+            }],
+            file_size_warnings: vec![rinkaku_core::file_size::FileSizeWarning {
+                path: "src/big.rs".to_string(),
+                line_count: 3000,
+                severity: FileSizeSeverity::Split,
+            }],
+            ..empty_report()
+        };
+
+        let tree = build_tree(&report);
+
+        let dir_node = &tree.roots[0];
+        assert_eq!(None, dir_node.badges.own_file_size_severity);
+        assert_eq!(None, dir_node.badges.own_file_line_count);
+        // Aggregates still count the descendant.
+        assert_eq!(1, dir_node.badges.file_size_split_count);
     }
 
     // Skipped-file tests: a file rinkaku could not extract symbols from

--- a/rinkaku-tui/src/ui/blast_radius.rs
+++ b/rinkaku-tui/src/ui/blast_radius.rs
@@ -149,6 +149,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/ui/detail_pane.rs
+++ b/rinkaku-tui/src/ui/detail_pane.rs
@@ -220,18 +220,23 @@ pub(crate) fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
 }
 
 /// Formats one file-size warning (ADR 0028) as the single line the Detail
-/// pane shows above the "Symbols" listing. The glyph tracks severity
-/// (`⚠` for `Warn`, `🚨` for `Split`) and the trailing hint names the
-/// threshold that was crossed, mirroring the Markdown surface's wording.
+/// pane shows above the "Symbols" listing. Uses a text label
+/// (`Warn:` / `Split:`) instead of an emoji glyph — terminal emoji
+/// rendering width is inconsistent enough to distort the pane's
+/// column layout, and severity is already legible from the whole-line
+/// color (yellow for Warn, red for Split; applied at the call site so
+/// this pure formatter stays a plain `String`). The trailing hint
+/// names the threshold that was crossed, mirroring the Markdown
+/// surface's wording without the glyph.
 fn file_size_warning_line(warning: &rinkaku_core::file_size::FileSizeWarning) -> String {
     use rinkaku_core::file_size::{FileSizeSeverity, SPLIT_LINE_THRESHOLD, WARN_LINE_THRESHOLD};
     match warning.severity {
         FileSizeSeverity::Warn => format!(
-            "\u{26a0} {} lines \u{2014} consider splitting (>{WARN_LINE_THRESHOLD} watch)",
+            "Warn: {} lines \u{2014} consider splitting (>{WARN_LINE_THRESHOLD} watch)",
             warning.line_count,
         ),
         FileSizeSeverity::Split => format!(
-            "\u{1f6a8} {} lines \u{2014} over the {SPLIT_LINE_THRESHOLD}-line split threshold",
+            "Split: {} lines \u{2014} over the {SPLIT_LINE_THRESHOLD}-line split threshold",
             warning.line_count,
         ),
     }
@@ -1078,11 +1083,12 @@ mod tests {
     }
 
     // ADR 0028: a `FileDetail` carrying a `size_warning` renders one
-    // extra line above the "Symbols" listing, with a severity-matched
-    // glyph and the crossed threshold named in the trailing hint. The
-    // `⚠` and `>1500 watch` wording pinned here is the same shape the
-    // Markdown surface uses, so a reviewer skimming either output reads
-    // the same signal.
+    // extra line above the "Symbols" listing, with the severity named as
+    // a text label (`Warn:` / `Split:`) rather than an emoji glyph —
+    // terminal emoji width is inconsistent enough to distort the pane
+    // layout — plus the crossed threshold named in the trailing hint.
+    // Severity color (yellow / red) is applied at the caller as a
+    // whole-line style, not baked into this string.
     #[test]
     fn should_render_size_warning_line_when_file_detail_has_size_warning() {
         let detail = FileDetail {
@@ -1116,15 +1122,16 @@ mod tests {
         assert!(
             rendered
                 .iter()
-                .any(|line| line == "\u{26a0} 1734 lines \u{2014} consider splitting (>1500 watch)"),
+                .any(|line| line == "Warn: 1734 lines \u{2014} consider splitting (>1500 watch)"),
             "expected watch-severity warning line among: {rendered:?}",
         );
     }
 
     // Companion to the Warn test above: the `Split` variant swaps the
-    // glyph to `🚨` and names the split threshold in the trailing hint.
+    // label to `Split:` and names the split threshold in the trailing
+    // hint. Color (red vs yellow) is applied at the caller.
     #[test]
-    fn should_render_split_severity_glyph_when_file_detail_size_warning_is_split() {
+    fn should_render_split_severity_label_when_file_detail_size_warning_is_split() {
         let detail = FileDetail {
             path: "src/huge.rs".to_string(),
             symbols: vec![],
@@ -1151,8 +1158,7 @@ mod tests {
         assert!(
             rendered
                 .iter()
-                .any(|line| line
-                    == "\u{1f6a8} 4837 lines \u{2014} over the 2000-line split threshold"),
+                .any(|line| line == "Split: 4837 lines \u{2014} over the 2000-line split threshold"),
             "expected split-severity warning line among: {rendered:?}",
         );
     }

--- a/rinkaku-tui/src/ui/detail_pane.rs
+++ b/rinkaku-tui/src/ui/detail_pane.rs
@@ -172,6 +172,22 @@ pub(crate) fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
         }
     }
 
+    // ADR 0028: an oversized-file warning renders above the "Symbols"
+    // listing, matching how `top_fan_in` sits above the equivalent
+    // rows on `DirDetail`. Skipped/deleted files never reach this point
+    // (the skip-reason arm returns early above), so the warning only
+    // shows for files rinkaku actually measured.
+    if let Some(warning) = &detail.size_warning {
+        lines.push(Line::styled(
+            file_size_warning_line(warning),
+            Style::default().fg(match warning.severity {
+                rinkaku_core::file_size::FileSizeSeverity::Warn => Color::Yellow,
+                rinkaku_core::file_size::FileSizeSeverity::Split => Color::Red,
+            }),
+        ));
+        lines.push(Line::raw(""));
+    }
+
     if !detail.symbols.is_empty() || detail.test_symbol_count.is_none() {
         lines.push(Line::styled(
             format!("Symbols ({})", detail.symbols.len()),
@@ -201,6 +217,24 @@ pub(crate) fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
     }
 
     lines
+}
+
+/// Formats one file-size warning (ADR 0028) as the single line the Detail
+/// pane shows above the "Symbols" listing. The glyph tracks severity
+/// (`⚠` for `Warn`, `🚨` for `Split`) and the trailing hint names the
+/// threshold that was crossed, mirroring the Markdown surface's wording.
+fn file_size_warning_line(warning: &rinkaku_core::file_size::FileSizeWarning) -> String {
+    use rinkaku_core::file_size::{FileSizeSeverity, SPLIT_LINE_THRESHOLD, WARN_LINE_THRESHOLD};
+    match warning.severity {
+        FileSizeSeverity::Warn => format!(
+            "\u{26a0} {} lines \u{2014} consider splitting (>{WARN_LINE_THRESHOLD} watch)",
+            warning.line_count,
+        ),
+        FileSizeSeverity::Split => format!(
+            "\u{1f6a8} {} lines \u{2014} over the {SPLIT_LINE_THRESHOLD}-line split threshold",
+            warning.line_count,
+        ),
+    }
 }
 
 pub(crate) fn kind_abbrev(kind: rinkaku_core::extract::SymbolKind) -> &'static str {
@@ -281,7 +315,9 @@ pub(crate) fn detail_lines(detail: &DetailView) -> Vec<Line<'static>> {
 
 #[cfg(test)]
 mod tests {
+    use super::file_detail_lines;
     use crate::app::{App, BlastRadiusSelection};
+    use crate::detail::FileDetail;
     use crate::ui::{DrawOutcome, draw};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -322,6 +358,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }
@@ -352,6 +389,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         // ADR 0020 defaults the right pane to Diff, whose own placeholder
@@ -394,6 +432,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         // ADR 0020 defaults the right pane to Diff; `ToggleDiff` switches to
@@ -446,6 +485,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         // See the sibling test above for why `ToggleDiff` is needed to
@@ -491,6 +531,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }
@@ -545,6 +586,7 @@ mod tests {
                 symbol_count: 3,
             }],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }
@@ -611,6 +653,7 @@ mod tests {
                 symbol_count: 5,
             }],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         // Row 0 is the "app.rs" file row itself.
@@ -693,6 +736,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }
@@ -942,6 +986,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         // ADR 0020 defaults the right pane to Diff, whose own placeholder
@@ -1002,6 +1047,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         // ADR 0020 defaults the right pane to Diff; `ToggleDiff` switches to
@@ -1029,5 +1075,85 @@ mod tests {
         // would have produced.
         assert!(text.contains("Detail (1-"));
         assert!(!text.contains("/2)"));
+    }
+
+    // ADR 0028: a `FileDetail` carrying a `size_warning` renders one
+    // extra line above the "Symbols" listing, with a severity-matched
+    // glyph and the crossed threshold named in the trailing hint. The
+    // `⚠` and `>1500 watch` wording pinned here is the same shape the
+    // Markdown surface uses, so a reviewer skimming either output reads
+    // the same signal.
+    #[test]
+    fn should_render_size_warning_line_when_file_detail_has_size_warning() {
+        let detail = FileDetail {
+            path: "src/big.rs".to_string(),
+            symbols: vec![],
+            skip_reason: None,
+            test_symbol_count: None,
+            size_warning: Some(rinkaku_core::file_size::FileSizeWarning {
+                path: "src/big.rs".to_string(),
+                line_count: 1734,
+                severity: rinkaku_core::file_size::FileSizeSeverity::Warn,
+            }),
+        };
+
+        let lines = file_detail_lines(&detail);
+
+        // NOTE: partial assert — the "File src/big.rs" header, the blank
+        // line, and the "Symbols (0)" listing come from unrelated arms
+        // of `file_detail_lines`; this test only pins the warning-line
+        // portion (a whole-vec compare would double-book coverage the
+        // sibling tests already have).
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect();
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line == "\u{26a0} 1734 lines \u{2014} consider splitting (>1500 watch)"),
+            "expected watch-severity warning line among: {rendered:?}",
+        );
+    }
+
+    // Companion to the Warn test above: the `Split` variant swaps the
+    // glyph to `🚨` and names the split threshold in the trailing hint.
+    #[test]
+    fn should_render_split_severity_glyph_when_file_detail_size_warning_is_split() {
+        let detail = FileDetail {
+            path: "src/huge.rs".to_string(),
+            symbols: vec![],
+            skip_reason: None,
+            test_symbol_count: None,
+            size_warning: Some(rinkaku_core::file_size::FileSizeWarning {
+                path: "src/huge.rs".to_string(),
+                line_count: 4837,
+                severity: rinkaku_core::file_size::FileSizeSeverity::Split,
+            }),
+        };
+
+        let lines = file_detail_lines(&detail);
+
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect();
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line
+                    == "\u{1f6a8} 4837 lines \u{2014} over the 2000-line split threshold"),
+            "expected split-severity warning line among: {rendered:?}",
+        );
     }
 }

--- a/rinkaku-tui/src/ui/detail_pane.rs
+++ b/rinkaku-tui/src/ui/detail_pane.rs
@@ -203,8 +203,11 @@ pub(crate) fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
                     Some(Classification::BodyOnly) | None => " ",
                 }
             };
+            // ADR 0013 amendment (2026-07-13): the compact fan-in badge
+            // matches `row_view::push_badge_spans`' `ref:N` labeling so
+            // the two panes agree on the badge legend.
             let fan_in = if symbol.fan_in > 0 {
-                format!(" ^{}", symbol.fan_in)
+                format!(" ref:{}", symbol.fan_in)
             } else {
                 String::new()
             };

--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -280,6 +280,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }
@@ -393,6 +394,7 @@ index e69de29..4b825dc 100644
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
             files: vec![],
         };
@@ -456,6 +458,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
             files: vec![],
         };
@@ -522,6 +525,7 @@ index e69de29..4b825dc 100644
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         let app = App::new(&report);
@@ -584,6 +588,7 @@ index e69de29..4b825dc 100644
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         // Row 0 is the "lib.rs" file row, row 1 is the "foo" symbol.
@@ -816,6 +821,7 @@ index e69de29..4b825dc 100644
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         // ADR 0020 defaults the right pane to Diff already, so no

--- a/rinkaku-tui/src/ui/entry.rs
+++ b/rinkaku-tui/src/ui/entry.rs
@@ -165,6 +165,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }
@@ -186,6 +187,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/ui/mod.rs
+++ b/rinkaku-tui/src/ui/mod.rs
@@ -178,7 +178,7 @@ pub fn draw(
         }
     };
 
-    draw_status_line(frame, app, status_area);
+    draw_status_line(frame, app, report, status_area);
 
     if app.help_open() {
         let (clamped_help_scroll, help_scroll_viewport_height) =

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -232,6 +232,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/ui/source_screen.rs
+++ b/rinkaku-tui/src/ui/source_screen.rs
@@ -196,6 +196,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }
@@ -354,6 +355,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         let app = App::new(&report)
@@ -422,6 +424,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         };
         let app = App::new(&report)

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -7,9 +7,10 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::widgets::Paragraph;
+use rinkaku_core::render::Report;
 
-pub(crate) fn draw_status_line(frame: &mut Frame, app: &App, area: Rect) {
-    let text = status_line_text(app);
+pub(crate) fn draw_status_line(frame: &mut Frame, app: &App, report: &Report, area: Rect) {
+    let text = status_line_text(app, report);
 
     let style = if app.status().is_some() {
         Style::default().fg(Color::Yellow)
@@ -42,7 +43,13 @@ pub(crate) fn draw_status_line(frame: &mut Frame, app: &App, area: Rect) {
 /// itself — not just that *something* renders — is unit-testable, mirroring
 /// [`super::scroll::clamp_scroll`]/[`super::scroll::scroll_indicator`]'s own precedent in this module for
 /// layout-adjacent pure logic.
-pub(crate) fn status_line_text(app: &App) -> String {
+///
+/// The `⚠ N file-size warnings` suffix (ADR 0028) is appended to the help
+/// segment whenever `report.file_size_warnings` is non-empty, so the
+/// aggregate count is visible from any pane without a dedicated screen.
+/// The suffix is dropped when the vec is empty (mirrors ADR 0013's
+/// "Hotspots is skipped when empty" rule).
+pub(crate) fn status_line_text(app: &App, report: &Report) -> String {
     let help = match app.screen() {
         Screen::Entry => {
             let order = match app.order_mode() {
@@ -65,6 +72,11 @@ pub(crate) fn status_line_text(app: &App) -> String {
         Screen::Source { .. } => {
             "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  esc/q: back".to_string()
         }
+    };
+
+    let help = match report.file_size_warnings.len() {
+        0 => help,
+        n => format!("{help}  |  \u{26a0} {n} file-size warnings"),
     };
 
     match app.status() {
@@ -117,6 +129,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }
@@ -146,6 +159,7 @@ mod tests {
             },
             tests: vec![],
             hotspots: vec![],
+            file_size_warnings: vec![],
             removed: vec![],
         }
     }
@@ -187,7 +201,7 @@ mod tests {
         let report = empty_report_for_status_line();
         let app = App::new(&report);
 
-        let actual = status_line_text(&app);
+        let actual = status_line_text(&app, &report);
 
         assert_eq!(
             "order: topological  |  j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
@@ -201,7 +215,7 @@ mod tests {
         let report = empty_report_for_status_line();
         let app = App::new(&report).handle_key(crate::app::InputKey::ToggleOrder);
 
-        let actual = status_line_text(&app);
+        let actual = status_line_text(&app, &report);
 
         assert!(actual.starts_with("order: alphabetical  |  "));
     }
@@ -215,7 +229,7 @@ mod tests {
         // `]/[: next/prev hunk` hint actually applies to.
         let app = App::new(&report).handle_key(crate::app::InputKey::Open);
 
-        let actual = status_line_text(&app);
+        let actual = status_line_text(&app, &report);
 
         assert_eq!(
             "order: topological  |  j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  ]/[: next/prev hunk  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
@@ -236,7 +250,7 @@ mod tests {
             .handle_key(crate::app::InputKey::ToggleDiff);
         assert_eq!(crate::app::RightPane::Detail, app.right_pane());
 
-        let actual = status_line_text(&app);
+        let actual = status_line_text(&app, &report);
 
         assert_eq!(
             "order: topological  |  j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
@@ -258,7 +272,7 @@ mod tests {
             .handle_key(crate::app::InputKey::Down)
             .handle_key(crate::app::InputKey::Source); // opens Screen::Source
 
-        let actual = status_line_text(&app);
+        let actual = status_line_text(&app, &report);
 
         assert_eq!(
             "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  esc/q: back".to_string(),
@@ -272,8 +286,56 @@ mod tests {
         let mut app = App::new(&report);
         app.set_status("a source read failed");
 
-        let actual = status_line_text(&app);
+        let actual = status_line_text(&app, &report);
 
         assert!(actual.starts_with("a source read failed  |  order: topological  |  "));
+    }
+
+    // ADR 0028: a report carrying at least one file-size warning must
+    // append the aggregate count to the help text so the reviewer sees
+    // the total from any pane. The count is the raw vec length — no
+    // per-severity split here, that lives on the detail pane per ADR
+    // 0028's "one signal per surface" split.
+    #[test]
+    fn should_append_file_size_warning_count_to_status_line_when_report_has_warnings() {
+        let report = Report {
+            file_size_warnings: vec![
+                rinkaku_core::file_size::FileSizeWarning {
+                    path: "src/big.rs".to_string(),
+                    line_count: 1734,
+                    severity: rinkaku_core::file_size::FileSizeSeverity::Warn,
+                },
+                rinkaku_core::file_size::FileSizeWarning {
+                    path: "src/huge.rs".to_string(),
+                    line_count: 4837,
+                    severity: rinkaku_core::file_size::FileSizeSeverity::Split,
+                },
+            ],
+            ..empty_report_for_status_line()
+        };
+        let app = App::new(&report);
+
+        let actual = status_line_text(&app, &report);
+
+        assert!(
+            actual.ends_with("  |  \u{26a0} 2 file-size warnings"),
+            "expected trailing warnings segment, got: {actual}",
+        );
+    }
+
+    // Companion to the test above: an empty `file_size_warnings` vec
+    // leaves the help text untouched — mirrors ADR 0013's "Hotspots is
+    // skipped when empty" rule for the Markdown surface.
+    #[test]
+    fn should_not_append_when_report_has_no_warnings() {
+        let report = empty_report_for_status_line();
+        let app = App::new(&report);
+
+        let actual = status_line_text(&app, &report);
+
+        assert!(
+            !actual.contains("file-size warnings"),
+            "expected no warnings segment, got: {actual}",
+        );
     }
 }

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -44,11 +44,18 @@ pub(crate) fn draw_status_line(frame: &mut Frame, app: &App, report: &Report, ar
 /// [`super::scroll::clamp_scroll`]/[`super::scroll::scroll_indicator`]'s own precedent in this module for
 /// layout-adjacent pure logic.
 ///
-/// The `⚠ N file-size warnings` suffix (ADR 0028) is appended to the help
-/// segment whenever `report.file_size_warnings` is non-empty, so the
-/// aggregate count is visible from any pane without a dedicated screen.
-/// The suffix is dropped when the vec is empty (mirrors ADR 0013's
-/// "Hotspots is skipped when empty" rule).
+/// The `warn:N split:M file-size` suffix (ADR 0028) is appended to the
+/// help segment whenever `report.file_size_warnings` is non-empty, so the
+/// aggregate counts are visible from any pane without a dedicated screen.
+/// The severity split (`warn:N` for `FileSizeSeverity::Warn`, `split:M`
+/// for `FileSizeSeverity::Split`) preserves the "how many yellow" /
+/// "how many red" distinction the Tree pane badge already surfaces; a
+/// half with a zero count is dropped so a small warnings vec never
+/// gains a stray `split:0`. Text labels (no emoji glyphs) — terminal
+/// emoji rendering width is inconsistent enough that a status-line
+/// glyph can push the help hints past the frame edge. The whole suffix
+/// is dropped when the vec is empty (mirrors ADR 0013's "Hotspots is
+/// skipped when empty" rule).
 pub(crate) fn status_line_text(app: &App, report: &Report) -> String {
     let help = match app.screen() {
         Screen::Entry => {
@@ -74,15 +81,42 @@ pub(crate) fn status_line_text(app: &App, report: &Report) -> String {
         }
     };
 
-    let help = match report.file_size_warnings.len() {
-        0 => help,
-        n => format!("{help}  |  \u{26a0} {n} file-size warnings"),
+    let help = match file_size_warning_suffix(report) {
+        Some(suffix) => format!("{help}  |  {suffix}"),
+        None => help,
     };
 
     match app.status() {
         Some(status) => format!("{status}  |  {help}"),
         None => help,
     }
+}
+
+/// Builds the trailing `warn:N split:M file-size` suffix for the status
+/// line (ADR 0028) — `Some(text)` when at least one severity has a
+/// nonzero count, `None` when the report has no warnings (matching the
+/// "skipped when empty" rule at the caller).
+fn file_size_warning_suffix(report: &Report) -> Option<String> {
+    use rinkaku_core::file_size::FileSizeSeverity;
+    let mut warn_count = 0usize;
+    let mut split_count = 0usize;
+    for warning in &report.file_size_warnings {
+        match warning.severity {
+            FileSizeSeverity::Warn => warn_count += 1,
+            FileSizeSeverity::Split => split_count += 1,
+        }
+    }
+    if warn_count == 0 && split_count == 0 {
+        return None;
+    }
+    let mut parts = Vec::new();
+    if warn_count > 0 {
+        parts.push(format!("warn:{warn_count}"));
+    }
+    if split_count > 0 {
+        parts.push(format!("split:{split_count}"));
+    }
+    Some(format!("{} file-size", parts.join(" ")))
 }
 
 #[cfg(test)]
@@ -292,10 +326,11 @@ mod tests {
     }
 
     // ADR 0028: a report carrying at least one file-size warning must
-    // append the aggregate count to the help text so the reviewer sees
-    // the total from any pane. The count is the raw vec length — no
-    // per-severity split here, that lives on the detail pane per ADR
-    // 0028's "one signal per surface" split.
+    // append the per-severity aggregate to the help text so the reviewer
+    // sees the totals from any pane. The suffix uses text labels
+    // (`warn:N split:M file-size`) rather than emoji glyphs — terminal
+    // emoji rendering width is inconsistent, and the color coding lives
+    // on the Tree pane badge anyway.
     #[test]
     fn should_append_file_size_warning_count_to_status_line_when_report_has_warnings() {
         let report = Report {
@@ -318,8 +353,31 @@ mod tests {
         let actual = status_line_text(&app, &report);
 
         assert!(
-            actual.ends_with("  |  \u{26a0} 2 file-size warnings"),
-            "expected trailing warnings segment, got: {actual}",
+            actual.ends_with("  |  warn:1 split:1 file-size"),
+            "expected trailing per-severity warnings segment, got: {actual}",
+        );
+    }
+
+    #[test]
+    fn should_drop_zero_severity_half_from_status_line_when_only_one_severity_present() {
+        // ADR 0028: with only Warn (no Split) files, the suffix reads
+        // `warn:N file-size` — the split:0 half is dropped, mirroring
+        // how the Tree pane badge omits a zero half.
+        let report = Report {
+            file_size_warnings: vec![rinkaku_core::file_size::FileSizeWarning {
+                path: "src/big.rs".to_string(),
+                line_count: 1734,
+                severity: rinkaku_core::file_size::FileSizeSeverity::Warn,
+            }],
+            ..empty_report_for_status_line()
+        };
+        let app = App::new(&report);
+
+        let actual = status_line_text(&app, &report);
+
+        assert!(
+            actual.ends_with("  |  warn:1 file-size"),
+            "expected trailing warn-only segment, got: {actual}",
         );
     }
 

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -581,6 +581,7 @@ fn run_base_pipeline(
                 },
                 tests: Vec::new(),
                 hotspots: Vec::new(),
+                file_size_warnings: Vec::new(),
                 removed: Vec::new(),
             },
             diff_text,
@@ -3716,6 +3717,7 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
                 },
                 tests: Vec::new(),
                 hotspots: Vec::new(),
+                file_size_warnings: Vec::new(),
                 removed: Vec::new(),
             },
             actual_report
@@ -3916,6 +3918,7 @@ fn should_add_two_numbers() {
                 graph: empty_graph(),
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             }
         }
@@ -3931,6 +3934,7 @@ fn should_add_two_numbers() {
                 graph: empty_graph(),
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             }
         }
@@ -3978,6 +3982,7 @@ fn should_add_two_numbers() {
                 graph: empty_graph(),
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
 
@@ -4004,6 +4009,7 @@ fn should_add_two_numbers() {
                     symbol_count: 1,
                 }],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
 
@@ -4042,6 +4048,7 @@ fn should_add_two_numbers() {
                 graph: empty_graph(),
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
 
@@ -4101,6 +4108,7 @@ fn should_add_two_numbers() {
                 graph,
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             }
         }
@@ -4159,6 +4167,7 @@ fn should_add_two_numbers() {
                 },
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             };
 
@@ -4189,6 +4198,7 @@ fn should_add_two_numbers() {
                 graph: empty_graph(),
                 tests: vec![],
                 hotspots: vec![],
+                file_size_warnings: vec![],
                 removed: vec![],
             }
         }


### PR DESCRIPTION
## Summary

Per [ADR 0028](docs/adr/0028-file-size-warnings.md), rinkaku itself now surfaces oversized source files as a distinct attention dimension in its Markdown / JSON / TUI output. Motivated by PR #82's 12000-line mechanical split of three files that had silently grown past reviewability — this feature would have flagged them before the debt piled up.

## What ships

- **`FileSizeWarning`** type on `Report`, populated by `analyze_diff` / `analyze_repo` from real file line counts (skipped files excluded)
- **Thresholds**: `WARN_LINE_THRESHOLD = 1500` (⚠), `SPLIT_LINE_THRESHOLD = 2000` (🚨) — as `pub const`, ADR-locked
- **Markdown**: new `## File size warnings` section between Hotspots and Definitions, skipped when empty
- **JSON**: additive `file_size_warnings` field, always present
- **TUI**: file-row Detail pane grows a warning line above symbol listing; status line gains `⚠ N file-size warnings` when non-empty; no new pane or keybinding
- **Mermaid**: not rendered (graph view, file size not a graph property; explicit non-goal in ADR)
- **CLAUDE.md**: new "File size discipline" section — thresholds, `#[cfg(test)] #[path = "tests.rs"]` co-location pattern (from PR #82's `app/` refactor), split-by-responsibility rule, "rinkaku's own warning is authoritative"

## Test plan

- [x] `make test` — **981 passed** (161 rinkaku + 350 core + 470 tui), up from 962 baseline (+19 new tests across `file_size`, `pipeline`, `markdown`, `detail`, `ui/detail_pane`, `ui/status`)
- [x] `make lint` clean (fmt + clippy `-D warnings`)
- [ ] **Manual smoke**: `cargo run` on this repo's diff — expect `## File size warnings` section listing `render/markdown.rs` (3627 lines, Split) among others; TUI shows the warning on the file's Detail pane

## Dogfooding note

This branch's own `rinkaku --base main` output will flag `rinkaku-core/src/render/markdown.rs` (3627 lines, over Split threshold) — an intentional consequence acknowledged in ADR 0028: PR #82 lowered top-level file weight, but that submodule still exceeds the threshold and is marked for a follow-up split. The tool telling itself to split is exactly the loop this PR closes.