### PR TITLE
fix(core): add id tie-break to compute_hotspots for full determinism

### DIFF
--- a/docs/adr/0013-hotspots-fan-in-section.md
+++ b/docs/adr/0013-hotspots-fan-in-section.md
@@ -123,3 +123,24 @@ This is a breaking change to the TUI's badge presentation, but has never
 shipped a release (per ADR 0015/0016), so no compatibility path is
 needed. Consumers of `Report` (Markdown / JSON / Mermaid) are
 untouched.
+
+## Amendment (2026-07-13, fix/hotspots-deterministic-tiebreak)
+
+Found while verifying byte-level output determinism during ADR 0031's
+parallel-parse work: `compute_hotspots`'s ordering was not fully
+deterministic even on `main` alone, unrelated to parallelization. The
+existing tie-break (fan-in descending, then `path` then `name` ascending,
+per this ADR's Decision section) leaves ties unresolved when two distinct
+symbols share both `path` and `name` and reach equal fan-in — e.g. two
+overloaded functions named `helper` in the same file, disambiguated only
+by the `@{start_line}` suffix in their `id` (`collect_nodes`'s
+disambiguation scheme). In that case the order between them was decided
+by `referrers_by_target`'s `HashMap` iteration order, which varies
+between runs under Rust's randomized `HashMap` hasher seed.
+
+Change: add `id` as a fourth, final tie-break key
+(`fan-in desc, path asc, name asc, id asc`) in `compute_hotspots`'s
+`sort_by` (`rinkaku-core/src/graph.rs`). `id` is always unique per node
+(`collect_nodes`'s contract), so this fully determines the order in every
+case. Purely an internal ordering fix — `Hotspot`'s fields and the
+Markdown/JSON output shapes are unchanged.

--- a/rinkaku-core/src/graph.rs
+++ b/rinkaku-core/src/graph.rs
@@ -94,8 +94,15 @@ pub struct Hotspot {
 /// symbols), so `used_by` can contain the same name twice in that case
 /// rather than silently under-counting fan-in.
 ///
-/// Results are sorted by fan-in descending, ties broken by `(path, name)`
-/// ascending for determinism independent of edge/node iteration order.
+/// Results are sorted by fan-in descending, ties broken by `(path, name,
+/// id)` ascending for determinism independent of edge/node iteration
+/// order. `id` is the final tie-break rather than `path`/`name` alone
+/// because two distinct symbols can share both — e.g. two overloaded
+/// functions named `helper` in the same file, disambiguated only by the
+/// `@{start_line}` suffix `collect_nodes` gives their `id` — and without
+/// it, `referrers_by_target`'s `HashMap` iteration order (which varies
+/// run to run under Rust's randomized `HashMap` seed) decided the order
+/// between them (see ADR 0013's amendment).
 pub fn compute_hotspots(graph: &SymbolGraph) -> Vec<Hotspot> {
     let node_by_id: HashMap<&str, &Node> = graph.nodes.iter().map(|n| (n.id.as_str(), n)).collect();
 
@@ -135,6 +142,7 @@ pub fn compute_hotspots(graph: &SymbolGraph) -> Vec<Hotspot> {
             .cmp(&a.used_by.len())
             .then_with(|| a.path.cmp(&b.path))
             .then_with(|| a.name.cmp(&b.name))
+            .then_with(|| a.id.cmp(&b.id))
     });
 
     hotspots

--- a/rinkaku-core/src/graph_tests/compute_hotspots.rs
+++ b/rinkaku-core/src/graph_tests/compute_hotspots.rs
@@ -228,6 +228,97 @@ fn should_sort_hotspots_by_fan_in_descending_when_multiple_hotspots_exist() {
 }
 
 #[test]
+fn should_break_fan_in_tie_by_id_when_path_and_name_are_also_equal() {
+    // Two distinct symbols share the same (path, name) — e.g. two
+    // overloaded `helper` functions in the same file, disambiguated only
+    // by `@line` in `id` (see `collect_nodes`'s doc comment) — and both
+    // reach fan-in 2. Without an id-based tie-break, `HashMap` iteration
+    // order in `compute_hotspots` decides the order non-deterministically
+    // across runs; the id ("a.rs::helper@1" before "a.rs::helper@9")
+    // must fix it instead.
+    let graph = SymbolGraph {
+        nodes: vec![
+            Node {
+                id: "a.rs::helper@9".to_string(),
+                path: "a.rs".to_string(),
+                name: "helper".to_string(),
+            },
+            Node {
+                id: "a.rs::helper@1".to_string(),
+                path: "a.rs".to_string(),
+                name: "helper".to_string(),
+            },
+            Node {
+                id: "a.rs::x".to_string(),
+                path: "a.rs".to_string(),
+                name: "x".to_string(),
+            },
+            Node {
+                id: "a.rs::y".to_string(),
+                path: "a.rs".to_string(),
+                name: "y".to_string(),
+            },
+            Node {
+                id: "a.rs::m".to_string(),
+                path: "a.rs".to_string(),
+                name: "m".to_string(),
+            },
+            Node {
+                id: "a.rs::n".to_string(),
+                path: "a.rs".to_string(),
+                name: "n".to_string(),
+            },
+        ],
+        edges: vec![
+            Edge {
+                from: "a.rs::x".to_string(),
+                to: "a.rs::helper@9".to_string(),
+                is_cycle: false,
+            },
+            Edge {
+                from: "a.rs::y".to_string(),
+                to: "a.rs::helper@9".to_string(),
+                is_cycle: false,
+            },
+            Edge {
+                from: "a.rs::m".to_string(),
+                to: "a.rs::helper@1".to_string(),
+                is_cycle: false,
+            },
+            Edge {
+                from: "a.rs::n".to_string(),
+                to: "a.rs::helper@1".to_string(),
+                is_cycle: false,
+            },
+        ],
+        roots: vec![
+            "a.rs::x".to_string(),
+            "a.rs::y".to_string(),
+            "a.rs::m".to_string(),
+            "a.rs::n".to_string(),
+        ],
+    };
+
+    let expected = vec![
+        Hotspot {
+            id: "a.rs::helper@1".to_string(),
+            path: "a.rs".to_string(),
+            name: "helper".to_string(),
+            used_by: vec!["m".to_string(), "n".to_string()],
+        },
+        Hotspot {
+            id: "a.rs::helper@9".to_string(),
+            path: "a.rs".to_string(),
+            name: "helper".to_string(),
+            used_by: vec!["x".to_string(), "y".to_string()],
+        },
+    ];
+    let actual = compute_hotspots(&graph);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn should_break_fan_in_tie_by_path_then_name_when_counts_are_equal() {
     // Both "b_target" (path b.rs) and "a_target" (path a.rs) have
     // fan-in 2 — must sort a.rs before b.rs by path, not by discovery


### PR DESCRIPTION
## Summary

- `compute_hotspots` (`rinkaku-core/src/graph.rs`) sorts hotspots by
  `(fan-in desc, path asc, name asc)`, but that tuple does not fully
  determine order: two distinct symbols can share both `path` and
  `name` while reaching equal fan-in — e.g. two same-named functions in
  one file, disambiguated only by the `@{start_line}` suffix in their
  `id` (`collect_nodes`'s disambiguation scheme). In that case the
  order between them was decided by `referrers_by_target`'s `HashMap`
  iteration order, which is randomized per-run under Rust's default
  hasher — producing a real, reproducible non-determinism in
  `rinkaku`'s own output for such diffs.
- Found (pre-existing, unrelated to parallelization) while verifying
  byte-level output determinism during ADR 0031's rayon parallel-parse
  work.
- Fix: add `id` as a fourth, final tie-break key. `id` is unique per
  node by construction, so the sort is now total.
- Documented as an amendment to ADR 0013 (hotspots section), matching
  the repo's convention for post-hoc design notes.

## Changes

- `rinkaku-core/src/graph.rs`: `compute_hotspots`'s `sort_by` gains
  `.then_with(|| a.id.cmp(&b.id))`; doc comment updated to explain why.
- `rinkaku-core/src/graph_tests/compute_hotspots.rs`: new test
  `should_break_fan_in_tie_by_id_when_path_and_name_are_also_equal`,
  constructing two nodes with identical `(path, name)` and equal
  fan-in, asserting the full expected `Vec<Hotspot>` ordering
  (`id` ascending). Confirmed flaky-red before the fix (failed ~half
  the time across repeated `cargo test` runs against the unpatched
  sort) and reliably green after (20/20 runs).
- `docs/adr/0013-hotspots-fan-in-section.md`: amendment recording the
  discovery and the fix.

## Test plan

- [x] `make test` — all crates pass (167 + 352 + 541 tests).
- [x] `make lint` — `cargo fmt --check` + `cargo clippy -D warnings`
      clean.
- [x] Reproduced the underlying non-determinism directly against a
      release build of `main` (7a03ce7) using a small synthetic repo
      with two identically-named `helper` functions each referenced by
      4 callers (equal fan-in, equal path/name — the exact tie case).
      20 repeated `rinkaku --base HEAD^ --format md` runs against
      unpatched `main` split 12/8 between the two possible orderings
      of the `## Hotspots` lines for the two `helper` entries.
- [x] Same synthetic-repo check against this branch's release build:
      20/20 runs produced byte-identical output (`helper@1` ordered
      before `helper@5` every time, matching `id` ascending).
- [x] Additionally ran a 10x stability check (`sha256` of `--format md`
      output) on a real historical diff (`470f85b^..0c3e362`, the
      "split three oversized files" PR, which does produce Hotspots
      including several duplicate-name entries) — stable both before
      and after the fix, since that particular diff's ties happened
      to already be broken by `path`/`name` alone (no real `id`
      collision in that dataset). The synthetic repro above is what
      actually exercises the fixed code path.