### PR TITLE
docs: add TUI splash ASCII art to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ Both share one engine: tree-sitter extraction of changed symbols, 1-hop
 dependency expansion, fan-in / contract-change / entry-point
 summarizers. Rust, Go, Python, and TypeScript out of the box.
 
+The TUI greets you with this on startup, while it scans the diff:
+
+```
+      _       _              _
+     (_)     | |            | |
+ _ __ _ _ __ | | ____ _ _ __| |___   _
+| '__| | '_ \| |/ / _` | '__| / / | | |
+| |  | | | | |   < (_| | |  | . \ |_| |
+|_|  |_|_| |_|_|\_\__,_|_|  |_|\_\__,_|
+```
+
 ## Try it in 30 seconds
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The TUI greets you with this on startup, while it scans the diff:
 brew install hiro-o918/tap/rinkaku
 # or:
 curl -fsSL https://raw.githubusercontent.com/hiro-o918/rinkaku/main/install.sh | bash
+# or install into your home directory (no sudo):
+INSTALL_DIR="$HOME/.local/bin" bash -c "$(curl -fsSL https://raw.githubusercontent.com/hiro-o918/rinkaku/main/install.sh)"
 
 # 2. Point it at any GitHub PR — a local clone is optional
 rinkaku --pr https://github.com/owner/repo/pull/123


### PR DESCRIPTION
## Summary
- Show the TUI's startup splash ASCII art (from `rinkaku-tui/src/splash.rs`'s `LOGO_LINES`) in the README, right after the terminal/action intro.
- Gives readers a quick visual preview of what the TUI looks like on launch before they try it.
- Document a user-local (no sudo) install option in "Try it in 30 seconds", using `install.sh`'s existing `INSTALL_DIR` env var override (e.g. `INSTALL_DIR="$HOME/.local/bin"`) — no script changes needed since `install.sh` already supported it.
- Docs-only, mechanical change — no code touched.

## Test plan
- [x] `make lint` passes in the worktree
- [x] Visually diffed the added ASCII art against `LOGO_LINES` in `rinkaku-tui/src/splash.rs` (trailing whitespace trimmed only)
- [x] Ran the documented `INSTALL_DIR="$TMPDIR" bash -c "$(curl ...)"` invocation locally against a `mktemp -d` directory and confirmed the `rinkaku` binary was installed there and runs (`rinkaku --version`)

## Scope
Docs-only PR: the splash ASCII art and the user-local install instructions both touch only README.md and are part of the same "first impression / getting started" surface, so they ship together rather than as two one-line PRs.