### PR TITLE
fix(tui): drop DIM modifier from DarkGray-styled text for readability

### DIFF
--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -150,9 +150,7 @@ pub(crate) fn diff_pane_lines(
             }
             lines.push(Line::styled(
                 attributed.hunk.header.clone(),
-                Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::DIM),
+                Style::default().fg(Color::DarkGray),
             ));
 
             let hunk_highlight = highlight::lookup_hunk_highlight_by_index(
@@ -762,7 +760,7 @@ index e69de29..4b825dc 100644
     }
 
     #[test]
-    fn should_keep_hunk_header_dim_when_diff_pane_is_highlighted() {
+    fn should_keep_hunk_header_dark_gray_when_diff_pane_is_highlighted() {
         let report = report_with_one_symbol();
         // ADR 0020 defaults the right pane to Diff already, so no
         // `ToggleDiff` press is needed to reach it here.
@@ -797,7 +795,10 @@ index e69de29..4b825dc 100644
 
         let header_style = find_cell_style(&terminal, "@@ -1,1 +1,2 @@", "@@");
         assert_eq!(Some(Color::DarkGray), header_style.fg);
-        assert!(header_style.add_modifier.contains(Modifier::DIM));
+        // DarkGray alone gives sufficient contrast; stacking `Modifier::DIM`
+        // on top of it double-dims the header to near-invisibility on many
+        // terminal themes (especially light backgrounds).
+        assert!(!header_style.add_modifier.contains(Modifier::DIM));
     }
 
     #[test]

--- a/rinkaku-tui/src/ui/style.rs
+++ b/rinkaku-tui/src/ui/style.rs
@@ -5,7 +5,7 @@
 //! background tint" composition (ADR 0018).
 
 use crate::highlight::{PALETTE, TokenSpan};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Color, Style};
 use ratatui::text::Span;
 
 /// Splits `content` into styled spans per `spans` (byte-offset [`TokenSpan`]s
@@ -74,9 +74,7 @@ pub(crate) fn palette_style(palette_index: usize) -> Style {
     match PALETTE.get(palette_index).copied() {
         Some("keyword") => Style::default().fg(Color::Magenta),
         Some("string") => Style::default().fg(Color::Yellow),
-        Some("comment") => Style::default()
-            .fg(Color::DarkGray)
-            .add_modifier(Modifier::DIM),
+        Some("comment") => Style::default().fg(Color::DarkGray),
         Some("function") => Style::default().fg(Color::Blue),
         Some("type") => Style::default().fg(Color::Cyan),
         Some("number") => Style::default().fg(Color::LightRed),
@@ -99,12 +97,7 @@ mod tests {
         let expected = vec![
             ("keyword", Style::default().fg(Color::Magenta)),
             ("string", Style::default().fg(Color::Yellow)),
-            (
-                "comment",
-                Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::DIM),
-            ),
+            ("comment", Style::default().fg(Color::DarkGray)),
             ("function", Style::default().fg(Color::Blue)),
             ("type", Style::default().fg(Color::Cyan)),
             ("number", Style::default().fg(Color::LightRed)),


### PR DESCRIPTION
## Summary

- Comment tokens (`palette_style` in `rinkaku-tui/src/ui/style.rs`) and diff hunk headers (`rinkaku-tui/src/ui/diff_pane.rs`) stacked `Color::DarkGray` with `Modifier::DIM`.
- `DarkGray` (ANSI bright black) is already low-contrast on many terminal themes; adding `DIM` on top double-dims the text, making it near-invisible — especially on light backgrounds.
- Removed `Modifier::DIM` from both sites, keeping `Color::DarkGray` alone. This stays terminal-palette-relative: no `Color::Rgb`/`Color::Indexed` introduced, consistent with the crate's existing convention of only named ANSI colors.
- Searched the crate for any other spot stacking an explicit `DarkGray` fg with `Modifier::DIM` — found none beyond the two fixed here. Standalone `Modifier::DIM` (default fg, e.g. `entry.rs`/`overlay.rs` empty-state hints) and standalone `DarkGray` usages (e.g. `row_view.rs`, `status.rs`, `detail_pane.rs`, `source_screen.rs`'s highlight background) were left untouched since they don't double-dim.

## Changes

- `rinkaku-tui/src/ui/style.rs`: `palette_style`'s `"comment"` arm drops `.add_modifier(Modifier::DIM)`; updated the pinned palette-style test table to match; dropped the now-unused `Modifier` import.
- `rinkaku-tui/src/ui/diff_pane.rs`: hunk header style drops `.add_modifier(Modifier::DIM)`; renamed and updated `should_keep_hunk_header_dim_when_diff_pane_is_highlighted` to assert `DIM` is now absent (kept the `DarkGray` fg assertion).

This is a small mechanical style fix (lightweight route per repo `CLAUDE.md`) — no ADR, no three-angle review pipeline, but tests were kept green throughout.

## Test plan

- [x] `make test` — 549 passed, 0 failed
- [x] `make lint` — `cargo fmt --all --check` + `cargo clippy --all-targets --all-features -- -D warnings` clean