### PR TITLE
fix(tui): attribute a hunk to every intersecting symbol in the diff pane

### DIFF
--- a/docs/adr/0029-diff-pane-multi-symbol-hunk-attribution.md
+++ b/docs/adr/0029-diff-pane-multi-symbol-hunk-attribution.md
@@ -67,21 +67,24 @@ the `MODULE_LEVEL_TITLE` bucket, unchanged.
 This amends ADR 0020 decision 4's "attributed to the first symbol
 (source order)" rule and confirms ADR 0027's decision 6 (`]c`/`[c`
 walks every hunk in the file) needs a companion rule: **hunk-jump order
-is deduplicated by `source_index`**, not by section. `hunk_start_lines`
-already walks sections in `crate::ui::draw_diff_pane`'s render order
-and would otherwise emit the *same* hunk's start line once per section
-it now appears in (e.g. a hunk shared by three adjacent symbols would
-make `]c` stop three times on what the reviewer sees as one hunk of
-text, since the section headers differ but the hunk body is identical
-content shown three times in the render itself). This ADR accepts that
-the **rendered content itself repeats the shared hunk once per owning
-section** (see Consequences) — the diff pane is not deduplicating the
-*display*, since a section without its own copy of the hunk would look
-incomplete when read on its own (exactly the "orient before reading"
-principle ADR 0020 built the section headers around) — but
-`hunk_start_lines` must still expose a distinct stop per **rendered**
-occurrence, so `]c`/`[c` continues to mean "jump to the next hunk
-header actually on screen", matching what the reviewer sees rather
+is *not* deduplicated by `source_index`** — it stays one stop per
+section, exactly as `hunk_start_lines` already computes it today.
+`hunk_start_lines` already walks sections in
+`crate::ui::draw_diff_pane`'s render order and, unchanged, emits the
+*same* hunk's start line once per section it now appears in (e.g. a
+hunk shared by three adjacent symbols makes `]c` stop three times on
+what the reviewer sees as one hunk of text, since the section headers
+differ but the hunk body is identical content shown three times in the
+render itself). This ADR accepts that the **rendered content itself
+repeats the shared hunk once per owning section** (see Consequences) —
+the diff pane is not deduplicating the *display*, since a section
+without its own copy of the hunk would look incomplete when read on
+its own (exactly the "orient before reading" principle ADR 0020 built
+the section headers around) — so `hunk_start_lines` needs no code
+change at all: its existing per-section walk already exposes a
+distinct stop per **rendered** occurrence, so `]c`/`[c` continues to
+mean "jump to the next hunk header actually on screen", matching what
+the reviewer sees rather
 than a deduplicated count that would silently skip over a hunk's
 second/third rendered appearance.
 

--- a/docs/adr/0029-diff-pane-multi-symbol-hunk-attribution.md
+++ b/docs/adr/0029-diff-pane-multi-symbol-hunk-attribution.md
@@ -1,0 +1,175 @@
+# 0029. Diff pane attributes a hunk to every symbol it intersects, not just the first
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+ADR 0020 decision 4 established the diff pane's file-selection shape:
+group a file's hunks under per-symbol section headers, and when one
+hunk intersects more than one symbol's line range, attribute it to
+**only the first symbol (source order) it intersects** — rejecting
+duplicate attribution because it "would make 'total lines shown' no
+longer match 'total lines in the diff', actively misleading about
+change size for exactly the file-level view meant to summarize it."
+ADR 0027 later made every symbol-row selection auto-scroll into this
+same shaped content (`crate::diff_shape::section_start_line_for_symbol`),
+so the first-match rule now also decides which symbols get a working
+auto-scroll target and which get none.
+
+Dogfooding on PR #86 (a real, unmerged PR adding
+`rinkaku-core/src/file_size.rs`, a **brand-new file**) surfaced a
+concrete failure of that assumption: moving the left-pane cursor
+between symbols in `file_size.rs` did not scroll the diff pane at all,
+for every symbol except the first one in the file. A reproduction
+built from the real diff and real file content confirmed the exact
+mechanism —
+
+- A brand-new file's diff is always exactly **one hunk**
+  (`@@ -0,0 +1,N @@` spanning the whole file), regardless of how many
+  symbols the file defines.
+- `build_file_content`'s owner lookup
+  (`symbols.iter().position(|s| hunk_intersects(hunk, s.range.start, s.range.end))`)
+  finds the *first* symbol whose range intersects a hunk and attributes
+  the whole hunk to it, full stop.
+- Every symbol in the file has a range inside `[1, N]`, so every one of
+  them "intersects" this one hunk — but only the first symbol in source
+  order ever wins the `position()` lookup. Every other symbol's section
+  gets zero hunks and is dropped by
+  `sections.retain(|section| !section.hunks.is_empty())`.
+- `section_start_line_for_symbol` then returns `None` for every
+  dropped symbol, so `crate::run_app`'s `auto_scroll_for_diff_focus`
+  (ADR 0027 decision 4) silently no-ops — the cursor moves, nothing
+  scrolls, and there is no error or log to explain why.
+
+This is not limited to free functions (an initial hypothesis while
+investigating) — the reproduction shows a `struct` and an `enum` in
+the same file are equally affected; the only fixed property is "this
+symbol did not happen to be first". It is also not limited to brand-new
+files in principle: any time git collapses a multi-symbol region into
+one hunk (a large formatting pass, a block indent change, a
+paste-and-adjust edit spanning several definitions) the same
+first-match rule silently drops every symbol after the first from the
+diff pane's per-symbol view and from auto-scroll — new files are simply
+the case where this is *guaranteed* to happen on every symbol but the
+first, rather than a rare adjacency accident.
+
+## Decision
+
+**Attribute a hunk to every symbol whose range it intersects, not just
+the first.** `build_file_content`'s owner lookup changes from
+`Iterator::position` (single index) to `Iterator::filter` (all matching
+indices); the hunk (cloned once per matching symbol, as
+`AttributedHunk` already is per section) is pushed onto every matching
+symbol's section. A hunk that intersects no symbol still falls back to
+the `MODULE_LEVEL_TITLE` bucket, unchanged.
+
+This amends ADR 0020 decision 4's "attributed to the first symbol
+(source order)" rule and confirms ADR 0027's decision 6 (`]c`/`[c`
+walks every hunk in the file) needs a companion rule: **hunk-jump order
+is deduplicated by `source_index`**, not by section. `hunk_start_lines`
+already walks sections in `crate::ui::draw_diff_pane`'s render order
+and would otherwise emit the *same* hunk's start line once per section
+it now appears in (e.g. a hunk shared by three adjacent symbols would
+make `]c` stop three times on what the reviewer sees as one hunk of
+text, since the section headers differ but the hunk body is identical
+content shown three times in the render itself). This ADR accepts that
+the **rendered content itself repeats the shared hunk once per owning
+section** (see Consequences) — the diff pane is not deduplicating the
+*display*, since a section without its own copy of the hunk would look
+incomplete when read on its own (exactly the "orient before reading"
+principle ADR 0020 built the section headers around) — but
+`hunk_start_lines` must still expose a distinct stop per **rendered**
+occurrence, so `]c`/`[c` continues to mean "jump to the next hunk
+header actually on screen", matching what the reviewer sees rather
+than a deduplicated count that would silently skip over a hunk's
+second/third rendered appearance.
+
+**Why the TUI departs from ADR 0020's summary-view reasoning here:**
+ADR 0020's rejection of duplicate attribution was scoped to "the
+file-level view meant to summarize" change size — true of a
+`## Definitions` / hotspot-style Markdown or JSON summary, where a
+reader sums line counts across entries and a duplicate would inflate
+that sum. The TUI diff pane is not that view: it has no "total lines
+changed" figure anywhere in its own UI (`crate::ui::status`, `crate::detail`
+checked — neither surfaces a change-size total derived from
+`DiffSection` counts), and its purpose per ADR 0020's own framing is
+"orient (what changed at the signature level) before reading the
+body" *per selected symbol*. A reviewer who selects `compute_file_size_warnings`
+and sees nothing scroll, with no indication that the function's own
+hunk exists but was claimed by a sibling section, cannot orient at
+all — the contract this ADR restores (every present symbol's row
+"just works" for auto-scroll and per-symbol viewing) outweighs the
+"hunk shown twice when two symbols share a region" cost, which is
+visible and self-explanatory (the reviewer can see the same lines
+appear under both section headers) rather than silent like the bug
+this ADR fixes.
+
+**No change to `rinkaku-core`.** This is purely a `rinkaku-tui`
+diff-pane presentation concern — `crate::diff_shape` is TUI-only
+(confirmed: `rinkaku-core`'s `render::markdown`/`render::report`/JSON
+output do not depend on `rinkaku-tui` or read `DiffSection` at all;
+they compute their own change-size figures, if any, directly from
+`Report`/`ExtractedSymbol`). Markdown and JSON output are unaffected by
+this ADR.
+
+## Alternatives
+
+- **Keep first-match, add a distinct "no section" indicator in the
+  Detail pane or status line instead.** Rejected: this treats the
+  symptom (auto-scroll doing nothing, silently) rather than the cause
+  (the symbol's own hunk exists but was never attributed to it). A
+  reviewer would still be unable to see `compute_file_size_warnings`'s
+  own diff lines highlighted under its own header; an indicator only
+  explains the absence, it does not restore the missing content.
+- **Split a multi-symbol hunk into per-symbol sub-hunks at attribution
+  time**, so each symbol's section shows only its own lines rather than
+  the whole shared hunk. Rejected as substantially more complex: hunk
+  bodies interleave context/added/removed lines
+  (`crate::diff_view::DiffLine`) with no per-line symbol association
+  already computed, so a correct split would need a second, finer
+  intersection pass per line — a bigger change than this ADR's problem
+  (auto-scroll silently doing nothing) requires solving. Can be
+  revisited if reviewers find the duplicated-hunk-body a real annoyance
+  in practice (see Consequences).
+- **Attribute the hunk only to the symbol whose range it is most
+  contained within (best-match instead of first-match or all-match).**
+  Rejected for new-file hunks specifically: the one `@@ -0,0 +1,N @@`
+  hunk is not "mostly contained" in any single symbol — it spans the
+  entire file by construction, so a containment heuristic degenerates
+  to an arbitrary tie-break no more principled than first-match, while
+  adding more logic to reason about.
+- **Special-case brand-new files only (detect `old_path` absent /
+  a single hunk covering the full symbol table) and duplicate
+  attribution only in that case.** Rejected: the same silent failure
+  can occur on an existing file whenever git happens to merge several
+  symbols' changes into one hunk (Context's "large formatting pass"
+  example) — narrowing the fix to new files would leave that case
+  unfixed for no simplification benefit, since the general "intersects
+  more than one symbol" check already subsumes the new-file case
+  without a special branch.
+
+## Consequences
+
+- Every symbol row in the TUI tree now gets a working auto-scroll
+  target whenever its range intersects at least one hunk — including
+  every symbol in a brand-new file, not just the first.
+- A hunk shared by two or more adjacent/overlapping symbols is now
+  rendered once per owning section instead of once total: a reviewer
+  scrolling through a file selection sees the same lines appear under
+  more than one section header. This is a deliberate, visible trade
+  documented above, not a bug; it only occurs when symbol ranges
+  genuinely share a hunk, which ADR 0020's own Context already flagged
+  as an edge case ("possible when two symbols are adjacent with no
+  gap") rather than the common case.
+- `hunk_start_lines`'s hunk-jump table (`]c`/`[c`) now has one entry per
+  **rendered** hunk occurrence rather than one entry per underlying
+  diff hunk — a shared hunk yields multiple consecutive jump stops
+  (one per section it was duplicated into), matching what is actually
+  on screen at each stop.
+- `rinkaku-core`'s Markdown/JSON output and their own change-size
+  figures are untouched by this ADR — confirmed no shared code path
+  with `crate::diff_shape`.
+- No backward-compatibility concern: the TUI has never shipped a
+  release (ADR 0015/0016, restated by ADR 0020 and ADR 0027), so this
+  amendment applies in place rather than needing a migration.

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -243,21 +243,35 @@ fn build_file_content(report: &Report, diff_files: &[FileHunks], path: &str) -> 
     let mut module_level_hunks: Vec<AttributedHunk> = Vec::new();
 
     for (source_index, hunk) in file_hunks.hunks.iter().enumerate() {
-        // First (source-order) symbol whose range intersects this hunk —
-        // ADR 0020's "Alternatives" section rejected attributing a hunk to
-        // every overlapping symbol (would misreport total change size for
-        // exactly the summary view meant to convey it); first-match keeps
-        // every hunk under exactly one section.
-        let owner = symbols.iter().position(|symbol| {
-            crate::diff_view::hunk_intersects(hunk, symbol.range.start, symbol.range.end)
-        });
-        let attributed = AttributedHunk {
-            source_index,
-            hunk: hunk.clone(),
-        };
-        match owner {
-            Some(index) => sections[index].hunks.push(attributed),
-            None => module_level_hunks.push(attributed),
+        // Every symbol (source order) whose range intersects this hunk —
+        // ADR 0029 amends ADR 0020's original first-match-only rule: a
+        // brand-new file's diff is always exactly one hunk spanning the
+        // whole file, so first-match silently dropped every symbol but the
+        // first from the diff pane and from auto-scroll (ADR 0027 decision
+        // 2). The hunk is cloned once per matching section — see ADR 0029
+        // for why the TUI departs from ADR 0020's "duplication misleads
+        // about total change size" reasoning (the TUI has no change-size
+        // total to mislead).
+        let owners: Vec<usize> = symbols
+            .iter()
+            .enumerate()
+            .filter(|(_, symbol)| {
+                crate::diff_view::hunk_intersects(hunk, symbol.range.start, symbol.range.end)
+            })
+            .map(|(index, _)| index)
+            .collect();
+        if owners.is_empty() {
+            module_level_hunks.push(AttributedHunk {
+                source_index,
+                hunk: hunk.clone(),
+            });
+        } else {
+            for index in owners {
+                sections[index].hunks.push(AttributedHunk {
+                    source_index,
+                    hunk: hunk.clone(),
+                });
+            }
         }
     }
 
@@ -548,13 +562,18 @@ mod tests {
     }
 
     #[test]
-    fn should_attribute_overlapping_hunk_to_first_symbol_in_source_order() {
+    fn should_attribute_overlapping_hunk_to_every_symbol_it_intersects() {
         // Two symbols with adjacent, overlapping ranges (a pathological
         // input a real extractor would not normally produce, but the
-        // shaping function's contract must still resolve deterministically
-        // rather than duplicate the hunk into both sections — ADR 0020's
-        // "Alternatives" section rejected duplication as misleading about
-        // total change size).
+        // shaping function's contract must still resolve deterministically).
+        // ADR 0029 amends ADR 0020's original first-match-only rule: a hunk
+        // intersecting more than one symbol's range is now attributed to
+        // every one of them, not just the first in source order — see ADR
+        // 0029 for why the TUI diff pane departs from ADR 0020's
+        // summary-view "duplication misleads about total change size"
+        // reasoning (the TUI has no change-size total to mislead, and a
+        // dropped section silently breaks that symbol's auto-scroll — ADR
+        // 0027 decision 2 — which is the worse failure mode here).
         let report = Report {
             files: vec![FileReport {
                 path: "lib.rs".to_string(),
@@ -575,16 +594,97 @@ mod tests {
 
         let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
 
-        let expected = DiffPaneContent::File(vec![DiffSection {
-            title: "fn foo()".to_string(),
-            symbol_id: Some("lib.rs::foo".to_string()),
-            contract_header: None,
-            hunks: vec![attributed(
-                0,
-                hunk("@@ -1,1 +1,5 @@", Some((3, 4)), vec!["shared line"]),
-            )],
-        }]);
+        let expected = DiffPaneContent::File(vec![
+            DiffSection {
+                title: "fn foo()".to_string(),
+                symbol_id: Some("lib.rs::foo".to_string()),
+                contract_header: None,
+                hunks: vec![attributed(
+                    0,
+                    hunk("@@ -1,1 +1,5 @@", Some((3, 4)), vec!["shared line"]),
+                )],
+            },
+            DiffSection {
+                title: "fn bar()".to_string(),
+                symbol_id: Some("lib.rs::bar".to_string()),
+                contract_header: None,
+                hunks: vec![attributed(
+                    0,
+                    hunk("@@ -1,1 +1,5 @@", Some((3, 4)), vec!["shared line"]),
+                )],
+            },
+        ]);
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_attribute_new_file_single_hunk_to_every_symbol_it_defines() {
+        // Regression test (PR #86 dogfooding, ADR 0029): a brand-new file's
+        // diff is always exactly one hunk spanning the whole file
+        // (`@@ -0,0 +1,N @@`), so every symbol the file defines has a
+        // range inside that one hunk. Before ADR 0029, only the first
+        // symbol in source order (`foo`) ever got a section; `bar` and
+        // `baz` were silently dropped, breaking their diff-pane auto-scroll
+        // (ADR 0027 decision 2) with no error or indicator.
+        let report = Report {
+            files: vec![FileReport {
+                path: "file_size.rs".to_string(),
+                symbols: vec![
+                    symbol("file_size.rs::foo", "foo", LineRange { start: 1, end: 3 }),
+                    symbol("file_size.rs::bar", "bar", LineRange { start: 5, end: 7 }),
+                    symbol("file_size.rs::baz", "baz", LineRange { start: 9, end: 11 }),
+                ],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "file_size.rs".to_string(),
+            hunks: vec![hunk(
+                "@@ -0,0 +1,11 @@",
+                Some((1, 11)),
+                vec!["whole new file"],
+            )],
+        }];
+        let target = DiffTarget::File {
+            path: "file_size.rs".to_string(),
+        };
+
+        let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let expected_hunk = attributed(
+            0,
+            hunk("@@ -0,0 +1,11 @@", Some((1, 11)), vec!["whole new file"]),
+        );
+        let expected = DiffPaneContent::File(vec![
+            DiffSection {
+                title: "fn foo()".to_string(),
+                symbol_id: Some("file_size.rs::foo".to_string()),
+                contract_header: None,
+                hunks: vec![expected_hunk.clone()],
+            },
+            DiffSection {
+                title: "fn bar()".to_string(),
+                symbol_id: Some("file_size.rs::bar".to_string()),
+                contract_header: None,
+                hunks: vec![expected_hunk.clone()],
+            },
+            DiffSection {
+                title: "fn baz()".to_string(),
+                symbol_id: Some("file_size.rs::baz".to_string()),
+                contract_header: None,
+                hunks: vec![expected_hunk],
+            },
+        ]);
+        assert_eq!(expected, actual);
+
+        // Every symbol now resolves an auto-scroll target (ADR 0027
+        // decision 2 / decision 4) — not just the first.
+        assert_eq!(
+            Some(0),
+            section_start_line_for_symbol(&actual, "file_size.rs::foo")
+        );
+        assert!(section_start_line_for_symbol(&actual, "file_size.rs::bar").is_some());
+        assert!(section_start_line_for_symbol(&actual, "file_size.rs::baz").is_some());
     }
 
     #[test]
@@ -846,6 +946,44 @@ mod tests {
 
         let actual = hunk_start_lines(&content);
 
+        assert_eq!(vec![2, 7], actual);
+    }
+
+    #[test]
+    fn should_emit_one_hunk_jump_stop_per_section_when_a_hunk_is_shared_by_two_symbols() {
+        // ADR 0029 consequence: a hunk attributed to more than one symbol
+        // (an overlapping-range case) is rendered once per owning section,
+        // so `]c`/`[c` (backed by this table) must stop once per rendered
+        // occurrence — matching what is actually on screen — rather than
+        // deduplicating by the shared `source_index` down to one stop.
+        // Built straight from `build_diff_pane_content`'s real output
+        // (not a hand-built `DiffPaneContent`) so this test exercises the
+        // same shape the overlapping-hunk attribution test above produces.
+        let report = Report {
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![
+                    symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 5 }),
+                    symbol("lib.rs::bar", "bar", LineRange { start: 3, end: 8 }),
+                ],
+            }],
+            ..empty_report()
+        };
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk("@@ -1,1 +1,5 @@", Some((3, 4)), vec!["shared line"])],
+        }];
+        let target = DiffTarget::File {
+            path: "lib.rs".to_string(),
+        };
+        let content = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+        let actual = hunk_start_lines(&content);
+
+        // Section 0 (`foo`): title(0), blank(1), hunk header(2), 1 body
+        // line(3) — 4 lines. Blank separator(4), section 1 (`bar`)
+        // title(5), blank(6), hunk header(7) — stop at 7. Two stops for
+        // the one underlying hunk, one per section it was duplicated into.
         assert_eq!(vec![2, 7], actual);
     }
 


### PR DESCRIPTION
## Summary

The TUI diff pane's auto-scroll-to-selected-symbol (ADR 0027) silently
did nothing for every symbol but the first one defined in a file,
whenever a diff's hunk spanned more than one symbol's line range. This
was found while dogfooding an unmerged PR that adds a brand-new,
multi-symbol source file.

## Root cause

`build_file_content` (`rinkaku-tui/src/diff_shape.rs`) attributed each
hunk to exactly one symbol — the *first* one (source order) whose
range intersected it (`Iterator::position`), per ADR 0020 decision 4.
That rule was written for the rare "two adjacent symbols overlap"
case, but a **brand-new file's diff is always exactly one hunk**
(`@@ -0,0 +1,N @@` spanning the whole file), so it is the common case
for every symbol *after* the first: they intersect that one hunk too,
but always lose the `position()` lookup to the first symbol. Their
sections end up with zero hunks and get dropped
(`sections.retain(|s| !s.hunks.is_empty())`), so
`section_start_line_for_symbol` returns `None` and
`crate::run_app`'s `auto_scroll_for_diff_focus` silently no-ops — the
tree cursor moves, nothing scrolls, no error anywhere.

Reproduced with a real diff + real file content (11 symbols: an enum,
a struct, two production functions, seven test functions) — only the
first symbol (the enum) ever got a working auto-scroll target before
this fix.

An initial hypothesis was "free functions specifically don't work",
but the repro showed the struct and enum were equally affected — the
real trigger is "one hunk intersecting more than one symbol's range",
which a new file's diff guarantees for every symbol but the first.

## Fix

Per new [ADR 0029](docs/adr/0029-diff-pane-multi-symbol-hunk-attribution.md)
(amends ADR 0020 decision 4, scoped to the TUI diff pane only —
`rinkaku-core`'s Markdown/JSON output is untouched):

- `build_file_content` now attributes a hunk to **every** symbol whose
  range it intersects, not just the first — the hunk is cloned once
  per matching section (same pattern `AttributedHunk` already used per
  section).
- `hunk_start_lines` needed no code change: it already walks
  per-section, so a hunk now shared by two sections correctly produces
  two `]c`/`[c` jump stops (one per rendered occurrence) rather than
  being silently deduplicated.

The ADR explains why the TUI departs from ADR 0020's original
"duplication misleads about total change size" reasoning: that
reasoning was scoped to summary views with a change-size total to
mislead (Markdown/JSON), which the TUI diff pane has none of — its
purpose is per-symbol orientation, and a dropped section breaks that
contract outright rather than merely double-counting a total nobody is
computing.

## Test plan

- [x] Reproduced the bug first with a Red test built from a real
      PR's new-file diff (one hunk, 11 symbols) — only the first
      symbol resolved an auto-scroll target.
- [x] `should_attribute_new_file_single_hunk_to_every_symbol_it_defines`
      (new): mirrors that real shape (one hunk, 3 symbols), asserts
      every symbol gets its own section and a working auto-scroll
      target.
- [x] `should_attribute_overlapping_hunk_to_every_symbol_it_intersects`
      (rewritten from the old first-match-only test): asserts the
      shared hunk lands in both overlapping symbols' sections.
- [x] `should_emit_one_hunk_jump_stop_per_section_when_a_hunk_is_shared_by_two_symbols`
      (new): built from `build_diff_pane_content`'s real output,
      confirms `]c`/`[c` gets one stop per rendered occurrence.
- [x] `make test` — **1005 passed**, 0 failed (161 rinkaku + 336 core + 508 tui)
- [x] `make lint` clean (fmt + clippy `-D warnings`)
- [x] Dynamic verification: built the CLI (`cargo build`), fed it the
      isolated new-file diff (real content, one hunk, 11 symbols) —
      exits 0, correct JSON with all 11 symbols, no panic. Also
      confirmed the pre-existing, correct "file not on disk" error
      path (no panic, clean `ReadFile` error) when piping a diff whose
      referenced file isn't checked out locally.

## Dogfooding note

This bug was found via the map-assisted + independent + dynamic
verification review workflow this repo's `CLAUDE.md` requires — the
dynamic-verification step (actually running the CLI against a real
diff, not just reading code) is what surfaced it in the first place.