### PR TITLE
feat(tui): add a startup splash screen with real progress (ADR 0033)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,12 @@ Design rationale for the choices above is recorded in
   that takes plain data in and returns plain data out, and unit-test
   that. Reserve integration-style tests (using real fixtures under
   `resources/` or `tempfile::TempDir`) for the adapter boundary itself.
+- **When a test module grows large, split it by topic**, not by
+  mechanical top/bottom cut: sibling in-module `mod`s, or
+  `#[cfg(test)] #[path = "..."] mod tests;` files under a `*_tests/`
+  directory (ADR 0028). Don't let one file's tests grow into a single
+  monolithic block. Precedents: PR #93 (`rinkaku-core`) and PR #95
+  (`rinkaku-tui`).
 - Run `make test` before committing; it must pass together with
   `make lint`.
 

--- a/docs/adr/0033-tui-splash-screen-with-progress.md
+++ b/docs/adr/0033-tui-splash-screen-with-progress.md
@@ -158,10 +158,70 @@ a real (not simulated) fraction-complete count.
    downgraded to `log::debug!`** (e.g. `"analyzing diff"`,
    `"resolving PR #{number} via gh"`) inside the TUI branch's own call
    path, mirroring the same reasoning ADR 0032 already applied when the
-   spinner made those lines redundant for non-TUI output; `eprintln!`
-   notices (empty diff, garbage input, `used_fallback` warning) are
-   unaffected — the splash never displays those messages, so they must
-   still reach stderr to be seen at all.
+   spinner made those lines redundant for non-TUI output.
+
+8. **Advisory notes are buffered during `--tui` mode and flushed only
+   after the terminal leaves the alternate screen (amendment, added
+   during review).** The original version of this decision left every
+   `eprintln!`/`log::warn!` notice (empty diff, garbage input, an
+   `--entry` path matching nothing, the PR base-commit fallback) firing
+   immediately, on the assumption that "the splash never displays those
+   messages, so they must still reach stderr to be seen at all" was
+   enough justification to leave them untouched. Dynamic verification
+   during review disproved that: `--tui --base <ref> --entry
+   <path-matching-nothing>` writes the raw, unstyled note bytes straight
+   into the terminal's alternate-screen frame stream — mid-redraw,
+   between the splash's "Analyzing diff..." frame and the entry screen's
+   first frame — because stderr and the alternate screen are the same
+   physical terminal, and nothing about entering the alternate screen
+   redirects or suppresses a plain `eprintln!` the way it would for, say,
+   `indicatif`'s TTY-aware draw target (ADR 0032's own note on why the
+   *spinner* needs no such handling: `indicatif` already detects and
+   defers to a non-interactive stream, but a bare `eprintln!` has no such
+   awareness at all).
+
+   `AnalysisProgress` (the port `run_base_pipeline`/`build_resolver`/
+   `main.rs` already thread through for phase/progress reporting, per
+   decision 2 above) gains a third method, `note(&self, message:
+   String)`, defaulting to today's immediate `eprintln!` — every non-TUI
+   caller (the stderr `Spinner`) leaves it at that default, since stderr
+   is not being drawn over by anything outside `--tui` mode.
+   `--tui` mode's `SplashProgress` is the one override: it pushes
+   `message` onto a `Vec<String>` guarded by the same `Mutex` that
+   already serializes its terminal access, instead of printing.
+   `main.rs` extracts that buffer via
+   `SplashProgress::into_session_and_notes` (renamed from the original
+   `into_session`) alongside the plain `TuiSession`, and flushes it with
+   a small `flush_notes` helper at exactly two points — after
+   `TuiSession::run` returns (both `Ok` and `Err`, since `run`'s own
+   postamble unconditionally restores the terminal first) and after an
+   early-return analysis error drops the `TuiSession` (whose `Drop`
+   safety net, decision 5 above, restores the terminal before the flush
+   runs). Every call site that used to call `eprintln!`/`log::warn!`
+   directly — `run_base_pipeline`'s two (empty diff, garbage input),
+   `main.rs`'s `run_analysis` two (repo-outline-empty, stdin empty-diff),
+   `main.rs`'s `finish_report` one (`--entry` empty), and the PR
+   base-commit fallback (`log::warn!` → `progress.note`, reclassified as
+   a plain note rather than a log line so it is buffered the same way) —
+   now goes through `progress.note(...)` instead.
+
+   `finish_report` itself moves *inside* the `--tui` branch's still-live
+   `SplashProgress` scope (called with `&progress` before
+   `into_session_and_notes` consumes it), rather than after, specifically
+   so its own `--entry`-empty note is captured by the same buffer — the
+   bug report's exact reproduction used `--entry` for this reason.
+
+## Amendment (review round 1)
+
+Decision 8 above **is** the amendment: it replaces the original
+Consequences bullet claiming "`eprintln!` notices ... are unaffected —
+the splash never displays those messages, so they must still reach
+stderr to be seen at all" with the buffer-then-flush design, after
+dynamic verification showed that claim was false — a note written to
+stderr during `--tui` mode is not simply "not displayed by the splash",
+it is interleaved into the same terminal the splash/entry screen are
+actively redrawing, corrupting whichever frame happens to be mid-write
+when the note lands.
 
 ## Alternatives
 
@@ -234,13 +294,36 @@ a real (not simulated) fraction-complete count.
   the two file-scanning phases and a plain phase label otherwise. Every
   non-TUI display mode is byte-for-byte unaffected: `on_progress: None`
   everywhere in that path, and ADR 0032's stderr spinner keeps running
-  exactly as before.
+  exactly as before — including its notes, which (decision 8's amendment)
+  still print immediately via `AnalysisProgress::note`'s default. `--tui`
+  mode's own notes now surface *after* the session ends instead of not at
+  all mid-session, which is a UX change from ADR 0032's baseline (a
+  reviewer previously saw these notes interleaved with `log::info!` output
+  before the TUI even started; now they appear on a clean stderr right
+  after quitting/erroring out of the TUI) but strictly better than the
+  data-corrupting alternative decision 8 replaces.
+- **`rinkaku` bin API** (all `pub(crate)`, no external surface):
+  `AnalysisProgress` gains a third method, `note(&self, message: String)`,
+  defaulting to `eprintln!`. `SplashProgress::into_session` is renamed to
+  `SplashProgress::into_session_and_notes`, returning `(TuiSession,
+  Vec<String>)` instead of just `TuiSession`. `finish_report` gains a
+  `progress: &dyn AnalysisProgress` parameter (previously just `cli` and
+  `report`). A new `flush_notes(Vec<String>)` helper in `main.rs` prints a
+  buffer's contents in order.
+- **`rinkaku-tui` API**: adds `pub mod splash` (`SplashState`,
+  `LOGO_LINES`, `draw_splash`) and `pub struct TuiSession` with
+  `init`/`draw_splash`/`run`. `pub fn run(...)`'s signature is unchanged;
+  its body now delegates to `TuiSession`.
 - **Testing**: `SplashState`/the phase→label mapping/the stride decision
   (`should_report_progress_this_index`, or similarly named) are unit
   tested as pure functions (`rstest` + `pretty_assertions`). `draw_splash`
   itself gets the same coarse `TestBackend` treatment `ui::draw`'s
   submodules already use — a snapshot-style assertion that the logo and
-  label/bar appear, not a pixel-exact pin. `TuiSession::init`/`run`'s
+  label/bar appear, not a pixel-exact pin. `AnalysisProgress::note`'s
+  contract (an implementer can override it to buffer instead of printing,
+  and buffering preserves call order) is unit tested against a
+  hand-rolled fake in `progress.rs`, mirroring `SplashProgress`'s actual
+  override without needing a real terminal. `TuiSession::init`/`run`'s
   actual terminal lifecycle is not unit-tested, matching ADR 0032's own
   precedent for `Spinner` (no mocking of a real terminal) — covered
   instead by this PR's dynamic verification (pty-driven manual runs).

--- a/docs/adr/0033-tui-splash-screen-with-progress.md
+++ b/docs/adr/0033-tui-splash-screen-with-progress.md
@@ -1,0 +1,252 @@
+# 0033. A TUI splash screen with real progress during pre-render analysis
+
+- Status: accepted
+- Date: 2026-07-13
+
+## Context
+
+ADR 0032 added a stderr spinner for the synchronous analysis pipeline that
+runs before any output is produced. It covers every input mode, but stops
+being useful the moment `--tui` is the selected display mode: `main.rs`
+clears the spinner (`Spinner::finish_and_clear`) and only then calls
+`rinkaku_tui::run`, which itself does not draw anything until `run_app`'s
+event loop reaches its first `terminal.draw` call — after `App::new` and
+the up-front `diff_view::parse_diff_hunks` / `highlight::highlight_diff_files`
+computation have already run. Between `ratatui::try_init` entering the
+alternate screen and that first frame, the terminal shows a blank screen
+with no feedback at all — worse than the pre-`--tui` gap ADR 0032 fixed,
+because the alternate screen swap itself is a visible flash into
+emptiness rather than a spinner line simply continuing to spin.
+
+Two more specific gaps compound this for `--tui`'s default configuration
+(`--deps 1`, stdin-is-a-terminal → whole-repo outline, ADR 0017):
+`rinkaku_core::pipeline::analyze_repo` and
+`rinkaku_core::deps::TagsResolver::new` both scan and parse every tracked
+file in the repository, which ADR 0031's profiling table shows can take
+seconds on a large tree. The stderr spinner (still shown for these phases
+in every *other* display mode) is an indeterminate animation — it proves
+the process is alive but gives no sense of how much work remains, which
+matters most exactly when the phase is slow.
+
+This ADR is not a revisit of ADR 0031's deferred "progressive TUI
+rendering" or "lazy start" alternatives (still deferred): neither
+alternative here starts the interactive session against partial data, or
+moves the parse to a background thread. The pipeline stays fully
+synchronous on the calling thread; what changes is what the terminal
+shows while it runs, and, for the two file-scanning phases above, showing
+a real (not simulated) fraction-complete count.
+
+## Decision
+
+1. **`rinkaku` decides the display mode before running any analysis.**
+   `resolve_display_mode` (introduced by ADR 0032's `main.rs` split) only
+   depends on `cli.tui`, `cli.format`, and whether stdout is a terminal —
+   none of which depend on a `Report` — so `main` now calls it once,
+   immediately after parsing `Cli`, rather than after the pipeline
+   produces a `Report`. When the result is `DisplayMode::Tui`, `main`
+   enters the alternate screen (`rinkaku_tui::TuiSession::init`) and draws
+   the splash screen *before* branching into the `--pr`/`--base`/stdin/
+   whole-repo analysis, instead of after. The ADR 0032 stderr spinner is
+   skipped entirely in this path (`Spinner::start` is simply not called);
+   every other display mode is unaffected and keeps the spinner exactly
+   as ADR 0032 left it — the two are mutually exclusive per run, matching
+   the two paths already being separate branches of `main`.
+
+2. **No threads or channels.** The splash screen's progress is updated by
+   redrawing the same `ratatui::DefaultTerminal` from inside the analysis
+   call stack, on the same thread that called `main`. `rinkaku-core`'s
+   `analyze_repo` and `deps::TagsResolver::new` — the only two phases with
+   real per-file work to report — each gain an `on_progress: Option<&(dyn
+   Fn(usize, usize) + Sync)>` parameter (`(files_done, files_total)`),
+   defined and consumed entirely inside `rinkaku-core` (a port, per
+   CLAUDE.md's "ports as traits/closures, defined on the consumer side"
+   rule) so the core stays free of any `ratatui`/terminal dependency.
+   `main.rs` supplies a closure that calls into `rinkaku_tui`'s splash
+   redraw; every other caller (every existing test, every non-TUI display
+   mode) passes `None`, a source-compatible default requiring no changes
+   beyond the new parameter itself.
+
+   `analyze_repo`'s per-file loop is already parallelised across rayon
+   worker threads (ADR 0031); `on_progress` is called from those worker
+   threads too, via an `AtomicUsize` counter each completed file
+   increments and a fixed stride (every 16 files) that decides whether
+   *this* increment also calls `on_progress` — bounding redraw frequency
+   regardless of file count or thread count, rather than calling it on
+   every single file (thousands of redraws for a large repository) or
+   trying to serialize calls through a single thread (reintroducing the
+   cross-thread coordination this ADR explicitly avoids elsewhere).
+   `on_progress` itself must therefore be `Sync`; the terminal redraw
+   underneath it is not actually reentered concurrently in practice
+   despite the `Sync` bound — rayon's worker threads all belong to the
+   same process and the redraw itself is a plain synchronous
+   `Terminal::draw` call, so the *danger* `Sync` usually protects against
+   (two threads mutating the terminal at once) is possible in principle
+   but made harmless by the stride: the closure `main.rs` supplies takes a
+   `std::sync::Mutex` around the `DefaultTerminal` handle for the
+   duration of each redraw specifically to make this safe, rather than
+   relying on the low probability of two strided calls landing
+   simultaneously.
+
+   `deps::TagsResolver::new`'s indexing loop is sequential (unchanged by
+   this ADR — parallelising it is out of scope, see Alternatives), so its
+   own `on_progress` call needs no atomic counter: a plain `usize` counter
+   incremented once per loop iteration, called every 16 files with the
+   same stride constant as `analyze_repo`, on the single calling thread.
+
+3. **The splash view-model is pure, the drawing is not.**
+   `rinkaku-tui` gains a new `splash` module: `SplashState { phase_label:
+   String, progress: Option<(usize, usize)> }` (plain data, `PartialEq`+
+   `Debug`, no `ratatui` types) and a static `LOGO_LINES: &[&str]` ASCII-art
+   constant, mirroring `help.rs`'s existing "static content as a `const`,
+   not computed" precedent. `draw_splash(frame: &mut Frame, state:
+   &SplashState)` is the thin, deliberately-uncovered-beyond-`TestBackend`
+   rendering function `ui::draw` already sets the precedent for. The
+   progress bar, when `state.progress` is `Some((done, total))`, is a
+   determinate `ratatui::widgets::Gauge` filled to `done as f64 / total as
+   f64`; when `state.progress` is `None` (every phase except index-building/
+   whole-repo-parsing), only `phase_label` is shown under the logo — no
+   fake animation stands in for the missing signal, per this task's
+   explicit "do not fake progress" requirement.
+
+4. **`rinkaku_tui::run` splits into `TuiSession`.** `pub struct
+   TuiSession` owns the live `ratatui::DefaultTerminal` and replaces
+   `run`'s previous one-shot preamble/postamble: `TuiSession::init()`
+   performs exactly what `run`'s preamble already did (panic-hook
+   chaining, `ratatui::try_init`, `EnableMouseCapture`, with the same
+   error-path terminal restoration `run`'s own doc comment already
+   describes) and returns `io::Result<Self>`; `TuiSession::draw_splash(&mut
+   self, state: &splash::SplashState) -> io::Result<()>` draws one splash
+   frame on the already-initialized terminal; `TuiSession::run(self,
+   report, diff_text, entry_path, repo_root) -> io::Result<()>` consumes
+   `self`, runs the existing `run_app` event loop against the terminal it
+   already owns, and performs exactly the postamble `run` used to
+   (`DisableMouseCapture` + `ratatui::restore()`) — on both the `Ok` and
+   `Err` paths, matching `run`'s existing unconditional cleanup. The
+   crate's top-level `pub fn run(...)` function is kept, now implemented
+   as `TuiSession::init()?.run(...)`, so every existing caller that does
+   not need a splash screen (this crate's own doc examples, any future
+   embedder) is unaffected.
+
+5. **Error path**: an analysis error occurring after `TuiSession::init`
+   (e.g. a failing `git`/`gh` subprocess inside `run_base_pipeline`, same
+   call sites ADR 0032 already documents) must not leave the terminal in
+   the alternate screen/raw mode. `main.rs`'s `?`-propagation on the
+   analysis branch is replaced with explicit handling once a
+   `TuiSession` is live: on error, `TuiSession` is dropped/its cleanup
+   path is invoked (`ratatui::restore()` + `DisableMouseCapture`) *before*
+   the error is formatted to stderr, mirroring `run`'s own existing
+   `EnableMouseCapture`-failure branch (that function's doc comment: "this
+   function calls `ratatui::restore()` itself on that path before
+   propagating the error"). Concretely, `main` wraps the analysis branch
+   in a closure/inner function once `TuiSession` is live, and always calls
+   `TuiSession`'s explicit teardown method before returning the error —
+   there is no `Drop`-based automatic restore on `TuiSession` today (unlike
+   `indicatif`'s `BarState`, `ratatui::restore()` is not run implicitly on
+   drop), so this ADR adds a `Drop` impl for `TuiSession` that calls
+   `ratatui::restore()` (idempotent, matching `ratatui::restore`'s own
+   contract) as a safety net for exactly this early-return case, on top of
+   `TuiSession::run`'s own explicit postamble on the success path.
+
+6. **Non-TUI parity is preserved by construction**: `on_progress: None` is
+   what every non-TUI call site (Markdown/JSON display modes, the
+   whole-repo-outline branch reached when stdout is not a terminal, every
+   existing test) passes, so `analyze_repo`/`TagsResolver::new`'s
+   behavior and output are unchanged whenever a progress callback isn't
+   supplied — this is an additive parameter, not a new default.
+
+7. **`log::info!` lines that now duplicate the splash's own label are
+   downgraded to `log::debug!`** (e.g. `"analyzing diff"`,
+   `"resolving PR #{number} via gh"`) inside the TUI branch's own call
+   path, mirroring the same reasoning ADR 0032 already applied when the
+   spinner made those lines redundant for non-TUI output; `eprintln!`
+   notices (empty diff, garbage input, `used_fallback` warning) are
+   unaffected — the splash never displays those messages, so they must
+   still reach stderr to be seen at all.
+
+## Alternatives
+
+- **Thread/channel-based lazy start** (ADR 0031's deferred alternative,
+  still deferred): would let the TUI open its main screen immediately and
+  fill in rows as parsing completes elsewhere, a strictly larger change
+  to `rinkaku-tui`'s state machine and a real concurrency surface (a
+  background thread mutating `App`/`Report` state the render loop reads).
+  Not what this ADR does — the splash is a *waiting* screen, shown while
+  the same synchronous, single-call-stack pipeline ADR 0031/0032 already
+  established keeps running, not a mechanism for interacting with partial
+  results.
+- **Parallelize `TagsResolver::new`'s indexing loop with rayon**, matching
+  `analyze_repo`: would give the dependency-index phase the same
+  wall-clock win ADR 0031 gave the whole-repo-outline phase, but is a
+  larger, independently-reviewable change to `deps.rs`'s sequential
+  per-file loop (which — unlike `analyze_repo`'s already-`collect`-shaped
+  body — interleaves index insertion with the prefilter's `AhoCorasick`
+  match) and is not needed to make its progress observable. Left for a
+  future PR/ADR if `TagsResolver::new`'s own wall-clock time (not just its
+  visibility) becomes the bottleneck worth solving.
+- **A fake/animated progress bar for phases with no real signal**
+  (`ResolvingPr`, `Diffing`, `AnalyzingDiff`): rejected outright per this
+  feature's own requirement — a bar that doesn't correspond to real work
+  either lies about how much is left or, worse, stalls visibly and looks
+  broken. A label-only splash for these phases is honest about what is
+  and isn't measurable, same spirit as ADR 0032's spinner being
+  indeterminate rather than a guessed determinate bar.
+- **Route splash progress through `indicatif`** (already a `rinkaku`
+  bin-crate dependency, ADR 0032): rejected — `indicatif` draws directly
+  to a terminal stream itself, which cannot coexist with `ratatui` already
+  owning the alternate screen/raw mode. The splash is drawn with
+  `ratatui`, matching CLAUDE.md's "rinkaku-tui does not depend on
+  indicatif" requirement and ADR 0032's own "kept in the `rinkaku` bin
+  crate, not `rinkaku-tui`" boundary for the stderr spinner specifically
+  — the splash inverts that boundary on purpose, since it is TUI-mode-only
+  content.
+- **Keep `rinkaku_tui::run`'s single-function shape and pass a
+  pre-initialized `Option<DefaultTerminal>` in**: considered, but
+  `TuiSession` reads more directly as "the TUI's terminal lifecycle,
+  explicitly staged" than a function whose behavior branches on whether an
+  `Option` argument was pre-filled — the two-phase `init`/`run` split also
+  matches the fact that `main.rs` genuinely does two separate things with
+  the terminal (draw splash frames during analysis, then hand off to the
+  full event loop) rather than one.
+
+## Consequences
+
+- **Core API**: `rinkaku_core::pipeline::analyze_repo` and
+  `rinkaku_core::deps::TagsResolver::new` each gain a new
+  `on_progress: Option<&(dyn Fn(usize, usize) + Sync)>` parameter (last
+  position). Every existing call site (tests included) is updated to pass
+  `None`; behavior and output are unchanged when it is `None`. This is a
+  breaking signature change for any external caller of these two
+  functions (both are `pub`), consistent with this project's
+  pre-1.0/`0.x` versioning tolerance for additive-but-signature-breaking
+  changes (same class of change ADR 0031 made to `analyze_repo`'s
+  `read_file` bound).
+- **`rinkaku-tui` API**: adds `pub mod splash` (`SplashState`,
+  `LOGO_LINES`, `draw_splash`) and `pub struct TuiSession` with
+  `init`/`draw_splash`/`run`. `pub fn run(...)`'s signature is unchanged;
+  its body now delegates to `TuiSession`.
+- **Dependencies**: no new crate dependencies anywhere — `splash`'s
+  progress bar uses `ratatui::widgets::Gauge`, already available via the
+  existing `ratatui` dependency; `rinkaku-core`'s new counter uses
+  `std::sync::atomic::AtomicUsize`, already in `std`.
+- **UX**: `--tui` runs (the default when stdout is a terminal, ADR 0017)
+  show the rinkaku logo immediately on startup instead of a blank
+  alternate-screen flash, with a real, non-simulated progress bar during
+  the two file-scanning phases and a plain phase label otherwise. Every
+  non-TUI display mode is byte-for-byte unaffected: `on_progress: None`
+  everywhere in that path, and ADR 0032's stderr spinner keeps running
+  exactly as before.
+- **Testing**: `SplashState`/the phase→label mapping/the stride decision
+  (`should_report_progress_this_index`, or similarly named) are unit
+  tested as pure functions (`rstest` + `pretty_assertions`). `draw_splash`
+  itself gets the same coarse `TestBackend` treatment `ui::draw`'s
+  submodules already use — a snapshot-style assertion that the logo and
+  label/bar appear, not a pixel-exact pin. `TuiSession::init`/`run`'s
+  actual terminal lifecycle is not unit-tested, matching ADR 0032's own
+  precedent for `Spinner` (no mocking of a real terminal) — covered
+  instead by this PR's dynamic verification (pty-driven manual runs).
+- **Debuggability**: `TuiSession`'s `Drop`-based `ratatui::restore()`
+  safety net means a future early-return added to the TUI analysis branch
+  in `main.rs` cannot strand the terminal in raw mode/the alternate
+  screen, even without remembering to call the explicit teardown method —
+  matching the same "belt and braces" precedent `rinkaku_tui::run`'s own
+  panic-hook layering already sets.

--- a/docs/experiments/0001-map-assisted-llm-review/rounds/021.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/021.md
@@ -1,0 +1,138 @@
+# Round 21
+
+- Subject: PR #100 — a TUI startup splash screen with real progress
+  (ADR 0033). `resolve_display_mode` moves to run before any analysis;
+  `--tui` mode enters the alternate screen and draws a logo/phase-label/
+  gauge splash *before* the pipeline starts, redrawn from inside the
+  synchronous analysis call stack via a new `AnalysisProgress` port
+  (`set_phase`/`report_file_progress`) that `rinkaku_core::pipeline::
+  analyze_repo` and `deps::TagsResolver::new` both gain as an additive
+  `on_progress: Option<OnProgress>` parameter (last position, `None`
+  everywhere outside `--tui`). `rinkaku_tui::run` splits into
+  `TuiSession::{init, draw_splash, run}` plus a `Drop`-based
+  `ratatui::restore()` safety net. 19 files, ~1200 lines changed
+  (`rinkaku-core/src/{deps.rs,pipeline.rs,progress.rs}`,
+  `rinkaku-tui/src/{lib.rs,splash.rs}`, `rinkaku/src/{main.rs,pipeline.rs,
+  progress.rs,spinner.rs,splash_progress.rs}`, plus test-file call-site
+  updates).
+- Protocol note: single-reviewer session covering all three angles, same
+  format as round 17/19 for continuity — not a harness-timed A/B pair.
+- **Map-assisted pass**: `rinkaku --base main` (trusted `main` build, not
+  the branch under review) reported 69 changed symbols across 16 files,
+  correctly surfacing `analyze_repo`'s signature change (used by 14
+  tests — the single largest fan-in in the report) and clustering the
+  new `TuiSession`/`SplashProgress`/`draw_splash`/`SplashState` symbols
+  as hotspots. No `## File size warnings` entry, ruling out a file-size
+  blocker. Used the hotspot list to prioritize deep-reading
+  `splash_progress.rs`'s `Mutex<(TuiSession, String)>`, the rayon/atomic
+  progress-counter changes in `pipeline.rs`/`deps.rs`, and the
+  `TuiSession` error-path handling in `main.rs`/`lib.rs` — all of which
+  turned out to be correctly implemented. **The map had nothing to say
+  about the note-ordering bug**: `finish_report`/`run_analysis`'s
+  `eprintln!` call sites are pre-existing functions whose *signatures*
+  are unchanged by this diff (only `main`'s own control-flow ordering
+  around them changed — when `TuiSession::init()` runs relative to when
+  they're called), so nothing about them appears as a hotspot, a
+  contract marker, or even a changed-symbol entry. The defect lives
+  entirely in call-site *sequencing* inside `fn main`, which the map's
+  symbol/signature representational model has no vocabulary for at all.
+- **Independent pass**: full `git diff main...HEAD` read without the
+  map, cross-checked against ADR 0033's seven decisions and ADR 0031/
+  0032 precedent. Verified `Mutex<(TuiSession, String)>`'s `Sync`
+  reasoning, the `should_report_progress` stride math (including the
+  final-file guarantee for both the atomic-counter parallel loop and
+  the sequential `deps.rs` loop), every `analyze_repo`/`TagsResolver::
+  new` call site's `None`/`Some` update (grep-verified, no misses), and
+  the `TuiSession::init`/`Drop`/explicit-teardown error-path logic
+  against ADR 0033 decision 5's own prose. **This pass also missed the
+  note-ordering bug on a first static read.** The `main.rs` diff *shows*
+  `TuiSession::init()` now running near the top of the `DisplayMode::Tui`
+  arm, but recognizing that as a problem requires holding a second,
+  separate piece of information in mind at the same time — the *removed*
+  code's own comment on `main` (trunk): "before `DisplayMode::Tui` enters
+  the alternate screen, since a spinner line still drawn on stderr at
+  that point would corrupt the TUI's first frame." That comment doesn't
+  appear anywhere in the new diff (it described 0032-era code being
+  restructured away), so a diff-only read has to *remember* an invariant
+  from code that no longer exists in the new shape, rather than being
+  reminded of it in context. A first static pass concluded "notes look
+  unaffected — same `eprintln!` call sites, same message text" without
+  re-deriving *when* those call sites now execute relative to alternate-
+  screen entry, which is a control-flow property, not a diff-visible
+  one. The pass only caught this after deliberately re-reading `main`'s
+  trunk version side by side and noticing the ordering had flipped.
+- **Dynamic verification — this is where the finding was actually made,
+  not merely confirmed.** Neither pass above produced the finding as a
+  *prediction*; it surfaced only once the branch's own binary was built
+  and run under a PTY harness (Python `pty`/`select`) with `--tui --base
+  main~1 --entry nonexistent/path.rs`, deliberately chosen to trigger
+  `entry_pivot_empty_note` while the TUI was live. The raw captured byte
+  stream showed `note: no symbols under nonexistent/path.rs\n` spliced
+  in plain text between two consecutive `Terminal::draw` redraw
+  sequences (`...\x1b[?25l` / `note: ...\n` / `\x1b[?25l...`), with no
+  cursor positioning around it — landing wherever the cursor happened to
+  be left, not scrolled cleanly above the terminal the way it would
+  outside `--tui` mode. This is exactly the shape of bug this
+  experiment's conclusions already generalize (rounds 5, 9): "a
+  regression whose mechanism lives in unchanged code" (here, the note
+  call sites and their message text are byte-identical to trunk) and
+  "whether a data-flow wire... carries the correct value" — except this
+  round's version is a *timing* wire, not a data wire: the same
+  `eprintln!` fires the same text at the same logical point in the
+  pipeline, but relative to a terminal-mode transition that moved. Also
+  verified in the same session: `make test` (547 passed) and `make
+  lint` clean; non-TTY stdin (empty diff, garbage input), a nonexistent
+  `--base`, `--tui` with piped (non-TTY) stdout, and conflicting flags
+  (`--tui`+`--format`, `--base`+`--pr`) all failed cleanly with no
+  panics; non-TUI Markdown output carried zero stray ESC bytes; a normal
+  `q`-quit PTY session showed correct terminal restoration
+  (`\x1b[?1049l`, mouse capture disabled, cursor shown — twice, matching
+  `TuiSession::run`'s explicit postamble plus the documented-idempotent
+  `Drop` safety net, not a bug).
+- **Fix applied this round** (commits `35f9943`, `971fcbe`, by the
+  implementing agent, not this reviewer): `AnalysisProgress` gains a
+  third method, `note(&self, message: String)`, defaulting to an
+  immediate `eprintln!` (unaffected non-TUI behavior via `Spinner`'s
+  default). `SplashProgress` overrides it to push onto a `Vec<String>`
+  behind the same `Mutex` that already serializes its terminal access;
+  `main.rs` extracts the buffer via a renamed
+  `SplashProgress::into_session_and_notes` and flushes it with a new
+  `flush_notes` helper only after `TuiSession` has actually left the
+  alternate screen, on both the success path (after `TuiSession::run`'s
+  postamble) and the early-return-error path (after `TuiSession`'s
+  `Drop` safety net restores the terminal). `finish_report` now takes
+  `&dyn AnalysisProgress` so its own `--entry`-empty note is captured by
+  the same buffer — closing the exact call site this round's PTY
+  reproduction used. ADR 0033 was amended in the same batch (commit
+  `971fcbe`, its own "Amendment (review round 1)" section) to replace
+  the original, now-disproven claim that "`eprintln!` notices... are
+  unaffected" with the buffer-then-flush design (decision 8).
+  Re-verification: `make test`/`make lint` clean post-fix (not
+  independently re-run under PTY by this reviewer as part of this
+  round; the fix commit's own message documents the reproduction case
+  it was built against).
+- Severity summary: one **major** finding (stderr notes corrupting the
+  alternate screen), found and fixed in this round; no other blocking
+  findings from either static pass.
+- Takeaway, sharpening this experiment's standing conclusion that
+  "dynamic verification is the strongest single predictor of finding
+  real behavioral defects" (rounds 5-9, 18, 20): this round's defect is
+  a **pure ordering regression with a byte-identical diff at every
+  individual call site** — grepping for `eprintln!`, comparing message
+  text, and checking that every `analyze_repo`/`TagsResolver::new` call
+  site was updated all came back clean, because none of those checks
+  ask "relative to which terminal-mode transition does this line now
+  execute?" That question has no representation in rinkaku's own
+  symbol/signature model (the map is silent by design, consistent with
+  round 17's finding that body-only/control-flow-only risk sits outside
+  its coverage) *and* survives a diff-only read specifically because the
+  invariant it violates was documented on a comment attached to code
+  this diff deletes, not code it adds — the new code has nothing
+  drawing a reviewer's eye toward re-deriving that same invariant. Only
+  literally running the binary against an input engineered to produce a
+  note while `--tui` was live turned a theoretical "did the ordering
+  change matter?" into an observed "yes, here are the corrupted raw
+  bytes." This is the sharpest version yet of the experiment's
+  standing warning: neither pass's absence of a finding may be read as
+  clearance on a control-flow-ordering change, even when every touched
+  line individually looks unchanged.

--- a/rinkaku-core/src/deps.rs
+++ b/rinkaku-core/src/deps.rs
@@ -50,6 +50,7 @@
 
 use crate::extract::extract_all_symbols;
 use crate::language::LanguageSupport;
+use crate::progress::{OnProgress, should_report_progress};
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 
@@ -146,6 +147,18 @@ impl TagsResolver {
     /// Files with no registered [`LanguageSupport`] for their extension
     /// are silently skipped, matching the pipeline's handling of
     /// unsupported files elsewhere (`pipeline::analyze_diff`).
+    ///
+    /// `on_progress` (ADR 0033), when `Some`, is called with `(files_done,
+    /// total)` as this loop works through `files` — `files` is materialized
+    /// into a `Vec` first (rather than iterated lazily) specifically so
+    /// `total` is known up front the same way `pipeline::analyze_repo`'s
+    /// `paths.len()` already is; every real call site already passes a
+    /// `Vec<(String, String)>` (`main.rs`'s `build_resolver`), so this adds
+    /// no new allocation. Reported approximately every
+    /// [`crate::progress::PROGRESS_REPORT_STRIDE`] files
+    /// (`crate::progress::should_report_progress`), always including a
+    /// final `(total, total)` call. `None` (every non-`--tui` caller, every
+    /// existing test) skips the counter entirely.
     pub fn new(
         files: impl IntoIterator<Item = (String, String)>,
         language_for_path: impl Fn(&str) -> Option<&'static dyn LanguageSupport>,
@@ -153,6 +166,7 @@ impl TagsResolver {
         include_tests: bool,
         generated_paths: &HashSet<String>,
         include_generated: bool,
+        on_progress: Option<OnProgress>,
     ) -> Self {
         let mut index: HashMap<String, Vec<ResolvedSymbol>> = HashMap::new();
         // `AhoCorasick::new` only errors on pathological inputs this call
@@ -168,30 +182,43 @@ impl TagsResolver {
         let matcher = aho_corasick::AhoCorasick::new(reference_names)
             .expect("reference_names must build a valid AhoCorasick matcher");
 
-        for (path, content) in files {
-            let Some(lang) = language_for_path(&path) else {
-                continue;
-            };
-            if !include_tests && lang.is_test_path(&path) {
-                continue;
-            }
-            if !include_generated && generated_paths.contains(&path) {
-                continue;
-            }
-            if !include_generated && is_generated_content(&content) {
-                continue;
-            }
-            if !should_parse_file(&matcher, &content) {
-                continue;
-            }
-            for symbol in extract_all_symbols(&content, lang) {
-                if !include_tests && symbol.is_test {
-                    continue;
+        let files: Vec<(String, String)> = files.into_iter().collect();
+        let total = files.len();
+        for (done, (path, content)) in files.into_iter().enumerate() {
+            let outcome = (|| {
+                let lang = language_for_path(&path)?;
+                if !include_tests && lang.is_test_path(&path) {
+                    return None;
                 }
-                index.entry(symbol.name).or_default().push(ResolvedSymbol {
-                    signature: symbol.signature,
-                    path: path.clone(),
-                });
+                if !include_generated && generated_paths.contains(&path) {
+                    return None;
+                }
+                if !include_generated && is_generated_content(&content) {
+                    return None;
+                }
+                if !should_parse_file(&matcher, &content) {
+                    return None;
+                }
+                Some((lang, content))
+            })();
+
+            if let Some((lang, content)) = outcome {
+                for symbol in extract_all_symbols(&content, lang) {
+                    if !include_tests && symbol.is_test {
+                        continue;
+                    }
+                    index.entry(symbol.name).or_default().push(ResolvedSymbol {
+                        signature: symbol.signature,
+                        path: path.clone(),
+                    });
+                }
+            }
+
+            if let Some(on_progress) = on_progress {
+                let done = done + 1;
+                if should_report_progress(done, total) {
+                    on_progress(done, total);
+                }
             }
         }
 

--- a/rinkaku-core/src/deps_tests/prefilter.rs
+++ b/rinkaku-core/src/deps_tests/prefilter.rs
@@ -17,6 +17,7 @@ fn should_index_definitions_from_file_containing_a_referenced_name() {
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected = vec![ResolvedSymbol {
@@ -48,6 +49,7 @@ fn should_skip_indexing_file_whose_content_contains_no_referenced_name() {
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected: Vec<ResolvedSymbol> = Vec::new();
@@ -79,6 +81,7 @@ fn should_still_index_file_when_referenced_name_appears_incidentally_in_content(
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected = vec![ResolvedSymbol {
@@ -105,6 +108,7 @@ fn should_index_nothing_when_reference_names_is_empty() {
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected: Vec<ResolvedSymbol> = Vec::new();

--- a/rinkaku-core/src/deps_tests/tags_resolver_exclusions.rs
+++ b/rinkaku-core/src/deps_tests/tags_resolver_exclusions.rs
@@ -14,6 +14,7 @@ fn should_exclude_test_path_file_from_index_by_default() {
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected: Vec<ResolvedSymbol> = Vec::new();
@@ -35,6 +36,7 @@ fn should_include_test_path_file_in_index_when_include_tests_is_true() {
         true,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected = vec![ResolvedSymbol {
@@ -66,6 +68,7 @@ fn should_add_two_numbers() {}
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected: Vec<ResolvedSymbol> = Vec::new();
@@ -88,6 +91,7 @@ fn should_exclude_file_marked_generated_by_attribute_path_from_index_by_default(
         false,
         &generated_paths,
         false,
+        None,
     );
 
     let expected: Vec<ResolvedSymbol> = Vec::new();
@@ -118,6 +122,7 @@ func Foo() int {
         false,
         &HashSet::new(),
         false,
+        None,
     );
 
     let expected: Vec<ResolvedSymbol> = Vec::new();
@@ -149,6 +154,7 @@ func Foo() int {
         false,
         &generated_paths,
         true,
+        None,
     );
 
     let expected = vec![ResolvedSymbol {
@@ -179,6 +185,7 @@ fn should_still_index_ordinary_files_when_a_generated_file_is_excluded() {
         false,
         &HashSet::new(),
         false,
+        None,
     );
 
     let expected_foo: Vec<ResolvedSymbol> = Vec::new();
@@ -219,6 +226,7 @@ fn should_add_two_numbers() {}
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected = vec![ResolvedSymbol {
@@ -243,6 +251,7 @@ fn should_skip_file_with_unsupported_language_when_building_index() {
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected: Vec<ResolvedSymbol> = Vec::new();
@@ -270,6 +279,7 @@ fn should_index_definitions_across_multiple_languages() {
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected = vec![ResolvedSymbol {

--- a/rinkaku-core/src/deps_tests/tags_resolver_indexing.rs
+++ b/rinkaku-core/src/deps_tests/tags_resolver_indexing.rs
@@ -14,6 +14,7 @@ fn should_resolve_function_call_when_callee_is_defined_in_repo() {
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected = vec![ResolvedSymbol {
@@ -38,6 +39,7 @@ fn should_resolve_type_reference_when_type_is_defined_in_repo() {
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let expected = vec![ResolvedSymbol {
@@ -67,6 +69,7 @@ fn should_return_empty_vec_when_name_has_no_definition_in_repo() {
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     // Covers both a built-in type (`i32`, never indexed since it has
@@ -99,6 +102,7 @@ fn should_return_all_matches_when_name_is_defined_multiple_times() {
         false,
         &HashSet::new(),
         true,
+        None,
     );
 
     let mut expected = vec![

--- a/rinkaku-core/src/lib.rs
+++ b/rinkaku-core/src/lib.rs
@@ -13,4 +13,5 @@ pub mod file_size;
 pub mod graph;
 pub mod language;
 pub mod pipeline;
+pub mod progress;
 pub mod render;

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -15,8 +15,10 @@ use crate::extract::{
 use crate::file_size::compute_file_size_warnings;
 use crate::graph::{build_graph, compute_hotspots, stamp_ids};
 use crate::language::{LanguageSupport, language_for_path};
+use crate::progress::{OnProgress, should_report_progress};
 use crate::render::{FileReport, Report, ReportOrigin, SkipReason, SkippedFile, TestFileSummary};
 use rayon::prelude::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use thiserror::Error;
 
 /// A `read_file`-shaped port for fetching a changed file's *base*-side
@@ -367,12 +369,22 @@ pub fn analyze_diff(
 /// them (`build_graph`, `stamp_ids`, `compute_hotspots`), so every
 /// downstream renderer (Markdown, JSON, TUI) sees the same `Report` shape
 /// regardless of which pipeline entry point produced it.
+///
+/// `on_progress` (ADR 0033), when `Some`, is called with `(files_done,
+/// paths.len())` as files finish being processed by the parallel loop
+/// below — approximately every [`crate::progress::PROGRESS_REPORT_STRIDE`]
+/// files (`crate::progress::should_report_progress`), always including a
+/// final `(paths.len(), paths.len())` call. `None` (every caller except
+/// `--tui` mode's `main.rs`) skips all counting overhead: the atomic
+/// counter is only incremented when a callback is actually present, so
+/// existing callers pay nothing for this parameter.
 pub fn analyze_repo(
     paths: &[String],
     read_file: impl Fn(&str) -> std::io::Result<String> + Sync + Send,
     include_tests: bool,
     generated_paths: &std::collections::HashSet<String>,
     include_generated: bool,
+    on_progress: Option<OnProgress>,
 ) -> Report {
     // ADR 0031: the per-file body below is embarrassingly parallel —
     // `extract_all_symbols` builds a fresh `tree_sitter::Parser` per call
@@ -400,41 +412,64 @@ pub fn analyze_repo(
         sized: (String, usize),
         report: Option<FileReport>,
     }
+    // ADR 0033: counts files as they finish, regardless of which branch
+    // below a given file took (skipped, filtered to empty, or reported) —
+    // "progress" here means "files the loop has looked at", matching what
+    // a reviewer watching a `done/total` bar expects it to track, not just
+    // the subset that ended up producing a `FileReport`. `AtomicUsize`
+    // rather than a per-thread-local counter: rayon's worker threads share
+    // this one counter, and `fetch_add`'s return value (the count *before*
+    // this increment) is turned into a 1-indexed "files done" count with
+    // `+ 1` so `should_report_progress` sees the same 1-indexed convention
+    // `TagsResolver::new`'s sequential loop below also uses.
+    let completed = AtomicUsize::new(0);
+    let total = paths.len();
     let per_file: Vec<Option<PerFileOutcome>> = paths
         .par_iter()
         .map(|path| {
-            let lang = language_for_path(path)?;
-            if !include_tests && lang.is_test_path(path) {
-                return None;
-            }
-            if !include_generated && generated_paths.contains(path) {
-                return None;
-            }
-            // A path `git ls-files` lists can still fail to read (e.g. a
-            // submodule gitlink entry, or a file deleted in the working
-            // tree but not yet staged) — skipped rather than aborting the
-            // whole outline, same best-effort stance `main.rs`'s
-            // `build_resolver` already takes for its own working-tree read
-            // loop.
-            let content = read_file(path).ok()?;
-            if !include_generated && is_generated_content(&content) {
-                return None;
-            }
-            let sized = (path.clone(), content.lines().count());
+            let outcome = (|| {
+                let lang = language_for_path(path)?;
+                if !include_tests && lang.is_test_path(path) {
+                    return None;
+                }
+                if !include_generated && generated_paths.contains(path) {
+                    return None;
+                }
+                // A path `git ls-files` lists can still fail to read (e.g. a
+                // submodule gitlink entry, or a file deleted in the working
+                // tree but not yet staged) — skipped rather than aborting the
+                // whole outline, same best-effort stance `main.rs`'s
+                // `build_resolver` already takes for its own working-tree read
+                // loop.
+                let content = read_file(path).ok()?;
+                if !include_generated && is_generated_content(&content) {
+                    return None;
+                }
+                let sized = (path.clone(), content.lines().count());
 
-            let symbols: Vec<ExtractedSymbol> = extract_all_symbols(&content, lang)
-                .into_iter()
-                .filter(|symbol| include_tests || !symbol.is_test)
-                .collect();
-            let report = if symbols.is_empty() {
-                None
-            } else {
-                Some(FileReport {
-                    path: path.clone(),
-                    symbols,
-                })
-            };
-            Some(PerFileOutcome { sized, report })
+                let symbols: Vec<ExtractedSymbol> = extract_all_symbols(&content, lang)
+                    .into_iter()
+                    .filter(|symbol| include_tests || !symbol.is_test)
+                    .collect();
+                let report = if symbols.is_empty() {
+                    None
+                } else {
+                    Some(FileReport {
+                        path: path.clone(),
+                        symbols,
+                    })
+                };
+                Some(PerFileOutcome { sized, report })
+            })();
+
+            if let Some(on_progress) = on_progress {
+                let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                if should_report_progress(done, total) {
+                    on_progress(done, total);
+                }
+            }
+
+            outcome
         })
         .collect();
 

--- a/rinkaku-core/src/pipeline_tests/analyze_repo.rs
+++ b/rinkaku-core/src/pipeline_tests/analyze_repo.rs
@@ -26,7 +26,7 @@ fn should_return_empty_report_when_paths_is_empty() {
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_repo(&[], read_file, true, &HashSet::new(), true);
+    let actual = analyze_repo(&[], read_file, true, &HashSet::new(), true, None);
 
     assert_eq!(expected, actual);
 }
@@ -109,7 +109,7 @@ struct Point {
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+    let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
 
     assert_eq!(expected, actual);
 }
@@ -123,7 +123,7 @@ fn should_leave_classification_none_for_every_symbol() {
     let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
     let paths = vec!["src/lib.rs".to_string()];
 
-    let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+    let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
 
     let expected: Option<crate::extract::Classification> = None;
     let actual = report.files[0].symbols[0].classification;
@@ -150,7 +150,7 @@ fn should_skip_path_without_registered_language_support() {
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+    let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
 
     assert_eq!(expected, actual);
 }
@@ -173,7 +173,7 @@ fn should_skip_path_when_read_file_fails() {
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+    let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
 
     assert_eq!(expected, actual);
 }
@@ -200,7 +200,7 @@ fn should_skip_path_in_generated_paths_set_without_reading_it() {
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_repo(&paths, read_file, true, &generated_paths, true);
+    let actual = analyze_repo(&paths, read_file, true, &generated_paths, true, None);
 
     assert_eq!(expected, actual);
 }
@@ -221,7 +221,7 @@ fn should_skip_file_with_generated_content_marker_when_include_generated_is_fals
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), false);
+    let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), false, None);
 
     assert_eq!(expected, actual);
 }
@@ -232,7 +232,7 @@ fn should_not_skip_file_with_generated_content_marker_when_include_generated_is_
     let read_file = fake_reader(HashMap::from([("models/user.rs", source)]));
     let paths = vec!["models/user.rs".to_string()];
 
-    let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+    let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
 
     assert_eq!(1, report.files.len());
 }
@@ -259,7 +259,7 @@ func TestFoo(t *testing.T) {
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_repo(&paths, read_file, false, &HashSet::new(), true);
+    let actual = analyze_repo(&paths, read_file, false, &HashSet::new(), true, None);
 
     assert_eq!(expected, actual);
 }
@@ -276,7 +276,7 @@ func TestFoo(t *testing.T) {
     let read_file = fake_reader(HashMap::from([("repo_test.go", source)]));
     let paths = vec!["repo_test.go".to_string()];
 
-    let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+    let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
 
     assert_eq!(1, report.files.len());
 }
@@ -304,7 +304,7 @@ mod tests {
     let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
     let paths = vec!["src/lib.rs".to_string()];
 
-    let report = analyze_repo(&paths, read_file, false, &HashSet::new(), true);
+    let report = analyze_repo(&paths, read_file, false, &HashSet::new(), true, None);
 
     let expected_names = vec!["add".to_string()];
     let actual_names: Vec<String> = report.files[0]
@@ -335,7 +335,7 @@ fn caller_two() -> i32 {
     let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
     let paths = vec!["src/lib.rs".to_string()];
 
-    let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+    let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
 
     let expected = vec![crate::graph::Hotspot {
         id: "src/lib.rs::shared_helper".to_string(),

--- a/rinkaku-core/src/pipeline_tests/file_size_warnings.rs
+++ b/rinkaku-core/src/pipeline_tests/file_size_warnings.rs
@@ -91,7 +91,7 @@ fn should_include_warn_when_analyze_repo_reads_a_file_over_warn_threshold() {
     )]));
     let paths = vec!["src/big.rs".to_string()];
 
-    let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true);
+    let report = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
 
     let expected = vec![FileSizeWarning {
         path: "src/big.rs".to_string(),

--- a/rinkaku-core/src/pipeline_tests/parallel_determinism.rs
+++ b/rinkaku-core/src/pipeline_tests/parallel_determinism.rs
@@ -39,7 +39,7 @@ fn should_produce_deterministic_output_on_repeated_calls() {
     let read_file = fake_reader(HashMap::from_iter(files.iter().copied()));
     let paths: Vec<String> = files.iter().map(|(p, _)| p.to_string()).collect();
 
-    let first = analyze_repo(&paths, &read_file, true, &HashSet::new(), true);
+    let first = analyze_repo(&paths, &read_file, true, &HashSet::new(), true, None);
     // Repeated calls must produce byte-identical `Report`s: the
     // per-file body is pure (no interior mutability, no
     // wall-clock), rayon's `par_iter().collect()` preserves source
@@ -47,7 +47,7 @@ fn should_produce_deterministic_output_on_repeated_calls() {
     // deterministic — so any inequality here means one of those
     // invariants regressed.
     for _ in 0..4 {
-        let again = analyze_repo(&paths, &read_file, true, &HashSet::new(), true);
+        let again = analyze_repo(&paths, &read_file, true, &HashSet::new(), true, None);
         assert_eq!(first, again);
     }
 

--- a/rinkaku-core/src/progress.rs
+++ b/rinkaku-core/src/progress.rs
@@ -1,0 +1,87 @@
+//! Optional progress reporting for the pipeline's two whole-repository
+//! file-scanning phases (ADR 0033): [`crate::pipeline::analyze_repo`]'s
+//! rayon-parallel parse and [`crate::deps::TagsResolver::new`]'s sequential
+//! indexing pass.
+//!
+//! Defined here (the consumer side, per CLAUDE.md's "ports as traits,
+//! defined on the consumer side" rule) as a plain callback type rather than
+//! a trait, matching the existing `read_file`-shaped ports elsewhere in this
+//! crate (`pipeline::analyze_diff`'s `read_file`/`read_base_file`): a single
+//! `(done, total)` call is all either phase needs, so a one-method trait
+//! would add a name (`ProgressSink`, `Reporter`, ...) without adding
+//! anything a closure type doesn't already say more directly.
+//!
+//! `Sync` (not `Send`) is the bound both call sites need: `analyze_repo`'s
+//! rayon workers call the same `&(dyn Fn(usize, usize) + Sync)` reference
+//! concurrently from multiple threads without moving it, so `Sync` (safe to
+//! share a `&reference` across threads) is what's required — `Send` (safe
+//! to move a value to another thread) is not, since the callback itself
+//! never crosses a thread boundary, only calls through a shared reference
+//! do. `TagsResolver::new`'s sequential loop does not need the bound at all,
+//! but takes the same type for call-site symmetry (`main.rs` builds one
+//! closure and passes `Some(&closure)` to both).
+//!
+//! `main.rs` is the only real caller (`--tui` mode, ADR 0033); every other
+//! caller — every other display mode, every existing test — passes `None`,
+//! which both `analyze_repo` and `TagsResolver::new` treat as "do not call
+//! this at all", leaving their behavior and output byte-for-byte unchanged
+//! from before this parameter existed.
+pub type OnProgress<'a> = &'a (dyn Fn(usize, usize) + Sync);
+
+/// How many completed files must pass between two [`OnProgress`] calls for
+/// the same phase — both [`crate::pipeline::analyze_repo`]'s parallel loop
+/// and [`crate::deps::TagsResolver::new`]'s sequential one use this same
+/// constant so a redraw at "file 16 of 842" means the same thing regardless
+/// of which phase produced it.
+///
+/// Chosen as a fixed stride rather than a time-based throttle (e.g. "redraw
+/// at most every N milliseconds"): a fixed file-count stride needs no clock
+/// read on the hot per-file path (`std::time::Instant::now()` inside a
+/// rayon worker's per-file closure would itself cost something on every
+/// single file, working against the very thing this stride exists to
+/// avoid), and produces a bounded, predictable number of redraws for a
+/// given repository size (`total / 16`, roughly) rather than one that
+/// depends on how fast each file happens to parse.
+pub const PROGRESS_REPORT_STRIDE: usize = 16;
+
+/// Whether the file at `completed_count` (1-indexed: the count *after* this
+/// file finished, matching how both call sites increment their counter
+/// before checking) should trigger an [`OnProgress`] call — every
+/// [`PROGRESS_REPORT_STRIDE`]th file, plus always the very last one so a
+/// caller watching the callback sees a final `(total, total)` call and
+/// knows the phase actually reached completion, rather than potentially
+/// stopping short at the last stride boundary before `total`.
+///
+/// Pure and total, extracted out of both call sites so this exact rule is
+/// unit-testable without a real rayon pool or a large file list.
+pub fn should_report_progress(completed_count: usize, total: usize) -> bool {
+    if total == 0 {
+        return false;
+    }
+    completed_count == total || completed_count.is_multiple_of(PROGRESS_REPORT_STRIDE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::should_report_at_first_stride_boundary(16, 100, true)]
+    #[case::should_not_report_between_stride_boundaries(15, 100, false)]
+    #[case::should_not_report_between_stride_boundaries_just_past_one(17, 100, false)]
+    #[case::should_report_at_second_stride_boundary(32, 100, true)]
+    #[case::should_report_on_final_file_even_off_stride(97, 97, true)]
+    #[case::should_report_on_final_file_when_total_is_smaller_than_stride(5, 5, true)]
+    #[case::should_not_report_on_non_final_file_smaller_than_stride(3, 5, false)]
+    #[case::should_not_report_when_total_is_zero(0, 0, false)]
+    fn should_report_progress_cases(
+        #[case] completed_count: usize,
+        #[case] total: usize,
+        #[case] expected: bool,
+    ) {
+        let actual = should_report_progress(completed_count, total);
+        assert_eq!(expected, actual);
+    }
+}

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -39,6 +39,7 @@ pub mod nav;
 pub mod order;
 pub mod row_view;
 pub mod source;
+pub mod splash;
 pub mod tree;
 pub mod ui;
 
@@ -112,40 +113,123 @@ use std::time::Duration;
 /// repository) rather than this crate ever shelling out to `git` itself
 /// (ADR 0016). Without it, the source view would only work when `rinkaku`
 /// happens to be invoked from the repository root.
+///
+/// A thin convenience wrapper around [`TuiSession::init`] +
+/// [`TuiSession::run`] for callers that have no splash screen to draw
+/// in between (ADR 0033) — every terminal-lifecycle detail this doc
+/// comment describes lives on `TuiSession` now, see that type's own doc
+/// comment for the same guarantees.
 pub fn run(
     report: &Report,
     diff_text: &str,
     entry_path: Option<&str>,
     repo_root: &std::path::Path,
 ) -> std::io::Result<()> {
-    // Chained *before* `ratatui::try_init`'s own `set_panic_hook` call
-    // below, so the hook `try_init` installs wraps this one: on panic,
-    // `try_init`'s hook runs `ratatui::restore()` (raw mode/alternate
-    // screen) and then this crate's hook (disable mouse capture), rather
-    // than mouse capture silently staying enabled in the panicking
-    // caller's terminal.
-    let previous_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
-        previous_hook(info);
-    }));
+    TuiSession::init()?.run(report, diff_text, entry_path, repo_root)
+}
 
-    let mut terminal = ratatui::try_init()?;
-    // Restore explicitly on this `?`'s early-return path (rather than
-    // letting `?` skip straight past the `ratatui::restore()` call below):
-    // `try_init` above already left raw mode/the alternate screen active,
-    // and a plain `EnableMouseCapture` IO failure is not a panic, so the
-    // panic-hook layer just installed does not run either — without this,
-    // that combination would strand the caller's terminal in raw mode/
-    // alternate screen with no cleanup at all.
-    if let Err(err) = execute!(std::io::stdout(), event::EnableMouseCapture) {
-        ratatui::restore();
-        return Err(err);
+/// Owns the terminal's raw-mode/alternate-screen/mouse-capture lifecycle
+/// (ADR 0033), split out of what used to be a single [`run`] call so
+/// `main.rs` can draw [`splash::SplashState`] frames on the same terminal
+/// while the pre-render analysis pipeline runs synchronously, *before*
+/// handing off to the full event loop — without tearing down and
+/// re-entering the alternate screen in between, which would flash the
+/// terminal and defeat the splash screen's own purpose.
+///
+/// [`TuiSession::init`] performs exactly the setup [`run`]'s preamble used
+/// to (panic-hook chaining, [`ratatui::try_init`], `EnableMouseCapture`,
+/// with the same error-path terminal restoration). [`TuiSession::draw_splash`]
+/// draws one splash frame on the already-initialized terminal — call it as
+/// many times as the pipeline has phase transitions/progress updates to
+/// report, all from the same thread that called `init` (ADR 0033 decision
+/// 2: no cross-thread terminal access). [`TuiSession::run`] consumes `self`
+/// and performs exactly the postamble `run` used to
+/// (`DisableMouseCapture` + [`ratatui::restore`]) on both its `Ok` and
+/// `Err` paths.
+///
+/// A [`Drop`] impl calls [`ratatui::restore`] as a safety net for a path
+/// that drops a `TuiSession` without ever calling `run` at all (e.g.
+/// `main.rs` returning early with a `?` from inside its own analysis
+/// branch, after `init` but before a `Report` exists to hand to `run`) —
+/// `ratatui::restore` is documented idempotent, so this is safe to run
+/// again even after `run`'s own explicit postamble already restored the
+/// terminal on the ordinary path.
+pub struct TuiSession {
+    terminal: ratatui::DefaultTerminal,
+}
+
+impl TuiSession {
+    /// See the type's own doc comment for the exact setup this performs.
+    pub fn init() -> std::io::Result<Self> {
+        // Chained *before* `ratatui::try_init`'s own `set_panic_hook` call
+        // below, so the hook `try_init` installs wraps this one: on panic,
+        // `try_init`'s hook runs `ratatui::restore()` (raw mode/alternate
+        // screen) and then this crate's hook (disable mouse capture),
+        // rather than mouse capture silently staying enabled in the
+        // panicking caller's terminal.
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
+            previous_hook(info);
+        }));
+
+        let terminal = ratatui::try_init()?;
+        // Restore explicitly on this `?`'s early-return path (rather than
+        // letting `?` skip straight past the `ratatui::restore()` call
+        // below): `try_init` above already left raw mode/the alternate
+        // screen active, and a plain `EnableMouseCapture` IO failure is
+        // not a panic, so the panic-hook layer just installed does not
+        // run either — without this, that combination would strand the
+        // caller's terminal in raw mode/alternate screen with no cleanup
+        // at all.
+        if let Err(err) = execute!(std::io::stdout(), event::EnableMouseCapture) {
+            ratatui::restore();
+            return Err(err);
+        }
+        Ok(Self { terminal })
     }
-    let result = run_app(&mut terminal, report, diff_text, entry_path, repo_root);
-    let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
-    ratatui::restore();
-    result
+
+    /// Draws one splash frame (ADR 0033) on the already-initialized
+    /// terminal. Intended to be called repeatedly from `main.rs`'s
+    /// analysis call stack as the pipeline moves between phases/reports
+    /// file-scan progress — each call is a plain, synchronous
+    /// `Terminal::draw`, not a background redraw loop.
+    pub fn draw_splash(&mut self, state: &splash::SplashState) -> std::io::Result<()> {
+        self.terminal
+            .draw(|frame| splash::draw_splash(frame, state))?;
+        Ok(())
+    }
+
+    /// Runs the interactive TUI's main event loop over `report` until the
+    /// user quits, consuming `self` and restoring the terminal
+    /// unconditionally before returning — on both the `Ok` and `Err` path,
+    /// matching the postamble the pre-ADR-0033 [`run`] function always ran.
+    /// See [`run`]'s own doc comment (preserved there) for what `report`,
+    /// `diff_text`, `entry_path`, and `repo_root` mean.
+    pub fn run(
+        mut self,
+        report: &Report,
+        diff_text: &str,
+        entry_path: Option<&str>,
+        repo_root: &std::path::Path,
+    ) -> std::io::Result<()> {
+        let result = run_app(&mut self.terminal, report, diff_text, entry_path, repo_root);
+        let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
+        ratatui::restore();
+        result
+    }
+}
+
+impl Drop for TuiSession {
+    fn drop(&mut self) {
+        // Idempotent per `ratatui::restore`'s own contract: a no-op if
+        // `TuiSession::run` already restored the terminal on the ordinary
+        // path, a real safety net if `self` is dropped without `run` ever
+        // being called (e.g. `main.rs` returning early with `?` from the
+        // analysis phase, after `init` succeeded but before a `Report`
+        // exists).
+        ratatui::restore();
+    }
 }
 
 fn run_app(

--- a/rinkaku-tui/src/splash.rs
+++ b/rinkaku-tui/src/splash.rs
@@ -1,0 +1,220 @@
+//! The startup splash screen (ADR 0033): the rinkaku logo plus the current
+//! analysis phase, shown while `main.rs` runs the pre-render pipeline
+//! synchronously on the same thread that already owns the terminal — see
+//! [`crate::TuiSession`] for how a caller drives this alongside the
+//! pipeline.
+//!
+//! Split the same way every other view in this crate is (module doc
+//! comment, `crate` root): [`SplashState`] is plain data with no
+//! `ratatui`/`crossterm` types, and [`draw_splash`] is the thin terminal
+//! adapter that lays it out — mirroring `crate::ui`'s own
+//! "view-model here, drawing there" split.
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Gauge, Paragraph};
+
+/// The rinkaku wordmark, hardcoded rather than generated (ADR 0033
+/// decision 3 — a static `const`, mirroring `crate::help::HelpContent`'s own
+/// "fixed content, not computed" precedent). Kept short and wide rather
+/// than tall, so it still fits above the phase label on a modest terminal
+/// height (e.g. a CI pty running at 24 rows).
+pub const LOGO_LINES: &[&str] = &[
+    r"      _       _              _          ",
+    r"     (_)     | |            | |         ",
+    r" _ __ _ _ __ | | ____ _ _ __| |___   _   ",
+    r"| '__| | '_ \| |/ / _` | '__| / / | | |  ",
+    r"| |  | | | | |   < (_| | |  | . \ |_| |  ",
+    r"|_|  |_|_| |_|_|\_\__,_|_|  |_|\_\__,_|  ",
+];
+
+/// The splash screen's pure view-model: which phase label to show under the
+/// logo, and — only for the two file-scanning phases that can measure real
+/// progress ([`rinkaku_core::pipeline::analyze_repo`],
+/// [`rinkaku_core::deps::TagsResolver::new`]) — a `(done, total)` pair to
+/// render as a determinate bar. `None` means "no real signal for this
+/// phase", which [`draw_splash`] renders as a label with no bar rather than
+/// a fake/simulated animation (ADR 0033 decision 3: "no fake progress").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SplashState {
+    pub phase_label: String,
+    pub progress: Option<(usize, usize)>,
+}
+
+impl SplashState {
+    /// A label-only state with no progress bar — every phase except the
+    /// two file-scanning ones (`--pr`/`--base` resolution, diffing,
+    /// analyzing the diff's own changed symbols).
+    pub fn label_only(phase_label: impl Into<String>) -> Self {
+        Self {
+            phase_label: phase_label.into(),
+            progress: None,
+        }
+    }
+
+    /// A state with a determinate progress bar — `analyze_repo`'s parallel
+    /// parse or `TagsResolver::new`'s sequential index build, both of which
+    /// know their total file count up front.
+    pub fn with_progress(phase_label: impl Into<String>, done: usize, total: usize) -> Self {
+        Self {
+            phase_label: phase_label.into(),
+            progress: Some((done, total)),
+        }
+    }
+}
+
+/// Draws one splash frame: the logo centered in the upper portion of the
+/// screen, the phase label beneath it, and — when [`SplashState::progress`]
+/// is `Some`, ADR 0033 decision 3 — a determinate [`Gauge`] beneath the
+/// label showing `done`/`total` as both a filled bar and a `"{done}/{total}"`
+/// label. Deliberately uncovered by unit tests beyond the coarse
+/// `TestBackend` snapshot in this module's own test block, matching
+/// `crate::ui::draw`'s own "rendering itself is covered separately... kept
+/// few and coarse" precedent — there is no per-pixel behavior here worth
+/// pinning beyond "the logo and the current phase both show up".
+pub fn draw_splash(frame: &mut Frame, state: &SplashState) {
+    let area = frame.area();
+
+    let logo_height = LOGO_LINES.len() as u16;
+    // Logo + one blank line + phase label + (optional) gauge, vertically
+    // centered as a block rather than each line individually — a
+    // fixed-height `Constraint::Length` block sized to exactly what this
+    // frame needs, with `Constraint::Fill` above/below splitting the
+    // remaining space evenly so the block sits in the middle regardless of
+    // terminal height.
+    let content_height = logo_height + 1 + 1 + if state.progress.is_some() { 1 } else { 0 };
+    let [_, content, _] = Layout::vertical([
+        Constraint::Fill(1),
+        Constraint::Length(content_height),
+        Constraint::Fill(1),
+    ])
+    .areas(area);
+
+    let mut constraints = vec![Constraint::Length(logo_height), Constraint::Length(1)];
+    if state.progress.is_some() {
+        constraints.push(Constraint::Length(1));
+    }
+    let rows = Layout::vertical(constraints).split(content);
+
+    let logo_lines: Vec<Line> = LOGO_LINES
+        .iter()
+        .map(|line| Line::from(Span::styled(*line, Style::default().fg(Color::Cyan))).centered())
+        .collect();
+    frame.render_widget(Paragraph::new(logo_lines), rows[0]);
+
+    let label_line = Line::from(Span::styled(
+        state.phase_label.clone(),
+        Style::default().fg(Color::White),
+    ))
+    .alignment(Alignment::Center);
+    frame.render_widget(Paragraph::new(label_line), rows[1]);
+
+    if let Some((done, total)) = state.progress {
+        let ratio = progress_ratio(done, total);
+        let gauge_area = centered_gauge_area(rows[2]);
+        let gauge = Gauge::default()
+            .gauge_style(Style::default().fg(Color::Cyan))
+            .ratio(ratio)
+            .label(format!("{done}/{total}"));
+        frame.render_widget(gauge, gauge_area);
+    }
+}
+
+/// Narrows `area` to a centered horizontal band for the gauge — the full
+/// terminal width looks disproportionately wide for a single progress bar
+/// sitting under a comparatively narrow logo/label, so this caps it at
+/// [`GAUGE_WIDTH`] columns (or the full area, whichever is narrower, for a
+/// terminal too small to fit that).
+fn centered_gauge_area(area: Rect) -> Rect {
+    let width = GAUGE_WIDTH.min(area.width);
+    let [_, gauge, _] = Layout::horizontal([
+        Constraint::Fill(1),
+        Constraint::Length(width),
+        Constraint::Fill(1),
+    ])
+    .areas(area);
+    gauge
+}
+
+const GAUGE_WIDTH: u16 = 40;
+
+/// `done / total` clamped into `Gauge::ratio`'s required `0.0..=1.0` range —
+/// extracted as its own pure function so the clamping (needed because
+/// `done` can theoretically be reported as equal to `total` from a strided
+/// call landing exactly on the last file, but never meaningfully exceeds
+/// it) is unit-testable without constructing a `Gauge`/`Frame` at all, and
+/// so a `total == 0` call (no files to scan — an edge case `SplashState`
+/// itself does not prevent a caller from constructing) degrades to an empty
+/// bar rather than a division-by-zero `NaN` reaching `Gauge::ratio`, which
+/// panics on out-of-range input.
+fn progress_ratio(done: usize, total: usize) -> f64 {
+    if total == 0 {
+        return 0.0;
+    }
+    (done as f64 / total as f64).clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::should_return_zero_ratio_when_total_is_zero(0, 0, 0.0)]
+    #[case::should_return_zero_ratio_when_done_is_zero(0, 10, 0.0)]
+    #[case::should_return_half_ratio_when_done_is_half_of_total(5, 10, 0.5)]
+    #[case::should_return_one_ratio_when_done_equals_total(10, 10, 1.0)]
+    fn progress_ratio_cases(#[case] done: usize, #[case] total: usize, #[case] expected: f64) {
+        let actual = progress_ratio(done, total);
+        assert_eq!(expected, actual);
+    }
+
+    fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn should_render_logo_and_phase_label_when_progress_is_none() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
+        let state = SplashState::label_only("Resolving PR...");
+
+        terminal
+            .draw(|frame| draw_splash(frame, &state))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Resolving PR..."));
+        // No "{done}/{total}" progress fraction anywhere in the buffer —
+        // checked via the label the gauge itself would render
+        // (`Gauge::label`'s own "{done}/{total}" format), not a bare `'/'`
+        // scan: the logo's own ASCII art legitimately contains `/`/`\`
+        // strokes, so a bare-slash check would false-positive on the logo
+        // alone regardless of whether a gauge was drawn.
+        assert!(!text.contains("0/0"));
+    }
+
+    #[test]
+    fn should_render_progress_fraction_when_progress_is_some() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
+        let state = SplashState::with_progress("Building index...", 132, 842);
+
+        terminal
+            .draw(|frame| draw_splash(frame, &state))
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Building index..."));
+        assert!(text.contains("132/842"));
+    }
+}

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -46,8 +46,10 @@ mod git;
 mod github;
 mod notes;
 mod pipeline;
+mod progress;
 mod self_update;
 mod spinner;
+mod splash_progress;
 
 #[cfg(test)]
 mod test_util;
@@ -70,9 +72,13 @@ use notes::{
 use pipeline::{
     build_resolver, changed_paths, read_stdin_diff, resolve_generated_paths, run_base_pipeline,
 };
-use rinkaku_core::render::render;
-use spinner::{AnalysisPhase, Spinner, phase_message};
+use progress::AnalysisProgress;
+use rinkaku_core::render::{Report, render};
+use rinkaku_tui::TuiSession;
+use spinner::{AnalysisPhase, Spinner};
+use splash_progress::SplashProgress;
 use std::io::IsTerminal;
+use std::path::PathBuf;
 
 fn main() -> anyhow::Result<()> {
     // Default to `info`-level progress output on stderr (env_logger's own
@@ -95,38 +101,132 @@ fn main() -> anyhow::Result<()> {
         return self_update::run_self_update(yes);
     }
 
+    // ADR 0033: the display mode is decided *before* analysis runs, not
+    // after a `Report` already exists — `resolve_display_mode` only
+    // depends on `cli.tui`/`cli.format`/whether stdout is a terminal, none
+    // of which depend on a `Report`, so this ordering was always available
+    // and is what lets the `DisplayMode::Tui` branch below enter the
+    // alternate screen and start drawing a splash screen before the
+    // pipeline's first byte of work runs, instead of only after it
+    // finishes.
+    let stdout_is_tty = std::io::stdout().is_terminal();
+    let display_mode = resolve_display_mode(cli.tui, cli.format, stdout_is_tty);
+
+    match display_mode {
+        DisplayMode::Tui => {
+            // No stderr spinner in this branch (ADR 0033 decision 1): the
+            // splash screen drawn on the alternate screen is this run's
+            // only progress feedback, replacing it rather than layering on
+            // top of it.
+            let mut session = TuiSession::init()?;
+            session.draw_splash(&rinkaku_tui::splash::SplashState::label_only(
+                spinner::phase_message(AnalysisPhase::Starting),
+            ))?;
+            let progress = SplashProgress::new(session);
+            let outcome = run_analysis(&cli, &progress);
+            let session = progress.into_session();
+            let analyzed = match outcome {
+                Ok(analyzed) => analyzed,
+                Err(err) => {
+                    // `session` (and with it, `TuiSession`'s `Drop` impl)
+                    // is dropped right here, before `err` propagates past
+                    // this function — restoring the terminal ahead of
+                    // `main`'s `anyhow` error path printing the failure to
+                    // stderr, exactly like `rinkaku_tui::run`'s pre-ADR-0033
+                    // `EnableMouseCapture`-failure branch already did for
+                    // its own early-return case.
+                    drop(session);
+                    return Err(err);
+                }
+            };
+            let report = finish_report(&cli, analyzed.report);
+            let repo_root = resolve_repo_root(analyzed.resolved_workdir.as_deref());
+            session
+                .run(
+                    &report,
+                    &analyzed.diff_text,
+                    cli.entry.as_deref(),
+                    &repo_root,
+                )
+                .map_err(anyhow::Error::from)
+        }
+        DisplayMode::Output(format) => {
+            // Started before any branch below runs and cleared right after
+            // the pipeline finishes (`spinner.finish_and_clear()`), so the
+            // whole synchronous analysis phase — the only part of a run
+            // with no per-symbol feedback of its own — gets a visible
+            // heartbeat on stderr. `Spinner::start` is a no-op-looking
+            // wrapper around `indicatif`, whose stderr draw target already
+            // suppresses drawing when stderr isn't a terminal (see
+            // `spinner.rs`'s own doc comment), so this is safe to run
+            // unconditionally in every non-TUI input mode, including piped
+            // stderr.
+            let spinner = Spinner::start(spinner::phase_message(AnalysisPhase::Starting));
+            let analyzed = run_analysis(&cli, &spinner)?;
+            // Cleared as soon as the `Report` is built, before the
+            // `--entry` pivot (pure/instant) and the render call below.
+            spinner.finish_and_clear();
+
+            let report = finish_report(&cli, analyzed.report);
+            let output = render(&report, format.into())?;
+            print!("{output}");
+            Ok(())
+        }
+    }
+}
+
+/// The result of [`run_analysis`]: a built [`Report`], the raw diff text
+/// (empty for the whole-repo-outline branch, ADR 0017), and the resolved
+/// working directory (`--pr`'s own clone/cache directory, `None` for every
+/// other input mode) — grouped into a named struct rather than a tuple so
+/// each field keeps its name at the one call site that destructures all
+/// three (a positional tuple invites a field-order mix-up the first time
+/// this return shape is touched, the same reasoning
+/// `rinkaku_tui::DiffPaneSelectionEffects` documents for itself).
+struct AnalyzedReport {
+    report: Report,
+    diff_text: String,
+    resolved_workdir: Option<PathBuf>,
+}
+
+/// Runs the same `--pr`/`--base`/stdin/whole-repo input-mode chain
+/// `main` always has, reporting progress through `progress` (ADR 0033) —
+/// `&dyn AnalysisProgress` rather than a concrete `Spinner`/`SplashProgress`
+/// so this one function serves both `DisplayMode`s in `main` without
+/// duplicating the chain itself. Extracted out of `main` specifically so
+/// the `DisplayMode::Tui` branch there can call it with a live
+/// `SplashProgress` sitting in between `TuiSession::init` and
+/// `TuiSession::run`, while the non-TUI branch calls it with a `Spinner` —
+/// the input-mode logic itself does not need to know which one it got.
+fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<AnalyzedReport> {
     // Tracks the same `cwd`/`workdir` each branch below already resolves for
     // its own `git`/`gh` calls, so the TUI's source view (`repo_root`,
-    // below) reads files from the repository the `Report` was actually
-    // built from rather than always the process's current directory —
-    // `--pr` in particular can run entirely against a ghq/cache clone
-    // elsewhere on disk (`resolve_pr_workdir`), and `resolve_repo_root(None)`
-    // would silently resolve the *process's* repo instead, showing an
-    // unrelated file if one happens to exist at the same relative path
-    // there.
+    // `main`'s own use of this result) reads files from the repository the
+    // `Report` was actually built from rather than always the process's
+    // current directory — `--pr` in particular can run entirely against a
+    // ghq/cache clone elsewhere on disk (`resolve_pr_workdir`), and
+    // `resolve_repo_root(None)` would silently resolve the *process's* repo
+    // instead, showing an unrelated file if one happens to exist at the
+    // same relative path there.
     let mut resolved_workdir: Option<std::path::PathBuf> = None;
-    // Started before any branch below runs and cleared right after the
-    // pipeline finishes (`spinner.finish_and_clear()`), so the whole
-    // synchronous analysis phase — the only part of a run with no
-    // per-symbol feedback of its own — gets a visible heartbeat on stderr.
-    // `Spinner::start` is a no-op-looking wrapper around `indicatif`, whose
-    // stderr draw target already suppresses drawing when stderr isn't a
-    // terminal (see `spinner.rs`'s own doc comment), so this is safe to run
-    // unconditionally in every input mode, including piped stderr.
-    let spinner = Spinner::start(phase_message(AnalysisPhase::Starting));
     let (report, diff_text) = if let Some(pr_arg) = &cli.pr {
         // Validate the arg and derive the fetch refspec's PR number, but
         // pass the original (trimmed) value — not the parsed number — to
         // `gh pr view` (see that function's doc comment for why).
         let parsed = parse_pr_arg(pr_arg)?;
         let number = parsed.number();
-        spinner.set_message(phase_message(AnalysisPhase::ResolvingPr));
+        progress.set_phase(AnalysisPhase::ResolvingPr);
         let workdir = resolve_pr_workdir(&parsed)?;
         resolved_workdir = workdir.clone();
-        log::info!("resolving PR #{number} via gh");
+        // ADR 0033: downgraded from `log::info!` to `log::debug!` — this
+        // and the sibling milestone lines below duplicate what the
+        // spinner/splash's own phase label already shows on every run
+        // (ADR 0032 already made the same call for the lines that overlap
+        // with `phase_message`'s own text).
+        log::debug!("resolving PR #{number} via gh");
         let pr_info = fetch_pr_info(pr_arg.trim())?;
         let cwd = workdir.as_deref();
-        log::info!("fetching PR #{number} head");
+        log::debug!("fetching PR #{number} head");
         let head_sha = fetch_pr_head(number, cwd)?;
         if head_sha != pr_info.head_ref_oid {
             anyhow::bail!(
@@ -137,7 +237,7 @@ fn main() -> anyhow::Result<()> {
                 expected = pr_info.head_ref_oid,
             );
         }
-        log::info!("resolving PR #{number} base commit");
+        log::debug!("resolving PR #{number} base commit");
         let (base_sha, used_fallback) = resolve_pr_base_sha(
             &pr_info.base_ref_oid,
             |oid| object_exists_locally(cwd, oid),
@@ -153,9 +253,9 @@ fn main() -> anyhow::Result<()> {
                 base_branch = pr_info.base_ref_name,
             );
         }
-        run_base_pipeline(&cli, &base_sha, &head_sha, cwd, &spinner)?
+        run_base_pipeline(cli, &base_sha, &head_sha, cwd, progress)?
     } else if let Some(base) = &cli.base {
-        run_base_pipeline(&cli, base, &cli.head, None, &spinner)?
+        run_base_pipeline(cli, base, &cli.head, None, progress)?
     } else if std::io::stdin().is_terminal() {
         // ADR 0017: this is the third arm of an `if let Some(pr) ... else if
         // let Some(base) ... else if <here>` chain, so reaching it already
@@ -172,8 +272,8 @@ fn main() -> anyhow::Result<()> {
         // but is kept as a defensive check in case this `if`/`else if` chain
         // is ever restructured — e.g. a future flag added between this arm
         // and the plain stdin-read fallback below.
-        log::info!("no diff input and stdin is a terminal; building a whole-repo outline");
-        spinner.set_message(phase_message(AnalysisPhase::ParsingRepository));
+        log::debug!("no diff input and stdin is a terminal; building a whole-repo outline");
+        progress.set_phase(AnalysisPhase::ParsingRepository);
         let paths = list_repo_files_for_outline(None)?;
         // `check_generated_paths_batch`, not `resolve_generated_paths`
         // (which shells out via `check_generated_paths`'s CLI-argument
@@ -187,6 +287,14 @@ fn main() -> anyhow::Result<()> {
         } else {
             check_generated_paths_batch(None, &paths)
         };
+        // ADR 0033: reports `(files_done, total)` back through `progress`
+        // as `analyze_repo`'s rayon-parallel loop works through `paths` —
+        // see `rinkaku_core::progress::OnProgress`'s own doc comment for
+        // why this closure must be `Sync` (it is called from worker
+        // threads), which `&dyn AnalysisProgress` already satisfies
+        // (`AnalysisProgress: Sync`).
+        let on_file_progress =
+            |done: usize, total: usize| progress.report_file_progress(done, total);
         let report = rinkaku_core::pipeline::analyze_repo(
             &paths,
             read_working_tree_file,
@@ -196,6 +304,7 @@ fn main() -> anyhow::Result<()> {
             !cli.exclude_tests,
             &generated_paths,
             cli.include_generated,
+            Some(&on_file_progress),
         );
         if let Some(note) = repo_outline_empty_note(&report) {
             eprintln!("{note}");
@@ -207,17 +316,17 @@ fn main() -> anyhow::Result<()> {
             eprintln!("note: diff is empty, nothing to analyze");
         }
         let resolver = build_resolver(
-            &cli,
+            cli,
             &diff_text,
             read_working_tree_file,
             None,
             None,
-            &spinner,
+            progress,
         )?;
         let changed_paths = changed_paths(&diff_text)?;
-        let generated_paths = resolve_generated_paths(&cli, &changed_paths, None);
-        log::info!("analyzing diff");
-        spinner.set_message(phase_message(AnalysisPhase::AnalyzingDiff));
+        let generated_paths = resolve_generated_paths(cli, &changed_paths, None);
+        log::debug!("analyzing diff");
+        progress.set_phase(AnalysisPhase::AnalyzingDiff);
         let report = rinkaku_core::pipeline::analyze_diff(
             &diff_text,
             read_working_tree_file,
@@ -241,14 +350,20 @@ fn main() -> anyhow::Result<()> {
         }
         (report, diff_text)
     };
-    // Cleared as soon as the `Report` is built, before the `--entry` pivot
-    // (pure/instant) and the display-mode dispatch below — in particular
-    // before `DisplayMode::Tui` enters the alternate screen, since a
-    // spinner line still drawn on stderr at that point would corrupt the
-    // TUI's first frame (`spinner.rs`'s own doc comment).
-    spinner.finish_and_clear();
 
-    let report = if let Some(entry) = &cli.entry {
+    Ok(AnalyzedReport {
+        report,
+        diff_text,
+        resolved_workdir,
+    })
+}
+
+/// Applies `--entry`'s pivot (ADR 0019) to `report`, printing the
+/// corresponding empty-result note when applicable — shared by both
+/// `DisplayMode` branches in `main`, which used to inline this
+/// identically.
+fn finish_report(cli: &Cli, report: Report) -> Report {
+    if let Some(entry) = &cli.entry {
         let pivoted = apply_entry_pivot(report, entry);
         if let Some(note) = entry_pivot_empty_note(&pivoted, entry) {
             eprintln!("{note}");
@@ -256,19 +371,5 @@ fn main() -> anyhow::Result<()> {
         pivoted
     } else {
         report
-    };
-
-    let stdout_is_tty = std::io::stdout().is_terminal();
-    match resolve_display_mode(cli.tui, cli.format, stdout_is_tty) {
-        DisplayMode::Tui => {
-            let repo_root = resolve_repo_root(resolved_workdir.as_deref());
-            rinkaku_tui::run(&report, &diff_text, cli.entry.as_deref(), &repo_root)?
-        }
-        DisplayMode::Output(format) => {
-            let output = render(&report, format.into())?;
-            print!("{output}");
-        }
     }
-
-    Ok(())
 }

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -123,9 +123,19 @@ fn main() -> anyhow::Result<()> {
                 spinner::phase_message(AnalysisPhase::Starting),
             ))?;
             let progress = SplashProgress::new(session);
-            let outcome = run_analysis(&cli, &progress);
-            let session = progress.into_session();
-            let analyzed = match outcome {
+            let outcome = run_analysis(&cli, &progress).map(|analyzed| {
+                // `finish_report` is called *before* `into_session_and_notes`
+                // below, while `progress` is still the active
+                // `AnalysisProgress` — its own `--entry`-empty note (ADR
+                // 0019) must go through the same buffering `note` does for
+                // every other advisory message in this branch, or it would
+                // reintroduce exactly the raw-bytes-mid-redraw bug this ADR
+                // amendment fixes, just for one more call site.
+                let report = finish_report(&cli, &progress, analyzed.report);
+                (report, analyzed.diff_text, analyzed.resolved_workdir)
+            });
+            let (session, buffered_notes) = progress.into_session_and_notes();
+            let (report, diff_text, resolved_workdir) = match outcome {
                 Ok(analyzed) => analyzed,
                 Err(err) => {
                     // `session` (and with it, `TuiSession`'s `Drop` impl)
@@ -134,21 +144,36 @@ fn main() -> anyhow::Result<()> {
                     // `main`'s `anyhow` error path printing the failure to
                     // stderr, exactly like `rinkaku_tui::run`'s pre-ADR-0033
                     // `EnableMouseCapture`-failure branch already did for
-                    // its own early-return case.
+                    // its own early-return case. `buffered_notes` are
+                    // flushed here too (before the terminal-restoring drop
+                    // completes, but after — `flush_notes` is plain
+                    // `eprintln!`, so ordering against the drop itself
+                    // doesn't matter for correctness, only that this runs
+                    // after the alternate screen is torn down, which
+                    // dropping `session` right below guarantees) so a note
+                    // buffered before the error (e.g. `used_fallback`'s
+                    // warning, ADR 0033) is not silently lost on an
+                    // early-return failure.
                     drop(session);
+                    flush_notes(buffered_notes);
                     return Err(err);
                 }
             };
-            let report = finish_report(&cli, analyzed.report);
-            let repo_root = resolve_repo_root(analyzed.resolved_workdir.as_deref());
-            session
-                .run(
-                    &report,
-                    &analyzed.diff_text,
-                    cli.entry.as_deref(),
-                    &repo_root,
-                )
-                .map_err(anyhow::Error::from)
+            let repo_root = resolve_repo_root(resolved_workdir.as_deref());
+            let result = session
+                .run(&report, &diff_text, cli.entry.as_deref(), &repo_root)
+                .map_err(anyhow::Error::from);
+            // Flushed after `TuiSession::run` has already restored the
+            // terminal (its own postamble, unconditional on both the `Ok`
+            // and `Err` paths — see that method's doc comment) — this is
+            // the whole point of buffering in the first place: every note
+            // accumulated during analysis (empty diff, garbage input, an
+            // `--entry` path matching nothing, the PR base-commit
+            // fallback) now reaches stderr as clean, ordinary text once
+            // the alternate screen is gone, instead of corrupting a splash
+            // or entry-screen frame mid-redraw.
+            flush_notes(buffered_notes);
+            result
         }
         DisplayMode::Output(format) => {
             // Started before any branch below runs and cleared right after
@@ -167,11 +192,29 @@ fn main() -> anyhow::Result<()> {
             // `--entry` pivot (pure/instant) and the render call below.
             spinner.finish_and_clear();
 
-            let report = finish_report(&cli, analyzed.report);
+            // Unaffected by ADR 0033's note-deferral amendment: `Spinner`
+            // leaves `AnalysisProgress::note` at its default (immediate
+            // `eprintln!`), since stderr is not being drawn over by
+            // anything in this display mode — every note in this branch
+            // still reaches stderr the instant it is produced, same as
+            // before this ADR existed.
+            let report = finish_report(&cli, &spinner, analyzed.report);
             let output = render(&report, format.into())?;
             print!("{output}");
             Ok(())
         }
+    }
+}
+
+/// Prints every buffered note (ADR 0033's note-deferral amendment) to
+/// stderr, in the order [`AnalysisProgress::note`] received them — the
+/// flush half of `--tui` mode's buffer-then-flush strategy, called only
+/// after the terminal has actually left the alternate screen (both of this
+/// function's two call sites in `main` are positioned that way; see each
+/// one's own comment).
+fn flush_notes(notes: Vec<String>) {
+    for note in notes {
+        eprintln!("{note}");
     }
 }
 
@@ -245,13 +288,19 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
             |oid| fetch_oid(cwd, oid),
         )?;
         if used_fallback {
-            log::warn!(
-                "could not resolve PR #{number}'s base commit ({base_oid}) locally; falling \
-                 back to the current tip of {base_branch}, which may not reproduce the original \
-                 PR diff for a merged PR",
+            // ADR 0033: routed through `progress.note` rather than a bare
+            // `log::warn!` (which — like every other stderr write this
+            // function used to make directly — would otherwise interleave
+            // raw bytes into the TUI's alternate-screen frame stream mid-
+            // redraw; see `AnalysisProgress::note`'s own doc comment for
+            // the dynamic-verification finding that drove this).
+            progress.note(format!(
+                "warning: could not resolve PR #{number}'s base commit ({base_oid}) locally; \
+                 falling back to the current tip of {base_branch}, which may not reproduce the \
+                 original PR diff for a merged PR",
                 base_oid = pr_info.base_ref_oid,
                 base_branch = pr_info.base_ref_name,
-            );
+            ));
         }
         run_base_pipeline(cli, &base_sha, &head_sha, cwd, progress)?
     } else if let Some(base) = &cli.base {
@@ -307,13 +356,13 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
             Some(&on_file_progress),
         );
         if let Some(note) = repo_outline_empty_note(&report) {
-            eprintln!("{note}");
+            progress.note(note.to_string());
         }
         (report, String::new())
     } else {
         let diff_text = read_stdin_diff()?;
         if diff_text.trim().is_empty() {
-            eprintln!("note: diff is empty, nothing to analyze");
+            progress.note("note: diff is empty, nothing to analyze".to_string());
         }
         let resolver = build_resolver(
             cli,
@@ -346,7 +395,7 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
             cli.include_generated,
         )?;
         if let Some(note) = garbage_input_note(&diff_text, &report) {
-            eprintln!("{note}");
+            progress.note(note.to_string());
         }
         (report, diff_text)
     };
@@ -358,15 +407,18 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
     })
 }
 
-/// Applies `--entry`'s pivot (ADR 0019) to `report`, printing the
-/// corresponding empty-result note when applicable — shared by both
-/// `DisplayMode` branches in `main`, which used to inline this
-/// identically.
-fn finish_report(cli: &Cli, report: Report) -> Report {
+/// Applies `--entry`'s pivot (ADR 0019) to `report`, reporting the
+/// corresponding empty-result note through `progress` (ADR 0033) when
+/// applicable — shared by both `DisplayMode` branches in `main`, which used
+/// to inline this identically. `progress` rather than a bare `eprintln!`:
+/// this function runs inside the `DisplayMode::Tui` branch too, while a
+/// `SplashProgress` is still buffering notes rather than printing them
+/// immediately (see `AnalysisProgress::note`'s own doc comment).
+fn finish_report(cli: &Cli, progress: &dyn AnalysisProgress, report: Report) -> Report {
     if let Some(entry) = &cli.entry {
         let pivoted = apply_entry_pivot(report, entry);
         if let Some(note) = entry_pivot_empty_note(&pivoted, entry) {
-            eprintln!("{note}");
+            progress.note(note);
         }
         pivoted
     } else {

--- a/rinkaku/src/pipeline.rs
+++ b/rinkaku/src/pipeline.rs
@@ -11,7 +11,8 @@ use crate::git::cat_file_batch::read_git_show_files_batch;
 use crate::git::commands::{list_git_files, run_git_diff};
 use crate::git::file_read::{read_git_show_file, read_working_tree_file};
 use crate::notes::garbage_input_note;
-use crate::spinner::{AnalysisPhase, Spinner, phase_message};
+use crate::progress::AnalysisProgress;
+use crate::spinner::AnalysisPhase;
 use rinkaku_core::deps::TagsResolver;
 use rinkaku_core::language::language_for_path;
 use rinkaku_core::pipeline::analyze_diff;
@@ -22,10 +23,10 @@ pub(crate) fn run_base_pipeline(
     base: &str,
     head: &str,
     cwd: Option<&std::path::Path>,
-    spinner: &Spinner,
+    progress: &dyn AnalysisProgress,
 ) -> anyhow::Result<(rinkaku_core::render::Report, String)> {
-    log::info!("diffing {base}...{head}");
-    spinner.set_message(phase_message(AnalysisPhase::Diffing));
+    log::debug!("diffing {base}...{head}");
+    progress.set_phase(AnalysisPhase::Diffing);
     let diff_text = run_git_diff(base, head, cwd)?;
     if diff_text.trim().is_empty() {
         eprintln!("note: diff is empty, nothing to analyze");
@@ -64,11 +65,11 @@ pub(crate) fn run_base_pipeline(
         let base = base.to_string();
         move |path: &str| read_git_show_file(cwd, &base, path)
     };
-    let resolver = build_resolver(cli, &diff_text, &read_file, Some(head), cwd, spinner)?;
+    let resolver = build_resolver(cli, &diff_text, &read_file, Some(head), cwd, progress)?;
     let changed_paths = changed_paths(&diff_text)?;
     let generated_paths = resolve_generated_paths(cli, &changed_paths, cwd);
-    log::info!("analyzing diff");
-    spinner.set_message(phase_message(AnalysisPhase::AnalyzingDiff));
+    log::debug!("analyzing diff");
+    progress.set_phase(AnalysisPhase::AnalyzingDiff);
     let report = analyze_diff(
         &diff_text,
         read_file,
@@ -112,18 +113,18 @@ pub(crate) fn build_resolver(
     diff_read_file: impl Fn(&str) -> std::io::Result<String>,
     head: Option<&str>,
     cwd: Option<&std::path::Path>,
-    spinner: &Spinner,
+    progress: &dyn AnalysisProgress,
 ) -> anyhow::Result<Option<TagsResolver>> {
     if cli.deps == 0 {
         return Ok(None);
     }
-    spinner.set_message(phase_message(AnalysisPhase::BuildingDependencyIndex));
+    progress.set_phase(AnalysisPhase::BuildingDependencyIndex);
 
     let reference_names =
         rinkaku_core::pipeline::collect_referenced_names(diff_text, diff_read_file)?;
 
     let paths = list_git_files(cwd)?;
-    log::info!(
+    log::debug!(
         "building dependency index over {} tracked files",
         paths.len()
     );
@@ -156,6 +157,13 @@ pub(crate) fn build_resolver(
             })
             .collect(),
     };
+    // ADR 0033: reports `(files_done, total)` back through `progress` as
+    // `TagsResolver::new`'s sequential indexing loop works through `files`
+    // — a plain closure over `progress` (a `&dyn AnalysisProgress`, already
+    // object-safe) rather than a new abstraction, since
+    // `rinkaku_core::progress::OnProgress` is exactly the `Fn(usize, usize)
+    // + Sync` shape `TagsResolver::new` expects.
+    let on_file_progress = |done: usize, total: usize| progress.report_file_progress(done, total);
     Ok(Some(TagsResolver::new(
         files,
         language_for_path,
@@ -165,6 +173,7 @@ pub(crate) fn build_resolver(
         !cli.exclude_tests,
         &generated_paths,
         cli.include_generated,
+        Some(&on_file_progress),
     )))
 }
 
@@ -182,6 +191,7 @@ pub(crate) fn read_stdin_diff() -> anyhow::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::spinner::Spinner;
     use crate::test_util::{init_repo_with_committed_file, run_git};
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;

--- a/rinkaku/src/pipeline.rs
+++ b/rinkaku/src/pipeline.rs
@@ -29,7 +29,11 @@ pub(crate) fn run_base_pipeline(
     progress.set_phase(AnalysisPhase::Diffing);
     let diff_text = run_git_diff(base, head, cwd)?;
     if diff_text.trim().is_empty() {
-        eprintln!("note: diff is empty, nothing to analyze");
+        // ADR 0033: routed through `progress.note` rather than a bare
+        // `eprintln!` — see `AnalysisProgress::note`'s own doc comment for
+        // why (a raw stderr write here would interleave into the TUI's
+        // alternate-screen frame stream mid-redraw during `--tui` mode).
+        progress.note("note: diff is empty, nothing to analyze".to_string());
         return Ok((
             rinkaku_core::render::Report {
                 origin: rinkaku_core::render::ReportOrigin::Diff,
@@ -84,7 +88,7 @@ pub(crate) fn run_base_pipeline(
         cli.include_generated,
     )?;
     if let Some(note) = garbage_input_note(&diff_text, &report) {
-        eprintln!("{note}");
+        progress.note(note.to_string());
     }
     Ok((report, diff_text))
 }

--- a/rinkaku/src/progress.rs
+++ b/rinkaku/src/progress.rs
@@ -2,18 +2,24 @@
 //! `pipeline::run_base_pipeline`/`build_resolver` (ADR 0033), replacing the
 //! bare `&Spinner` parameter those functions used to take.
 //!
-//! Two phase-reporting concerns used to be conflated in `&Spinner`: "which
-//! phase is running" (every display mode wants this) and "how far along a
-//! file-scanning phase is" (only `--tui` mode's splash screen can show a
-//! real bar for — ADR 0032's stderr spinner is deliberately indeterminate).
-//! [`AnalysisProgress`] separates them into two methods so a caller that has
-//! no file-count signal (the stderr [`crate::spinner::Spinner`]) can just
-//! no-op the second one, rather than every display mode having to fake a
-//! `(done, total)` pair it doesn't have.
+//! Three concerns used to be conflated in `&Spinner`/bare `eprintln!` calls
+//! scattered across `main.rs`/`pipeline.rs`: "which phase is running"
+//! (every display mode wants this), "how far along a file-scanning phase
+//! is" (only `--tui` mode's splash screen can show a real bar for — ADR
+//! 0032's stderr spinner is deliberately indeterminate), and "a one-shot
+//! advisory note unrelated to phase/progress" (empty diff, garbage input,
+//! an `--entry` path matching nothing, a PR base-commit fallback —
+//! previously raw `eprintln!`/`log::warn!` calls at each site).
+//! [`AnalysisProgress`] separates all three into their own methods so each
+//! caller only overrides what it actually needs to handle differently: the
+//! stderr [`crate::spinner::Spinner`] no-ops `report_file_progress` and
+//! prints `note` immediately (unchanged from before this port existed),
+//! while `--tui` mode's `crate::splash_progress::SplashProgress` renders a
+//! real bar for the former and *buffers* the latter (see `note`'s own doc
+//! comment for why).
 //!
-//! Kept small (two methods) and defined here, on the consumer side
-//! (`pipeline.rs` is what actually calls through this port) per CLAUDE.md's
-//! port convention.
+//! Kept small and defined here, on the consumer side (`pipeline.rs` is
+//! what actually calls through this port) per CLAUDE.md's port convention.
 
 use crate::spinner::AnalysisPhase;
 
@@ -42,6 +48,26 @@ pub(crate) trait AnalysisProgress: Sync {
     /// needs to override this — the stderr spinner stays indeterminate
     /// (ADR 0032), so its impl leaves this at the default no-op.
     fn report_file_progress(&self, _done: usize, _total: usize) {}
+
+    /// A one-shot advisory note unrelated to phase/progress (empty diff,
+    /// garbage input, an `--entry` path matching nothing, a PR base-commit
+    /// fallback) — what every call site in `main.rs`/`pipeline.rs` used to
+    /// hand straight to a bare `eprintln!` before this method existed.
+    ///
+    /// Defaults to printing immediately (`eprintln!`), matching that
+    /// pre-existing behavior exactly — every non-TUI caller (the stderr
+    /// [`crate::spinner::Spinner`]) leaves this at the default, since
+    /// stderr is not being drawn over by anything in that mode. `--tui`
+    /// mode's `crate::splash_progress::SplashProgress` is the one override:
+    /// printing immediately there would interleave raw bytes into the
+    /// terminal's alternate-screen frame stream mid-redraw (this method's
+    /// whole reason for existing — a bug found by dynamic verification,
+    /// `--tui --base <ref> --entry <path-matching-nothing>`), so it buffers
+    /// the message instead and `main.rs` flushes the buffer to stderr only
+    /// after `TuiSession` has torn down the alternate screen.
+    fn note(&self, message: String) {
+        eprintln!("{message}");
+    }
 }
 
 #[cfg(test)]
@@ -85,6 +111,50 @@ mod tests {
         let expected = vec![AnalysisPhase::Diffing];
         let actual = progress
             .phases
+            .into_inner()
+            .expect("lock must not be poisoned");
+        assert_eq!(expected, actual);
+    }
+
+    // A second fake, this one overriding `note` — proves an implementer can
+    // replace the default's immediate `eprintln!` with buffering (the exact
+    // shape `crate::splash_progress::SplashProgress` needs) without
+    // touching `set_phase`/`report_file_progress`. The default `note`
+    // body's own `eprintln!` is deliberately left untested here: it is a
+    // one-line, branchless IO call with nothing to assert against besides
+    // "did it write to stderr", which this project's "no mocking of
+    // external processes" convention does not ask for (mirrors ADR 0032's
+    // own stance on not unit-testing `Spinner`'s IO).
+    struct BufferingProgress {
+        notes: Mutex<Vec<String>>,
+    }
+
+    impl AnalysisProgress for BufferingProgress {
+        fn set_phase(&self, _phase: AnalysisPhase) {}
+
+        fn note(&self, message: String) {
+            self.notes
+                .lock()
+                .expect("lock must not be poisoned")
+                .push(message);
+        }
+    }
+
+    #[test]
+    fn should_buffer_note_instead_of_printing_when_note_is_overridden() {
+        let progress = BufferingProgress {
+            notes: Mutex::new(Vec::new()),
+        };
+
+        progress.note("note: diff is empty, nothing to analyze".to_string());
+        progress.note("note: no symbols under nonexistent/path.rs".to_string());
+
+        let expected = vec![
+            "note: diff is empty, nothing to analyze".to_string(),
+            "note: no symbols under nonexistent/path.rs".to_string(),
+        ];
+        let actual = progress
+            .notes
             .into_inner()
             .expect("lock must not be poisoned");
         assert_eq!(expected, actual);

--- a/rinkaku/src/progress.rs
+++ b/rinkaku/src/progress.rs
@@ -1,0 +1,92 @@
+//! The pre-render analysis progress port `main.rs` threads through
+//! `pipeline::run_base_pipeline`/`build_resolver` (ADR 0033), replacing the
+//! bare `&Spinner` parameter those functions used to take.
+//!
+//! Two phase-reporting concerns used to be conflated in `&Spinner`: "which
+//! phase is running" (every display mode wants this) and "how far along a
+//! file-scanning phase is" (only `--tui` mode's splash screen can show a
+//! real bar for — ADR 0032's stderr spinner is deliberately indeterminate).
+//! [`AnalysisProgress`] separates them into two methods so a caller that has
+//! no file-count signal (the stderr [`crate::spinner::Spinner`]) can just
+//! no-op the second one, rather than every display mode having to fake a
+//! `(done, total)` pair it doesn't have.
+//!
+//! Kept small (two methods) and defined here, on the consumer side
+//! (`pipeline.rs` is what actually calls through this port) per CLAUDE.md's
+//! port convention.
+
+use crate::spinner::AnalysisPhase;
+
+/// What `pipeline::run_base_pipeline`/`build_resolver` report through as
+/// the analysis pipeline progresses, decoupling them from which concrete
+/// display mode is running (ADR 0032's stderr spinner vs. ADR 0033's TUI
+/// splash screen — exactly one of the two is active per run, `main.rs`'s
+/// own doc comment on why).
+///
+/// `Sync`: `report_file_progress` is called through
+/// `rinkaku_core::pipeline::analyze_repo`'s `on_progress` port from rayon
+/// worker threads during the parallel whole-repo parse (ADR 0031), so a
+/// `&dyn AnalysisProgress` reference must be safe to share across those
+/// threads — the same reasoning `rinkaku_core::progress::OnProgress`'s own
+/// doc comment gives for its `Sync` bound.
+pub(crate) trait AnalysisProgress: Sync {
+    /// Called when the pipeline moves into a new named phase (resolving a
+    /// PR, diffing, building the dependency index, analyzing the diff) —
+    /// mirrors the granularity `Spinner::set_message`/`phase_message`
+    /// already established under ADR 0032.
+    fn set_phase(&self, phase: AnalysisPhase);
+
+    /// Called with `(files_done, total)` while a file-scanning phase (the
+    /// dependency index build) is in progress. A no-op default: only a
+    /// caller that can actually render a determinate bar (the TUI splash)
+    /// needs to override this — the stderr spinner stays indeterminate
+    /// (ADR 0032), so its impl leaves this at the default no-op.
+    fn report_file_progress(&self, _done: usize, _total: usize) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::sync::Mutex;
+
+    // A minimal fake exercising the default `report_file_progress` no-op —
+    // this project's "no mocking of external processes" rule does not
+    // apply here (no process/terminal is touched), but there is also
+    // nothing to fake beyond recording calls, so a plain hand-rolled fake
+    // is used rather than a mocking framework. `Mutex` rather than
+    // `RefCell`: `AnalysisProgress: Sync` (this module's own doc comment
+    // on why), so any implementer — including this test fake — must be
+    // `Sync` too, which `RefCell` is not.
+    struct RecordingProgress {
+        phases: Mutex<Vec<AnalysisPhase>>,
+    }
+
+    impl AnalysisProgress for RecordingProgress {
+        fn set_phase(&self, phase: AnalysisPhase) {
+            self.phases
+                .lock()
+                .expect("lock must not be poisoned")
+                .push(phase);
+        }
+    }
+
+    #[test]
+    fn should_record_phase_and_no_op_file_progress_when_using_default_impl() {
+        let progress = RecordingProgress {
+            phases: Mutex::new(Vec::new()),
+        };
+
+        progress.set_phase(AnalysisPhase::Diffing);
+        // Must not panic and must not require an override — this is the
+        // exact contract the default no-op body exists to provide.
+        progress.report_file_progress(3, 10);
+
+        let expected = vec![AnalysisPhase::Diffing];
+        let actual = progress
+            .phases
+            .into_inner()
+            .expect("lock must not be poisoned");
+        assert_eq!(expected, actual);
+    }
+}

--- a/rinkaku/src/spinner.rs
+++ b/rinkaku/src/spinner.rs
@@ -12,7 +12,13 @@
 //! Kept in the `rinkaku` bin crate, not `rinkaku-core`: this is terminal IO
 //! tied to how *this specific binary* reports progress, not part of the
 //! pure diff-condensation core (CLAUDE.md's "core logic is pure" rule).
+//!
+//! Used only outside `--tui` mode (ADR 0033): `main.rs` shows this spinner
+//! or the TUI splash screen (`rinkaku_tui::splash`), never both in the same
+//! run — see `main.rs`'s own doc comment on why display mode is decided
+//! before analysis starts.
 
+use crate::progress::AnalysisProgress;
 use indicatif::{ProgressBar, ProgressStyle};
 
 /// Wraps an `indicatif::ProgressBar` configured as an indeterminate spinner
@@ -60,6 +66,20 @@ impl Spinner {
     pub fn finish_and_clear(&self) {
         self.bar.finish_and_clear();
     }
+}
+
+impl AnalysisProgress for Spinner {
+    /// Forwards to [`Spinner::set_message`] via [`phase_message`] — the
+    /// same mapping every call site used before `AnalysisProgress` existed.
+    fn set_phase(&self, phase: AnalysisPhase) {
+        self.set_message(phase_message(phase));
+    }
+
+    // `report_file_progress` is left at `AnalysisProgress`'s default no-op:
+    // ADR 0032 chose an indeterminate spinner on purpose (see this module's
+    // own doc comment), so a `(done, total)` count arriving here is
+    // intentionally dropped rather than reformatted into the spinner's
+    // single message line.
 }
 
 // Note: an early `?`-propagated error in `main` (e.g. a failing `git`/`gh`

--- a/rinkaku/src/splash_progress.rs
+++ b/rinkaku/src/splash_progress.rs
@@ -20,18 +20,27 @@ use rinkaku_tui::TuiSession;
 use rinkaku_tui::splash::SplashState;
 use std::sync::Mutex;
 
+/// The mutable state [`SplashProgress`] guards behind one [`Mutex`] — the
+/// live terminal, the currently-cached phase label (so a file-progress
+/// redraw can still show *which* phase is measuring that progress, since
+/// `rinkaku-core`'s `on_progress` callback only ever receives `(done,
+/// total)`), and the buffered notes (ADR 0033's note-deferral decision, see
+/// [`AnalysisProgress::note`]'s own doc comment for why raw `eprintln!`
+/// during `--tui` mode corrupts the alternate screen).
+struct SplashProgressState {
+    session: TuiSession,
+    phase_label: String,
+    buffered_notes: Vec<String>,
+}
+
 /// See the module doc comment. Owns the [`TuiSession`] for the duration of
 /// the analysis phase; `main.rs` extracts it back out via
-/// [`SplashProgress::into_session`] once analysis finishes, to hand off to
-/// [`TuiSession::run`]'s main event loop.
+/// [`SplashProgress::into_session_and_notes`] once analysis finishes, to
+/// hand the terminal off to [`TuiSession::run`]'s main event loop and flush
+/// the buffered notes to stderr only after that terminal has torn down the
+/// alternate screen.
 pub(crate) struct SplashProgress {
-    // `phase_label` is cached alongside the terminal so a file-progress
-    // redraw (`report_file_progress`) can still show *which* phase is
-    // measuring that progress — `rinkaku_core`'s `on_progress` callback
-    // only ever receives `(done, total)`, not a phase label, so without
-    // this cache a progress redraw mid-phase would have nothing to put in
-    // `SplashState::phase_label`.
-    inner: Mutex<(TuiSession, String)>,
+    inner: Mutex<SplashProgressState>,
 }
 
 impl SplashProgress {
@@ -40,49 +49,61 @@ impl SplashProgress {
     /// itself (`main.rs` does, via `TuiSession`'s own `Drop`/`run`).
     pub(crate) fn new(session: TuiSession) -> Self {
         Self {
-            inner: Mutex::new((session, phase_message(AnalysisPhase::Starting).to_string())),
+            inner: Mutex::new(SplashProgressState {
+                session,
+                phase_label: phase_message(AnalysisPhase::Starting).to_string(),
+                buffered_notes: Vec::new(),
+            }),
         }
     }
 
-    /// Unwraps back into the plain [`TuiSession`] once analysis is done,
-    /// so `main.rs` can hand it to [`TuiSession::run`] without tearing down
-    /// and re-initializing the terminal in between.
-    pub(crate) fn into_session(self) -> TuiSession {
+    /// Unwraps back into the plain [`TuiSession`] and the notes buffered
+    /// during analysis (in the order [`AnalysisProgress::note`] received
+    /// them), once analysis is done — so `main.rs` can hand the session to
+    /// [`TuiSession::run`] without tearing down and re-initializing the
+    /// terminal in between, and flush the notes to stderr only once that
+    /// terminal has actually left the alternate screen (either via
+    /// `TuiSession::run`'s own postamble on success, or `TuiSession`'s
+    /// `Drop` safety net on an early-return error — both restore the
+    /// terminal before `main.rs` can reach the flush call, since the notes
+    /// are extracted here, before either teardown path runs, and only
+    /// printed by the caller afterward).
+    pub(crate) fn into_session_and_notes(self) -> (TuiSession, Vec<String>) {
         // `.expect()`: a poisoned mutex here means an earlier
-        // `set_phase`/`report_file_progress` call panicked while holding
-        // the lock — since neither does anything beyond a `Terminal::draw`
-        // call and a couple of field writes, that would itself be a bug
-        // worth surfacing loudly (a raw panic message) rather than papering
-        // over with a fallback session, which `main.rs`'s caller has no way
-        // to recover from anyway (the terminal state would already be
-        // indeterminate).
-        let (session, _label) = self
+        // `set_phase`/`report_file_progress`/`note` call panicked while
+        // holding the lock — since none of them do anything beyond a
+        // `Terminal::draw` call or a `Vec::push`, that would itself be a
+        // bug worth surfacing loudly (a raw panic message) rather than
+        // papering over with a fallback session, which `main.rs`'s caller
+        // has no way to recover from anyway (the terminal state would
+        // already be indeterminate).
+        let state = self
             .inner
             .into_inner()
             .expect("splash progress mutex must not be poisoned");
-        session
+        (state.session, state.buffered_notes)
     }
 }
 
 impl AnalysisProgress for SplashProgress {
     fn set_phase(&self, phase: AnalysisPhase) {
         let label = phase_message(phase).to_string();
-        // Same poisoning stance as `into_session`: a draw failure here
-        // (`io::Result::Err`) is dropped rather than propagated — this
-        // trait's methods return `()` (`AnalysisProgress`'s own doc
-        // comment on why: every call site is inside `rinkaku-core`'s
-        // callback contract, `Fn(usize, usize)`/phase notification, neither
-        // of which is `Result`-returning) — a failed splash redraw is not
-        // worth aborting the whole analysis pipeline over, the same
-        // judgment call ADR 0032's spinner already makes implicitly by
-        // never checking `indicatif`'s own draw failures either.
+        // Same poisoning stance as `into_session_and_notes`: a draw
+        // failure here (`io::Result::Err`) is dropped rather than
+        // propagated — this trait's methods return `()`
+        // (`AnalysisProgress`'s own doc comment on why: every call site is
+        // inside `rinkaku-core`'s callback contract, `Fn(usize, usize)`/
+        // phase notification, neither of which is `Result`-returning) — a
+        // failed splash redraw is not worth aborting the whole analysis
+        // pipeline over, the same judgment call ADR 0032's spinner already
+        // makes implicitly by never checking `indicatif`'s own draw
+        // failures either.
         let mut guard = self
             .inner
             .lock()
             .expect("splash progress mutex must not be poisoned");
-        let (session, cached_label) = &mut *guard;
-        cached_label.clone_from(&label);
-        let _ = session.draw_splash(&SplashState::label_only(label));
+        guard.phase_label.clone_from(&label);
+        let _ = guard.session.draw_splash(&SplashState::label_only(label));
     }
 
     fn report_file_progress(&self, done: usize, total: usize) {
@@ -90,11 +111,40 @@ impl AnalysisProgress for SplashProgress {
             .inner
             .lock()
             .expect("splash progress mutex must not be poisoned");
-        let (session, cached_label) = &mut *guard;
-        let _ = session.draw_splash(&SplashState::with_progress(
-            cached_label.clone(),
-            done,
-            total,
-        ));
+        let label = guard.phase_label.clone();
+        let _ = guard
+            .session
+            .draw_splash(&SplashState::with_progress(label, done, total));
+    }
+
+    /// Buffers `message` instead of printing it immediately (ADR 0033):
+    /// while the splash is on screen, stderr is not being drawn over by
+    /// anything a human can watch happen — the *terminal* itself is in the
+    /// alternate screen, so a raw `eprintln!` here would write bytes that
+    /// land wherever the alternate-screen buffer's cursor currently sits,
+    /// corrupting the next redraw (this method's whole reason for
+    /// existing — a bug found by dynamic verification, `--tui --base <ref>
+    /// --entry <path-matching-nothing>`, see this crate's `main.rs` for the
+    /// flush call this buffer feeds into after the terminal has torn down).
+    fn note(&self, message: String) {
+        let mut guard = self
+            .inner
+            .lock()
+            .expect("splash progress mutex must not be poisoned");
+        guard.buffered_notes.push(message);
     }
 }
+
+// No unit tests in this module: `TuiSession::init` needs a real terminal
+// (ADR 0033's own doc comment on why `TuiSession`'s lifecycle is not
+// unit-tested, mirroring ADR 0032's stance on `Spinner`), so a real
+// `SplashProgress` cannot be constructed in a unit test — every method here
+// is a thin wrapper (a `Mutex::lock` plus a field write/`Vec::push`/
+// `TuiSession::draw_splash` call) with no branching logic of its own to
+// exercise in isolation. The two things actually worth pinning as pure
+// logic — "an `AnalysisProgress` implementer can override `note` to buffer
+// instead of printing" and "buffering preserves call order" — are covered
+// by `crate::progress::tests::should_buffer_note_instead_of_printing_when_note_is_overridden`,
+// which exercises the exact same trait contract this type implements
+// without needing a terminal. This type's own behavior is covered by this
+// PR's dynamic verification (pty-driven `--tui` runs, see the PR body).

--- a/rinkaku/src/splash_progress.rs
+++ b/rinkaku/src/splash_progress.rs
@@ -1,0 +1,100 @@
+//! The `--tui` mode implementation of [`AnalysisProgress`] (ADR 0033):
+//! redraws `rinkaku_tui`'s splash screen on the same terminal
+//! `TuiSession::init` already opened, in place of ADR 0032's stderr
+//! spinner.
+//!
+//! Wraps the live [`rinkaku_tui::TuiSession`] in a [`std::sync::Mutex`]
+//! rather than holding a plain `&mut` — `rinkaku_core::pipeline::analyze_repo`'s
+//! `on_progress` callback (ADR 0033) is called from rayon worker threads
+//! during the parallel whole-repo parse (ADR 0031), so the closure
+//! `main.rs` builds around this type must be `Sync`. No genuine concurrent
+//! contention is expected in practice (the stride in
+//! `rinkaku_core::progress::should_report_progress` already bounds how
+//! often any thread calls in), but the `Mutex` makes the one-terminal-at-a-
+//! time invariant a compile-time guarantee rather than an informal
+//! assumption about how often two strided calls could land at once.
+
+use crate::progress::AnalysisProgress;
+use crate::spinner::{AnalysisPhase, phase_message};
+use rinkaku_tui::TuiSession;
+use rinkaku_tui::splash::SplashState;
+use std::sync::Mutex;
+
+/// See the module doc comment. Owns the [`TuiSession`] for the duration of
+/// the analysis phase; `main.rs` extracts it back out via
+/// [`SplashProgress::into_session`] once analysis finishes, to hand off to
+/// [`TuiSession::run`]'s main event loop.
+pub(crate) struct SplashProgress {
+    // `phase_label` is cached alongside the terminal so a file-progress
+    // redraw (`report_file_progress`) can still show *which* phase is
+    // measuring that progress — `rinkaku_core`'s `on_progress` callback
+    // only ever receives `(done, total)`, not a phase label, so without
+    // this cache a progress redraw mid-phase would have nothing to put in
+    // `SplashState::phase_label`.
+    inner: Mutex<(TuiSession, String)>,
+}
+
+impl SplashProgress {
+    /// `session` must already be initialized (`TuiSession::init`) — this
+    /// type only draws on it, it does not own the init/teardown lifecycle
+    /// itself (`main.rs` does, via `TuiSession`'s own `Drop`/`run`).
+    pub(crate) fn new(session: TuiSession) -> Self {
+        Self {
+            inner: Mutex::new((session, phase_message(AnalysisPhase::Starting).to_string())),
+        }
+    }
+
+    /// Unwraps back into the plain [`TuiSession`] once analysis is done,
+    /// so `main.rs` can hand it to [`TuiSession::run`] without tearing down
+    /// and re-initializing the terminal in between.
+    pub(crate) fn into_session(self) -> TuiSession {
+        // `.expect()`: a poisoned mutex here means an earlier
+        // `set_phase`/`report_file_progress` call panicked while holding
+        // the lock — since neither does anything beyond a `Terminal::draw`
+        // call and a couple of field writes, that would itself be a bug
+        // worth surfacing loudly (a raw panic message) rather than papering
+        // over with a fallback session, which `main.rs`'s caller has no way
+        // to recover from anyway (the terminal state would already be
+        // indeterminate).
+        let (session, _label) = self
+            .inner
+            .into_inner()
+            .expect("splash progress mutex must not be poisoned");
+        session
+    }
+}
+
+impl AnalysisProgress for SplashProgress {
+    fn set_phase(&self, phase: AnalysisPhase) {
+        let label = phase_message(phase).to_string();
+        // Same poisoning stance as `into_session`: a draw failure here
+        // (`io::Result::Err`) is dropped rather than propagated — this
+        // trait's methods return `()` (`AnalysisProgress`'s own doc
+        // comment on why: every call site is inside `rinkaku-core`'s
+        // callback contract, `Fn(usize, usize)`/phase notification, neither
+        // of which is `Result`-returning) — a failed splash redraw is not
+        // worth aborting the whole analysis pipeline over, the same
+        // judgment call ADR 0032's spinner already makes implicitly by
+        // never checking `indicatif`'s own draw failures either.
+        let mut guard = self
+            .inner
+            .lock()
+            .expect("splash progress mutex must not be poisoned");
+        let (session, cached_label) = &mut *guard;
+        cached_label.clone_from(&label);
+        let _ = session.draw_splash(&SplashState::label_only(label));
+    }
+
+    fn report_file_progress(&self, done: usize, total: usize) {
+        let mut guard = self
+            .inner
+            .lock()
+            .expect("splash progress mutex must not be poisoned");
+        let (session, cached_label) = &mut *guard;
+        let _ = session.draw_splash(&SplashState::with_progress(
+            cached_label.clone(),
+            done,
+            total,
+        ));
+    }
+}


### PR DESCRIPTION
## Motivation

Follow-up to #91 (ADR 0032's pre-TUI stderr spinner). That spinner is
cleared before `rinkaku_tui::run` enters the alternate screen, so between
`ratatui::try_init` and the event loop's first `terminal.draw` call the
terminal shows a blank flash with no feedback -- worse than the pre-#91
gap, since alternate-screen entry is itself a visible flip into
emptiness. It's also worst exactly when `--tui`'s default configuration
(whole-repo outline / dependency-index build) is slowest, since the
spinner it replaces was indeterminate.

## Design (ADR 0033)

- `rinkaku-core` gains an optional `on_progress: Option<&(dyn Fn(usize,
  usize) + Sync)>` port on `pipeline::analyze_repo` (rayon-parallel,
  `AtomicUsize` counter + a 16-file stride) and `deps::TagsResolver::new`
  (sequential). `None` everywhere existing callers don't need it --
  behavior/output unchanged.
- `rinkaku-tui` gains a `splash` module (`SplashState` + `draw_splash`,
  ratatui `Gauge` for determinate phases, label-only for the rest -- no
  fake/simulated progress) and splits `run()` into `TuiSession`
  (`init`/`draw_splash`/`run`) so `main.rs` can draw splash frames on the
  already-initialized terminal *during* analysis, before handing off to
  the main event loop, without re-entering the alternate screen.
- `main.rs` decides the display mode before running any analysis
  (`resolve_display_mode` only needs `cli.tui`/`cli.format`/stdout-tty,
  not a `Report`) and threads a new `AnalysisProgress` port through
  `run_base_pipeline`/`build_resolver`, implemented by either the
  existing stderr `Spinner` (non-TUI) or the new `SplashProgress` (TUI).
  No threads or channels -- same synchronous, single-call-stack pipeline
  as before.

## Review finding and fix

A reviewer's dynamic verification (`--tui --base <ref> --entry
<path-matching-nothing>`) found that every advisory `eprintln!`/
`log::warn!` note (empty diff, garbage input, an `--entry` path matching
nothing, the PR base-commit fallback) wrote raw bytes straight into the
terminal's alternate-screen frame stream mid-redraw, corrupting whatever
frame was drawing at the time. `AnalysisProgress` gained a third method,
`note`, defaulting to immediate `eprintln!` (unchanged for `Spinner`);
`--tui` mode's `SplashProgress` overrides it to buffer instead, and
`main.rs` flushes the buffer to stderr only after `TuiSession` has
actually left the alternate screen (both on success, after
`TuiSession::run`'s postamble, and on an early-return analysis error,
after `TuiSession`'s `Drop` safety net). Recorded as decision 8 / an
amendment in ADR 0033.

## Dynamic verification (pty-driven, release build)

- (a) splash logo + phase label appear immediately on `--tui` launch.
- (b) real, non-simulated progress bar during dependency-index build --
  verified against `astral-sh/ruff` (9327 files): observed
  `16/9327 -> 44/9327 -> 96/9327 -> 272/9327 -> 560/9327 -> ...`.
- (c) no splash residue after switching to the main entry screen.
- (d) analysis error (`--tui --base nonexistent-ref`) -- enters/leaves
  the alternate screen cleanly, then prints `Error: git diff ...
  failed: ...` to stderr; no corruption.
- (e) non-TUI mode unaffected -- zero ESC bytes in stdout/stderr for
  `--format md`/default/JSON; stderr spinner still animates on a real
  TTY.
- **Reproduction scenario** (`--tui --base main~1 --entry
  nonexistent/path.rs`, sending `q` to quit): before the fix, raw
  `note: no symbols under nonexistent/path.rs` bytes appeared unstyled
  mid-frame, between the splash's "Analyzing diff..." and the entry
  screen's first redraw. After the fix: zero unstyled raw `note:`
  occurrences anywhere before the terminal's `\x1b[?1049l` (alternate
  screen exit); the note appears cleanly as `\x1b[?1049l\x1b[?25hnote:
  no symbols under nonexistent/path.rs` right after. Confirmed the one
  remaining pre-exit `note:`-like text is the TUI's own styled
  status-line rendering (`\x1b[38;5;3;49mnote: no tree row matches
  ...`), not a raw byte leak.

## File size

`rinkaku --base <merge-base>` (built from a trusted `main` checkout)
shows no `## File size warnings` section for this diff.
`rinkaku-tui/src/lib.rs` is at 1212 lines -- already in ADR 0028's
1000-1500 "watch" band before this PR (1128 lines on `main`), still well
under the 1500-line warn threshold; the increase here is `TuiSession`'s
~84 lines.

## make test / make lint

Both pass (`cargo test --all-features`: 169 + 360 + 549 + 0 + 0 = 1078
tests, 0 failures; `cargo fmt --all --check` + `cargo clippy
--all-targets --all-features -- -D warnings`: clean).

## Experiment record

This PR's review is recorded as [round 21](docs/experiments/0001-map-assisted-llm-review/rounds/021.md)
of experiment 0001 (map-assisted LLM review). Takeaway: the major finding
above (stderr notes corrupting the TUI's alternate-screen frame stream)
is a pure call-site-*ordering* regression with a byte-identical diff at
every individual line -- both the map-assisted pass and the independent
static pass missed it, and it was found only by dynamic verification
(a PTY-driven run reproducing the corrupted byte stream). This sharpens
the experiment's standing conclusion that no amount of static/map-assisted
reading can be trusted to catch a control-flow-ordering change on its own.
