### PR TITLE
refactor(tui): split TuiSession into its own module

### DIFF
--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -38,201 +38,27 @@ pub mod highlight;
 pub mod nav;
 pub mod order;
 pub mod row_view;
+mod session;
 pub mod source;
 pub mod splash;
 pub mod tree;
 pub mod ui;
 
+pub use session::{TuiSession, run};
+
 use app::{App, BlastRadiusSelection, InputKey, Screen};
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
-use ratatui::crossterm::execute;
 use rinkaku_core::render::Report;
 use std::time::Duration;
 
-/// Runs the interactive TUI over `report` until the user quits, taking
-/// over the terminal for the duration of the call (raw mode + alternate
-/// screen via [`ratatui::try_init`], restored on return **and** on panic —
-/// `ratatui::try_init`'s own panic hook covers the latter, so a bug in this
-/// crate cannot leave the caller's terminal in raw mode).
-///
-/// Uses `try_init` rather than [`ratatui::init`] specifically so terminal
-/// setup failure (e.g. stdin/stdout is not a TTY at all — piped input,
-/// `< /dev/null`, a CI runner) surfaces as an `Err` for `main.rs`'s
-/// `anyhow` path to print cleanly and exit 1, instead of `ratatui::init`'s
-/// own `.expect(...)` panicking with a raw Rust panic message and exit
-/// code 101.
-///
-/// Also enables mouse capture (`EnableMouseCapture`) so the wheel/trackpad
-/// scroll support below can receive `Event::Mouse` at all — without it, a
-/// scroll gesture is intercepted by the terminal emulator itself (moving
-/// its own scrollback) and never reaches this process. `ratatui::try_init`/
-/// `restore` do not touch mouse capture (mouse support is opt-in, unlike
-/// raw mode/alternate screen which every TUI needs), so this function
-/// enables and disables it itself, and installs its own panic-hook layer
-/// (chained *before* calling `try_init`, so `try_init`'s own hook wraps
-/// this one and both run on panic — see `try_init`'s own doc comment: "set
-/// a panic hook that restores the terminal") to disable mouse capture on
-/// panic too, mirroring the guarantee `try_init` already gives raw mode/
-/// alternate screen. `EnableMouseCapture` failing outright (as opposed to
-/// panicking) is handled the same way: `try_init` has already put the
-/// terminal into raw mode/the alternate screen by that point, so this
-/// function calls `ratatui::restore()` itself on that path before
-/// propagating the error, rather than relying on `?` to skip straight to
-/// the caller (which would strand the terminal mid-setup, since that
-/// particular failure is a plain `Err`, not a panic the installed hook
-/// would catch).
-///
-/// This is the only function in the crate that touches a real terminal or
-/// blocks on input; everything it calls into (`App`, `row_view`, `ui`,
-/// `source`) is either pure or an isolated, narrowly-scoped IO call (a
-/// single source-file read).
-///
-/// `diff_text` is the exact same raw diff string every `main.rs` input mode
-/// already holds before handing it to `rinkaku_core::pipeline::analyze_diff`
-/// — passed through unchanged, not re-fetched or re-derived here, so this
-/// crate never runs `git` itself (ADR 0016: `rinkaku-core`/adapters own IO,
-/// not `rinkaku-tui`'s view layer beyond the one source-file read
-/// `crate::source` already makes).
-///
-/// `entry_path` is `main.rs`'s `--entry <path>` flag (ADR 0019), passed
-/// through unchanged when the user combines it with `--tui`: `None` when
-/// `--entry` was not given (the ordinary case), `Some(path)` to open
-/// straight into [`app::RightPane::BlastRadius`] (ADR 0023) with the cursor
-/// already on the matching tree row (`App::with_entry_pivot`) instead of
-/// requiring the reviewer to hunt for the row and press `R` themselves. Note
-/// this crate does *not* itself re-root `report.graph` — `main.rs` already
-/// applied `--entry`'s `pivot_graph` re-rooting to `report` before calling
-/// here (the same `Report` both the TUI and Markdown/JSON render from), so
-/// this parameter only drives where the TUI *starts*, not what the
-/// underlying graph looks like.
-///
-/// `repo_root` anchors `Report` paths (always repository-root-relative) for
-/// the source drill-down's file reads (`crate::source::load_symbol_source`)
-/// — `main.rs` resolves it once at startup (`git rev-parse --show-toplevel`,
-/// falling back to the process's current directory outside a git
-/// repository) rather than this crate ever shelling out to `git` itself
-/// (ADR 0016). Without it, the source view would only work when `rinkaku`
-/// happens to be invoked from the repository root.
-///
-/// A thin convenience wrapper around [`TuiSession::init`] +
-/// [`TuiSession::run`] for callers that have no splash screen to draw
-/// in between (ADR 0033) — every terminal-lifecycle detail this doc
-/// comment describes lives on `TuiSession` now, see that type's own doc
-/// comment for the same guarantees.
-pub fn run(
-    report: &Report,
-    diff_text: &str,
-    entry_path: Option<&str>,
-    repo_root: &std::path::Path,
-) -> std::io::Result<()> {
-    TuiSession::init()?.run(report, diff_text, entry_path, repo_root)
-}
-
-/// Owns the terminal's raw-mode/alternate-screen/mouse-capture lifecycle
-/// (ADR 0033), split out of what used to be a single [`run`] call so
-/// `main.rs` can draw [`splash::SplashState`] frames on the same terminal
-/// while the pre-render analysis pipeline runs synchronously, *before*
-/// handing off to the full event loop — without tearing down and
-/// re-entering the alternate screen in between, which would flash the
-/// terminal and defeat the splash screen's own purpose.
-///
-/// [`TuiSession::init`] performs exactly the setup [`run`]'s preamble used
-/// to (panic-hook chaining, [`ratatui::try_init`], `EnableMouseCapture`,
-/// with the same error-path terminal restoration). [`TuiSession::draw_splash`]
-/// draws one splash frame on the already-initialized terminal — call it as
-/// many times as the pipeline has phase transitions/progress updates to
-/// report, all from the same thread that called `init` (ADR 0033 decision
-/// 2: no cross-thread terminal access). [`TuiSession::run`] consumes `self`
-/// and performs exactly the postamble `run` used to
-/// (`DisableMouseCapture` + [`ratatui::restore`]) on both its `Ok` and
-/// `Err` paths.
-///
-/// A [`Drop`] impl calls [`ratatui::restore`] as a safety net for a path
-/// that drops a `TuiSession` without ever calling `run` at all (e.g.
-/// `main.rs` returning early with a `?` from inside its own analysis
-/// branch, after `init` but before a `Report` exists to hand to `run`) —
-/// `ratatui::restore` is documented idempotent, so this is safe to run
-/// again even after `run`'s own explicit postamble already restored the
-/// terminal on the ordinary path.
-pub struct TuiSession {
-    terminal: ratatui::DefaultTerminal,
-}
-
-impl TuiSession {
-    /// See the type's own doc comment for the exact setup this performs.
-    pub fn init() -> std::io::Result<Self> {
-        // Chained *before* `ratatui::try_init`'s own `set_panic_hook` call
-        // below, so the hook `try_init` installs wraps this one: on panic,
-        // `try_init`'s hook runs `ratatui::restore()` (raw mode/alternate
-        // screen) and then this crate's hook (disable mouse capture),
-        // rather than mouse capture silently staying enabled in the
-        // panicking caller's terminal.
-        let previous_hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(move |info| {
-            let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
-            previous_hook(info);
-        }));
-
-        let terminal = ratatui::try_init()?;
-        // Restore explicitly on this `?`'s early-return path (rather than
-        // letting `?` skip straight past the `ratatui::restore()` call
-        // below): `try_init` above already left raw mode/the alternate
-        // screen active, and a plain `EnableMouseCapture` IO failure is
-        // not a panic, so the panic-hook layer just installed does not
-        // run either — without this, that combination would strand the
-        // caller's terminal in raw mode/alternate screen with no cleanup
-        // at all.
-        if let Err(err) = execute!(std::io::stdout(), event::EnableMouseCapture) {
-            ratatui::restore();
-            return Err(err);
-        }
-        Ok(Self { terminal })
-    }
-
-    /// Draws one splash frame (ADR 0033) on the already-initialized
-    /// terminal. Intended to be called repeatedly from `main.rs`'s
-    /// analysis call stack as the pipeline moves between phases/reports
-    /// file-scan progress — each call is a plain, synchronous
-    /// `Terminal::draw`, not a background redraw loop.
-    pub fn draw_splash(&mut self, state: &splash::SplashState) -> std::io::Result<()> {
-        self.terminal
-            .draw(|frame| splash::draw_splash(frame, state))?;
-        Ok(())
-    }
-
-    /// Runs the interactive TUI's main event loop over `report` until the
-    /// user quits, consuming `self` and restoring the terminal
-    /// unconditionally before returning — on both the `Ok` and `Err` path,
-    /// matching the postamble the pre-ADR-0033 [`run`] function always ran.
-    /// See [`run`]'s own doc comment (preserved there) for what `report`,
-    /// `diff_text`, `entry_path`, and `repo_root` mean.
-    pub fn run(
-        mut self,
-        report: &Report,
-        diff_text: &str,
-        entry_path: Option<&str>,
-        repo_root: &std::path::Path,
-    ) -> std::io::Result<()> {
-        let result = run_app(&mut self.terminal, report, diff_text, entry_path, repo_root);
-        let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
-        ratatui::restore();
-        result
-    }
-}
-
-impl Drop for TuiSession {
-    fn drop(&mut self) {
-        // Idempotent per `ratatui::restore`'s own contract: a no-op if
-        // `TuiSession::run` already restored the terminal on the ordinary
-        // path, a real safety net if `self` is dropped without `run` ever
-        // being called (e.g. `main.rs` returning early with `?` from the
-        // analysis phase, after `init` succeeded but before a `Report`
-        // exists).
-        ratatui::restore();
-    }
-}
-
-fn run_app(
+/// The event loop [`TuiSession::run`] (`crate::session`) drives once it has
+/// taken over the terminal — see [`run`]'s doc comment (re-exported from
+/// `crate::session`, which retains the full terminal-lifecycle rationale
+/// that used to live here) for what `report`, `diff_text`, `entry_path`,
+/// and `repo_root` mean. `pub(crate)` rather than private: `crate::session`
+/// is a sibling module, not a submodule, so it needs this visibility to
+/// call in.
+pub(crate) fn run_app(
     terminal: &mut ratatui::DefaultTerminal,
     report: &Report,
     diff_text: &str,

--- a/rinkaku-tui/src/session.rs
+++ b/rinkaku-tui/src/session.rs
@@ -1,0 +1,198 @@
+//! Terminal lifecycle ownership (ADR 0033), split out of `crate::lib` (ADR
+//! 0028's file-size threshold) — [`TuiSession`] and the crate's
+//! [`run`] entry point both belong here rather than in `lib.rs` because
+//! they are the one piece of this crate that performs IO and holds a live
+//! `Terminal` (`lib.rs`'s own module doc comment on the view-model/terminal-
+//! adapter split). [`crate::run_app`] (the pure-dispatch event loop
+//! `TuiSession::run` calls into) stays in `lib.rs` itself, alongside the
+//! `translate_key`/`dispatch_non_source_key`/etc. helpers it composes —
+//! only the terminal-lifecycle wrapper around that loop moves here.
+
+use crate::run_app;
+use crate::splash;
+use ratatui::crossterm::event;
+use ratatui::crossterm::execute;
+use rinkaku_core::render::Report;
+
+/// Runs the interactive TUI over `report` until the user quits, taking
+/// over the terminal for the duration of the call (raw mode + alternate
+/// screen via [`ratatui::try_init`], restored on return **and** on panic —
+/// `ratatui::try_init`'s own panic hook covers the latter, so a bug in this
+/// crate cannot leave the caller's terminal in raw mode).
+///
+/// Uses `try_init` rather than [`ratatui::init`] specifically so terminal
+/// setup failure (e.g. stdin/stdout is not a TTY at all — piped input,
+/// `< /dev/null`, a CI runner) surfaces as an `Err` for `main.rs`'s
+/// `anyhow` path to print cleanly and exit 1, instead of `ratatui::init`'s
+/// own `.expect(...)` panicking with a raw Rust panic message and exit
+/// code 101.
+///
+/// Also enables mouse capture (`EnableMouseCapture`) so the wheel/trackpad
+/// scroll support below can receive `Event::Mouse` at all — without it, a
+/// scroll gesture is intercepted by the terminal emulator itself (moving
+/// its own scrollback) and never reaches this process. `ratatui::try_init`/
+/// `restore` do not touch mouse capture (mouse support is opt-in, unlike
+/// raw mode/alternate screen which every TUI needs), so this function
+/// enables and disables it itself, and installs its own panic-hook layer
+/// (chained *before* calling `try_init`, so `try_init`'s own hook wraps
+/// this one and both run on panic — see `try_init`'s own doc comment: "set
+/// a panic hook that restores the terminal") to disable mouse capture on
+/// panic too, mirroring the guarantee `try_init` already gives raw mode/
+/// alternate screen. `EnableMouseCapture` failing outright (as opposed to
+/// panicking) is handled the same way: `try_init` has already put the
+/// terminal into raw mode/the alternate screen by that point, so this
+/// function calls `ratatui::restore()` itself on that path before
+/// propagating the error, rather than relying on `?` to skip straight to
+/// the caller (which would strand the terminal mid-setup, since that
+/// particular failure is a plain `Err`, not a panic the installed hook
+/// would catch).
+///
+/// This is the only function in the crate that touches a real terminal or
+/// blocks on input; everything it calls into (`App`, `row_view`, `ui`,
+/// `source`) is either pure or an isolated, narrowly-scoped IO call (a
+/// single source-file read).
+///
+/// `diff_text` is the exact same raw diff string every `main.rs` input mode
+/// already holds before handing it to `rinkaku_core::pipeline::analyze_diff`
+/// — passed through unchanged, not re-fetched or re-derived here, so this
+/// crate never runs `git` itself (ADR 0016: `rinkaku-core`/adapters own IO,
+/// not `rinkaku-tui`'s view layer beyond the one source-file read
+/// `crate::source` already makes).
+///
+/// `entry_path` is `main.rs`'s `--entry <path>` flag (ADR 0019), passed
+/// through unchanged when the user combines it with `--tui`: `None` when
+/// `--entry` was not given (the ordinary case), `Some(path)` to open
+/// straight into [`crate::app::RightPane::BlastRadius`] (ADR 0023) with the
+/// cursor already on the matching tree row (`App::with_entry_pivot`)
+/// instead of requiring the reviewer to hunt for the row and press `R`
+/// themselves. Note this crate does *not* itself re-root `report.graph` —
+/// `main.rs` already applied `--entry`'s `pivot_graph` re-rooting to
+/// `report` before calling here (the same `Report` both the TUI and
+/// Markdown/JSON render from), so this parameter only drives where the TUI
+/// *starts*, not what the underlying graph looks like.
+///
+/// `repo_root` anchors `Report` paths (always repository-root-relative) for
+/// the source drill-down's file reads (`crate::source::load_symbol_source`)
+/// — `main.rs` resolves it once at startup (`git rev-parse --show-toplevel`,
+/// falling back to the process's current directory outside a git
+/// repository) rather than this crate ever shelling out to `git` itself
+/// (ADR 0016). Without it, the source view would only work when `rinkaku`
+/// happens to be invoked from the repository root.
+///
+/// A thin convenience wrapper around [`TuiSession::init`] +
+/// [`TuiSession::run`] for callers that have no splash screen to draw
+/// in between (ADR 0033) — every terminal-lifecycle detail this doc
+/// comment describes lives on `TuiSession` now, see that type's own doc
+/// comment for the same guarantees.
+pub fn run(
+    report: &Report,
+    diff_text: &str,
+    entry_path: Option<&str>,
+    repo_root: &std::path::Path,
+) -> std::io::Result<()> {
+    TuiSession::init()?.run(report, diff_text, entry_path, repo_root)
+}
+
+/// Owns the terminal's raw-mode/alternate-screen/mouse-capture lifecycle
+/// (ADR 0033), split out of what used to be a single [`run`] call so
+/// `main.rs` can draw [`splash::SplashState`] frames on the same terminal
+/// while the pre-render analysis pipeline runs synchronously, *before*
+/// handing off to the full event loop — without tearing down and
+/// re-entering the alternate screen in between, which would flash the
+/// terminal and defeat the splash screen's own purpose.
+///
+/// [`TuiSession::init`] performs exactly the setup [`run`]'s preamble used
+/// to (panic-hook chaining, [`ratatui::try_init`], `EnableMouseCapture`,
+/// with the same error-path terminal restoration). [`TuiSession::draw_splash`]
+/// draws one splash frame on the already-initialized terminal — call it as
+/// many times as the pipeline has phase transitions/progress updates to
+/// report, all from the same thread that called `init` (ADR 0033 decision
+/// 2: no cross-thread terminal access). [`TuiSession::run`] consumes `self`
+/// and performs exactly the postamble `run` used to
+/// (`DisableMouseCapture` + [`ratatui::restore`]) on both its `Ok` and
+/// `Err` paths.
+///
+/// A [`Drop`] impl calls [`ratatui::restore`] as a safety net for a path
+/// that drops a `TuiSession` without ever calling `run` at all (e.g.
+/// `main.rs` returning early with a `?` from inside its own analysis
+/// branch, after `init` but before a `Report` exists to hand to `run`) —
+/// `ratatui::restore` is documented idempotent, so this is safe to run
+/// again even after `run`'s own explicit postamble already restored the
+/// terminal on the ordinary path.
+pub struct TuiSession {
+    terminal: ratatui::DefaultTerminal,
+}
+
+impl TuiSession {
+    /// See the type's own doc comment for the exact setup this performs.
+    pub fn init() -> std::io::Result<Self> {
+        // Chained *before* `ratatui::try_init`'s own `set_panic_hook` call
+        // below, so the hook `try_init` installs wraps this one: on panic,
+        // `try_init`'s hook runs `ratatui::restore()` (raw mode/alternate
+        // screen) and then this crate's hook (disable mouse capture),
+        // rather than mouse capture silently staying enabled in the
+        // panicking caller's terminal.
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
+            previous_hook(info);
+        }));
+
+        let terminal = ratatui::try_init()?;
+        // Restore explicitly on this `?`'s early-return path (rather than
+        // letting `?` skip straight past the `ratatui::restore()` call
+        // below): `try_init` above already left raw mode/the alternate
+        // screen active, and a plain `EnableMouseCapture` IO failure is
+        // not a panic, so the panic-hook layer just installed does not
+        // run either — without this, that combination would strand the
+        // caller's terminal in raw mode/alternate screen with no cleanup
+        // at all.
+        if let Err(err) = execute!(std::io::stdout(), event::EnableMouseCapture) {
+            ratatui::restore();
+            return Err(err);
+        }
+        Ok(Self { terminal })
+    }
+
+    /// Draws one splash frame (ADR 0033) on the already-initialized
+    /// terminal. Intended to be called repeatedly from `main.rs`'s
+    /// analysis call stack as the pipeline moves between phases/reports
+    /// file-scan progress — each call is a plain, synchronous
+    /// `Terminal::draw`, not a background redraw loop.
+    pub fn draw_splash(&mut self, state: &splash::SplashState) -> std::io::Result<()> {
+        self.terminal
+            .draw(|frame| splash::draw_splash(frame, state))?;
+        Ok(())
+    }
+
+    /// Runs the interactive TUI's main event loop over `report` until the
+    /// user quits, consuming `self` and restoring the terminal
+    /// unconditionally before returning — on both the `Ok` and `Err` path,
+    /// matching the postamble the pre-ADR-0033 [`run`] function always ran.
+    /// See [`run`]'s own doc comment (preserved there) for what `report`,
+    /// `diff_text`, `entry_path`, and `repo_root` mean.
+    pub fn run(
+        mut self,
+        report: &Report,
+        diff_text: &str,
+        entry_path: Option<&str>,
+        repo_root: &std::path::Path,
+    ) -> std::io::Result<()> {
+        let result = run_app(&mut self.terminal, report, diff_text, entry_path, repo_root);
+        let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
+        ratatui::restore();
+        result
+    }
+}
+
+impl Drop for TuiSession {
+    fn drop(&mut self) {
+        // Idempotent per `ratatui::restore`'s own contract: a no-op if
+        // `TuiSession::run` already restored the terminal on the ordinary
+        // path, a real safety net if `self` is dropped without `run` ever
+        // being called (e.g. `main.rs` returning early with `?` from the
+        // analysis phase, after `init` succeeded but before a `Report`
+        // exists).
+        ratatui::restore();
+    }
+}


### PR DESCRIPTION
## Summary

- `rinkaku-tui/src/lib.rs` sat in ADR 0028's file-size watch band (1212 lines, threshold 1000-1500). This PR splits `TuiSession` (terminal lifecycle: `init`/`draw_splash`/`run`, the `Drop` safety net) and the crate's `run()` entry point out into a new `rinkaku-tui/src/session.rs` sibling module.
- The split follows the seam `lib.rs`'s own module doc comment already draws between the "view-model" layer (`tree`/`nav`/`order`/`detail`/`app`/`row_view`, no `ratatui`/`crossterm` types) and the "terminal adapter" layer (`ui`/`source`/the terminal-lifecycle code) — `TuiSession` is squarely the latter, while `run_app` and its `translate_key`/`dispatch_non_source_key`/etc. helpers stay in `lib.rs` as the pure dispatch glue.
- Purely mechanical: no behavior change, no public API change.
  - `run_app` becomes `pub(crate)` so `session.rs` can call into it (it was already private, called only from the code that moved).
  - `TuiSession`/`run` are re-exported from the crate root (`pub use session::{TuiSession, run}`), so every existing caller path — notably `main.rs`'s `use rinkaku_tui::TuiSession;` and `rinkaku_tui::run` doc references — is unaffected.
- `lib.rs`: 1212 → 1038 lines (still technically in the watch band, but well clear of the 1500-line warn threshold; `rinkaku --base main`'s own file-size warning did not fire before or after).

## Motivation

Follow-up from PR #100 review (splash-screen work), which added `TuiSession` to `lib.rs` and pushed it further into the watch band. Filed as its own PR per CLAUDE.md's file-size discipline ("start planning the split now" at the 1000-1500 band) rather than letting it drift toward the 1500-line warn threshold.

**This is a stacked PR**: based on `feat/tui-splash-screen` (PR #100, not yet merged). Once #100 merges into `main`, GitHub will automatically retarget this PR's base to `main`.

## Test plan

- [x] `make test` — all 1078 tests pass (169 + 360 + 549 across the workspace, 0 failed)
- [x] `make lint` — `cargo fmt --all --check` + `cargo clippy --all-targets --all-features -- -D warnings` both clean
- [x] `cargo build --all-features` — whole workspace builds, confirming `main.rs`'s `rinkaku_tui::TuiSession` re-export path still resolves
- [x] Dogfooding: ran `rinkaku` (built from a trusted `main` checkout) over this diff — change graph shows exactly the expected 7 "new" symbols in `session.rs` (all moved verbatim) correctly wired back to `run_app` in `lib.rs`, confirming the split introduced no accidental behavior drift