### PR TITLE
docs: renumber duplicate ADR 0029 to 0031

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tree-sitter-go = "0.25"
 tree-sitter-python = "0.25"
 tree-sitter-typescript = "0.23"
 aho-corasick = "1.1"
-# ADR 0029: parallelises `pipeline::analyze_repo`'s per-file tree-sitter
+# ADR 0031: parallelises `pipeline::analyze_repo`'s per-file tree-sitter
 # parse. Only rinkaku-core depends on it directly today; declared at the
 # workspace level to match the convention every other core crate follows.
 rayon = "1.10"

--- a/docs/adr/0031-parallel-whole-repo-parse.md
+++ b/docs/adr/0031-parallel-whole-repo-parse.md
@@ -1,4 +1,4 @@
-# 0029. Parallel whole-repo tree-sitter parse with rayon
+# 0031. Parallel whole-repo tree-sitter parse with rayon
 
 - Status: accepted
 - Date: 2026-07-13

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -374,7 +374,7 @@ pub fn analyze_repo(
     generated_paths: &std::collections::HashSet<String>,
     include_generated: bool,
 ) -> Report {
-    // ADR 0029: the per-file body below is embarrassingly parallel —
+    // ADR 0031: the per-file body below is embarrassingly parallel —
     // `extract_all_symbols` builds a fresh `tree_sitter::Parser` per call
     // (see `extract::with_definition_nodes`), the `read_file` port is
     // `Sync + Send` (bound tightened above), and every filter reads
@@ -2918,7 +2918,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
         }
     }
 
-    /// ADR 0029 regression: `analyze_repo`'s per-file loop is now driven
+    /// ADR 0031 regression: `analyze_repo`'s per-file loop is now driven
     /// by rayon's `par_iter`, whose ordered `collect` contract is what
     /// keeps the output for a given input deterministic (byte-identical
     /// across runs and, within a single run, in the same order as the


### PR DESCRIPTION
## Summary

`main` has two ADRs both numbered 0029, landed by PR #87 and PR #88
in parallel off the same base:

- `0029-diff-pane-multi-symbol-hunk-attribution.md` (PR #87, merged
  first)
- `0029-parallel-whole-repo-parse.md` (PR #88, merged second)

0030 is already taken by a follow-up PR (#89), so this PR renumbers
the later-merged one — `0029-parallel-whole-repo-parse.md` — to
`0031`, keeping `0029-diff-pane-multi-symbol-hunk-attribution.md` as
is.

## Changes

- `git mv docs/adr/0029-parallel-whole-repo-parse.md docs/adr/0031-parallel-whole-repo-parse.md`
  and updated its own title line.
- Updated every code comment referencing it: `Cargo.toml` (the
  `rayon` dependency comment) and `rinkaku-core/src/pipeline.rs` (two
  comments in `analyze_repo` and its regression test).
- Grepped the whole repo for `0029`/`ADR 0029`/the ADR's own title
  string — the remaining `0029` references are all
  `rinkaku-tui/src/diff_shape.rs`'s comments about the *other* ADR
  0029 (hunk attribution), which are correct and untouched.
- Checked PR #89 (`feat/tui-scroll-syncs-tree-selection`, adds ADR
  0030) for any reference to the parallel-parse ADR — it only
  mentions "ADR 0027/0029" referring to the diff-pane ADRs, so no
  follow-up commit is needed there.

## Test plan

- [x] `make lint` clean (fmt + clippy `-D warnings`)
- [x] `make test` — 1036 passed, 0 failed (comment/filename-only
      change, no behavior touched)