### PR TITLE
feat(cli): show a stderr spinner while analyzing before the TUI starts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,6 +2104,7 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger",
+ "indicatif",
  "log",
  "pretty_assertions",
  "rinkaku-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,12 @@ tempfile = "3.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 self_update = { version = "0.42", default-features = false, features = ["archive-tar", "compression-flate2", "rustls"] }
+# ADR 0032: renders the pre-TUI stderr analysis spinner. Only the `rinkaku`
+# bin crate depends on it directly; already pulled in transitively via
+# `self_update`'s own dependency tree, so this pins the version rinkaku's
+# own terminal-progress code compiles against rather than relying on
+# whatever version `self_update` happens to pull in.
+indicatif = "0.17"
 # Only rinkaku-tui depends on this (ADR 0016 decision 2): rinkaku-core's
 # dependency set stays untouched. Most crossterm usage goes through
 # ratatui's own `ratatui::crossterm` re-export rather than a direct

--- a/docs/adr/0032-pre-tui-stderr-spinner.md
+++ b/docs/adr/0032-pre-tui-stderr-spinner.md
@@ -64,14 +64,25 @@ Implementation:
   plus a pure `AnalysisPhase` enum and `phase_message` function mapping
   each phase to its stderr text — kept pure and unit-tested
   (`rstest` + `pretty_assertions`) per this project's IO-boundary
-  testing convention, with the `indicatif`-touching `Spinner` type kept
-  thin and untested (same treatment `self_update.rs` gives its own
-  process/network IO wrapper).
+  testing convention. The `indicatif`-touching `Spinner` type itself is
+  kept thin (no branching logic beyond forwarding to `ProgressBar`) and
+  left untested, per CLAUDE.md's "no mocking of external processes"
+  test strategy — there is no real terminal to assert against in a unit
+  test, so the pure `phase_message` split is what carries the test
+  coverage instead.
 - `main()` starts one `Spinner` right after the `SelfUpdate` early
   return and threads a `&Spinner` through `run_base_pipeline` and
   `build_resolver` so each can update the message as its own sub-phase
   starts, mirroring the existing `log::info!` call sites at each of
   those same milestones.
+
+An early `?`-propagated error (e.g. a failing `git`/`gh` subprocess call
+inside `run_base_pipeline`/`build_resolver`) drops the `Spinner` before
+`finish_and_clear()` is ever reached. This is not a gap: `indicatif`'s
+`BarState` clears the line on `Drop` unless the bar was already finished,
+using `ProgressFinish::AndClear` — the crate's documented default — so a
+spinner is guaranteed to be cleared from the terminal one way or another
+before the process's error message reaches stderr.
 
 Non-TTY stderr (piped, redirected, CI) needs no special-casing:
 `indicatif`'s `ProgressDrawTarget::stderr()` (the default target
@@ -130,3 +141,7 @@ before the Markdown/TUI output starts.
   private to `main.rs`) gain a `&Spinner` parameter; their existing test
   call sites in `main.rs`'s own test module were updated to pass a
   `Spinner::start(...)` instance. No change to any public crate API.
+- **Error-path cleanup**: no explicit `finish_and_clear()` call is needed
+  on any early-return error path — `indicatif`'s `Drop` impl for
+  `BarState` clears the line by default, so an early `?` return leaves
+  no visual artifact on stderr either.

--- a/docs/adr/0032-pre-tui-stderr-spinner.md
+++ b/docs/adr/0032-pre-tui-stderr-spinner.md
@@ -1,0 +1,132 @@
+# 0032. A stderr spinner during pre-TUI analysis
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+Every input mode `rinkaku` supports runs a synchronous analysis pipeline
+before producing any output at all: `analyze_repo` for the whole-repo
+outline, `build_resolver` + `analyze_diff` for stdin-piped diffs, and
+`run_git_diff` + `build_resolver` + `analyze_diff` for `--base`/`--pr`.
+ADR 0031's profiling table shows this can take anywhere from tens of
+milliseconds (a small repo, `--deps 0`) to multiple seconds (a large
+repository's dependency index, or a whole-repo outline on a big tree).
+For the whole of that window, the terminal shows nothing — no output,
+no cursor movement, nothing — so the process looks hung, particularly
+right before `--tui` (the default when stdout is a terminal, ADR 0017)
+opens the alternate screen with its own more informative loading state.
+
+`main.rs` already has some feedback here via `log::info!` lines
+(`env_logger`'s default is `info` level, per `main`'s own comment), but
+those are one-shot, print-once log lines tied to specific milestones
+(`"diffing {base}...{head}"`, `"building dependency index over N
+files"`, `"analyzing diff"`) — there is no continuous signal that the
+process is alive *between* those lines, and a long-running phase (e.g.
+tree-sitter parsing thousands of files in `analyze_repo`, or indexing a
+large repository's dependency graph in `build_resolver`) still produces
+a silent gap.
+
+ADR 0031's Alternatives section already named two options for
+addressing perceived latency around this same pipeline — progressive
+TUI rendering and lazy start — and explicitly deferred both as "a
+larger architectural change to `rinkaku-tui`'s state machine". This ADR
+is not a revisit of that decision: a spinner does not compete with
+either alternative, it addresses a narrower problem (visible liveness
+during a wait, not reduced wait time or earlier interactivity) with a
+much smaller change.
+
+## Decision
+
+Show an indeterminate spinner on stderr for the whole duration of the
+pre-output analysis phase, across every input mode. The spinner's
+message updates as the pipeline moves between phases (resolving a
+`--pr` argument, diffing, building the dependency index, parsing the
+repository, analyzing the diff), and is cleared
+(`ProgressBar::finish_and_clear`) before either the `Report` is handed
+to `--entry`'s pivot step or any output (Markdown/JSON/TUI) is
+produced — in particular, before `rinkaku_tui::run` enters the
+alternate screen, so no stray spinner line is left behind for the TUI's
+first frame to render over.
+
+Implementation:
+
+- New `indicatif = "0.17"` workspace dependency, consumed only by the
+  `rinkaku` bin crate (`rinkaku-core` and `rinkaku-tui` stay untouched —
+  `rinkaku-core` because CLAUDE.md's pure-core rule forbids IO there,
+  `rinkaku-tui` because rendering progress before the TUI even starts is
+  not the TUI's concern). `indicatif` was already present in
+  `Cargo.lock` as a transitive dependency of `self_update` (same
+  version, 0.17.11), so this adds no new major dependency to the
+  build — only promotes an existing transitive dependency to direct.
+- A new `rinkaku/src/spinner.rs` module: a thin `Spinner` wrapper around
+  `indicatif::ProgressBar` (`start`/`set_message`/`finish_and_clear`),
+  plus a pure `AnalysisPhase` enum and `phase_message` function mapping
+  each phase to its stderr text — kept pure and unit-tested
+  (`rstest` + `pretty_assertions`) per this project's IO-boundary
+  testing convention, with the `indicatif`-touching `Spinner` type kept
+  thin and untested (same treatment `self_update.rs` gives its own
+  process/network IO wrapper).
+- `main()` starts one `Spinner` right after the `SelfUpdate` early
+  return and threads a `&Spinner` through `run_base_pipeline` and
+  `build_resolver` so each can update the message as its own sub-phase
+  starts, mirroring the existing `log::info!` call sites at each of
+  those same milestones.
+
+Non-TTY stderr (piped, redirected, CI) needs no special-casing:
+`indicatif`'s `ProgressDrawTarget::stderr()` (the default target
+`ProgressBar::new_spinner()` uses) wraps `console::Term`, which detects
+whether the underlying stream is a real terminal and suppresses all
+drawing when it isn't — verified both by reading `draw_target.rs`'s own
+doc comment ("if the terminal is not user attended the entire progress
+bar will be hidden") and empirically: `rinkaku --base HEAD~1 --format md
+2>err.log` produces zero ESC bytes in `err.log`, and a `script`-driven
+pseudo-TTY session shows the same run redrawing the spinner in place
+(`\x1b[2K` clears) through each phase and then clearing cleanly right
+before the Markdown/TUI output starts.
+
+## Alternatives
+
+- **Do nothing / rely on `log::info!` lines alone**: cheapest, but
+  leaves the exact gaps described above — a phase with no further log
+  line until it finishes (large `analyze_repo`/`build_resolver` runs)
+  still looks hung for its whole duration.
+- **Progressive TUI rendering / lazy start** (ADR 0031's deferred
+  alternatives): solve a different problem — reducing time-to-first-
+  interaction rather than making an unavoidable wait visible — and
+  remain a substantially larger change to `rinkaku-tui`'s state
+  machine. Not superseded by this ADR; still open for a future PR if
+  time-to-interaction itself needs to improve.
+- **A hand-rolled spinner** (raw ANSI escapes + a background thread):
+  avoids the new dependency, but reimplements TTY detection, frame
+  timing, and line-clearing that `indicatif` already gets right — not
+  justified when `indicatif` is already in the dependency tree
+  transitively.
+- **Emit periodic `log::info!` heartbeat lines instead of a spinner**:
+  simpler, no new dependency, but produces scrolling log noise on a
+  real terminal instead of a single redrawn line, which is a worse
+  experience for the common case (an interactive user watching the
+  terminal) to optimize for the uncommon one (structured log capture).
+
+## Consequences
+
+- **Dependencies**: `rinkaku` (the bin crate) gains a direct dependency
+  on `indicatif`, declared at the workspace level like every other
+  shared dependency. No change to `rinkaku-core`'s or `rinkaku-tui`'s
+  dependency sets. `Cargo.lock` is otherwise unchanged (`indicatif` was
+  already resolved to 0.17.11 via `self_update`).
+- **UX**: every input mode now shows continuous stderr feedback during
+  analysis, not just milestone log lines. On a non-TTY stderr (CI,
+  redirected output), behavior is unchanged — no spinner bytes are
+  written, so existing scripts parsing `2>` output are unaffected.
+- **Testing**: `phase_message`'s phase → text mapping is unit-tested as
+  a pure function. `Spinner` itself is not unit-tested (same rationale
+  CLAUDE.md gives for not mocking external processes: it is a thin IO
+  wrapper with no branching logic of its own to exercise). Dynamic
+  verification (this PR's body) covers the non-TTY silence guarantee
+  and the TTY draw/clear sequence directly, since neither is expressible
+  as a unit test without a real terminal.
+- **API surface**: `run_base_pipeline` and `build_resolver` (both
+  private to `main.rs`) gain a `&Spinner` parameter; their existing test
+  call sites in `main.rs`'s own test module were updated to pass a
+  `Spinner::start(...)` instance. No change to any public crate API.

--- a/rinkaku/Cargo.toml
+++ b/rinkaku/Cargo.toml
@@ -27,6 +27,7 @@ env_logger = { workspace = true }
 self_update = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+indicatif = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -228,7 +228,7 @@ fn main() -> anyhow::Result<()> {
     // stderr draw target already suppresses drawing when stderr isn't a
     // terminal (see `spinner.rs`'s own doc comment), so this is safe to run
     // unconditionally in every input mode, including piped stderr.
-    let spinner = Spinner::start(phase_message(AnalysisPhase::AnalyzingDiff));
+    let spinner = Spinner::start(phase_message(AnalysisPhase::Starting));
     let (report, diff_text) = if let Some(pr_arg) = &cli.pr {
         // Validate the arg and derive the fetch refspec's PR number, but
         // pass the original (trimmed) value — not the parsed number — to

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -40,12 +40,14 @@
 //!   may not line up with the actual file content.
 
 mod self_update;
+mod spinner;
 
 use clap::{Parser, Subcommand};
 use rinkaku_core::deps::TagsResolver;
 use rinkaku_core::language::language_for_path;
 use rinkaku_core::pipeline::analyze_diff;
 use rinkaku_core::render::{OutputFormat, render};
+use spinner::{AnalysisPhase, Spinner, phase_message};
 use std::io::BufRead;
 use std::io::IsTerminal;
 use std::io::Read;
@@ -218,12 +220,22 @@ fn main() -> anyhow::Result<()> {
     // unrelated file if one happens to exist at the same relative path
     // there.
     let mut resolved_workdir: Option<std::path::PathBuf> = None;
+    // Started before any branch below runs and cleared right after the
+    // pipeline finishes (`spinner.finish_and_clear()`), so the whole
+    // synchronous analysis phase — the only part of a run with no
+    // per-symbol feedback of its own — gets a visible heartbeat on stderr.
+    // `Spinner::start` is a no-op-looking wrapper around `indicatif`, whose
+    // stderr draw target already suppresses drawing when stderr isn't a
+    // terminal (see `spinner.rs`'s own doc comment), so this is safe to run
+    // unconditionally in every input mode, including piped stderr.
+    let spinner = Spinner::start(phase_message(AnalysisPhase::AnalyzingDiff));
     let (report, diff_text) = if let Some(pr_arg) = &cli.pr {
         // Validate the arg and derive the fetch refspec's PR number, but
         // pass the original (trimmed) value — not the parsed number — to
         // `gh pr view` (see that function's doc comment for why).
         let parsed = parse_pr_arg(pr_arg)?;
         let number = parsed.number();
+        spinner.set_message(phase_message(AnalysisPhase::ResolvingPr));
         let workdir = resolve_pr_workdir(&parsed)?;
         resolved_workdir = workdir.clone();
         log::info!("resolving PR #{number} via gh");
@@ -256,9 +268,9 @@ fn main() -> anyhow::Result<()> {
                 base_branch = pr_info.base_ref_name,
             );
         }
-        run_base_pipeline(&cli, &base_sha, &head_sha, cwd)?
+        run_base_pipeline(&cli, &base_sha, &head_sha, cwd, &spinner)?
     } else if let Some(base) = &cli.base {
-        run_base_pipeline(&cli, base, &cli.head, None)?
+        run_base_pipeline(&cli, base, &cli.head, None, &spinner)?
     } else if std::io::stdin().is_terminal() {
         // ADR 0017: this is the third arm of an `if let Some(pr) ... else if
         // let Some(base) ... else if <here>` chain, so reaching it already
@@ -276,6 +288,7 @@ fn main() -> anyhow::Result<()> {
         // is ever restructured — e.g. a future flag added between this arm
         // and the plain stdin-read fallback below.
         log::info!("no diff input and stdin is a terminal; building a whole-repo outline");
+        spinner.set_message(phase_message(AnalysisPhase::ParsingRepository));
         let paths = list_repo_files_for_outline(None)?;
         // `check_generated_paths_batch`, not `resolve_generated_paths`
         // (which shells out via `check_generated_paths`'s CLI-argument
@@ -308,10 +321,18 @@ fn main() -> anyhow::Result<()> {
         if diff_text.trim().is_empty() {
             eprintln!("note: diff is empty, nothing to analyze");
         }
-        let resolver = build_resolver(&cli, &diff_text, read_working_tree_file, None, None)?;
+        let resolver = build_resolver(
+            &cli,
+            &diff_text,
+            read_working_tree_file,
+            None,
+            None,
+            &spinner,
+        )?;
         let changed_paths = changed_paths(&diff_text)?;
         let generated_paths = resolve_generated_paths(&cli, &changed_paths, None);
         log::info!("analyzing diff");
+        spinner.set_message(phase_message(AnalysisPhase::AnalyzingDiff));
         let report = analyze_diff(
             &diff_text,
             read_working_tree_file,
@@ -335,6 +356,12 @@ fn main() -> anyhow::Result<()> {
         }
         (report, diff_text)
     };
+    // Cleared as soon as the `Report` is built, before the `--entry` pivot
+    // (pure/instant) and the display-mode dispatch below — in particular
+    // before `DisplayMode::Tui` enters the alternate screen, since a
+    // spinner line still drawn on stderr at that point would corrupt the
+    // TUI's first frame (`spinner.rs`'s own doc comment).
+    spinner.finish_and_clear();
 
     let report = if let Some(entry) = &cli.entry {
         let pivoted = apply_entry_pivot(report, entry);
@@ -559,13 +586,21 @@ fn resolve_pr_workdir(parsed: &PrArg) -> anyhow::Result<Option<std::path::PathBu
 /// from to slice hunks out of, and this is the only place that owns it for
 /// `--base`/`--pr` mode — `main`'s stdin branch already has `diff_text` in
 /// a local variable, so it needs no such plumbing.
+///
+/// `spinner` updates its message as each phase (diffing, then building the
+/// dependency index via `build_resolver`, then the diff analysis itself)
+/// starts, so the pre-TUI stderr spinner (`main`'s `Spinner::start`) tracks
+/// which phase is running rather than sitting on a single static message
+/// for the whole `--base`/`--pr` pipeline.
 fn run_base_pipeline(
     cli: &Cli,
     base: &str,
     head: &str,
     cwd: Option<&std::path::Path>,
+    spinner: &Spinner,
 ) -> anyhow::Result<(rinkaku_core::render::Report, String)> {
     log::info!("diffing {base}...{head}");
+    spinner.set_message(phase_message(AnalysisPhase::Diffing));
     let diff_text = run_git_diff(base, head, cwd)?;
     if diff_text.trim().is_empty() {
         eprintln!("note: diff is empty, nothing to analyze");
@@ -604,10 +639,11 @@ fn run_base_pipeline(
         let base = base.to_string();
         move |path: &str| read_git_show_file(cwd, &base, path)
     };
-    let resolver = build_resolver(cli, &diff_text, &read_file, Some(head), cwd)?;
+    let resolver = build_resolver(cli, &diff_text, &read_file, Some(head), cwd, spinner)?;
     let changed_paths = changed_paths(&diff_text)?;
     let generated_paths = resolve_generated_paths(cli, &changed_paths, cwd);
     log::info!("analyzing diff");
+    spinner.set_message(phase_message(AnalysisPhase::AnalyzingDiff));
     let report = analyze_diff(
         &diff_text,
         read_file,
@@ -771,16 +807,23 @@ fn repo_outline_empty_note(report: &rinkaku_core::render::Report) -> Option<&'st
 /// generated file's definition (e.g. an ORM's model struct, dragging in
 /// every column as noise) as a test helper — see ADR 0010/0011's
 /// Consequences.
+///
+/// `spinner`'s message is updated to reflect the indexing phase once it's
+/// clear there is indexing work to do (i.e. after the `cli.deps == 0` early
+/// return) — same pre-TUI stderr spinner `main` starts before dispatching
+/// to any input-mode branch.
 fn build_resolver(
     cli: &Cli,
     diff_text: &str,
     diff_read_file: impl Fn(&str) -> std::io::Result<String>,
     head: Option<&str>,
     cwd: Option<&std::path::Path>,
+    spinner: &Spinner,
 ) -> anyhow::Result<Option<TagsResolver>> {
     if cli.deps == 0 {
         return Ok(None);
     }
+    spinner.set_message(phase_message(AnalysisPhase::BuildingDependencyIndex));
 
     let reference_names =
         rinkaku_core::pipeline::collect_referenced_names(diff_text, diff_read_file)?;
@@ -3621,7 +3664,8 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             panic!("read_file must not be called when deps == 0")
         };
 
-        let actual = build_resolver(&cli, "", read_file, None, Some(dir.path()))
+        let spinner = Spinner::start("test");
+        let actual = build_resolver(&cli, "", read_file, None, Some(dir.path()), &spinner)
             .expect("deps == 0 must not touch the repository at all");
 
         assert!(actual.is_none());
@@ -3649,7 +3693,8 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
         };
         let read_file = |_: &str| -> std::io::Result<String> { Ok(String::new()) };
 
-        let actual = build_resolver(&cli, "", read_file, None, Some(dir.path()));
+        let spinner = Spinner::start("test");
+        let actual = build_resolver(&cli, "", read_file, None, Some(dir.path()), &spinner);
 
         assert!(actual.is_err());
     }
@@ -3693,7 +3738,8 @@ Cargo.lock\0diff\0unset\0Cargo.lock\0linguist-generated\0unspecified\0normal.rs\
             entry: None,
             tui: false,
         };
-        let actual = run_base_pipeline(&cli, "HEAD", "HEAD", Some(dir.path()));
+        let spinner = Spinner::start("test");
+        let actual = run_base_pipeline(&cli, "HEAD", "HEAD", Some(dir.path()), &spinner);
 
         // Restore permissions before asserting so a failed assertion
         // doesn't leave an unreadable file behind for the tempdir cleanup.
@@ -3780,8 +3826,10 @@ fn should_add_two_numbers() {
             entry: None,
             tui: false,
         };
-        let (actual, _diff_text) = run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()))
-            .expect("run_base_pipeline should succeed for a test-only diff");
+        let spinner = Spinner::start("test");
+        let (actual, _diff_text) =
+            run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()), &spinner)
+                .expect("run_base_pipeline should succeed for a test-only diff");
 
         let expected_files: Vec<rinkaku_core::render::FileReport> = Vec::new();
         let expected_skipped: Vec<rinkaku_core::render::SkippedFile> = Vec::new();
@@ -3841,8 +3889,10 @@ fn should_add_two_numbers() {
             entry: None,
             tui: false,
         };
-        let (actual, _diff_text) = run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()))
-            .expect("run_base_pipeline should succeed for a test-only diff");
+        let spinner = Spinner::start("test");
+        let (actual, _diff_text) =
+            run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()), &spinner)
+                .expect("run_base_pipeline should succeed for a test-only diff");
 
         let expected_tests: Vec<rinkaku_core::render::TestFileSummary> = Vec::new();
         assert_eq!(expected_tests, actual.tests);
@@ -3883,8 +3933,10 @@ fn should_add_two_numbers() {
             entry: None,
             tui: false,
         };
-        let (actual, _diff_text) = run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()))
-            .expect("run_base_pipeline should succeed");
+        let spinner = Spinner::start("test");
+        let (actual, _diff_text) =
+            run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()), &spinner)
+                .expect("run_base_pipeline should succeed");
 
         let symbol = &actual.files[0].symbols[0];
         assert_eq!(

--- a/rinkaku/src/spinner.rs
+++ b/rinkaku/src/spinner.rs
@@ -31,6 +31,13 @@ impl Spinner {
     pub fn start(message: &str) -> Self {
         let bar = ProgressBar::new_spinner();
         bar.set_style(
+            // `with_template` only fails on a malformed template string
+            // (unknown placeholder, unbalanced braces); the template here
+            // is a fixed literal using two placeholders documented in
+            // `indicatif::ProgressStyle`'s own reference, so this can never
+            // fail at runtime — the `expect` exists to satisfy the
+            // `Result`-returning signature, not to guard a real failure
+            // mode.
             ProgressStyle::with_template("{spinner:.cyan} {msg}")
                 .expect("static spinner template is valid"),
         );
@@ -55,6 +62,14 @@ impl Spinner {
     }
 }
 
+// Note: an early `?`-propagated error in `main` (e.g. a failing `git`/`gh`
+// call inside `run_base_pipeline`/`build_resolver`) drops the `Spinner`
+// without ever reaching a `finish_and_clear()` call. This is still safe:
+// `indicatif`'s underlying `BarState` clears the line on `Drop` unless the
+// bar was already finished, using `ProgressFinish::AndClear` — the crate's
+// documented default — so the spinner never survives past the process
+// printing its error to stderr, with or without an explicit clear call.
+
 /// Which analysis phase is currently running, decided from the same
 /// input-mode branching `main` already does (`--pr` / `--base` / stdin /
 /// whole-repo). Kept as its own enum — rather than passing message strings
@@ -63,6 +78,12 @@ impl Spinner {
 /// without touching `indicatif`/stderr at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnalysisPhase {
+    /// The spinner's initial state, shown for the brief window between
+    /// `Spinner::start` and `main` determining which input mode (`--pr` /
+    /// `--base` / stdin / whole-repo) actually applies — none of the other
+    /// variants is correct yet at that point, so this exists to avoid
+    /// mislabeling that window as e.g. "Analyzing diff...".
+    Starting,
     /// Resolving a `--pr` argument via `gh` (fetching PR metadata, base/head
     /// commits) before any diffing starts.
     ResolvingPr,
@@ -83,6 +104,7 @@ pub enum AnalysisPhase {
 /// real terminal.
 pub fn phase_message(phase: AnalysisPhase) -> &'static str {
     match phase {
+        AnalysisPhase::Starting => "Starting...",
         AnalysisPhase::ResolvingPr => "Resolving PR...",
         AnalysisPhase::Diffing => "Diffing...",
         AnalysisPhase::BuildingDependencyIndex => "Building dependency index...",
@@ -98,6 +120,10 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
+    #[case::should_return_starting_message_when_phase_is_starting(
+        AnalysisPhase::Starting,
+        "Starting..."
+    )]
     #[case::should_return_resolving_pr_message_when_phase_is_resolving_pr(
         AnalysisPhase::ResolvingPr,
         "Resolving PR..."

--- a/rinkaku/src/spinner.rs
+++ b/rinkaku/src/spinner.rs
@@ -1,0 +1,128 @@
+//! A stderr progress spinner shown while `main` runs the analysis pipeline
+//! (`analyze_repo`/`build_resolver`/`analyze_diff`/`run_git_diff`) before
+//! either the TUI starts or Markdown/JSON output is printed.
+//!
+//! This exists because that pipeline is entirely synchronous and, for a
+//! large repository or a PR with many files, can take from hundreds of
+//! milliseconds to several seconds (ADR 0031's profiling table) with no
+//! terminal feedback at all in between — the process just appears to hang.
+//! ADR 0032 records why a spinner (rather than ADR 0031's deferred lazy
+//! start / progressive rendering alternatives) was chosen for this.
+//!
+//! Kept in the `rinkaku` bin crate, not `rinkaku-core`: this is terminal IO
+//! tied to how *this specific binary* reports progress, not part of the
+//! pure diff-condensation core (CLAUDE.md's "core logic is pure" rule).
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+/// Wraps an `indicatif::ProgressBar` configured as an indeterminate spinner
+/// on stderr. `indicatif`'s `Term`-backed stderr draw target already
+/// detects non-TTY stderr (piped/redirected) and suppresses all drawing in
+/// that case — see `ProgressDrawTarget::stderr`'s own doc comment — so no
+/// explicit `IsTerminal` check is needed here; this type only has to get
+/// the *style* and *message* right, not the TTY decision.
+pub struct Spinner {
+    bar: ProgressBar,
+}
+
+impl Spinner {
+    /// Starts a new spinner on stderr with `message` as its initial phase
+    /// label (see [`phase_message`]).
+    pub fn start(message: &str) -> Self {
+        let bar = ProgressBar::new_spinner();
+        bar.set_style(
+            ProgressStyle::with_template("{spinner:.cyan} {msg}")
+                .expect("static spinner template is valid"),
+        );
+        bar.enable_steady_tick(std::time::Duration::from_millis(100));
+        bar.set_message(message.to_string());
+        Self { bar }
+    }
+
+    /// Updates the spinner's message in place (e.g. moving from "resolving
+    /// PR" to "analyzing diff") without starting a new spinner line.
+    pub fn set_message(&self, message: &str) {
+        self.bar.set_message(message.to_string());
+    }
+
+    /// Clears the spinner from the terminal. Must be called before printing
+    /// anything else to stdout/stderr that should not be interleaved with
+    /// spinner redraws, and in particular before the TUI takes over the
+    /// terminal (entering the alternate screen with a stray spinner line
+    /// still drawn would corrupt the TUI's first frame).
+    pub fn finish_and_clear(&self) {
+        self.bar.finish_and_clear();
+    }
+}
+
+/// Which analysis phase is currently running, decided from the same
+/// input-mode branching `main` already does (`--pr` / `--base` / stdin /
+/// whole-repo). Kept as its own enum — rather than passing message strings
+/// straight from each call site — so the phase → message mapping
+/// ([`phase_message`]) is a single pure function callers can unit-test
+/// without touching `indicatif`/stderr at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnalysisPhase {
+    /// Resolving a `--pr` argument via `gh` (fetching PR metadata, base/head
+    /// commits) before any diffing starts.
+    ResolvingPr,
+    /// Running `git diff <base>...<head>` (`--base`/`--pr` mode).
+    Diffing,
+    /// Building the repo-wide dependency index (`build_resolver`, `--deps
+    /// 1`, the default).
+    BuildingDependencyIndex,
+    /// Parsing every tracked file for the whole-repo outline
+    /// (`analyze_repo`, ADR 0017's default when stdin is a terminal).
+    ParsingRepository,
+    /// Slicing signatures out of the changed files (`analyze_diff`).
+    AnalyzingDiff,
+}
+
+/// The stderr message for `phase`. Pure mapping, split out from
+/// [`Spinner::set_message`]'s call sites so it is unit-testable without a
+/// real terminal.
+pub fn phase_message(phase: AnalysisPhase) -> &'static str {
+    match phase {
+        AnalysisPhase::ResolvingPr => "Resolving PR...",
+        AnalysisPhase::Diffing => "Diffing...",
+        AnalysisPhase::BuildingDependencyIndex => "Building dependency index...",
+        AnalysisPhase::ParsingRepository => "Parsing repository...",
+        AnalysisPhase::AnalyzingDiff => "Analyzing diff...",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::should_return_resolving_pr_message_when_phase_is_resolving_pr(
+        AnalysisPhase::ResolvingPr,
+        "Resolving PR..."
+    )]
+    #[case::should_return_diffing_message_when_phase_is_diffing(
+        AnalysisPhase::Diffing,
+        "Diffing..."
+    )]
+    #[case::should_return_dependency_index_message_when_phase_is_building_dependency_index(
+        AnalysisPhase::BuildingDependencyIndex,
+        "Building dependency index..."
+    )]
+    #[case::should_return_parsing_repository_message_when_phase_is_parsing_repository(
+        AnalysisPhase::ParsingRepository,
+        "Parsing repository..."
+    )]
+    #[case::should_return_analyzing_diff_message_when_phase_is_analyzing_diff(
+        AnalysisPhase::AnalyzingDiff,
+        "Analyzing diff..."
+    )]
+    fn phase_message_returns_expected_text_per_phase(
+        #[case] phase: AnalysisPhase,
+        #[case] expected: &str,
+    ) {
+        let actual = phase_message(phase);
+        assert_eq!(expected, actual);
+    }
+}


### PR DESCRIPTION
## Summary

Every input mode (`--pr`, `--base`, stdin diff, whole-repo outline)
runs a synchronous analysis pipeline (`run_git_diff` /
`build_resolver` / `analyze_diff` / `analyze_repo`) before any output
is produced. ADR 0031's profiling table shows this ranges from tens of
milliseconds to several seconds, and today the terminal shows nothing
in between the existing one-shot `log::info!` milestones — the process
looks hung, especially right before `--tui` (the default when stdout
is a terminal) opens the alternate screen.

This adds an `indicatif`-backed stderr spinner that runs for the whole
analysis phase, updates its message as the pipeline moves between
phases (resolving a `--pr`, diffing, building the dependency index,
parsing the repository, analyzing the diff), and is cleared before any
output — Markdown, JSON, or the TUI's alternate screen — is written.

## Implementation

- New `indicatif = "0.17"` workspace dependency, consumed only by the
  `rinkaku` bin crate. It was already present in `Cargo.lock` as a
  transitive dependency of `self_update` at the same version
  (0.17.11), so this only promotes an existing transitive dependency
  to direct — no new major dependency, and `Cargo.lock`'s diff is a
  single added edge.
- New `rinkaku/src/spinner.rs`: a thin `Spinner` wrapper around
  `indicatif::ProgressBar` (`start`/`set_message`/`finish_and_clear`),
  plus a pure `AnalysisPhase` enum and `phase_message` function so the
  phase → message mapping is unit-tested without touching a real
  terminal.
- `main()` starts one `Spinner` right after the `SelfUpdate` early
  return and threads `&Spinner` through `run_base_pipeline` and
  `build_resolver`, updating the message at the same milestones the
  existing `log::info!` calls already mark.
- Non-TTY stderr needs no explicit handling: `indicatif`'s default
  stderr draw target wraps `console::Term`, which auto-detects a
  non-terminal stream and suppresses all drawing — confirmed by
  reading `indicatif`'s own doc comment and by the dynamic
  verification below.

See `docs/adr/0032-pre-tui-stderr-spinner.md` for the full design
writeup, including why this doesn't replace ADR 0031's deferred
"lazy start" / "progressive rendering" alternatives (different
problem: visible liveness during an unavoidable wait, not less wait
time), and how the spinner is guaranteed to be cleared even on an
early-return error path (`indicatif`'s `Drop`-based `AndClear`
default, not just the explicit `finish_and_clear()` call).

## File size warning (main.rs)

`rinkaku --base main`'s own map already flags `rinkaku/src/main.rs` as
over ADR 0028's 2000-line split threshold at `main`'s current tip
(4289 lines, pre-existing before this PR). This PR adds +52 lines
(the `Spinner` threading through `main`, `run_base_pipeline`, and
`build_resolver`), taking it to 4341 — the warning is not new, and
this PR does not make a passing file fail; it's already well past the
threshold and this change doesn't meaningfully move the needle.

Per CLAUDE.md's "do not merge past the warning silently" rule, this is
the required justification for not splitting in this PR: a split needs
an independent responsibility to extract (per CLAUDE.md's own
guidance, "split along responsibility, not line count"), and this PR's
diff is a thin wiring change (a `&Spinner` parameter threaded through
two existing functions plus a few `set_message` calls) with no new
responsibility of its own to pull out. `main.rs`'s CLI-wiring
composition-root role is exactly the kind of file that benefits from a
deliberate, scoped split (e.g. separating `--pr` resolution,
`--base`/diff-pipeline wiring, and `.gitattributes`/generated-path
helpers into sibling modules) rather than a split bundled
incidentally into an unrelated feature PR. Filed as a follow-up rather
than attempted here.

## Test plan

- [x] `make test` — 1059 tests pass (167 + 351 + 541 across the three
      crates), including 6 `phase_message` cases (adds `Starting`).
- [x] `make lint` — `cargo fmt --all --check` and
      `cargo clippy --all-targets --all-features -- -D warnings` both
      clean.
- [x] Dynamic verification (release build):
  - Non-TTY: `rinkaku --base HEAD~1 --format md 2>err.log` — `err.log`
    contains zero ESC bytes (spinner never drew), stdout has only the
    Markdown report. Same check repeated for stdin-piped diff mode and
    an empty-diff run; behavior matches pre-change output byte-for-byte
    aside from the pre-existing `log::info!` lines.
  - TTY (`script`-driven pseudo-tty): captured session shows the
    spinner redrawing in place (`\x1b[2K` line-clear + new frame) as it
    moves through "Analyzing diff..." → "Diffing..." → "Building
    dependency index..." → "Analyzing diff..." and then a final
    `\x1b[2K` immediately followed by the Markdown output (`##
    Change graph`) with no leftover spinner artifact.
  - TUI mode under the same pty harness: the last spinner clear
    (`\x1b[2K`) occurs immediately before the alternate-screen-enter
    sequence (`\x1b[?1049h`) — confirms `finish_and_clear()` always
    runs before the TUI takes over the terminal.

## Review follow-ups addressed

- Documented the `main.rs` file-size warning justification above
  (should-fix).
- Documented why an early `?`-propagated error still clears the
  spinner (`indicatif`'s `Drop`-based `ProgressFinish::AndClear`
  default) in both `spinner.rs` and ADR 0032 (should-fix).
- Added `AnalysisPhase::Starting` for the spinner's initial message,
  replacing the previously-inaccurate `AnalyzingDiff` placeholder
  (nit).
- Added a why-comment to the `ProgressStyle::with_template` `.expect`
  and corrected ADR 0032's inaccurate `self_update.rs` precedent claim
  (nit).
