### PR TITLE
feat(tui): sync tree cursor to symbol when diff pane is scrolled

### DIFF
--- a/docs/adr/0030-diff-scroll-syncs-tree-selection.md
+++ b/docs/adr/0030-diff-scroll-syncs-tree-selection.md
@@ -232,11 +232,29 @@ ADR needs to touch.
   already established as this crate's canonical example — `lib.rs` had
   already crossed the 1500-line warn threshold (ADR 0028) primarily on
   test-code weight, and this ADR's own new tests would have pushed it
-  further. Production code in `lib.rs` now sits at roughly 1100 lines
-  (the 1000-1500 "watch" band, no action required); `tests.rs` itself
-  is under the 2000-line split threshold. This is bookkeeping the ADR
-  performs as part of implementing decision 6's new function, not a
-  separate structural decision of its own.
+  further. Production code in `lib.rs` now sits at roughly 1130 lines
+  (the 1000-1500 "watch" band, no action required) after the split.
+  This is bookkeeping the ADR performs as part of implementing
+  decision 6's new function, not a separate structural decision of
+  its own.
+- **Two files still cross the 1500-line warn threshold after this
+  PR**, per rinkaku's own dogfooded `## File size warnings` output
+  (CLAUDE.md's "rinkaku's own warning is authoritative" rule, so this
+  is recorded rather than silently merged past): the new
+  `rinkaku-tui/src/tests.rs` itself, at 1619 lines (moved wholesale out
+  of `lib.rs`, still under the 2000-line split threshold, and this
+  ADR's own new tests are a small fraction of it), and
+  `rinkaku-tui/src/app/mod.rs`, which this ADR's `+24`-line
+  `sync_tree_cursor_to_symbol` addition pushed from 1480 to 1504 —
+  just over the line. Neither is split in this PR: `tests.rs` has no
+  natural sub-responsibility to carve out (it is one flat suite for
+  `App`'s key-translation/dispatch surface, not several independent
+  concerns per CLAUDE.md's "split along responsibility, not line
+  count" rule), and `app/mod.rs` crossing by 4 lines from one small,
+  cohesive method addition is not itself a signal that a split is due
+  now — both are left as a known, acknowledged watch item for a future
+  PR that touches either file for its own reason, rather than forcing
+  an unrelated split into this one.
 - No backward-compatibility concern: the TUI has never shipped a
   release (ADR 0015/0016, restated by every TUI-scoped ADR since),
   so this amendment applies in place.

--- a/docs/adr/0030-diff-scroll-syncs-tree-selection.md
+++ b/docs/adr/0030-diff-scroll-syncs-tree-selection.md
@@ -1,0 +1,242 @@
+# 0030. Manual diff-pane scrolling syncs the tree cursor back to the visible symbol
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+ADR 0027 made the tree cursor drive the diff pane: selecting a symbol
+row auto-scrolls the right pane to that symbol's section (decision 2),
+and decision 5 explicitly chose the opposite direction to be a
+one-way street — "**Symbol-move preserves auto-scroll, not the manual
+scroll offset**... A reviewer who scrolled by hand within one symbol's
+section and then moves the cursor to a sibling symbol gets the
+sibling's section start — not their prior manual offset translated
+onto the new section." That decision was about what happens to the
+*scroll offset* when the *cursor* moves; it did not say anything about
+what should happen to the *cursor* when the reviewer scrolls the pane
+by hand instead, because at the time nothing built that direction of
+sync. In practice the two directions read as one-way sync: cursor
+movement scrolls the pane, but scrolling the pane never updates the
+cursor.
+
+Dogfooding on ADR 0027/0029's own diff pane found this asymmetry
+disorienting during an actual review pass: with `Focus::Right` and a
+file selected, holding `j`/`k` (or the mouse wheel, ADR — mouse wheel
+support, PR #84 — which is just `Up`/`Down` under a different input
+source, per `translate_mouse_event`) scrolls down through several
+symbols' sections in sequence, but the tree's cursor and Detail-pane-
+style status stay frozen on whichever symbol was selected before the
+scroll started. A reviewer who scrolls three sections down, then
+presses `h`/`Esc` to return to `Focus::Tree` to open that symbol's own
+Detail view or jump elsewhere, lands back on the *original* symbol
+instead of the one they were just reading — exactly the "where am I"
+problem a source-control web UI's split diff view does not have:
+GitHub's/GitLab's file-tree sidebar highlights whichever file is
+scrolled into view, so switching context (e.g. to comment, or open a
+different file) starts from "where you actually are," not "where you
+started." The diff pane's whole point (ADR 0015: TUI review surface)
+is to let the reviewer treat scrolling and cursor movement as one
+continuous "reading position," not two independently-tracked cursors
+that can silently diverge.
+
+## Decision
+
+**1. Manual right-pane scrolling re-syncs the tree cursor to the
+visible symbol's section, one-way (diff → tree), the mirror image of
+ADR 0027's tree → diff sync.** After any key that changes
+`right_pane_scroll` while `Focus::Right` and `RightPane::Diff` is
+showing (`j`/`k`, the ADR 0026 half-page/top-bottom keys, `]c`/`[c`,
+and mouse wheel — every one of them already funnels through the same
+`right_pane_scroll` mutation, per `translate_mouse_event`'s own doc
+comment "wheel input always acts on whichever pane already has
+focus, exactly like a keyboard j/k press would"), `crate::run_app`
+looks up which symbol section the new scroll offset's line falls
+inside and, if that differs from the tree's current symbol, moves the
+tree cursor there.
+
+**2. The reverse lookup is a new pure function,
+`crate::diff_shape::symbol_id_for_scroll_line`,** sitting next to
+`section_start_line_for_symbol` (the forward lookup ADR 0027 already
+added) and reusing the same `walk_sections` layout table — the two
+functions are literal mirror images (`symbol_id -> start_line` vs.
+`start_line -> symbol_id`) and belong in the same module for the same
+reason `hunk_start_lines`/`section_start_line_for_symbol` already share
+`walk_sections` rather than each re-deriving the layout.
+
+**3. Lines with no owning symbol section do not move the cursor.**
+Two cases produce this: the scroll offset sits inside the
+`"(module level)"` bucket (a hunk touching no symbol — imports, a
+module-level `use` change), or past the end of every section (an
+overscroll about to be clamped by `crate::ui::clamp_scroll` next
+frame, or briefly during a terminal resize). Both cases return `None`
+from `symbol_id_for_scroll_line`, and `run_app` leaves the tree cursor
+exactly where it was. Moving the cursor to *some* nearby symbol
+anyway (nearest-section heuristics, "last symbol before this line")
+was considered and rejected: the module-level bucket has no
+`symbol_id` at all by construction (`DiffSection::symbol_id: None`,
+ADR 0020 decision 4), so "the nearest symbol" would be a guess this
+ADR has no principled way to make, and a guessed cursor jump reads as
+more disorienting than simply not moving — the reviewer is looking at
+content, just not any one symbol's content, and the tree cursor
+staying put reflects that honestly.
+
+**4. A tree row hidden under a collapsed ancestor is expanded, not
+skipped.** Reuses `Nav::move_cursor_to_symbol`'s existing behavior
+unchanged (ADR 0022's jump-navigation precedent: "a mid-session jump
+target is very likely to be folded away by the time the reviewer
+presses `gd`/`gr`... this method expands whatever stands in the way
+instead of giving up"). The same reasoning applies here with more
+force: `move_cursor_to_path`'s alternative "no-op if hidden" contract
+exists for a *startup-time* pivot where a fresh, fully-expanded `App`
+folding is a genuine caller error; a scrolling-driven sync happens
+continuously mid-session, when the reviewer may well have collapsed
+the very directory the pane is currently scrolled into (e.g. they
+collapsed it after opening a different file's diff, then scrolled the
+still-open pane back past that boundary). Silently refusing to sync
+in that case would reintroduce exactly the "frozen cursor" problem
+this ADR exists to fix, just gated on fold state instead of on
+`Focus`.
+
+**5. New method `App::sync_tree_cursor_to_symbol`, not
+`App::jump_to_symbol`.** `jump_to_symbol` (ADR 0022) does three things
+the scroll-sync must *not* do: it pushes the current position onto the
+jumplist's back-stack, clears the forward-stack, and resets
+`right_pane_scroll` to 0. All three are correct for an explicit
+`gd`/`gr` jump (a deliberate navigation the reviewer should be able to
+undo with `Ctrl-o`, landing on a fresh section top) and wrong for a
+passive scroll-follow (recording every scroll-crossed symbol as a
+jumplist entry would flood the jumplist with noise the reviewer never
+asked to navigate through, and resetting the very `right_pane_scroll`
+that triggered this whole sync would fight the scroll the reviewer
+just performed). The new method only moves `self.nav` via
+`Nav::move_cursor_to_symbol` (decision 4) and touches nothing else —
+no jumplist, no scroll write.
+
+**6. The feedback-loop guard: `last_diff_focus` must be updated by the
+sync, not just read by it.** ADR 0027 decision 2's existing loop
+(`crate::run_app`) already tracks `last_diff_focus` and only fires the
+tree→diff auto-scroll when `app.selected_diff_focus(report)` differs
+from it since the previous handled key — precisely to stop the
+auto-scroll from re-firing on every idle-equivalent key and snapping
+the pane back to the section top (that guard's own comment: "firing
+auto-scroll unconditionally here would overwrite the reviewer's own
+j/k... scrolling immediately after they pressed it"). Without this
+ADR's sync writing its own new cursor position into `last_diff_focus`
+*before* the loop iteration ends, the *next* handled key would see
+`app.selected_diff_focus(report)` (now the synced symbol) differ from
+the stale `last_diff_focus` (still the pre-scroll symbol), treat that
+as a genuine cursor-driven selection change, and fire
+`auto_scroll_for_diff_focus` — snapping `right_pane_scroll` right back
+to the section start the reviewer had just scrolled past. `run_app`'s
+new scroll→tree step therefore ends by setting
+`last_diff_focus = app.selected_diff_focus(report)` (the post-sync
+value) whenever the sync moved the cursor, closing the loop in the
+same handled-key iteration rather than leaving it to resolve itself
+one keypress later (verified by a regression test — see Consequences
+— that a scroll immediately followed by another scroll key does not
+reset `right_pane_scroll`).
+
+**7. `h`/Esc back to `Focus::Tree` keeps ADR 0020's existing
+scroll-reset rule unchanged.** `App::handle_key`'s blanket
+"reset `right_pane_scroll` to 0 on every key except the `Focus::Right`
+scroll exceptions" still runs for `InputKey::FocusLeft` — returning to
+`Focus::Tree` resets the pane's scroll the same way it always has.
+This ADR does not change that: the cursor now correctly reflects
+where the reviewer scrolled to (decision 1), so pressing `h`/Esc opens
+Detail/BlastRadius/whatever comes next for the *right* symbol; the
+diff pane itself resetting to that symbol's own section top on the
+next re-entry to `RightPane::Diff` (ADR 0027 decision 2's ordinary
+auto-scroll) is the existing, desired behavior, not a regression this
+ADR needs to touch.
+
+## Alternatives
+
+- **Two-way live binding (keep cursor and scroll offset as one
+  continuously-reconciled value) instead of a one-shot sync per
+  handled key.** Rejected as unnecessary complexity: `run_app`'s
+  existing per-key dispatch loop (ADR 0020's caching discipline) only
+  ever recomputes derived state once per handled key, never per draw
+  frame — a "continuous" binding would still, in practice, resolve to
+  exactly this ADR's per-key sync, just described with a fuzzier name.
+- **Move the cursor to the nearest symbol when the scroll offset falls
+  in the module-level bucket or past the end of content**, instead of
+  leaving the cursor untouched (decision 3). Rejected: see decision
+  3's own reasoning — no principled "nearest" definition exists for a
+  bucket that structurally has no `symbol_id`, and a guessed jump is a
+  worse UX than no jump.
+- **Reuse `App::jump_to_symbol` directly, accepting the jumplist noise
+  and scroll reset as a known cost.** Rejected outright: the scroll
+  reset would make the sync fight its own trigger (scrolling to line
+  40 would sync the cursor, which would reset scroll to 0, undoing the
+  very scroll that triggered it) — not a tunable trade-off, a
+  correctness bug. `App::sync_tree_cursor_to_symbol` (decision 5) was
+  the only viable shape once that was clear.
+- **Gate the sync on a debounce/threshold (e.g. only sync after the
+  cursor has been inside a section for N frames) to avoid rapid
+  cursor flicker during a fast scroll (holding `j` or a fast wheel
+  spin).** Rejected: `run_app` only recomputes derived state once per
+  *handled key* (decision 6's own point), and a human holding a key or
+  spinning a wheel still generates one discrete `Up`/`Down` event per
+  physical tick — there is no sub-key-press frame rate to debounce
+  against in this architecture, so a debounce would add a state
+  machine for a problem that structurally cannot occur here.
+- **Sync eagerly inside `App::handle_key` itself** (folding the lookup
+  into the same method that mutates `right_pane_scroll`) rather than
+  as a separate step in `crate::run_app`. Rejected: `App::handle_key`
+  has no access to `report`/`diff_pane_content` (the same reason
+  `NextHunk`/`PrevHunk`'s hunk-jump target and ADR 0027's auto-scroll
+  itself both already live in `crate::run_app` instead of `App` —
+  `InputKey::NextHunk`'s own doc comment on why), so this ADR's sync
+  joins that existing precedent rather than breaking it.
+
+## Consequences
+
+- The tree cursor and the diff pane's visible content can no longer
+  silently diverge while `Focus::Right` is showing `RightPane::Diff`:
+  scrolling past a symbol's section moves the cursor onto it, mirrored
+  by ADR 0027's existing "selecting a symbol scrolls to it" direction.
+  `h`/Esc back to `Focus::Tree` now reliably opens Detail/BlastRadius/
+  Source for whichever symbol the reviewer was actually reading, not
+  whichever symbol they started reading from.
+- `crate::diff_shape` gains one new pure function
+  (`symbol_id_for_scroll_line`) with its own unit tests, mirroring
+  `section_start_line_for_symbol`'s existing test shape — no new
+  `ratatui`/IO dependency, keeping the module's "pure view-model" scope
+  unchanged.
+- `crate::app::App` gains one new method
+  (`sync_tree_cursor_to_symbol`) that is deliberately *not*
+  `jump_to_symbol`: no jumplist entries are recorded for scroll-driven
+  cursor moves, so `Ctrl-o`/`Ctrl-i` (jump back/forward, ADR 0022)
+  continue to reflect only explicit `gd`/`gr` navigation, unpolluted
+  by passive scrolling — a scroll session through ten symbols does not
+  leave ten jumplist entries behind.
+- `crate::run_app`'s loop body gains a new "did the scroll offset
+  change and, if so, does it point at a different symbol" step. The
+  diff-content-recompute-plus-both-sync-directions sequence (ADR 0027's
+  auto-scroll and this ADR's scroll→tree sync) is extracted into its
+  own pure `apply_diff_pane_selection_effects` function — mirroring why
+  `dispatch_non_source_key` (ADR 0022) exists as a separate function at
+  all: `run_app` itself takes a live `ratatui::DefaultTerminal` and
+  cannot be driven directly in a test, so a bug in the *sequencing* of
+  two dispatched keys (as opposed to a bug in one branch's own logic)
+  would otherwise have no regression coverage. A dedicated test calls
+  this function twice back-to-back, simulating two consecutive scroll
+  keys, and asserts the second key's own scroll motion survives
+  untouched — pinning decision 6's feedback-loop guard directly rather
+  than only through code review.
+- This PR also moves `crate::lib.rs`'s test module out to a sibling
+  `tests.rs` (`#[cfg(test)] #[path = "tests.rs"] mod tests;`), the same
+  co-location-but-not-counted pattern CLAUDE.md's file-size discipline
+  documents and PR #82's `rinkaku-tui/src/app/{mod,input_key,tests}.rs`
+  already established as this crate's canonical example — `lib.rs` had
+  already crossed the 1500-line warn threshold (ADR 0028) primarily on
+  test-code weight, and this ADR's own new tests would have pushed it
+  further. Production code in `lib.rs` now sits at roughly 1100 lines
+  (the 1000-1500 "watch" band, no action required); `tests.rs` itself
+  is under the 2000-line split threshold. This is bookkeeping the ADR
+  performs as part of implementing decision 6's new function, not a
+  separate structural decision of its own.
+- No backward-compatibility concern: the TUI has never shipped a
+  release (ADR 0015/0016, restated by every TUI-scoped ADR since),
+  so this amendment applies in place.

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -671,6 +671,30 @@ impl App {
         self
     }
 
+    /// Moves the tree cursor to `symbol_id` (ADR 0030: manual diff-pane
+    /// scrolling syncs the cursor back to the visible symbol), expanding
+    /// collapsed ancestors on the way via [`Nav::move_cursor_to_symbol`] —
+    /// same underlying move [`Self::jump_to_symbol`] performs, but
+    /// deliberately *not* that method: this sync must not push a jumplist
+    /// entry (a scroll session through several symbols would otherwise
+    /// flood `Ctrl-o`/`Ctrl-i`'s history with moves the reviewer never
+    /// asked to navigate through — ADR 0022's jumplist is for explicit
+    /// `gd`/`gr` jumps only) and must not reset [`Self::right_pane_scroll`]
+    /// (the scroll offset that just triggered this sync is exactly the
+    /// value the caller wants preserved — resetting it here would make the
+    /// sync fight its own trigger). A no-op (returning `self` unchanged,
+    /// no status message — unlike `jump_to_symbol`'s, since a missing
+    /// symbol here is an ordinary transient case, e.g. mid-recompute after
+    /// a report reload, not a reviewer-facing navigation failure) when no
+    /// row's symbol id matches `symbol_id`.
+    pub fn sync_tree_cursor_to_symbol(mut self, symbol_id: &str) -> Self {
+        let mut nav = self.nav.clone();
+        if nav.move_cursor_to_symbol(&self.tree, symbol_id) {
+            self.nav = nav;
+        }
+        self
+    }
+
     /// Opens the jump-target popup (ADR 0022) over `candidates` — called by
     /// `crate::run_app` once it has resolved more than one candidate for a
     /// pending `gd`/`gr` (`InputKey::GotoDefinition`/`GotoReferences`'s own

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -148,6 +148,42 @@ pub fn section_start_line_for_symbol(content: &DiffPaneContent, symbol_id: &str)
         .map(|(_, _, section_start, _)| section_start)
 }
 
+/// The mirror image of [`section_start_line_for_symbol`] (ADR 0030): given
+/// `scroll_line` (the same "requested-scroll unit" both that function and
+/// [`hunk_start_lines`] use — [`crate::app::App::right_pane_scroll`]'s own
+/// value), finds which section's rendered span `scroll_line` falls inside
+/// and returns that section's `symbol_id`. A section's span runs from its
+/// own start line (inclusive) up to the next section's start line
+/// (exclusive), or through the end of the content for the last section —
+/// so scrolling anywhere within a symbol's title/contract-header/hunks
+/// resolves to that symbol, not just its exact first line.
+///
+/// Returns `None` in two cases `crate::run_app`'s caller treats
+/// identically (ADR 0030 decision 3 — leave the tree cursor untouched
+/// rather than guess): `scroll_line` falls inside the
+/// `"(module level)"` bucket (`DiffSection::symbol_id: None` by
+/// construction, same as [`section_start_line_for_symbol`]'s own
+/// module-level exclusion), or `scroll_line` is past the end of every
+/// section (an overscroll about to be clamped by `crate::ui::clamp_scroll`
+/// next frame) — also `None` on [`DiffPaneContent::Empty`].
+pub fn symbol_id_for_scroll_line(content: &DiffPaneContent, scroll_line: usize) -> Option<&str> {
+    let sections: Vec<(usize, &DiffSection, usize, Vec<usize>)> = walk_sections(content).collect();
+    let (_, (_, section, _, _)) =
+        sections
+            .iter()
+            .enumerate()
+            .find(|(index, (_, _, start, _))| {
+                let next_start = sections
+                    .get(index + 1)
+                    .map(|(_, _, next_start, _)| *next_start);
+                match next_start {
+                    Some(next_start) => (*start..next_start).contains(&scroll_line),
+                    None => scroll_line >= *start,
+                }
+            })?;
+    section.symbol_id.as_deref()
+}
+
 /// One entry per section for line-counting consumers ([`hunk_start_lines`]
 /// and [`section_start_line_for_symbol`] both need the exact same layout
 /// walk, kept in one place so a change to
@@ -1119,5 +1155,142 @@ mod tests {
         let actual = section_start_line_for_symbol(&content, "lib.rs::nonexistent");
 
         assert_eq!(None, actual);
+    }
+
+    // --- symbol_id_for_scroll_line (ADR 0030) ---
+
+    #[test]
+    fn should_return_none_for_scroll_line_when_content_is_empty() {
+        let actual = symbol_id_for_scroll_line(&DiffPaneContent::Empty, 0);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_return_the_only_symbol_when_scroll_line_is_its_title_line() {
+        // Only section: title(0), blank(1), header(2), body(3).
+        let content = DiffPaneContent::File(vec![DiffSection {
+            title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+            )],
+        }]);
+
+        let actual = symbol_id_for_scroll_line(&content, 0);
+
+        assert_eq!(Some("lib.rs::foo"), actual);
+    }
+
+    #[test]
+    fn should_return_the_only_symbol_when_scroll_line_is_inside_its_hunk_body_not_just_its_title() {
+        // Same layout as above; scroll_line 3 (the hunk body line, not the
+        // title at 0) must still resolve to the same symbol — a section's
+        // span covers every line inside it, not just its first.
+        let content = DiffPaneContent::File(vec![DiffSection {
+            title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+            )],
+        }]);
+
+        let actual = symbol_id_for_scroll_line(&content, 3);
+
+        assert_eq!(Some("lib.rs::foo"), actual);
+    }
+
+    #[test]
+    fn should_return_the_second_symbol_when_scroll_line_falls_inside_its_section() {
+        // Section 0 (`foo`): title(0), blank(1), header(2), body(3) — 4
+        // lines. Blank separator(4), section 1 (`bar`) title(5), blank(6),
+        // header(7). scroll_line 5 (bar's own title) and 6/7 must all
+        // resolve to `bar`, not `foo`.
+        let content = DiffPaneContent::File(vec![
+            DiffSection {
+                title: "fn foo()".to_string(),
+                symbol_id: Some("lib.rs::foo".to_string()),
+                contract_header: None,
+                hunks: vec![attributed(
+                    0,
+                    hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+                )],
+            },
+            DiffSection {
+                title: "fn bar()".to_string(),
+                symbol_id: Some("lib.rs::bar".to_string()),
+                contract_header: None,
+                hunks: vec![attributed(
+                    1,
+                    hunk("@@ -10,1 +10,2 @@", Some((10, 11)), vec!["fn bar() {}"]),
+                )],
+            },
+        ]);
+
+        assert_eq!(Some("lib.rs::bar"), symbol_id_for_scroll_line(&content, 5));
+        assert_eq!(Some("lib.rs::bar"), symbol_id_for_scroll_line(&content, 7));
+        // The boundary immediately before section 1 still belongs to
+        // section 0.
+        assert_eq!(Some("lib.rs::foo"), symbol_id_for_scroll_line(&content, 4));
+    }
+
+    #[test]
+    fn should_return_none_when_scroll_line_falls_inside_the_module_level_bucket() {
+        // ADR 0030 decision 3: the module-level bucket has `symbol_id:
+        // None` by construction, so a scroll line landing there must not
+        // resolve to any symbol — not even the nearest one.
+        let content = DiffPaneContent::File(vec![
+            DiffSection {
+                title: "fn foo()".to_string(),
+                symbol_id: Some("lib.rs::foo".to_string()),
+                contract_header: None,
+                hunks: vec![attributed(
+                    0,
+                    hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+                )],
+            },
+            DiffSection {
+                title: MODULE_LEVEL_TITLE.to_string(),
+                symbol_id: None,
+                contract_header: None,
+                hunks: vec![attributed(
+                    1,
+                    hunk("@@ -20,1 +20,2 @@", Some((20, 21)), vec!["use foo::bar;"]),
+                )],
+            },
+        ]);
+
+        // Module-level section starts at line 5 (same layout math as the
+        // two-symbol test above).
+        let actual = symbol_id_for_scroll_line(&content, 5);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_return_the_last_symbol_when_scroll_line_is_past_every_section_start_but_still_within_it()
+     {
+        let content = DiffPaneContent::File(vec![DiffSection {
+            title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
+            contract_header: None,
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo() {}"]),
+            )],
+        }]);
+
+        // Line 100 is past the section's actual rendered content (4 lines
+        // total) but there is no *next* section to bound it — the last
+        // section's span is open-ended, matching an overscroll that is
+        // about to be clamped by `crate::ui::clamp_scroll` next frame
+        // rather than a position inside some other symbol.
+        let actual = symbol_id_for_scroll_line(&content, 100);
+
+        assert_eq!(Some("lib.rs::foo"), actual);
     }
 }

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -1,13 +1,16 @@
-//! Diff-pane content shaping (ADR 0020, ADR 0027): given the row currently
-//! selected in the entry view (a symbol or a file) plus the already-parsed
-//! diff hunks (`crate::diff_view`), decides how the diff pane groups and
-//! annotates that content. Per ADR 0027, both symbol-row and file-row
-//! selections now produce the same file-scoped shape: hunks grouped under
-//! per-symbol section headers (unchanged from ADR 0020's file-selection
-//! semantics), with each section carrying an optional `symbol_id` so
-//! `crate::run_app` can look up the selected symbol's section start and
-//! auto-scroll to it. The old `DiffPaneContent::Symbol` clip variant is gone
-//! (ADR 0027 decision 1).
+//! Diff-pane content shaping (ADR 0020, ADR 0027, ADR 0030): given the row
+//! currently selected in the entry view (a symbol or a file) plus the
+//! already-parsed diff hunks (`crate::diff_view`), decides how the diff
+//! pane groups and annotates that content. Per ADR 0027, both symbol-row
+//! and file-row selections now produce the same file-scoped shape: hunks
+//! grouped under per-symbol section headers (unchanged from ADR 0020's
+//! file-selection semantics), with each section carrying an optional
+//! `symbol_id` so `crate::run_app` can look up the selected symbol's
+//! section start and auto-scroll to it. The old `DiffPaneContent::Symbol`
+//! clip variant is gone (ADR 0027 decision 1). ADR 0030 adds the mirror
+//! image — [`symbol_id_for_scroll_line`] resolves a scroll offset back to
+//! the symbol whose section it falls inside, so `crate::run_app` can sync
+//! the tree cursor when the reviewer scrolls the pane manually.
 //!
 //! Each section whose symbol's contract changed gets a 2-line old/new
 //! signature header up front.

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -316,6 +316,14 @@ fn run_app(
         };
 
         if let Some(input_key) = translated_input_key {
+            // ADR 0030: captured before dispatch so the scroll->tree sync
+            // below can tell whether *this* key actually moved
+            // `right_pane_scroll` — comparing against the value at loop-top
+            // rather than re-deriving it from `input_key` itself, since
+            // several different keys (`Up`/`Down`, the four ADR 0026 scroll
+            // variants, `]c`/`[c`) can all change the scroll offset and this
+            // sync applies uniformly to any of them.
+            let scroll_before_dispatch = app.right_pane_scroll();
             if let InputKey::Source = input_key {
                 app = app.handle_key(input_key);
                 if let Screen::Source { symbol_id, .. } = app.screen().clone()
@@ -399,35 +407,154 @@ fn run_app(
                 blast_radius_selection = app.selected_blast_radius_view(report);
             }
             if should_recompute_diff_pane_content(&app) {
-                diff_pane_content = diff_shape::build_diff_pane_content(
+                let effects = apply_diff_pane_selection_effects(
+                    app,
                     report,
                     &diff_hunks,
-                    app.selected_diff_target(report).as_ref(),
+                    last_diff_focus,
+                    scroll_before_dispatch,
                 );
-                // ADR 0027 decision 2: auto-scroll to the focused symbol's
-                // section start only when the focus *actually changed* since
-                // the previous key. `should_recompute_diff_pane_content` is
-                // `true` on every key while Diff is showing (it just gates
-                // the cache rebuild, not a selection-change signal), so
-                // firing auto-scroll unconditionally here would overwrite
-                // the reviewer's own `j`/`k`/`Ctrl-d` scrolling immediately
-                // after they pressed it (dogfooding finding: Enter into
-                // Focus::Right + subsequent `j`/`k` had no visible effect
-                // because this override snapped back to the section start
-                // every keystroke). Only when the tree cursor lands on a
-                // different symbol do we retarget the pane.
-                let next_focus = app.selected_diff_focus(report);
-                if next_focus != last_diff_focus {
-                    last_diff_focus = next_focus;
-                    if let Some(target_scroll) =
-                        auto_scroll_for_diff_focus(&app, report, &diff_pane_content)
-                    {
-                        app = app.with_right_pane_scroll(target_scroll);
-                    }
-                }
+                app = effects.app;
+                diff_pane_content = effects.diff_pane_content;
+                last_diff_focus = effects.last_diff_focus;
             }
         }
     }
+}
+
+/// The result of [`apply_diff_pane_selection_effects`]: the next `App`,
+/// the diff pane's freshly rebuilt shaped content, and the `last_diff_focus`
+/// value `crate::run_app`'s loop should carry into the next handled key.
+/// Grouped into one struct rather than a tuple so the three fields keep
+/// their names at every call site (all three change together, and a
+/// positional tuple would invite a `(app, content, focus)` vs.
+/// `(app, focus, content)` mix-up the first time this function's argument
+/// order is touched).
+struct DiffPaneSelectionEffects {
+    app: App,
+    diff_pane_content: diff_shape::DiffPaneContent,
+    last_diff_focus: Option<app::DiffFocus>,
+}
+
+/// Rebuilds the diff pane's shaped content for the just-dispatched key and
+/// applies both directions of ADR 0027/ADR 0030's cursor<->scroll sync,
+/// given `last_diff_focus` (the tree-cursor-driven focus as of the
+/// *previous* handled key) and `scroll_before_dispatch` (`right_pane_scroll`
+/// as of *before* this key's dispatch, ADR 0030's own doc comment on why
+/// scroll-vs-focus need two different "before" snapshots).
+///
+/// Extracted out of `run_app`'s loop body for the same reason
+/// `dispatch_non_source_key` was (that function's own doc comment): a bug
+/// in the *sequencing* of "rebuild content, then decide which sync
+/// direction fires" has no regression coverage when every existing test
+/// only exercises `auto_scroll_for_diff_focus`/`sync_target_for_scroll` in
+/// isolation — ADR 0030 decision 6's feedback-loop guard specifically
+/// depends on `last_diff_focus` being updated *within* this same step, a
+/// property only a test that calls this exact function back-to-back for
+/// two simulated keys can pin.
+///
+/// **Exactly one** of ADR 0027's tree->diff auto-scroll or ADR 0030's
+/// diff->tree cursor sync can fire per call, never both: the auto-scroll
+/// branch only runs when `selected_diff_focus` changed since
+/// `last_diff_focus` (a cursor-driven selection change), and the sync
+/// branch's `else` only runs when it did not — the two conditions are
+/// complements of each other by construction, matching decision 6's "the
+/// two directions must not re-trigger one another in the same step" rule.
+fn apply_diff_pane_selection_effects(
+    mut app: App,
+    report: &Report,
+    diff_hunks: &[diff_view::FileHunks],
+    last_diff_focus: Option<app::DiffFocus>,
+    scroll_before_dispatch: usize,
+) -> DiffPaneSelectionEffects {
+    let diff_pane_content = diff_shape::build_diff_pane_content(
+        report,
+        diff_hunks,
+        app.selected_diff_target(report).as_ref(),
+    );
+    // ADR 0027 decision 2: auto-scroll to the focused symbol's section
+    // start only when the focus *actually changed* since the previous key.
+    // The caller's `should_recompute_diff_pane_content` gate is `true` on
+    // every key while Diff is showing (it just gates the cache rebuild,
+    // not a selection-change signal), so firing auto-scroll
+    // unconditionally here would overwrite the reviewer's own
+    // `j`/`k`/`Ctrl-d` scrolling immediately after they pressed it
+    // (dogfooding finding: Enter into Focus::Right + subsequent `j`/`k`
+    // had no visible effect because this override snapped back to the
+    // section start every keystroke). Only when the tree cursor lands on
+    // a different symbol do we retarget the pane.
+    let next_focus = app.selected_diff_focus(report);
+    let last_diff_focus = if next_focus != last_diff_focus {
+        if let Some(target_scroll) = auto_scroll_for_diff_focus(&app, report, &diff_pane_content) {
+            app = app.with_right_pane_scroll(target_scroll);
+        }
+        next_focus
+    } else if let Some(target_symbol_id) =
+        sync_target_for_scroll(&app, &diff_pane_content, scroll_before_dispatch)
+    {
+        // ADR 0030: the mirror-image sync — this key's dispatch did not
+        // itself move the cursor (`next_focus == last_diff_focus`, the `if`
+        // branch above), but it did move `right_pane_scroll` onto a
+        // *different* symbol's section than the cursor is currently on, so
+        // move the cursor to match. The returned `last_diff_focus` is the
+        // post-sync focus, not the pre-sync `next_focus` — critical to
+        // avoid the auto-scroll-vs-scroll-sync feedback loop decision 6
+        // documents: without this, the next handled key would see
+        // `selected_diff_focus` (now the synced symbol) differ from a
+        // stale `last_diff_focus` (still the pre-scroll symbol), treat that
+        // as a fresh cursor-driven selection change, and auto-scroll
+        // `right_pane_scroll` right back to that symbol's section start —
+        // undoing the very scroll that triggered this sync.
+        app = app.sync_tree_cursor_to_symbol(&target_symbol_id);
+        app.selected_diff_focus(report)
+    } else {
+        next_focus
+    };
+    DiffPaneSelectionEffects {
+        app,
+        diff_pane_content,
+        last_diff_focus,
+    }
+}
+
+/// The symbol id `crate::run_app`'s scroll->tree sync (ADR 0030) should
+/// move the tree cursor to, or `None` when no sync should happen this key —
+/// extracted as its own pure function (mirroring
+/// [`auto_scroll_for_diff_focus`]/[`jump_scroll_target`]'s own precedent)
+/// so the gating logic is unit-testable without a live
+/// `ratatui::DefaultTerminal`.
+///
+/// `None` when: the right pane isn't showing the diff pane with focus on it
+/// (`should_apply_hunk_jump`'s own focus/pane gate — scrolling a pane that
+/// isn't the diff pane, e.g. Detail/BlastRadius, has no per-symbol section
+/// to sync against); this key's dispatch did not actually change
+/// `right_pane_scroll` from `scroll_before_dispatch` (a key that reached
+/// this point already passed the "focus didn't change" check above, but
+/// plenty of keys — `Enter`, `d`, `?`, arbitrary no-ops — reach here without
+/// touching scroll at all, and re-deriving the same symbol id every one of
+/// those keys would be wasted work, not just a correctness no-op);
+/// [`diff_shape::symbol_id_for_scroll_line`] resolves to `None` (ADR 0030
+/// decision 3: the module-level bucket or past-content overscroll, where
+/// there is no principled symbol to sync to); or the resolved symbol id is
+/// already the one currently focused (nothing to do — most scroll keys that
+/// stay within the same section land here).
+fn sync_target_for_scroll(
+    app: &App,
+    diff_pane_content: &diff_shape::DiffPaneContent,
+    scroll_before_dispatch: usize,
+) -> Option<String> {
+    if !should_apply_hunk_jump(app) {
+        return None;
+    }
+    if app.right_pane_scroll() == scroll_before_dispatch {
+        return None;
+    }
+    let target_symbol_id =
+        diff_shape::symbol_id_for_scroll_line(diff_pane_content, app.right_pane_scroll())?;
+    if Some(target_symbol_id) == app.selected_symbol_id() {
+        return None;
+    }
+    Some(target_symbol_id.to_string())
 }
 
 /// Folds `ui::draw`'s clamped scroll offset (`ui::draw`'s own doc comment)
@@ -997,1264 +1124,5 @@ fn translate_mouse_event(kind: event::MouseEventKind) -> Option<InputKey> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use rinkaku_core::graph::SymbolGraph;
-
-    fn empty_report() -> Report {
-        Report {
-            origin: rinkaku_core::render::ReportOrigin::Diff,
-            files: vec![],
-            skipped: vec![],
-            graph: SymbolGraph {
-                nodes: vec![],
-                edges: vec![],
-                roots: vec![],
-            },
-            tests: vec![],
-            hotspots: vec![],
-            file_size_warnings: vec![],
-            removed: vec![],
-        }
-    }
-
-    #[test]
-    fn should_translate_ctrl_c_to_quit_regardless_of_screen() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('c'), KeyModifiers::CONTROL, &app);
-
-        assert_eq!(Some(InputKey::Quit), actual);
-    }
-
-    #[test]
-    fn should_translate_q_to_quit_on_entry_screen() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('q'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::Quit), actual);
-    }
-
-    #[test]
-    fn should_translate_esc_to_none_on_entry_screen() {
-        // Esc has no "back" target on the entry screen (App::handle_key's
-        // own doc comment) and is not bound to quit there either — quit is
-        // 'q'/Ctrl-C only, so Esc is simply not handled at this screen.
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
-
-        assert_eq!(None, actual);
-    }
-
-    #[test]
-    fn should_translate_enter_to_open() {
-        // ADR 0020: Enter is `Open` (may move focus), distinct from Space's
-        // `Select` (never moves focus) — see the two tests right after this
-        // one.
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Enter, KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::Open), actual);
-    }
-
-    #[test]
-    fn should_translate_space_to_select() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char(' '), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::Select), actual);
-    }
-
-    #[test]
-    fn should_translate_h_to_focus_left_when_right_focused() {
-        let report = report_with_one_symbol();
-        let app = App::new(&report).handle_key(InputKey::Open);
-        assert_eq!(app::Focus::Right, app.focus());
-
-        let actual = translate_key(KeyCode::Char('h'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::FocusLeft), actual);
-    }
-
-    #[test]
-    fn should_not_translate_h_at_all_when_tree_focused() {
-        // `h` has no meaning while Focus::Tree (ADR 0020 only assigns it a
-        // "move left/back" meaning while Focus::Right) — must fall through
-        // to `None`, not be swallowed by some other arm.
-        let report = empty_report();
-        let app = App::new(&report);
-        assert_eq!(app::Focus::Tree, app.focus());
-
-        let actual = translate_key(KeyCode::Char('h'), KeyModifiers::NONE, &app);
-
-        assert_eq!(None, actual);
-    }
-
-    #[test]
-    fn should_translate_esc_to_focus_left_when_right_focused_on_entry_screen() {
-        let report = report_with_one_symbol();
-        let app = App::new(&report).handle_key(InputKey::Open);
-        assert_eq!(app::Focus::Right, app.focus());
-
-        let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::FocusLeft), actual);
-    }
-
-    #[test]
-    fn should_translate_lowercase_r_to_toggle_blast_radius() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('r'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::ToggleBlastRadius), actual);
-    }
-
-    #[test]
-    fn should_translate_uppercase_r_to_toggle_blast_radius() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('R'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::ToggleBlastRadius), actual);
-    }
-
-    #[test]
-    fn should_translate_right_bracket_to_next_hunk() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char(']'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::NextHunk), actual);
-    }
-
-    #[test]
-    fn should_translate_left_bracket_to_prev_hunk() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('['), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::PrevHunk), actual);
-    }
-
-    #[test]
-    fn should_translate_question_mark_to_toggle_help() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('?'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::ToggleHelp), actual);
-    }
-
-    #[test]
-    fn should_translate_esc_to_toggle_help_when_overlay_is_open() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
-
-        let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::ToggleHelp), actual);
-    }
-
-    #[test]
-    fn should_translate_q_to_toggle_help_instead_of_quit_when_overlay_is_open() {
-        // ADR 0020: `q` must close the overlay, not fall through to its
-        // normal `Quit` meaning, while it is open.
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
-
-        let actual = translate_key(KeyCode::Char('q'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::ToggleHelp), actual);
-    }
-
-    #[test]
-    fn should_translate_unbound_key_to_none_when_overlay_is_open() {
-        // `'j'` used to be this test's example key, back when the overlay
-        // had no scroll gestures of its own and swallowed every key but
-        // `?`/Esc/`q` (`should_ignore_navigation_keys_while_help_overlay_is_open`'s
-        // own App-level counterpart). Scrolling the overlay now maps `'j'`
-        // to `InputKey::Down` even while it is open — see
-        // `should_translate_j_to_down_for_overlay_scroll_when_overlay_is_open`
-        // below — so this test switched to `'z'`, a key with no meaning
-        // anywhere in the keymap, to keep pinning "arbitrary keys are
-        // swallowed" without asserting something that is no longer true.
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
-
-        let actual = translate_key(KeyCode::Char('z'), KeyModifiers::NONE, &app);
-
-        assert_eq!(None, actual);
-    }
-
-    #[test]
-    fn should_translate_j_to_down_for_overlay_scroll_when_overlay_is_open() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
-
-        let actual = translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::Down), actual);
-    }
-
-    #[test]
-    fn should_translate_k_to_up_for_overlay_scroll_when_overlay_is_open() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
-
-        let actual = translate_key(KeyCode::Char('k'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::Up), actual);
-    }
-
-    #[test]
-    fn should_translate_ctrl_d_to_scroll_half_page_down_when_overlay_is_open() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
-
-        let actual = translate_key(KeyCode::Char('d'), KeyModifiers::CONTROL, &app);
-
-        assert_eq!(Some(InputKey::ScrollHalfPageDown), actual);
-    }
-
-    #[test]
-    fn should_translate_ctrl_u_to_scroll_half_page_up_when_overlay_is_open() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
-
-        let actual = translate_key(KeyCode::Char('u'), KeyModifiers::CONTROL, &app);
-
-        assert_eq!(Some(InputKey::ScrollHalfPageUp), actual);
-    }
-
-    #[test]
-    fn should_translate_uppercase_g_to_scroll_to_bottom_when_overlay_is_open() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
-
-        let actual = translate_key(KeyCode::Char('G'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::ScrollToBottom), actual);
-    }
-
-    #[test]
-    fn should_translate_double_g_to_scroll_to_top_when_overlay_is_open() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleHelp);
-        let first_g = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
-        assert_eq!(Some(InputKey::PendingGoto), first_g);
-        let app = app.handle_key(first_g.expect("first g translates"));
-
-        let actual = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::ScrollToTop), actual);
-    }
-
-    #[test]
-    fn should_translate_lowercase_j_to_down_regardless_of_focus() {
-        // Regression guard: lowercase j/k are always translated to the same
-        // `InputKey::Down`/`Up` regardless of focus — `App::handle_key`, not
-        // `translate_key`, is what decides whether that means "move cursor"
-        // or "scroll" (ADR 0020).
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::Down), actual);
-    }
-
-    // Regression guard for the per-frame blast-radius recompute bug:
-    // `run_app` used to call `App::selected_blast_radius_view` from inside
-    // `ui::draw`, which runs on every ~100ms idle poll tick, not only on a
-    // key press. Pinning `should_recompute_blast_radius_selection`'s
-    // contract (recompute exactly when the blast-radius pane is the active
-    // right pane on the entry screen, and nowhere else) is the closest
-    // unit-testable proxy for that fix, since `run_app` itself takes a live
-    // `ratatui::DefaultTerminal` and cannot be driven directly in a test.
-    #[test]
-    fn should_recompute_blast_radius_selection_when_blast_radius_pane_is_active_on_entry_screen() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleBlastRadius);
-
-        let actual = should_recompute_blast_radius_selection(&app);
-
-        assert!(actual);
-    }
-
-    #[test]
-    fn should_not_recompute_blast_radius_selection_when_right_pane_is_detail() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = should_recompute_blast_radius_selection(&app);
-
-        assert!(!actual);
-    }
-
-    #[test]
-    fn should_not_recompute_blast_radius_selection_when_right_pane_is_diff() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleDiff);
-
-        let actual = should_recompute_blast_radius_selection(&app);
-
-        assert!(!actual);
-    }
-
-    #[test]
-    fn should_not_recompute_blast_radius_selection_while_source_screen_is_open() {
-        let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(InputKey::Down)
-            .handle_key(InputKey::ToggleBlastRadius)
-            .handle_key(InputKey::Source);
-
-        let actual = should_recompute_blast_radius_selection(&app);
-
-        assert!(!actual);
-    }
-
-    fn report_with_one_symbol() -> Report {
-        use rinkaku_core::diff::LineRange;
-        use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
-        use rinkaku_core::render::FileReport;
-
-        Report {
-            files: vec![FileReport {
-                path: "lib.rs".to_string(),
-                symbols: vec![ExtractedSymbol {
-                    id: "lib.rs::foo".to_string(),
-                    name: "foo".to_string(),
-                    kind: SymbolKind::Function,
-                    signature: "fn foo()".to_string(),
-                    range: LineRange { start: 1, end: 1 },
-                    container: None,
-                    referenced_names: vec![],
-                    dependencies: vec![],
-                    omitted_dependency_matches: 0,
-                    is_test: false,
-                    classification: None,
-                    previous_signature: None,
-                }],
-            }],
-            ..empty_report()
-        }
-    }
-
-    #[test]
-    fn should_recompute_diff_pane_content_when_diff_pane_is_active_on_entry_screen() {
-        let report = empty_report();
-        let app = App::new(&report);
-        assert_eq!(app::RightPane::Diff, app.right_pane()); // ADR 0020 default
-
-        let actual = should_recompute_diff_pane_content(&app);
-
-        assert!(actual);
-    }
-
-    #[test]
-    fn should_not_recompute_diff_pane_content_when_right_pane_is_detail() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleDiff);
-
-        let actual = should_recompute_diff_pane_content(&app);
-
-        assert!(!actual);
-    }
-
-    #[test]
-    fn should_not_recompute_diff_pane_content_when_right_pane_is_blast_radius() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::ToggleBlastRadius);
-
-        let actual = should_recompute_diff_pane_content(&app);
-
-        assert!(!actual);
-    }
-
-    #[test]
-    fn should_not_recompute_diff_pane_content_while_source_screen_is_open() {
-        let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(InputKey::Down)
-            .handle_key(InputKey::Source);
-
-        let actual = should_recompute_diff_pane_content(&app);
-
-        assert!(!actual);
-    }
-
-    // --- should_reload_source_content ---
-    //
-    // Regression coverage for the `s`-connot-invariant this guard closes:
-    // `run_app`'s [`InputKey::Source`] arm used to call
-    // `source::load_highlighted_symbol_source` unconditionally, so pressing
-    // `s` a second time on the same row re-read the file and re-ran a full
-    // tree-sitter parse — a leak in the "no reparse per user-observable
-    // state change" invariant this cache exists to hold, at the explicit-
-    // key-press granularity that the idle-poll-tick coverage did not close.
-
-    fn dummy_view(path: &str) -> source::HighlightedSourceView {
-        source::HighlightedSourceView {
-            view: source::SourceView {
-                path: path.to_string(),
-                lines: vec![],
-                highlight_start: 1,
-                highlight_end: 1,
-            },
-            token_highlights: vec![],
-        }
-    }
-
-    #[test]
-    fn should_reload_source_content_when_cache_is_empty() {
-        let actual = should_reload_source_content(None, None, "src/lib.rs::foo");
-
-        assert!(actual);
-    }
-
-    #[test]
-    fn should_reload_source_content_when_cached_symbol_differs() {
-        let cached = Ok(dummy_view("src/lib.rs"));
-
-        let actual =
-            should_reload_source_content(Some("src/lib.rs::foo"), Some(&cached), "src/lib.rs::bar");
-
-        assert!(actual);
-    }
-
-    #[test]
-    fn should_skip_reload_when_cached_ok_matches_next_symbol() {
-        let cached = Ok(dummy_view("src/lib.rs"));
-
-        let actual =
-            should_reload_source_content(Some("src/lib.rs::foo"), Some(&cached), "src/lib.rs::foo");
-
-        assert!(!actual);
-    }
-
-    #[test]
-    fn should_reload_source_content_when_cached_err_even_for_same_symbol() {
-        // Retryability contract: a failed load remains retryable on the
-        // reviewer's next `s` press (e.g. after editing the file back into
-        // existence), so a cached `Err(_)` must never suppress the reload —
-        // the small parse cost is worth keeping the recovery gesture live.
-        let cached: Result<source::HighlightedSourceView, String> =
-            Err("failed to read".to_string());
-
-        let actual =
-            should_reload_source_content(Some("src/lib.rs::foo"), Some(&cached), "src/lib.rs::foo");
-
-        assert!(actual);
-    }
-
-    #[test]
-    fn should_reload_source_content_when_cache_has_symbol_but_no_content() {
-        // Defensive combination the loop never actually reaches today
-        // (`source_content` and `source_content_symbol` are always written
-        // together): if they ever fall out of sync, the safe default is to
-        // reload rather than trust the stale symbol id alone.
-        let actual = should_reload_source_content(Some("src/lib.rs::foo"), None, "src/lib.rs::foo");
-
-        assert!(actual);
-    }
-
-    // --- should_apply_hunk_jump ---
-    //
-    // Regression coverage for the cross-pane key-leak this gate was added
-    // to fix: `]`/`[` used to fire (scrolling `diff_pane_content`'s cached
-    // hunk-offset table) whenever `Focus::Right` held, regardless of which
-    // right pane was actually showing — so opening a file (Focus::Right,
-    // RightPane::Diff by default), pressing `d` to switch to Detail, then
-    // pressing `]`, silently jumped the Detail pane's scroll to a Diff-pane
-    // offset that has no meaning there. `should_recompute_blast_radius_selection`'s
-    // own existing tests only pin cache-staleness for the blast-radius pane's
-    // *recompute* trigger; none of them cover this key's *application* gate,
-    // which is a separate condition (`run_app` applies the jump only when
-    // this returns true, independent of whether anything gets recomputed).
-    #[test]
-    fn should_apply_hunk_jump_when_right_focused_on_diff_pane() {
-        let report = report_with_one_symbol();
-        let app = App::new(&report).handle_key(InputKey::Open);
-        assert_eq!(app::Focus::Right, app.focus());
-        assert_eq!(app::RightPane::Diff, app.right_pane()); // ADR 0020 default
-
-        let actual = should_apply_hunk_jump(&app);
-
-        assert!(actual);
-    }
-
-    #[test]
-    fn should_not_apply_hunk_jump_when_right_focused_on_detail_pane() {
-        let report = report_with_one_symbol();
-        // Open reaches Focus::Right on RightPane::Diff (its default), then
-        // ToggleDiff ('d') switches to RightPane::Detail without touching
-        // focus — exactly the sequence (Enter -> d -> ]) the bug report
-        // describes.
-        let app = App::new(&report)
-            .handle_key(InputKey::Open)
-            .handle_key(InputKey::ToggleDiff);
-        assert_eq!(app::Focus::Right, app.focus());
-        assert_eq!(app::RightPane::Detail, app.right_pane());
-
-        let actual = should_apply_hunk_jump(&app);
-
-        assert!(!actual);
-    }
-
-    #[test]
-    fn should_not_apply_hunk_jump_when_right_focused_on_blast_radius_pane() {
-        let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(InputKey::Open)
-            .handle_key(InputKey::ToggleBlastRadius);
-        assert_eq!(app::Focus::Right, app.focus());
-        assert_eq!(app::RightPane::BlastRadius, app.right_pane());
-
-        let actual = should_apply_hunk_jump(&app);
-
-        assert!(!actual);
-    }
-
-    #[test]
-    fn should_not_apply_hunk_jump_when_tree_focused_even_if_right_pane_is_diff() {
-        let report = report_with_one_symbol();
-        let app = App::new(&report);
-        assert_eq!(app::Focus::Tree, app.focus());
-        assert_eq!(app::RightPane::Diff, app.right_pane()); // ADR 0020 default
-
-        let actual = should_apply_hunk_jump(&app);
-
-        assert!(!actual);
-    }
-
-    #[test]
-    fn should_jump_to_the_next_hunk_start_strictly_after_current_scroll() {
-        let hunk_starts = vec![0, 5, 12];
-
-        let actual = jump_scroll_target(&hunk_starts, 5, InputKey::NextHunk);
-
-        assert_eq!(Some(12), actual);
-    }
-
-    #[test]
-    fn should_return_none_when_next_hunk_is_pressed_at_the_last_hunk() {
-        let hunk_starts = vec![0, 5, 12];
-
-        let actual = jump_scroll_target(&hunk_starts, 12, InputKey::NextHunk);
-
-        assert_eq!(None, actual);
-    }
-
-    #[test]
-    fn should_jump_to_the_previous_hunk_start_strictly_before_current_scroll() {
-        let hunk_starts = vec![0, 5, 12];
-
-        let actual = jump_scroll_target(&hunk_starts, 12, InputKey::PrevHunk);
-
-        assert_eq!(Some(5), actual);
-    }
-
-    #[test]
-    fn should_return_none_when_prev_hunk_is_pressed_at_the_first_hunk() {
-        let hunk_starts = vec![0, 5, 12];
-
-        let actual = jump_scroll_target(&hunk_starts, 0, InputKey::PrevHunk);
-
-        assert_eq!(None, actual);
-    }
-
-    #[test]
-    fn should_return_none_when_hunk_starts_is_empty() {
-        let hunk_starts: Vec<usize> = vec![];
-
-        let actual = jump_scroll_target(&hunk_starts, 0, InputKey::NextHunk);
-
-        assert_eq!(None, actual);
-    }
-
-    #[test]
-    fn should_jump_to_the_first_hunk_after_scroll_lands_between_two_hunks() {
-        // Scroll sitting mid-hunk (not exactly on a hunk boundary) still
-        // finds the next hunk strictly after it, not the one it's inside.
-        let hunk_starts = vec![0, 10];
-
-        let actual = jump_scroll_target(&hunk_starts, 3, InputKey::NextHunk);
-
-        assert_eq!(Some(10), actual);
-    }
-
-    // --- clamp_right_pane_scroll_after_draw ---
-    //
-    // Dogfooding fix: `render_scrollable_pane`'s clamp only ever affected
-    // what was drawn, never `App`'s own `right_pane_scroll` — so an
-    // overshot scroll request stayed recorded in `App` even once the pane
-    // visibly stopped moving, and winding it back down took as many `k`
-    // presses as it took to overshoot in the first place. These tests pin
-    // the fold-back that keeps `App`'s state in sync with the frame that
-    // was actually drawn.
-
-    #[test]
-    fn should_overwrite_right_pane_scroll_with_the_clamped_value_when_some() {
-        let report = empty_report();
-        let app = App::new(&report).with_right_pane_scroll(999);
-
-        let app = clamp_right_pane_scroll_after_draw(app, Some(7));
-
-        assert_eq!(7, app.right_pane_scroll());
-    }
-
-    #[test]
-    fn should_leave_right_pane_scroll_untouched_when_none() {
-        // `None` means the drawn pane had nothing scrollable this frame
-        // (`ui::draw`'s own doc comment: the source screen, or a
-        // placeholder) — `App`'s own requested scroll must survive
-        // unchanged rather than being zeroed or otherwise disturbed by a
-        // frame that never consulted it.
-        let report = empty_report();
-        let app = App::new(&report).with_right_pane_scroll(3);
-
-        let app = clamp_right_pane_scroll_after_draw(app, None);
-
-        assert_eq!(3, app.right_pane_scroll());
-    }
-
-    // --- clamp_help_scroll_after_draw ---
-    //
-    // Same fold-back discipline as `clamp_right_pane_scroll_after_draw`
-    // above, applied to the `?` help overlay's own independent scroll
-    // state (this feature).
-
-    #[test]
-    fn should_overwrite_help_scroll_with_the_clamped_value_when_some() {
-        let report = empty_report();
-        let app = App::new(&report).with_help_scroll(999);
-
-        let app = clamp_help_scroll_after_draw(app, Some(4));
-
-        assert_eq!(4, app.help_scroll());
-    }
-
-    #[test]
-    fn should_leave_help_scroll_untouched_when_none() {
-        let report = empty_report();
-        let app = App::new(&report).with_help_scroll(2);
-
-        let app = clamp_help_scroll_after_draw(app, None);
-
-        assert_eq!(2, app.help_scroll());
-    }
-
-    // --- is_scroll_input_key ---
-
-    #[test]
-    fn should_treat_the_four_adr_0026_scroll_variants_as_scroll_input_keys() {
-        for key in [
-            InputKey::ScrollHalfPageDown,
-            InputKey::ScrollHalfPageUp,
-            InputKey::ScrollToTop,
-            InputKey::ScrollToBottom,
-        ] {
-            assert!(is_scroll_input_key(key), "{key:?} should be a scroll key");
-        }
-    }
-
-    #[test]
-    fn should_not_treat_up_or_down_as_scroll_input_keys() {
-        // `Up`/`Down` scroll the help overlay too, but through the ordinary
-        // `dispatch_non_source_key` path (`App::handle_key`'s own
-        // `help_open` branch), not the two-step `handle_scroll_key`
-        // dispatch reserved for the four ADR 0026 variants — this pins
-        // that boundary stays where `run_app`'s own dispatch expects it.
-        assert!(!is_scroll_input_key(InputKey::Up));
-        assert!(!is_scroll_input_key(InputKey::Down));
-    }
-
-    // g-prefix and jump-popup translate_key tests (ADR 0022).
-
-    #[test]
-    fn should_translate_g_to_pending_goto() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::PendingGoto), actual);
-    }
-
-    #[test]
-    fn should_translate_d_to_goto_definition_when_g_is_pending() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::PendingGoto);
-
-        let actual = translate_key(KeyCode::Char('d'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::GotoDefinition), actual);
-    }
-
-    #[test]
-    fn should_translate_r_to_goto_references_when_g_is_pending() {
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::PendingGoto);
-
-        let actual = translate_key(KeyCode::Char('r'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::GotoReferences), actual);
-    }
-
-    #[test]
-    fn should_translate_d_to_toggle_diff_when_no_prefix_is_pending() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('d'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::ToggleDiff), actual);
-    }
-
-    #[test]
-    fn should_fall_through_to_ordinary_meaning_when_a_non_dr_key_follows_pending_goto() {
-        // `gj` is not a bound sequence — `j` must still translate to its own
-        // ordinary `Down` meaning, not be swallowed just because a prefix
-        // was pending (`App::handle_key`'s blanket clear-unless-`PendingGoto`
-        // rule is what actually unwinds `pending_prefix` on the next key;
-        // this test only pins `translate_key`'s own half of that contract).
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::PendingGoto);
-
-        let actual = translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::Down), actual);
-    }
-
-    #[test]
-    fn should_translate_ctrl_o_to_jump_back() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('o'), KeyModifiers::CONTROL, &app);
-
-        assert_eq!(Some(InputKey::JumpBack), actual);
-    }
-
-    #[test]
-    fn should_translate_ctrl_i_to_jump_forward() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('i'), KeyModifiers::CONTROL, &app);
-
-        assert_eq!(Some(InputKey::JumpForward), actual);
-    }
-
-    #[test]
-    fn should_translate_tab_to_jump_forward() {
-        // A real Ctrl-I keypress arrives here as `KeyCode::Tab`, not
-        // `KeyCode::Char('i')` + `CONTROL` — confirmed via manual testing
-        // against a real terminal (tmux), since Ctrl-I and Tab share the
-        // same control code (0x09) without Kitty's keyboard-enhancement
-        // protocol, which this crate does not enable. Without this mapping,
-        // Ctrl-i silently did nothing in practice despite the
-        // `Char('i') + CONTROL` test above passing.
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Tab, KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::JumpForward), actual);
-    }
-
-    #[test]
-    fn should_translate_plain_o_to_toggle_order_without_control_modifier() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('o'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::ToggleOrder), actual);
-    }
-
-    // ADR 0026 scroll bindings (translate_key half).
-
-    #[test]
-    fn should_translate_ctrl_d_to_scroll_half_page_down() {
-        // Must resolve *before* the plain `Char('d')` arm below (which
-        // maps to `ToggleDiff`) — a stale ordering would silently
-        // rebind Ctrl-d to Diff-toggle instead of half-page-down.
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('d'), KeyModifiers::CONTROL, &app);
-
-        assert_eq!(Some(InputKey::ScrollHalfPageDown), actual);
-    }
-
-    #[test]
-    fn should_translate_ctrl_u_to_scroll_half_page_up() {
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('u'), KeyModifiers::CONTROL, &app);
-
-        assert_eq!(Some(InputKey::ScrollHalfPageUp), actual);
-    }
-
-    #[test]
-    fn should_translate_second_g_to_scroll_to_top_when_g_prefix_is_pending() {
-        // `gg` (ADR 0026) resolves through the same `pending_prefix`
-        // arm `gd`/`gr` do (ADR 0022) — this test pins that a *second*
-        // `g` after a pending `g` means "scroll to top", not restart
-        // the prefix. Restarting is what a *first* `g` does when no
-        // prefix is pending (the `should_translate_g_to_pending_goto`
-        // test above); this arm's behavior is the second-key half of
-        // the two-key `gg` sequence.
-        let report = empty_report();
-        let app = App::new(&report).handle_key(InputKey::PendingGoto);
-
-        let actual = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::ScrollToTop), actual);
-    }
-
-    #[test]
-    fn should_translate_uppercase_g_to_scroll_to_bottom() {
-        // Distinct from single-key lowercase `g` (`PendingGoto`, tested
-        // above): `G` is a one-key gesture, not the leader of a sequence.
-        let report = empty_report();
-        let app = App::new(&report);
-
-        let actual = translate_key(KeyCode::Char('G'), KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::ScrollToBottom), actual);
-    }
-
-    fn candidate(id: &str, name: &str, path: &str) -> app::JumpCandidate {
-        app::JumpCandidate {
-            id: id.to_string(),
-            name: name.to_string(),
-            path: path.to_string(),
-        }
-    }
-
-    #[test]
-    fn should_translate_j_and_k_to_popup_motion_while_jump_popup_is_open() {
-        let report = empty_report();
-        let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
-
-        assert_eq!(
-            Some(InputKey::Down),
-            translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app)
-        );
-        assert_eq!(
-            Some(InputKey::Up),
-            translate_key(KeyCode::Char('k'), KeyModifiers::NONE, &app)
-        );
-    }
-
-    #[test]
-    fn should_translate_enter_to_popup_confirm_while_jump_popup_is_open() {
-        let report = empty_report();
-        let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
-
-        let actual = translate_key(KeyCode::Enter, KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::PopupConfirm), actual);
-    }
-
-    #[test]
-    fn should_translate_esc_to_popup_cancel_while_jump_popup_is_open() {
-        let report = empty_report();
-        let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
-
-        let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
-
-        assert_eq!(Some(InputKey::PopupCancel), actual);
-    }
-
-    #[test]
-    fn should_translate_q_to_none_while_jump_popup_is_open() {
-        // `q` must not fall through to `Quit` while the popup is open —
-        // mirrors the help overlay's own "swallow everything but the
-        // close/confirm/cancel keys" contract.
-        let report = empty_report();
-        let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
-
-        let actual = translate_key(KeyCode::Char('q'), KeyModifiers::NONE, &app);
-
-        assert_eq!(None, actual);
-    }
-
-    // resolve_goto tests (ADR 0022): the 0/1/many candidate resolution that
-    // needs `report`, extracted so it is unit-testable without a live
-    // terminal (this function's own doc comment).
-
-    fn report_with_symbols_and_edges(
-        symbols_by_file: Vec<(&str, Vec<&str>)>,
-        edges: Vec<(&str, &str)>,
-    ) -> Report {
-        use rinkaku_core::diff::LineRange;
-        use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
-        use rinkaku_core::graph::{Edge, Node, SymbolGraph};
-        use rinkaku_core::render::FileReport;
-
-        let files: Vec<FileReport> = symbols_by_file
-            .iter()
-            .map(|(path, names)| FileReport {
-                path: path.to_string(),
-                symbols: names
-                    .iter()
-                    .map(|name| ExtractedSymbol {
-                        id: format!("{path}::{name}"),
-                        name: name.to_string(),
-                        kind: SymbolKind::Function,
-                        signature: format!("fn {name}()"),
-                        range: LineRange { start: 1, end: 1 },
-                        container: None,
-                        referenced_names: vec![],
-                        dependencies: vec![],
-                        omitted_dependency_matches: 0,
-                        is_test: false,
-                        classification: None,
-                        previous_signature: None,
-                    })
-                    .collect(),
-            })
-            .collect();
-
-        let nodes: Vec<Node> = symbols_by_file
-            .iter()
-            .flat_map(|(path, names)| {
-                names.iter().map(move |name| Node {
-                    id: format!("{path}::{name}"),
-                    path: path.to_string(),
-                    name: name.to_string(),
-                })
-            })
-            .collect();
-
-        let graph_edges: Vec<Edge> = edges
-            .into_iter()
-            .map(|(from, to)| Edge {
-                from: from.to_string(),
-                to: to.to_string(),
-                is_cycle: false,
-            })
-            .collect();
-
-        Report {
-            files,
-            graph: SymbolGraph {
-                nodes,
-                edges: graph_edges,
-                roots: vec![],
-            },
-            ..empty_report()
-        }
-    }
-
-    #[test]
-    fn should_return_no_symbol_selected_when_cursor_is_not_on_a_symbol_row() {
-        let report = report_with_symbols_and_edges(vec![("lib.rs", vec!["foo"])], vec![]);
-        let app = App::new(&report); // cursor on "lib.rs" (a File row)
-
-        let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
-
-        assert_eq!(GotoOutcome::NoSymbolSelected, actual);
-    }
-
-    #[test]
-    fn should_return_no_candidates_when_selected_symbol_has_no_callees() {
-        let report = report_with_symbols_and_edges(vec![("lib.rs", vec!["foo"])], vec![]);
-        let app = App::new(&report).handle_key(InputKey::Down); // cursor on "foo"
-
-        let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
-
-        assert_eq!(GotoOutcome::NoCandidates("callees"), actual);
-    }
-
-    #[test]
-    fn should_return_one_candidate_when_selected_symbol_has_exactly_one_callee() {
-        let report = report_with_symbols_and_edges(
-            vec![("lib.rs", vec!["foo", "bar"])],
-            vec![("lib.rs::foo", "lib.rs::bar")],
-        );
-        let app = App::new(&report).handle_key(InputKey::Down); // cursor on "foo"
-
-        let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
-
-        assert_eq!(
-            GotoOutcome::One(candidate("lib.rs::bar", "bar", "lib.rs")),
-            actual
-        );
-    }
-
-    #[test]
-    fn should_return_many_candidates_when_selected_symbol_has_multiple_callees() {
-        let report = report_with_symbols_and_edges(
-            vec![("lib.rs", vec!["foo", "bar", "baz"])],
-            vec![
-                ("lib.rs::foo", "lib.rs::bar"),
-                ("lib.rs::foo", "lib.rs::baz"),
-            ],
-        );
-        let app = App::new(&report).handle_key(InputKey::Down); // cursor on "foo"
-
-        let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
-
-        assert_eq!(
-            GotoOutcome::Many(vec![
-                candidate("lib.rs::bar", "bar", "lib.rs"),
-                candidate("lib.rs::baz", "baz", "lib.rs"),
-            ]),
-            actual
-        );
-    }
-
-    #[test]
-    fn should_resolve_callers_direction_when_goto_references_is_requested() {
-        let report = report_with_symbols_and_edges(
-            vec![("lib.rs", vec!["foo", "bar"])],
-            vec![("lib.rs::foo", "lib.rs::bar")],
-        );
-        // Cursor on "bar" (row 2): "foo" is its one caller.
-        let app = App::new(&report)
-            .handle_key(InputKey::Down)
-            .handle_key(InputKey::Down);
-
-        let actual = resolve_goto(&app, &report, InputKey::GotoReferences);
-
-        assert_eq!(
-            GotoOutcome::One(candidate("lib.rs::foo", "foo", "lib.rs")),
-            actual
-        );
-    }
-
-    // dispatch_non_source_key regression tests: the `run_app`-equivalent
-    // dispatch sequence (as opposed to calling `App::handle_key` directly,
-    // which every test above this point does and which was exactly why the
-    // `pending_prefix` bug survived until manual/review testing caught it —
-    // `App::handle_key`'s own unconditional prefix-clear ran fine in every
-    // one of those tests, but `run_app`'s old inline `GotoDefinition`/
-    // `GotoReferences` branch skipped calling it in the first place).
-
-    #[test]
-    fn should_clear_pending_prefix_so_next_d_toggles_diff_after_a_one_candidate_gd_jump() {
-        let report = report_with_symbols_and_edges(
-            vec![("lib.rs", vec!["foo", "bar"])],
-            vec![("lib.rs::foo", "lib.rs::bar")],
-        );
-        // Cursor on "foo" (row 1): "bar" is its one callee, so `gd` jumps
-        // immediately rather than opening the popup.
-        let app = App::new(&report).handle_key(InputKey::Down);
-        let diff_content = diff_shape::DiffPaneContent::Empty;
-
-        // Simulates the real `g` then `d` key sequence: `translate_key`
-        // emits `PendingGoto` for `g`, then (because `pending_prefix` is
-        // now set) `GotoDefinition` for the following `d` — both routed
-        // through `dispatch_non_source_key`, the same function `run_app`
-        // itself calls, rather than `App::handle_key` directly.
-        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
-        assert_eq!(Some(app::PendingPrefix::G), app.pending_prefix());
-        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoDefinition);
-        assert_eq!(None, app.pending_prefix(), "gd must clear pending_prefix");
-
-        // The regression itself: a *plain* `d` right after the jump must
-        // toggle the right pane (`ToggleDiff`'s own ordinary meaning), not
-        // silently re-resolve as another `gd` because `pending_prefix` was
-        // still `Some(G)` — `crate::lib::translate_key` only produces
-        // `GotoDefinition` for a `d` when `pending_prefix() == Some(G)`, so
-        // this assertion on `right_pane()` is an indirect but faithful proxy
-        // for "the next `d` meant ToggleDiff, not gd".
-        let right_pane_before = app.right_pane();
-        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::ToggleDiff);
-        assert_ne!(
-            right_pane_before,
-            app.right_pane(),
-            "d after gd must toggle the right pane like an ordinary ToggleDiff press"
-        );
-    }
-
-    #[test]
-    fn should_clear_pending_prefix_so_next_d_toggles_diff_after_a_multi_candidate_gr_popup_is_cancelled()
-     {
-        let report = report_with_symbols_and_edges(
-            vec![("lib.rs", vec!["foo", "bar", "baz"])],
-            vec![
-                ("lib.rs::foo", "lib.rs::bar"),
-                ("lib.rs::baz", "lib.rs::bar"),
-            ],
-        );
-        // Cursor on "bar" (row 2): both "foo" and "baz" call it, so `gr`
-        // opens the popup rather than jumping immediately.
-        let app = App::new(&report)
-            .handle_key(InputKey::Down)
-            .handle_key(InputKey::Down);
-        let diff_content = diff_shape::DiffPaneContent::Empty;
-
-        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
-        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoReferences);
-        assert!(
-            app.jump_popup().is_some(),
-            "gr with 2 candidates must open the popup"
-        );
-        assert_eq!(
-            None,
-            app.pending_prefix(),
-            "gr must clear pending_prefix even though it opened a popup instead of jumping"
-        );
-
-        // Cancel the popup (Esc) — `App::handle_key`'s own popup-open early
-        // return is the second path the #61-review finding flagged: it used
-        // to return before the (then-later-positioned) `pending_prefix`
-        // clear, so a stale prefix could survive an entire popup session.
-        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PopupCancel);
-        assert_eq!(None, app.jump_popup());
-        assert_eq!(None, app.pending_prefix());
-
-        // Same regression check as the single-candidate test above: a plain
-        // `d` after the cancelled popup must toggle the right pane, not
-        // silently re-resolve as another `gr`.
-        let right_pane_before = app.right_pane();
-        let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::ToggleDiff);
-        assert_ne!(
-            right_pane_before,
-            app.right_pane(),
-            "d after a cancelled gr popup must toggle the right pane like an ordinary ToggleDiff press"
-        );
-    }
-
-    #[test]
-    fn should_restore_the_scroll_offset_the_reviewer_was_at_when_jumping_back_after_gd() {
-        // Independent-review finding: `dispatch_non_source_key` always calls
-        // `app.handle_key(GotoDefinition)` first (for the `pending_prefix`
-        // clear — see the test group above), and before this fix that call
-        // hit `App::handle_key`'s own blanket scroll reset before
-        // `App::jump_to_symbol` ever read `right_pane_scroll` to save it into
-        // the jumplist entry — so every jumplist entry's saved scroll was
-        // always 0 and `Ctrl-o` could never restore a real reading position.
-        //
-        // This test drives the *real* two-key `g` then `d` sequence
-        // (`InputKey::PendingGoto` then `InputKey::GotoDefinition`), each
-        // through `dispatch_non_source_key` — not `App::handle_key` directly,
-        // and not `GotoDefinition` alone. An earlier version of this test did
-        // call `GotoDefinition` alone and passed while the underlying bug was
-        // still only half-fixed: `PendingGoto` (the leading `g`) is also
-        // dispatched through `handle_key` on its own, one keypress *before*
-        // `GotoDefinition`, and its own blanket scroll reset zeroed
-        // `right_pane_scroll` before `d` was even pressed — a gap only a
-        // real terminal run surfaced (see `InputKey::PendingGoto`'s own doc
-        // comment). Scrolls to a nonzero offset, jumps via the real `gd` key
-        // sequence, then jumps back via `Ctrl-o` (`InputKey::JumpBack`) and
-        // asserts the original scroll offset is restored rather than 0.
-        let report = report_with_symbols_and_edges(
-            vec![("lib.rs", vec!["foo", "bar"])],
-            vec![("lib.rs::foo", "lib.rs::bar")],
-        );
-        let diff_content = diff_shape::DiffPaneContent::Empty;
-
-        // Cursor on "foo" (row 1), scrolled 5 lines into its Diff pane.
-        let mut app = App::new(&report).handle_key(InputKey::Down);
-        app = dispatch_non_source_key(app, &report, &diff_content, InputKey::Open); // focus -> Right, RightPane::Diff
-        for _ in 0..5 {
-            app = dispatch_non_source_key(app, &report, &diff_content, InputKey::Down);
-        }
-        assert_eq!(5, app.right_pane_scroll());
-
-        // The real `gd` key sequence: `g` (PendingGoto) then `d`
-        // (GotoDefinition) — "bar" is "foo"'s one callee, so this jumps
-        // immediately (`GotoOutcome::One`) rather than opening the popup.
-        app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
-        assert_eq!(
-            5,
-            app.right_pane_scroll(),
-            "the leading g of gd must not disturb scroll either"
-        );
-        app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoDefinition);
-        assert_eq!(Some("lib.rs::bar"), app.selected_symbol_id());
-        assert_eq!(
-            0,
-            app.right_pane_scroll(),
-            "the new target's own scroll must start at 0 (App::jump_to_symbol's own reset)"
-        );
-
-        // Ctrl-o: jump back to "foo" — the regression this test guards.
-        app = dispatch_non_source_key(app, &report, &diff_content, InputKey::JumpBack);
-
-        assert_eq!(Some("lib.rs::foo"), app.selected_symbol_id());
-        assert_eq!(
-            5,
-            app.right_pane_scroll(),
-            "jumping back must restore the scroll offset recorded when gd was pressed, not 0"
-        );
-    }
-
-    // translate_mouse_event tests (mouse wheel scroll support).
-
-    #[test]
-    fn should_translate_scroll_up_to_input_key_up() {
-        let actual = translate_mouse_event(event::MouseEventKind::ScrollUp);
-
-        assert_eq!(Some(InputKey::Up), actual);
-    }
-
-    #[test]
-    fn should_translate_scroll_down_to_input_key_down() {
-        let actual = translate_mouse_event(event::MouseEventKind::ScrollDown);
-
-        assert_eq!(Some(InputKey::Down), actual);
-    }
-
-    #[test]
-    fn should_translate_scroll_left_to_none() {
-        // Horizontal wheel/trackpad input has no mapping — this crate has
-        // no horizontally-scrollable pane (this function's own doc comment).
-        let actual = translate_mouse_event(event::MouseEventKind::ScrollLeft);
-
-        assert_eq!(None, actual);
-    }
-
-    #[test]
-    fn should_translate_scroll_right_to_none() {
-        let actual = translate_mouse_event(event::MouseEventKind::ScrollRight);
-
-        assert_eq!(None, actual);
-    }
-
-    #[test]
-    fn should_translate_click_to_none() {
-        // Clicks/drags/moves are deliberately out of scope (no pane
-        // targeting by click position) — this function's own doc comment.
-        let actual = translate_mouse_event(event::MouseEventKind::Down(event::MouseButton::Left));
-
-        assert_eq!(None, actual);
-    }
-
-    #[test]
-    fn should_translate_drag_to_none() {
-        let actual = translate_mouse_event(event::MouseEventKind::Drag(event::MouseButton::Left));
-
-        assert_eq!(None, actual);
-    }
-
-    #[test]
-    fn should_translate_mouse_moved_to_none() {
-        let actual = translate_mouse_event(event::MouseEventKind::Moved);
-
-        assert_eq!(None, actual);
-    }
-}
+#[path = "tests.rs"]
+mod tests;

--- a/rinkaku-tui/src/tests.rs
+++ b/rinkaku-tui/src/tests.rs
@@ -1,0 +1,1619 @@
+use super::*;
+use rinkaku_core::graph::SymbolGraph;
+
+fn empty_report() -> Report {
+    Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        hotspots: vec![],
+        file_size_warnings: vec![],
+        removed: vec![],
+    }
+}
+
+#[test]
+fn should_translate_ctrl_c_to_quit_regardless_of_screen() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('c'), KeyModifiers::CONTROL, &app);
+
+    assert_eq!(Some(InputKey::Quit), actual);
+}
+
+#[test]
+fn should_translate_q_to_quit_on_entry_screen() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('q'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::Quit), actual);
+}
+
+#[test]
+fn should_translate_esc_to_none_on_entry_screen() {
+    // Esc has no "back" target on the entry screen (App::handle_key's
+    // own doc comment) and is not bound to quit there either — quit is
+    // 'q'/Ctrl-C only, so Esc is simply not handled at this screen.
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_enter_to_open() {
+    // ADR 0020: Enter is `Open` (may move focus), distinct from Space's
+    // `Select` (never moves focus) — see the two tests right after this
+    // one.
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Enter, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::Open), actual);
+}
+
+#[test]
+fn should_translate_space_to_select() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char(' '), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::Select), actual);
+}
+
+#[test]
+fn should_translate_h_to_focus_left_when_right_focused() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report).handle_key(InputKey::Open);
+    assert_eq!(app::Focus::Right, app.focus());
+
+    let actual = translate_key(KeyCode::Char('h'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::FocusLeft), actual);
+}
+
+#[test]
+fn should_not_translate_h_at_all_when_tree_focused() {
+    // `h` has no meaning while Focus::Tree (ADR 0020 only assigns it a
+    // "move left/back" meaning while Focus::Right) — must fall through
+    // to `None`, not be swallowed by some other arm.
+    let report = empty_report();
+    let app = App::new(&report);
+    assert_eq!(app::Focus::Tree, app.focus());
+
+    let actual = translate_key(KeyCode::Char('h'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_esc_to_focus_left_when_right_focused_on_entry_screen() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report).handle_key(InputKey::Open);
+    assert_eq!(app::Focus::Right, app.focus());
+
+    let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::FocusLeft), actual);
+}
+
+#[test]
+fn should_translate_lowercase_r_to_toggle_blast_radius() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('r'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ToggleBlastRadius), actual);
+}
+
+#[test]
+fn should_translate_uppercase_r_to_toggle_blast_radius() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('R'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ToggleBlastRadius), actual);
+}
+
+#[test]
+fn should_translate_right_bracket_to_next_hunk() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char(']'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::NextHunk), actual);
+}
+
+#[test]
+fn should_translate_left_bracket_to_prev_hunk() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('['), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::PrevHunk), actual);
+}
+
+#[test]
+fn should_translate_question_mark_to_toggle_help() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('?'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ToggleHelp), actual);
+}
+
+#[test]
+fn should_translate_esc_to_toggle_help_when_overlay_is_open() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ToggleHelp), actual);
+}
+
+#[test]
+fn should_translate_q_to_toggle_help_instead_of_quit_when_overlay_is_open() {
+    // ADR 0020: `q` must close the overlay, not fall through to its
+    // normal `Quit` meaning, while it is open.
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    let actual = translate_key(KeyCode::Char('q'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ToggleHelp), actual);
+}
+
+#[test]
+fn should_translate_unbound_key_to_none_when_overlay_is_open() {
+    // `'j'` used to be this test's example key, back when the overlay
+    // had no scroll gestures of its own and swallowed every key but
+    // `?`/Esc/`q` (`should_ignore_navigation_keys_while_help_overlay_is_open`'s
+    // own App-level counterpart). Scrolling the overlay now maps `'j'`
+    // to `InputKey::Down` even while it is open — see
+    // `should_translate_j_to_down_for_overlay_scroll_when_overlay_is_open`
+    // below — so this test switched to `'z'`, a key with no meaning
+    // anywhere in the keymap, to keep pinning "arbitrary keys are
+    // swallowed" without asserting something that is no longer true.
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    let actual = translate_key(KeyCode::Char('z'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_j_to_down_for_overlay_scroll_when_overlay_is_open() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    let actual = translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::Down), actual);
+}
+
+#[test]
+fn should_translate_k_to_up_for_overlay_scroll_when_overlay_is_open() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    let actual = translate_key(KeyCode::Char('k'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::Up), actual);
+}
+
+#[test]
+fn should_translate_ctrl_d_to_scroll_half_page_down_when_overlay_is_open() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    let actual = translate_key(KeyCode::Char('d'), KeyModifiers::CONTROL, &app);
+
+    assert_eq!(Some(InputKey::ScrollHalfPageDown), actual);
+}
+
+#[test]
+fn should_translate_ctrl_u_to_scroll_half_page_up_when_overlay_is_open() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    let actual = translate_key(KeyCode::Char('u'), KeyModifiers::CONTROL, &app);
+
+    assert_eq!(Some(InputKey::ScrollHalfPageUp), actual);
+}
+
+#[test]
+fn should_translate_uppercase_g_to_scroll_to_bottom_when_overlay_is_open() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    let actual = translate_key(KeyCode::Char('G'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ScrollToBottom), actual);
+}
+
+#[test]
+fn should_translate_double_g_to_scroll_to_top_when_overlay_is_open() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleHelp);
+    let first_g = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
+    assert_eq!(Some(InputKey::PendingGoto), first_g);
+    let app = app.handle_key(first_g.expect("first g translates"));
+
+    let actual = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ScrollToTop), actual);
+}
+
+#[test]
+fn should_translate_lowercase_j_to_down_regardless_of_focus() {
+    // Regression guard: lowercase j/k are always translated to the same
+    // `InputKey::Down`/`Up` regardless of focus — `App::handle_key`, not
+    // `translate_key`, is what decides whether that means "move cursor"
+    // or "scroll" (ADR 0020).
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::Down), actual);
+}
+
+// Regression guard for the per-frame blast-radius recompute bug:
+// `run_app` used to call `App::selected_blast_radius_view` from inside
+// `ui::draw`, which runs on every ~100ms idle poll tick, not only on a
+// key press. Pinning `should_recompute_blast_radius_selection`'s
+// contract (recompute exactly when the blast-radius pane is the active
+// right pane on the entry screen, and nowhere else) is the closest
+// unit-testable proxy for that fix, since `run_app` itself takes a live
+// `ratatui::DefaultTerminal` and cannot be driven directly in a test.
+#[test]
+fn should_recompute_blast_radius_selection_when_blast_radius_pane_is_active_on_entry_screen() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleBlastRadius);
+
+    let actual = should_recompute_blast_radius_selection(&app);
+
+    assert!(actual);
+}
+
+#[test]
+fn should_not_recompute_blast_radius_selection_when_right_pane_is_detail() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = should_recompute_blast_radius_selection(&app);
+
+    assert!(!actual);
+}
+
+#[test]
+fn should_not_recompute_blast_radius_selection_when_right_pane_is_diff() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleDiff);
+
+    let actual = should_recompute_blast_radius_selection(&app);
+
+    assert!(!actual);
+}
+
+#[test]
+fn should_not_recompute_blast_radius_selection_while_source_screen_is_open() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::ToggleBlastRadius)
+        .handle_key(InputKey::Source);
+
+    let actual = should_recompute_blast_radius_selection(&app);
+
+    assert!(!actual);
+}
+
+fn report_with_one_symbol() -> Report {
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+    use rinkaku_core::render::FileReport;
+
+    Report {
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![ExtractedSymbol {
+                id: "lib.rs::foo".to_string(),
+                name: "foo".to_string(),
+                kind: SymbolKind::Function,
+                signature: "fn foo()".to_string(),
+                range: LineRange { start: 1, end: 1 },
+                container: None,
+                referenced_names: vec![],
+                dependencies: vec![],
+                omitted_dependency_matches: 0,
+                is_test: false,
+                classification: None,
+                previous_signature: None,
+            }],
+        }],
+        ..empty_report()
+    }
+}
+
+#[test]
+fn should_recompute_diff_pane_content_when_diff_pane_is_active_on_entry_screen() {
+    let report = empty_report();
+    let app = App::new(&report);
+    assert_eq!(app::RightPane::Diff, app.right_pane()); // ADR 0020 default
+
+    let actual = should_recompute_diff_pane_content(&app);
+
+    assert!(actual);
+}
+
+#[test]
+fn should_not_recompute_diff_pane_content_when_right_pane_is_detail() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleDiff);
+
+    let actual = should_recompute_diff_pane_content(&app);
+
+    assert!(!actual);
+}
+
+#[test]
+fn should_not_recompute_diff_pane_content_when_right_pane_is_blast_radius() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::ToggleBlastRadius);
+
+    let actual = should_recompute_diff_pane_content(&app);
+
+    assert!(!actual);
+}
+
+#[test]
+fn should_not_recompute_diff_pane_content_while_source_screen_is_open() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Source);
+
+    let actual = should_recompute_diff_pane_content(&app);
+
+    assert!(!actual);
+}
+
+// --- should_reload_source_content ---
+//
+// Regression coverage for the `s`-connot-invariant this guard closes:
+// `run_app`'s [`InputKey::Source`] arm used to call
+// `source::load_highlighted_symbol_source` unconditionally, so pressing
+// `s` a second time on the same row re-read the file and re-ran a full
+// tree-sitter parse — a leak in the "no reparse per user-observable
+// state change" invariant this cache exists to hold, at the explicit-
+// key-press granularity that the idle-poll-tick coverage did not close.
+
+fn dummy_view(path: &str) -> source::HighlightedSourceView {
+    source::HighlightedSourceView {
+        view: source::SourceView {
+            path: path.to_string(),
+            lines: vec![],
+            highlight_start: 1,
+            highlight_end: 1,
+        },
+        token_highlights: vec![],
+    }
+}
+
+#[test]
+fn should_reload_source_content_when_cache_is_empty() {
+    let actual = should_reload_source_content(None, None, "src/lib.rs::foo");
+
+    assert!(actual);
+}
+
+#[test]
+fn should_reload_source_content_when_cached_symbol_differs() {
+    let cached = Ok(dummy_view("src/lib.rs"));
+
+    let actual =
+        should_reload_source_content(Some("src/lib.rs::foo"), Some(&cached), "src/lib.rs::bar");
+
+    assert!(actual);
+}
+
+#[test]
+fn should_skip_reload_when_cached_ok_matches_next_symbol() {
+    let cached = Ok(dummy_view("src/lib.rs"));
+
+    let actual =
+        should_reload_source_content(Some("src/lib.rs::foo"), Some(&cached), "src/lib.rs::foo");
+
+    assert!(!actual);
+}
+
+#[test]
+fn should_reload_source_content_when_cached_err_even_for_same_symbol() {
+    // Retryability contract: a failed load remains retryable on the
+    // reviewer's next `s` press (e.g. after editing the file back into
+    // existence), so a cached `Err(_)` must never suppress the reload —
+    // the small parse cost is worth keeping the recovery gesture live.
+    let cached: Result<source::HighlightedSourceView, String> = Err("failed to read".to_string());
+
+    let actual =
+        should_reload_source_content(Some("src/lib.rs::foo"), Some(&cached), "src/lib.rs::foo");
+
+    assert!(actual);
+}
+
+#[test]
+fn should_reload_source_content_when_cache_has_symbol_but_no_content() {
+    // Defensive combination the loop never actually reaches today
+    // (`source_content` and `source_content_symbol` are always written
+    // together): if they ever fall out of sync, the safe default is to
+    // reload rather than trust the stale symbol id alone.
+    let actual = should_reload_source_content(Some("src/lib.rs::foo"), None, "src/lib.rs::foo");
+
+    assert!(actual);
+}
+
+// --- should_apply_hunk_jump ---
+//
+// Regression coverage for the cross-pane key-leak this gate was added
+// to fix: `]`/`[` used to fire (scrolling `diff_pane_content`'s cached
+// hunk-offset table) whenever `Focus::Right` held, regardless of which
+// right pane was actually showing — so opening a file (Focus::Right,
+// RightPane::Diff by default), pressing `d` to switch to Detail, then
+// pressing `]`, silently jumped the Detail pane's scroll to a Diff-pane
+// offset that has no meaning there. `should_recompute_blast_radius_selection`'s
+// own existing tests only pin cache-staleness for the blast-radius pane's
+// *recompute* trigger; none of them cover this key's *application* gate,
+// which is a separate condition (`run_app` applies the jump only when
+// this returns true, independent of whether anything gets recomputed).
+#[test]
+fn should_apply_hunk_jump_when_right_focused_on_diff_pane() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report).handle_key(InputKey::Open);
+    assert_eq!(app::Focus::Right, app.focus());
+    assert_eq!(app::RightPane::Diff, app.right_pane()); // ADR 0020 default
+
+    let actual = should_apply_hunk_jump(&app);
+
+    assert!(actual);
+}
+
+#[test]
+fn should_not_apply_hunk_jump_when_right_focused_on_detail_pane() {
+    let report = report_with_one_symbol();
+    // Open reaches Focus::Right on RightPane::Diff (its default), then
+    // ToggleDiff ('d') switches to RightPane::Detail without touching
+    // focus — exactly the sequence (Enter -> d -> ]) the bug report
+    // describes.
+    let app = App::new(&report)
+        .handle_key(InputKey::Open)
+        .handle_key(InputKey::ToggleDiff);
+    assert_eq!(app::Focus::Right, app.focus());
+    assert_eq!(app::RightPane::Detail, app.right_pane());
+
+    let actual = should_apply_hunk_jump(&app);
+
+    assert!(!actual);
+}
+
+#[test]
+fn should_not_apply_hunk_jump_when_right_focused_on_blast_radius_pane() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(InputKey::Open)
+        .handle_key(InputKey::ToggleBlastRadius);
+    assert_eq!(app::Focus::Right, app.focus());
+    assert_eq!(app::RightPane::BlastRadius, app.right_pane());
+
+    let actual = should_apply_hunk_jump(&app);
+
+    assert!(!actual);
+}
+
+#[test]
+fn should_not_apply_hunk_jump_when_tree_focused_even_if_right_pane_is_diff() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report);
+    assert_eq!(app::Focus::Tree, app.focus());
+    assert_eq!(app::RightPane::Diff, app.right_pane()); // ADR 0020 default
+
+    let actual = should_apply_hunk_jump(&app);
+
+    assert!(!actual);
+}
+
+#[test]
+fn should_jump_to_the_next_hunk_start_strictly_after_current_scroll() {
+    let hunk_starts = vec![0, 5, 12];
+
+    let actual = jump_scroll_target(&hunk_starts, 5, InputKey::NextHunk);
+
+    assert_eq!(Some(12), actual);
+}
+
+#[test]
+fn should_return_none_when_next_hunk_is_pressed_at_the_last_hunk() {
+    let hunk_starts = vec![0, 5, 12];
+
+    let actual = jump_scroll_target(&hunk_starts, 12, InputKey::NextHunk);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_jump_to_the_previous_hunk_start_strictly_before_current_scroll() {
+    let hunk_starts = vec![0, 5, 12];
+
+    let actual = jump_scroll_target(&hunk_starts, 12, InputKey::PrevHunk);
+
+    assert_eq!(Some(5), actual);
+}
+
+#[test]
+fn should_return_none_when_prev_hunk_is_pressed_at_the_first_hunk() {
+    let hunk_starts = vec![0, 5, 12];
+
+    let actual = jump_scroll_target(&hunk_starts, 0, InputKey::PrevHunk);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_return_none_when_hunk_starts_is_empty() {
+    let hunk_starts: Vec<usize> = vec![];
+
+    let actual = jump_scroll_target(&hunk_starts, 0, InputKey::NextHunk);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_jump_to_the_first_hunk_after_scroll_lands_between_two_hunks() {
+    // Scroll sitting mid-hunk (not exactly on a hunk boundary) still
+    // finds the next hunk strictly after it, not the one it's inside.
+    let hunk_starts = vec![0, 10];
+
+    let actual = jump_scroll_target(&hunk_starts, 3, InputKey::NextHunk);
+
+    assert_eq!(Some(10), actual);
+}
+
+// --- sync_target_for_scroll (ADR 0030) ---
+
+fn report_with_two_symbols() -> Report {
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+    use rinkaku_core::render::FileReport;
+
+    fn symbol(id: &str, name: &str, range: LineRange) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature: format!("fn {name}()"),
+            range,
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        }
+    }
+
+    Report {
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![
+                symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 2 }),
+                symbol("lib.rs::bar", "bar", LineRange { start: 10, end: 11 }),
+            ],
+        }],
+        ..empty_report()
+    }
+}
+
+/// Two-section [`diff_shape::DiffPaneContent`] matching
+/// `report_with_two_symbols`'s two symbols, with the same layout math
+/// `diff_shape`'s own tests already use: section 0 (`foo`) spans lines
+/// 0-4, section 1 (`bar`) starts at line 5.
+fn diff_pane_content_with_two_symbol_sections() -> diff_shape::DiffPaneContent {
+    use diff_view::{DiffLine, DiffLineKind, Hunk};
+
+    fn hunk(header: &str, new_range: (usize, usize), line: &str) -> Hunk {
+        Hunk {
+            header: header.to_string(),
+            new_range: Some(new_range),
+            lines: vec![DiffLine {
+                kind: DiffLineKind::Context,
+                content: line.to_string(),
+            }],
+        }
+    }
+
+    diff_shape::DiffPaneContent::File(vec![
+        diff_shape::DiffSection {
+            title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
+            contract_header: None,
+            hunks: vec![diff_shape::AttributedHunk {
+                source_index: 0,
+                hunk: hunk("@@ -1,1 +1,2 @@", (1, 2), "fn foo() {}"),
+            }],
+        },
+        diff_shape::DiffSection {
+            title: "fn bar()".to_string(),
+            symbol_id: Some("lib.rs::bar".to_string()),
+            contract_header: None,
+            hunks: vec![diff_shape::AttributedHunk {
+                source_index: 1,
+                hunk: hunk("@@ -10,1 +10,2 @@", (10, 11), "fn bar() {}"),
+            }],
+        },
+    ])
+}
+
+/// `App` on `report_with_two_symbols`'s `foo` symbol row, already
+/// `Focus::Right` on `RightPane::Diff` (`Open` reaches both at once,
+/// same sequence `should_apply_hunk_jump_when_right_focused_on_diff_pane`
+/// uses) and at `right_pane_scroll` set to `scroll` directly, bypassing
+/// `handle_key` (these tests exercise `sync_target_for_scroll` standalone,
+/// not the dispatch that would normally produce that scroll value).
+/// `Down` first (row 0 is `lib.rs`'s file row, matching
+/// `should_return_none_selected_symbol_id_when_cursor_is_on_a_file_row`'s
+/// own row-shape note — row 1 is `foo`) so `selected_symbol_id()`
+/// resolves to `Some("lib.rs::foo")`, matching the diff-pane-content
+/// fixture the tests below pair this with.
+fn app_focused_on_diff_pane_with_scroll(report: &Report, scroll: usize) -> App {
+    App::new(report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Open)
+        .with_right_pane_scroll(scroll)
+}
+
+#[test]
+fn should_return_none_when_scroll_did_not_change_this_key() {
+    let report = report_with_two_symbols();
+    let content = diff_pane_content_with_two_symbol_sections();
+    // scroll_before_dispatch == current scroll: this key's dispatch
+    // did not move right_pane_scroll at all (e.g. Enter, d, an
+    // unrelated no-op), so there is nothing to sync regardless of
+    // which symbol the unchanged offset happens to point at.
+    let app = app_focused_on_diff_pane_with_scroll(&report, 5);
+
+    let actual = sync_target_for_scroll(&app, &content, 5);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_return_none_when_tree_is_focused_even_if_scroll_changed() {
+    let report = report_with_two_symbols();
+    let content = diff_pane_content_with_two_symbol_sections();
+    let app = App::new(&report).with_right_pane_scroll(5);
+    assert_eq!(app::Focus::Tree, app.focus());
+
+    let actual = sync_target_for_scroll(&app, &content, 0);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_return_none_when_right_pane_is_not_diff_even_if_focus_is_right() {
+    let report = report_with_two_symbols();
+    let content = diff_pane_content_with_two_symbol_sections();
+    let app = App::new(&report)
+        .handle_key(InputKey::Open)
+        .handle_key(InputKey::ToggleDiff)
+        .with_right_pane_scroll(5);
+    assert_eq!(app::RightPane::Detail, app.right_pane());
+
+    let actual = sync_target_for_scroll(&app, &content, 0);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_return_bar_when_scroll_moved_into_bars_section() {
+    let report = report_with_two_symbols();
+    let content = diff_pane_content_with_two_symbol_sections();
+    // Cursor still on `foo` (row 0); scroll moved from foo's section
+    // (line 2) down into bar's section (line 5, its title line).
+    let app = app_focused_on_diff_pane_with_scroll(&report, 5);
+
+    let actual = sync_target_for_scroll(&app, &content, 2);
+
+    assert_eq!(Some("lib.rs::bar".to_string()), actual);
+}
+
+#[test]
+fn should_return_none_when_scroll_moved_but_stayed_within_the_current_symbols_section() {
+    let report = report_with_two_symbols();
+    let content = diff_pane_content_with_two_symbol_sections();
+    // Cursor on `foo`; scroll moved from line 0 to line 2, both still
+    // inside foo's own section (0-4) — nothing to sync.
+    let app = app_focused_on_diff_pane_with_scroll(&report, 2);
+
+    let actual = sync_target_for_scroll(&app, &content, 0);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_return_none_when_scroll_moved_into_the_module_level_bucket() {
+    use diff_view::{DiffLine, DiffLineKind, Hunk};
+
+    let report = report_with_two_symbols();
+    let content = diff_shape::DiffPaneContent::File(vec![
+        diff_shape::DiffSection {
+            title: "fn foo()".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
+            contract_header: None,
+            hunks: vec![diff_shape::AttributedHunk {
+                source_index: 0,
+                hunk: Hunk {
+                    header: "@@ -1,1 +1,2 @@".to_string(),
+                    new_range: Some((1, 2)),
+                    lines: vec![DiffLine {
+                        kind: DiffLineKind::Context,
+                        content: "fn foo() {}".to_string(),
+                    }],
+                },
+            }],
+        },
+        diff_shape::DiffSection {
+            title: diff_shape::MODULE_LEVEL_TITLE.to_string(),
+            symbol_id: None,
+            contract_header: None,
+            hunks: vec![diff_shape::AttributedHunk {
+                source_index: 1,
+                hunk: Hunk {
+                    header: "@@ -20,1 +20,2 @@".to_string(),
+                    new_range: Some((20, 21)),
+                    lines: vec![DiffLine {
+                        kind: DiffLineKind::Context,
+                        content: "use foo::bar;".to_string(),
+                    }],
+                },
+            }],
+        },
+    ]);
+    // Module-level section starts at line 5 (same layout as the
+    // two-symbol fixture).
+    let app = app_focused_on_diff_pane_with_scroll(&report, 5);
+
+    let actual = sync_target_for_scroll(&app, &content, 2);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_move_the_tree_cursor_to_bar_when_synced() {
+    let report = report_with_two_symbols();
+    let app = app_focused_on_diff_pane_with_scroll(&report, 0);
+    assert_eq!(Some("lib.rs::foo"), app.selected_symbol_id());
+
+    let app = app.sync_tree_cursor_to_symbol("lib.rs::bar");
+
+    assert_eq!(Some("lib.rs::bar"), app.selected_symbol_id());
+}
+
+#[test]
+fn should_preserve_right_pane_scroll_when_syncing_tree_cursor() {
+    // The whole point of `sync_tree_cursor_to_symbol` over
+    // `jump_to_symbol`: the scroll offset that triggered the sync must
+    // survive it, or the sync would fight its own trigger.
+    let report = report_with_two_symbols();
+    let app = app_focused_on_diff_pane_with_scroll(&report, 5);
+
+    let app = app.sync_tree_cursor_to_symbol("lib.rs::bar");
+
+    assert_eq!(5, app.right_pane_scroll());
+}
+
+#[test]
+fn should_leave_cursor_untouched_when_syncing_to_a_symbol_id_with_no_matching_row() {
+    let report = report_with_two_symbols();
+    let app = app_focused_on_diff_pane_with_scroll(&report, 0);
+    assert_eq!(Some("lib.rs::foo"), app.selected_symbol_id());
+
+    let app = app.sync_tree_cursor_to_symbol("lib.rs::nonexistent");
+
+    assert_eq!(Some("lib.rs::foo"), app.selected_symbol_id());
+}
+
+// --- apply_diff_pane_selection_effects (ADR 0030 decision 6: the
+// feedback-loop guard) ---
+
+/// `diff_view::FileHunks` for `lib.rs` matching `report_with_two_symbols`'s
+/// two symbol ranges (`foo`: lines 1-2, `bar`: lines 10-11), so
+/// `apply_diff_pane_selection_effects`'s own internal
+/// `build_diff_pane_content` call produces the same two-section shape
+/// `diff_pane_content_with_two_symbol_sections` hand-builds for the
+/// standalone `sync_target_for_scroll` tests above — this fixture feeds
+/// the *real* pipeline instead, since this test exercises the actual
+/// sequencing `crate::run_app`'s loop performs, not a hand-shaped
+/// content value.
+fn diff_hunks_with_two_symbol_sections() -> Vec<diff_view::FileHunks> {
+    use diff_view::{DiffLine, DiffLineKind, Hunk};
+
+    vec![diff_view::FileHunks {
+        path: "lib.rs".to_string(),
+        hunks: vec![
+            Hunk {
+                header: "@@ -1,1 +1,2 @@".to_string(),
+                new_range: Some((1, 2)),
+                lines: vec![DiffLine {
+                    kind: DiffLineKind::Context,
+                    content: "fn foo() {}".to_string(),
+                }],
+            },
+            Hunk {
+                header: "@@ -10,1 +10,2 @@".to_string(),
+                new_range: Some((10, 11)),
+                lines: vec![DiffLine {
+                    kind: DiffLineKind::Context,
+                    content: "fn bar() {}".to_string(),
+                }],
+            },
+        ],
+    }]
+}
+
+#[test]
+fn should_sync_tree_cursor_when_scroll_moves_into_a_different_symbols_section() {
+    let report = report_with_two_symbols();
+    let diff_hunks = diff_hunks_with_two_symbol_sections();
+    let app = app_focused_on_diff_pane_with_scroll(&report, 0);
+    let last_diff_focus = app.selected_diff_focus(&report);
+    assert_eq!(Some("lib.rs::foo"), app.selected_symbol_id());
+
+    // Simulates one `Down` (`InputKey::Down`) scroll key while
+    // `Focus::Right`: `right_pane_scroll` moves from 0 to 5 (bar's
+    // section start, same layout math as the standalone
+    // `sync_target_for_scroll` tests), landing inside bar's section.
+    let scroll_before_dispatch = app.right_pane_scroll();
+    let app = app.with_right_pane_scroll(5);
+    let effects = apply_diff_pane_selection_effects(
+        app,
+        &report,
+        &diff_hunks,
+        last_diff_focus,
+        scroll_before_dispatch,
+    );
+
+    assert_eq!(Some("lib.rs::bar"), effects.app.selected_symbol_id());
+    // The scroll itself must survive the sync unchanged — the whole
+    // point of `App::sync_tree_cursor_to_symbol` over `jump_to_symbol`.
+    assert_eq!(5, effects.app.right_pane_scroll());
+}
+
+#[test]
+fn should_not_bounce_scroll_back_on_the_next_key_after_a_sync() {
+    // ADR 0030 decision 6's own regression test: without
+    // `apply_diff_pane_selection_effects` updating `last_diff_focus` to
+    // the *post-sync* focus, a second handled key right after the sync
+    // would see `selected_diff_focus` (now bar) differ from a stale
+    // `last_diff_focus` (still foo), misread that as a fresh
+    // cursor-driven selection change, and auto-scroll `right_pane_scroll`
+    // straight back to bar's own section start — undoing whatever the
+    // second key's own scroll motion was trying to do.
+    let report = report_with_two_symbols();
+    let diff_hunks = diff_hunks_with_two_symbol_sections();
+    let app = app_focused_on_diff_pane_with_scroll(&report, 0);
+    let last_diff_focus = app.selected_diff_focus(&report);
+
+    // First key: scroll from 0 to 5, syncing the cursor onto `bar`
+    // (previous test's own scenario).
+    let scroll_before_first_key = app.right_pane_scroll();
+    let app = app.with_right_pane_scroll(5);
+    let first = apply_diff_pane_selection_effects(
+        app,
+        &report,
+        &diff_hunks,
+        last_diff_focus,
+        scroll_before_first_key,
+    );
+    assert_eq!(Some("lib.rs::bar"), first.app.selected_symbol_id());
+    assert_eq!(5, first.app.right_pane_scroll());
+
+    // Second key: scroll one more line further into bar's own section
+    // (5 -> 6, still inside bar's span per the two-symbol fixture's
+    // layout). If `last_diff_focus` were stale (still pointing at
+    // `foo` instead of the post-sync `bar`), this call would
+    // misinterpret the *unchanged* cursor position as a fresh
+    // selection change and auto-scroll back to bar's section start (5),
+    // clobbering the manual scroll to 6.
+    let scroll_before_second_key = first.app.right_pane_scroll();
+    let app = first.app.with_right_pane_scroll(6);
+    let second = apply_diff_pane_selection_effects(
+        app,
+        &report,
+        &diff_hunks,
+        first.last_diff_focus,
+        scroll_before_second_key,
+    );
+
+    assert_eq!(6, second.app.right_pane_scroll());
+    assert_eq!(Some("lib.rs::bar"), second.app.selected_symbol_id());
+}
+
+// --- clamp_right_pane_scroll_after_draw ---
+//
+// Dogfooding fix: `render_scrollable_pane`'s clamp only ever affected
+// what was drawn, never `App`'s own `right_pane_scroll` — so an
+// overshot scroll request stayed recorded in `App` even once the pane
+// visibly stopped moving, and winding it back down took as many `k`
+// presses as it took to overshoot in the first place. These tests pin
+// the fold-back that keeps `App`'s state in sync with the frame that
+// was actually drawn.
+
+#[test]
+fn should_overwrite_right_pane_scroll_with_the_clamped_value_when_some() {
+    let report = empty_report();
+    let app = App::new(&report).with_right_pane_scroll(999);
+
+    let app = clamp_right_pane_scroll_after_draw(app, Some(7));
+
+    assert_eq!(7, app.right_pane_scroll());
+}
+
+#[test]
+fn should_leave_right_pane_scroll_untouched_when_none() {
+    // `None` means the drawn pane had nothing scrollable this frame
+    // (`ui::draw`'s own doc comment: the source screen, or a
+    // placeholder) — `App`'s own requested scroll must survive
+    // unchanged rather than being zeroed or otherwise disturbed by a
+    // frame that never consulted it.
+    let report = empty_report();
+    let app = App::new(&report).with_right_pane_scroll(3);
+
+    let app = clamp_right_pane_scroll_after_draw(app, None);
+
+    assert_eq!(3, app.right_pane_scroll());
+}
+
+// --- clamp_help_scroll_after_draw ---
+//
+// Same fold-back discipline as `clamp_right_pane_scroll_after_draw`
+// above, applied to the `?` help overlay's own independent scroll
+// state (this feature).
+
+#[test]
+fn should_overwrite_help_scroll_with_the_clamped_value_when_some() {
+    let report = empty_report();
+    let app = App::new(&report).with_help_scroll(999);
+
+    let app = clamp_help_scroll_after_draw(app, Some(4));
+
+    assert_eq!(4, app.help_scroll());
+}
+
+#[test]
+fn should_leave_help_scroll_untouched_when_none() {
+    let report = empty_report();
+    let app = App::new(&report).with_help_scroll(2);
+
+    let app = clamp_help_scroll_after_draw(app, None);
+
+    assert_eq!(2, app.help_scroll());
+}
+
+// --- is_scroll_input_key ---
+
+#[test]
+fn should_treat_the_four_adr_0026_scroll_variants_as_scroll_input_keys() {
+    for key in [
+        InputKey::ScrollHalfPageDown,
+        InputKey::ScrollHalfPageUp,
+        InputKey::ScrollToTop,
+        InputKey::ScrollToBottom,
+    ] {
+        assert!(is_scroll_input_key(key), "{key:?} should be a scroll key");
+    }
+}
+
+#[test]
+fn should_not_treat_up_or_down_as_scroll_input_keys() {
+    // `Up`/`Down` scroll the help overlay too, but through the ordinary
+    // `dispatch_non_source_key` path (`App::handle_key`'s own
+    // `help_open` branch), not the two-step `handle_scroll_key`
+    // dispatch reserved for the four ADR 0026 variants — this pins
+    // that boundary stays where `run_app`'s own dispatch expects it.
+    assert!(!is_scroll_input_key(InputKey::Up));
+    assert!(!is_scroll_input_key(InputKey::Down));
+}
+
+// g-prefix and jump-popup translate_key tests (ADR 0022).
+
+#[test]
+fn should_translate_g_to_pending_goto() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::PendingGoto), actual);
+}
+
+#[test]
+fn should_translate_d_to_goto_definition_when_g_is_pending() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::PendingGoto);
+
+    let actual = translate_key(KeyCode::Char('d'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::GotoDefinition), actual);
+}
+
+#[test]
+fn should_translate_r_to_goto_references_when_g_is_pending() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::PendingGoto);
+
+    let actual = translate_key(KeyCode::Char('r'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::GotoReferences), actual);
+}
+
+#[test]
+fn should_translate_d_to_toggle_diff_when_no_prefix_is_pending() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('d'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ToggleDiff), actual);
+}
+
+#[test]
+fn should_fall_through_to_ordinary_meaning_when_a_non_dr_key_follows_pending_goto() {
+    // `gj` is not a bound sequence — `j` must still translate to its own
+    // ordinary `Down` meaning, not be swallowed just because a prefix
+    // was pending (`App::handle_key`'s blanket clear-unless-`PendingGoto`
+    // rule is what actually unwinds `pending_prefix` on the next key;
+    // this test only pins `translate_key`'s own half of that contract).
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::PendingGoto);
+
+    let actual = translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::Down), actual);
+}
+
+#[test]
+fn should_translate_ctrl_o_to_jump_back() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('o'), KeyModifiers::CONTROL, &app);
+
+    assert_eq!(Some(InputKey::JumpBack), actual);
+}
+
+#[test]
+fn should_translate_ctrl_i_to_jump_forward() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('i'), KeyModifiers::CONTROL, &app);
+
+    assert_eq!(Some(InputKey::JumpForward), actual);
+}
+
+#[test]
+fn should_translate_tab_to_jump_forward() {
+    // A real Ctrl-I keypress arrives here as `KeyCode::Tab`, not
+    // `KeyCode::Char('i')` + `CONTROL` — confirmed via manual testing
+    // against a real terminal (tmux), since Ctrl-I and Tab share the
+    // same control code (0x09) without Kitty's keyboard-enhancement
+    // protocol, which this crate does not enable. Without this mapping,
+    // Ctrl-i silently did nothing in practice despite the
+    // `Char('i') + CONTROL` test above passing.
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Tab, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::JumpForward), actual);
+}
+
+#[test]
+fn should_translate_plain_o_to_toggle_order_without_control_modifier() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('o'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ToggleOrder), actual);
+}
+
+// ADR 0026 scroll bindings (translate_key half).
+
+#[test]
+fn should_translate_ctrl_d_to_scroll_half_page_down() {
+    // Must resolve *before* the plain `Char('d')` arm below (which
+    // maps to `ToggleDiff`) — a stale ordering would silently
+    // rebind Ctrl-d to Diff-toggle instead of half-page-down.
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('d'), KeyModifiers::CONTROL, &app);
+
+    assert_eq!(Some(InputKey::ScrollHalfPageDown), actual);
+}
+
+#[test]
+fn should_translate_ctrl_u_to_scroll_half_page_up() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('u'), KeyModifiers::CONTROL, &app);
+
+    assert_eq!(Some(InputKey::ScrollHalfPageUp), actual);
+}
+
+#[test]
+fn should_translate_second_g_to_scroll_to_top_when_g_prefix_is_pending() {
+    // `gg` (ADR 0026) resolves through the same `pending_prefix`
+    // arm `gd`/`gr` do (ADR 0022) — this test pins that a *second*
+    // `g` after a pending `g` means "scroll to top", not restart
+    // the prefix. Restarting is what a *first* `g` does when no
+    // prefix is pending (the `should_translate_g_to_pending_goto`
+    // test above); this arm's behavior is the second-key half of
+    // the two-key `gg` sequence.
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::PendingGoto);
+
+    let actual = translate_key(KeyCode::Char('g'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ScrollToTop), actual);
+}
+
+#[test]
+fn should_translate_uppercase_g_to_scroll_to_bottom() {
+    // Distinct from single-key lowercase `g` (`PendingGoto`, tested
+    // above): `G` is a one-key gesture, not the leader of a sequence.
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('G'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ScrollToBottom), actual);
+}
+
+fn candidate(id: &str, name: &str, path: &str) -> app::JumpCandidate {
+    app::JumpCandidate {
+        id: id.to_string(),
+        name: name.to_string(),
+        path: path.to_string(),
+    }
+}
+
+#[test]
+fn should_translate_j_and_k_to_popup_motion_while_jump_popup_is_open() {
+    let report = empty_report();
+    let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
+
+    assert_eq!(
+        Some(InputKey::Down),
+        translate_key(KeyCode::Char('j'), KeyModifiers::NONE, &app)
+    );
+    assert_eq!(
+        Some(InputKey::Up),
+        translate_key(KeyCode::Char('k'), KeyModifiers::NONE, &app)
+    );
+}
+
+#[test]
+fn should_translate_enter_to_popup_confirm_while_jump_popup_is_open() {
+    let report = empty_report();
+    let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
+
+    let actual = translate_key(KeyCode::Enter, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::PopupConfirm), actual);
+}
+
+#[test]
+fn should_translate_esc_to_popup_cancel_while_jump_popup_is_open() {
+    let report = empty_report();
+    let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
+
+    let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::PopupCancel), actual);
+}
+
+#[test]
+fn should_translate_q_to_none_while_jump_popup_is_open() {
+    // `q` must not fall through to `Quit` while the popup is open —
+    // mirrors the help overlay's own "swallow everything but the
+    // close/confirm/cancel keys" contract.
+    let report = empty_report();
+    let app = App::new(&report).open_jump_popup(vec![candidate("a", "a", "a.rs")]);
+
+    let actual = translate_key(KeyCode::Char('q'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
+}
+
+// resolve_goto tests (ADR 0022): the 0/1/many candidate resolution that
+// needs `report`, extracted so it is unit-testable without a live
+// terminal (this function's own doc comment).
+
+fn report_with_symbols_and_edges(
+    symbols_by_file: Vec<(&str, Vec<&str>)>,
+    edges: Vec<(&str, &str)>,
+) -> Report {
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+    use rinkaku_core::graph::{Edge, Node, SymbolGraph};
+    use rinkaku_core::render::FileReport;
+
+    let files: Vec<FileReport> = symbols_by_file
+        .iter()
+        .map(|(path, names)| FileReport {
+            path: path.to_string(),
+            symbols: names
+                .iter()
+                .map(|name| ExtractedSymbol {
+                    id: format!("{path}::{name}"),
+                    name: name.to_string(),
+                    kind: SymbolKind::Function,
+                    signature: format!("fn {name}()"),
+                    range: LineRange { start: 1, end: 1 },
+                    container: None,
+                    referenced_names: vec![],
+                    dependencies: vec![],
+                    omitted_dependency_matches: 0,
+                    is_test: false,
+                    classification: None,
+                    previous_signature: None,
+                })
+                .collect(),
+        })
+        .collect();
+
+    let nodes: Vec<Node> = symbols_by_file
+        .iter()
+        .flat_map(|(path, names)| {
+            names.iter().map(move |name| Node {
+                id: format!("{path}::{name}"),
+                path: path.to_string(),
+                name: name.to_string(),
+            })
+        })
+        .collect();
+
+    let graph_edges: Vec<Edge> = edges
+        .into_iter()
+        .map(|(from, to)| Edge {
+            from: from.to_string(),
+            to: to.to_string(),
+            is_cycle: false,
+        })
+        .collect();
+
+    Report {
+        files,
+        graph: SymbolGraph {
+            nodes,
+            edges: graph_edges,
+            roots: vec![],
+        },
+        ..empty_report()
+    }
+}
+
+#[test]
+fn should_return_no_symbol_selected_when_cursor_is_not_on_a_symbol_row() {
+    let report = report_with_symbols_and_edges(vec![("lib.rs", vec!["foo"])], vec![]);
+    let app = App::new(&report); // cursor on "lib.rs" (a File row)
+
+    let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
+
+    assert_eq!(GotoOutcome::NoSymbolSelected, actual);
+}
+
+#[test]
+fn should_return_no_candidates_when_selected_symbol_has_no_callees() {
+    let report = report_with_symbols_and_edges(vec![("lib.rs", vec!["foo"])], vec![]);
+    let app = App::new(&report).handle_key(InputKey::Down); // cursor on "foo"
+
+    let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
+
+    assert_eq!(GotoOutcome::NoCandidates("callees"), actual);
+}
+
+#[test]
+fn should_return_one_candidate_when_selected_symbol_has_exactly_one_callee() {
+    let report = report_with_symbols_and_edges(
+        vec![("lib.rs", vec!["foo", "bar"])],
+        vec![("lib.rs::foo", "lib.rs::bar")],
+    );
+    let app = App::new(&report).handle_key(InputKey::Down); // cursor on "foo"
+
+    let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
+
+    assert_eq!(
+        GotoOutcome::One(candidate("lib.rs::bar", "bar", "lib.rs")),
+        actual
+    );
+}
+
+#[test]
+fn should_return_many_candidates_when_selected_symbol_has_multiple_callees() {
+    let report = report_with_symbols_and_edges(
+        vec![("lib.rs", vec!["foo", "bar", "baz"])],
+        vec![
+            ("lib.rs::foo", "lib.rs::bar"),
+            ("lib.rs::foo", "lib.rs::baz"),
+        ],
+    );
+    let app = App::new(&report).handle_key(InputKey::Down); // cursor on "foo"
+
+    let actual = resolve_goto(&app, &report, InputKey::GotoDefinition);
+
+    assert_eq!(
+        GotoOutcome::Many(vec![
+            candidate("lib.rs::bar", "bar", "lib.rs"),
+            candidate("lib.rs::baz", "baz", "lib.rs"),
+        ]),
+        actual
+    );
+}
+
+#[test]
+fn should_resolve_callers_direction_when_goto_references_is_requested() {
+    let report = report_with_symbols_and_edges(
+        vec![("lib.rs", vec!["foo", "bar"])],
+        vec![("lib.rs::foo", "lib.rs::bar")],
+    );
+    // Cursor on "bar" (row 2): "foo" is its one caller.
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Down);
+
+    let actual = resolve_goto(&app, &report, InputKey::GotoReferences);
+
+    assert_eq!(
+        GotoOutcome::One(candidate("lib.rs::foo", "foo", "lib.rs")),
+        actual
+    );
+}
+
+// dispatch_non_source_key regression tests: the `run_app`-equivalent
+// dispatch sequence (as opposed to calling `App::handle_key` directly,
+// which every test above this point does and which was exactly why the
+// `pending_prefix` bug survived until manual/review testing caught it —
+// `App::handle_key`'s own unconditional prefix-clear ran fine in every
+// one of those tests, but `run_app`'s old inline `GotoDefinition`/
+// `GotoReferences` branch skipped calling it in the first place).
+
+#[test]
+fn should_clear_pending_prefix_so_next_d_toggles_diff_after_a_one_candidate_gd_jump() {
+    let report = report_with_symbols_and_edges(
+        vec![("lib.rs", vec!["foo", "bar"])],
+        vec![("lib.rs::foo", "lib.rs::bar")],
+    );
+    // Cursor on "foo" (row 1): "bar" is its one callee, so `gd` jumps
+    // immediately rather than opening the popup.
+    let app = App::new(&report).handle_key(InputKey::Down);
+    let diff_content = diff_shape::DiffPaneContent::Empty;
+
+    // Simulates the real `g` then `d` key sequence: `translate_key`
+    // emits `PendingGoto` for `g`, then (because `pending_prefix` is
+    // now set) `GotoDefinition` for the following `d` — both routed
+    // through `dispatch_non_source_key`, the same function `run_app`
+    // itself calls, rather than `App::handle_key` directly.
+    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
+    assert_eq!(Some(app::PendingPrefix::G), app.pending_prefix());
+    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoDefinition);
+    assert_eq!(None, app.pending_prefix(), "gd must clear pending_prefix");
+
+    // The regression itself: a *plain* `d` right after the jump must
+    // toggle the right pane (`ToggleDiff`'s own ordinary meaning), not
+    // silently re-resolve as another `gd` because `pending_prefix` was
+    // still `Some(G)` — `crate::lib::translate_key` only produces
+    // `GotoDefinition` for a `d` when `pending_prefix() == Some(G)`, so
+    // this assertion on `right_pane()` is an indirect but faithful proxy
+    // for "the next `d` meant ToggleDiff, not gd".
+    let right_pane_before = app.right_pane();
+    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::ToggleDiff);
+    assert_ne!(
+        right_pane_before,
+        app.right_pane(),
+        "d after gd must toggle the right pane like an ordinary ToggleDiff press"
+    );
+}
+
+#[test]
+fn should_clear_pending_prefix_so_next_d_toggles_diff_after_a_multi_candidate_gr_popup_is_cancelled()
+ {
+    let report = report_with_symbols_and_edges(
+        vec![("lib.rs", vec!["foo", "bar", "baz"])],
+        vec![
+            ("lib.rs::foo", "lib.rs::bar"),
+            ("lib.rs::baz", "lib.rs::bar"),
+        ],
+    );
+    // Cursor on "bar" (row 2): both "foo" and "baz" call it, so `gr`
+    // opens the popup rather than jumping immediately.
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Down);
+    let diff_content = diff_shape::DiffPaneContent::Empty;
+
+    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
+    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoReferences);
+    assert!(
+        app.jump_popup().is_some(),
+        "gr with 2 candidates must open the popup"
+    );
+    assert_eq!(
+        None,
+        app.pending_prefix(),
+        "gr must clear pending_prefix even though it opened a popup instead of jumping"
+    );
+
+    // Cancel the popup (Esc) — `App::handle_key`'s own popup-open early
+    // return is the second path the #61-review finding flagged: it used
+    // to return before the (then-later-positioned) `pending_prefix`
+    // clear, so a stale prefix could survive an entire popup session.
+    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PopupCancel);
+    assert_eq!(None, app.jump_popup());
+    assert_eq!(None, app.pending_prefix());
+
+    // Same regression check as the single-candidate test above: a plain
+    // `d` after the cancelled popup must toggle the right pane, not
+    // silently re-resolve as another `gr`.
+    let right_pane_before = app.right_pane();
+    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::ToggleDiff);
+    assert_ne!(
+        right_pane_before,
+        app.right_pane(),
+        "d after a cancelled gr popup must toggle the right pane like an ordinary ToggleDiff press"
+    );
+}
+
+#[test]
+fn should_restore_the_scroll_offset_the_reviewer_was_at_when_jumping_back_after_gd() {
+    // Independent-review finding: `dispatch_non_source_key` always calls
+    // `app.handle_key(GotoDefinition)` first (for the `pending_prefix`
+    // clear — see the test group above), and before this fix that call
+    // hit `App::handle_key`'s own blanket scroll reset before
+    // `App::jump_to_symbol` ever read `right_pane_scroll` to save it into
+    // the jumplist entry — so every jumplist entry's saved scroll was
+    // always 0 and `Ctrl-o` could never restore a real reading position.
+    //
+    // This test drives the *real* two-key `g` then `d` sequence
+    // (`InputKey::PendingGoto` then `InputKey::GotoDefinition`), each
+    // through `dispatch_non_source_key` — not `App::handle_key` directly,
+    // and not `GotoDefinition` alone. An earlier version of this test did
+    // call `GotoDefinition` alone and passed while the underlying bug was
+    // still only half-fixed: `PendingGoto` (the leading `g`) is also
+    // dispatched through `handle_key` on its own, one keypress *before*
+    // `GotoDefinition`, and its own blanket scroll reset zeroed
+    // `right_pane_scroll` before `d` was even pressed — a gap only a
+    // real terminal run surfaced (see `InputKey::PendingGoto`'s own doc
+    // comment). Scrolls to a nonzero offset, jumps via the real `gd` key
+    // sequence, then jumps back via `Ctrl-o` (`InputKey::JumpBack`) and
+    // asserts the original scroll offset is restored rather than 0.
+    let report = report_with_symbols_and_edges(
+        vec![("lib.rs", vec!["foo", "bar"])],
+        vec![("lib.rs::foo", "lib.rs::bar")],
+    );
+    let diff_content = diff_shape::DiffPaneContent::Empty;
+
+    // Cursor on "foo" (row 1), scrolled 5 lines into its Diff pane.
+    let mut app = App::new(&report).handle_key(InputKey::Down);
+    app = dispatch_non_source_key(app, &report, &diff_content, InputKey::Open); // focus -> Right, RightPane::Diff
+    for _ in 0..5 {
+        app = dispatch_non_source_key(app, &report, &diff_content, InputKey::Down);
+    }
+    assert_eq!(5, app.right_pane_scroll());
+
+    // The real `gd` key sequence: `g` (PendingGoto) then `d`
+    // (GotoDefinition) — "bar" is "foo"'s one callee, so this jumps
+    // immediately (`GotoOutcome::One`) rather than opening the popup.
+    app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
+    assert_eq!(
+        5,
+        app.right_pane_scroll(),
+        "the leading g of gd must not disturb scroll either"
+    );
+    app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoDefinition);
+    assert_eq!(Some("lib.rs::bar"), app.selected_symbol_id());
+    assert_eq!(
+        0,
+        app.right_pane_scroll(),
+        "the new target's own scroll must start at 0 (App::jump_to_symbol's own reset)"
+    );
+
+    // Ctrl-o: jump back to "foo" — the regression this test guards.
+    app = dispatch_non_source_key(app, &report, &diff_content, InputKey::JumpBack);
+
+    assert_eq!(Some("lib.rs::foo"), app.selected_symbol_id());
+    assert_eq!(
+        5,
+        app.right_pane_scroll(),
+        "jumping back must restore the scroll offset recorded when gd was pressed, not 0"
+    );
+}
+
+// translate_mouse_event tests (mouse wheel scroll support).
+
+#[test]
+fn should_translate_scroll_up_to_input_key_up() {
+    let actual = translate_mouse_event(event::MouseEventKind::ScrollUp);
+
+    assert_eq!(Some(InputKey::Up), actual);
+}
+
+#[test]
+fn should_translate_scroll_down_to_input_key_down() {
+    let actual = translate_mouse_event(event::MouseEventKind::ScrollDown);
+
+    assert_eq!(Some(InputKey::Down), actual);
+}
+
+#[test]
+fn should_translate_scroll_left_to_none() {
+    // Horizontal wheel/trackpad input has no mapping — this crate has
+    // no horizontally-scrollable pane (this function's own doc comment).
+    let actual = translate_mouse_event(event::MouseEventKind::ScrollLeft);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_scroll_right_to_none() {
+    let actual = translate_mouse_event(event::MouseEventKind::ScrollRight);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_click_to_none() {
+    // Clicks/drags/moves are deliberately out of scope (no pane
+    // targeting by click position) — this function's own doc comment.
+    let actual = translate_mouse_event(event::MouseEventKind::Down(event::MouseButton::Left));
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_drag_to_none() {
+    let actual = translate_mouse_event(event::MouseEventKind::Drag(event::MouseButton::Left));
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_mouse_moved_to_none() {
+    let actual = translate_mouse_event(event::MouseEventKind::Moved);
+
+    assert_eq!(None, actual);
+}


### PR DESCRIPTION
## Summary

ADR 0027 made the tree cursor drive the diff pane: selecting a symbol
row auto-scrolls the right pane to that symbol's section. This PR adds
the mirror image, per new [ADR 0030](docs/adr/0030-diff-scroll-syncs-tree-selection.md):
manually scrolling the diff pane (j/k, mouse wheel, half-page/top-bottom
keys, `]c`/`[c`) while `Focus::Right` now moves the tree cursor onto
whichever symbol section the new scroll offset falls inside.

## Motivation

Without this, scrolling through several symbols' sections in the diff
pane left the tree cursor (and Detail/BlastRadius panes, and `h`/Esc's
destination) frozen on whichever symbol was selected before the scroll
started — a reviewer who scrolls three sections down, then presses
`h`/Esc to open that symbol's Detail view, lands on the wrong symbol.
This is the same "where am I" problem GitHub/GitLab's split diff view
avoids by highlighting whichever file is scrolled into view in the
sidebar.

## What ships

- **`diff_shape::symbol_id_for_scroll_line`**: new pure reverse lookup
  (`scroll_line -> symbol_id`), the mirror image of the existing
  `section_start_line_for_symbol` (`symbol_id -> start_line`), reusing
  the same `walk_sections` layout table. Returns `None` for the
  module-level bucket or an overscroll past the last section — the
  tree cursor is left untouched in both cases rather than guessing a
  nearest symbol (see ADR 0030 decision 3 for why).
- **`App::sync_tree_cursor_to_symbol`**: moves the cursor via the
  existing `Nav::move_cursor_to_symbol` (expanding collapsed
  ancestors, same behavior ADR 0022's `gd`/`gr` jump already relies
  on), but deliberately *not* `App::jump_to_symbol` — no jumplist
  entry, no `right_pane_scroll` reset, since both would fight this
  sync's own trigger.
- **The feedback-loop guard (ADR 0030 decision 6)**: `run_app`'s
  per-key "recompute diff content, then apply exactly one of the two
  sync directions" sequence is extracted into a new pure
  `apply_diff_pane_selection_effects` function (mirroring why
  `dispatch_non_source_key` exists as its own function — ADR 0022).
  `last_diff_focus` is updated to the *post-sync* symbol within the
  same handled key, so the very next key does not misread the synced
  cursor position as a fresh cursor-driven move and auto-scroll
  `right_pane_scroll` straight back to where it just was.
- **File-size housekeeping**: `rinkaku-tui/src/lib.rs`'s test module
  moves out to a sibling `tests.rs`
  (`#[cfg(test)] #[path = "tests.rs"] mod tests;`), the same pattern
  CLAUDE.md's file-size discipline documents and PR #82 already
  established — `lib.rs` had already crossed the 1500-line warn
  threshold on test-code weight, and this PR's own new tests would
  have pushed it further. Production code in `lib.rs` now sits at
  ~1130 lines (the 1000-1500 "watch" band).

## Edge cases (see ADR 0030 for full reasoning)

- **Scroll lands in the module-level bucket or past all content**: no
  sync, cursor stays put — there is no principled "nearest symbol" to
  guess for a bucket that structurally has no `symbol_id`.
- **Target row is hidden under a collapsed directory**: expanded, not
  skipped — reuses `Nav::move_cursor_to_symbol`'s existing ADR 0022
  behavior; a scroll-driven sync happens continuously mid-session, so
  silently refusing to sync over fold state would reintroduce the
  "frozen cursor" problem this PR fixes.
- **`h`/Esc back to `Focus::Tree`**: unchanged — ADR 0020's existing
  scroll-reset rule still fires; the cursor now just reflects the
  right symbol when that happens.

## File-size note (self-review finding)

Per CLAUDE.md's "rinkaku's own warning is authoritative" rule: this
branch's own `rinkaku --base main` output flags two files over the
1500-line watch threshold — the new `rinkaku-tui/src/tests.rs` (1619
lines, the `lib.rs` test-module split above) and
`rinkaku-tui/src/app/mod.rs` (pushed from 1480 to 1504 by this PR's
`+24`-line `sync_tree_cursor_to_symbol` addition). Neither is split
here: neither has an independent sub-responsibility to carve out yet
(ADR 0030's Consequences has the full reasoning). Recorded rather than
merged past silently.

## Test plan

- [x] `diff_shape::symbol_id_for_scroll_line` — 6 new unit tests
      (empty content, title line, mid-section line, second section,
      module-level bucket, past-content overscroll).
- [x] `sync_target_for_scroll` (gating logic) — 6 new unit tests
      (no scroll change, tree focused, non-Diff right pane, moved into
      a different section, stayed within the same section, module-level
      bucket).
- [x] `App::sync_tree_cursor_to_symbol` — 3 new unit tests (moves
      cursor, preserves scroll, no-op on unknown symbol id).
- [x] `apply_diff_pane_selection_effects` — 2 new unit tests, including
      the decision-6 regression test: two simulated consecutive scroll
      keys, asserting the second key's own scroll motion is not bounced
      back by a stale `last_diff_focus`. Verified this test is a real
      Red/Green guard by temporarily reintroducing the stale-focus bug
      and confirming the test fails (`left: 6, right: 5` — scroll
      snapped back), then restoring the fix.
- [x] `make test` — **1053 passed**, 0 failed (161 rinkaku + 351
      rinkaku-core + 541 rinkaku-tui)
- [x] `make lint` clean (fmt + clippy `-D warnings`)
- [x] Dynamic verification: built the release binary, fed it this PR's
      own diff (`git diff main -- rinkaku-tui/...`) — exits 0, valid
      JSON, no panic. Also ran `--tui` with stdin redirected from
      `/dev/null` (non-TTY) — clean `Error: Device not configured`,
      exit 1, no panic (matches the documented `try_init` failure
      path).

## Self-review

Map-assisted pass (rinkaku built from a trusted `main` checkout,
applied to this branch's diff) plus an independent re-read found one
real issue (the file-size threshold crossing above, now recorded) and
one wording bug in the ADR's own decision text (hunk-jump dedup
description was inverted relative to the actual implementation), both
fixed in a follow-up commit before requesting review.