### PR TITLE
docs: renumber duplicate ADR 0033 (fan-in rename) to 0034

### DIFF
--- a/docs/adr/0013-hotspots-fan-in-section.md
+++ b/docs/adr/0013-hotspots-fan-in-section.md
@@ -181,13 +181,13 @@ signal the original `!` glyph carried on its own.
 
 ## Amendment (2026-07-13, feat/rename-hotspots-to-fan-in)
 
-Superseded by [ADR 0033](0033-rename-hotspots-vocabulary-to-fan-in.md):
+Superseded by [ADR 0034](0034-rename-hotspots-vocabulary-to-fan-in.md):
 user testing found "hotspot" collides with an unrelated, well-known
 term (CodeScene's change-frequency × complexity metric) and the `ref:`
 badge label collides visually with the `gr` keybinding despite naming
 unrelated concepts. Every "hotspot" identifier and string named in this
 ADR (`Hotspot`, `compute_hotspots`, `Report.hotspots`, the Markdown
 `## Hotspots` heading, the Mermaid `hotspot` class, and the `ref:N`
-badge label) is renamed to "fan-in" by ADR 0033. This ADR's Decision
+badge label) is renamed to "fan-in" by ADR 0034. This ADR's Decision
 and both prior amendments remain the historical record of what shipped
-and why; see ADR 0033 for the current naming.
+and why; see ADR 0034 for the current naming.

--- a/docs/adr/0034-rename-hotspots-vocabulary-to-fan-in.md
+++ b/docs/adr/0034-rename-hotspots-vocabulary-to-fan-in.md
@@ -1,4 +1,4 @@
-# 0033. Rename the "hotspot" vocabulary to "fan-in"
+# 0034. Rename the "hotspot" vocabulary to "fan-in"
 
 - Status: accepted
 - Date: 2026-07-13

--- a/rinkaku-core/src/graph.rs
+++ b/rinkaku-core/src/graph.rs
@@ -58,7 +58,7 @@ pub struct SymbolGraph {
     pub roots: Vec<NodeId>,
 }
 
-/// Line-count-style eligibility threshold (ADR 0033, mirroring
+/// Line-count-style eligibility threshold (ADR 0034, mirroring
 /// `file_size.rs`'s `WARN_LINE_THRESHOLD`/`SPLIT_LINE_THRESHOLD`
 /// convention): a node with `used_by.len() >= HIGH_FAN_IN_THRESHOLD`
 /// qualifies as a [`FanIn`] entry. This is a judgment call, not derived
@@ -69,7 +69,7 @@ pub struct SymbolGraph {
 pub const HIGH_FAN_IN_THRESHOLD: usize = 2;
 
 /// A changed symbol with two or more distinct referrers (ADR 0013, named
-/// "fan-in" per ADR 0033): a symbol a reviewer should pay extra attention
+/// "fan-in" per ADR 0034): a symbol a reviewer should pay extra attention
 /// to, since changing its signature has a wider blast radius than a symbol
 /// only one other changed symbol depends on.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/rinkaku-core/src/pipeline_tests/analyze_diff.rs
+++ b/rinkaku-core/src/pipeline_tests/analyze_diff.rs
@@ -3,7 +3,7 @@
 //! and read-file error paths, multi-file mixed outcomes, Go
 //! interface/receiver nesting end-to-end (ADR 0012 decision 2), resolver
 //! invocation contract (`Some`/`None`), and fan-in wiring (ADR 0013,
-//! named per ADR 0033, end-to-end).
+//! named per ADR 0034, end-to-end).
 
 use super::{empty_graph, fake_reader};
 use crate::diff::LineRange;

--- a/rinkaku-core/src/pipeline_tests/mod.rs
+++ b/rinkaku-core/src/pipeline_tests/mod.rs
@@ -8,7 +8,7 @@
 //!   rename), diff-parse and read-file error paths, multi-file mixed
 //!   outcomes, Go interface/receiver nesting end-to-end, resolver
 //!   invocation contract (`Some`/`None`), and fan-in wiring
-//!   (ADR 0013, named per ADR 0033, end-to-end).
+//!   (ADR 0013, named per ADR 0034, end-to-end).
 //! - [`is_generated_content`] — ADR 0011: the `is_generated_content`
 //!   marker-detection helper's positive and negative cases (rstest).
 //! - [`test_symbol_exclusion`] — ADR 0009: `partition_test_symbols`'s

--- a/rinkaku-core/src/render/markdown_tests/sections_skipped_fan_in_filesize.rs
+++ b/rinkaku-core/src/render/markdown_tests/sections_skipped_fan_in_filesize.rs
@@ -1,5 +1,5 @@
 //! The three optional post-graph sections — "## Skipped files",
-//! "## High fan-in symbols" (ADR 0013, named per ADR 0033), and
+//! "## High fan-in symbols" (ADR 0013, named per ADR 0034), and
 //! "## File size warnings" (ADR 0028) — plus the ADR 0028 shape of
 //! `file_size_warnings` in JSON output. Pins that each section is
 //! emitted only when its list is non-empty and that they land in the

--- a/rinkaku-core/src/render/mod.rs
+++ b/rinkaku-core/src/render/mod.rs
@@ -14,7 +14,7 @@
 //! "Repository graph" for a whole-repo outline (names only, rooted at the
 //! graph's auto-detected entry points) giving the reader a call-hierarchy
 //! reading order, with an optional "High fan-in symbols" sub-section
-//! (ADR 0013, named per ADR 0033) right after it; "Definitions" — the full
+//! (ADR 0013, named per ADR 0034) right after it; "Definitions" — the full
 //! signature of every symbol, in the
 //! same tree order, each shown exactly once (ADR 0008's decision to avoid
 //! duplicating a symbol reachable from multiple roots); "Removed symbols" —

--- a/rinkaku-core/src/render/report.rs
+++ b/rinkaku-core/src/render/report.rs
@@ -42,7 +42,7 @@ pub struct Report {
     /// populated when the CLI passes `--exclude-tests`. Source order (the
     /// order files were first encountered in the diff), same as `files`.
     pub tests: Vec<TestFileSummary>,
-    /// Fan-in symbols (ADR 0013, named "fan-in" per ADR 0033): changed
+    /// Fan-in symbols (ADR 0013, named "fan-in" per ADR 0034): changed
     /// symbols referenced by two or more other changed symbols, sorted by
     /// fan-in descending. Derived from `graph` via
     /// [`crate::graph::compute_fan_ins`] and kept as its own `Report` field

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -215,7 +215,7 @@ enum BadgeContext {
 ///   for fan-in) conveyed no semantic hint on their own to a first-time
 ///   reviewer — `!` in particular read as generic "warning" rather than
 ///   pointing at *what* changed. The fan-in badge's label itself was
-///   later relabeled again, from `ref:` to `fan-in:` (ADR 0033): `ref:`
+///   later relabeled again, from `ref:` to `fan-in:` (ADR 0034): `ref:`
 ///   collided visually with the unrelated `gr` ("go to references")
 ///   keybinding despite naming a different concept, and "hotspot" (the
 ///   underlying aggregation's original name) collided with an unrelated

--- a/rinkaku-tui/src/row_view_tests/entry_row_line.rs
+++ b/rinkaku-tui/src/row_view_tests/entry_row_line.rs
@@ -19,7 +19,7 @@ fn should_include_badge_labels_for_nonzero_badges_on_a_dir_row() {
     // ADR 0013 amendments (2026-07-13): all three badges use text labels
     // (`chg:` / `api:` / `fan-in:`) instead of glyphs — the first
     // amendment relabeled changed-symbol/fan-in (as `ref:`, later
-    // relabeled `fan-in:` per ADR 0033), the second (feat/label-contract-
+    // relabeled `fan-in:` per ADR 0034), the second (feat/label-contract-
     // changes-badge) relabeled contract-change from a bare `!` after
     // user testing showed it read as generic "warning" with no hint of
     // what changed.

--- a/rinkaku-tui/src/ui/detail_pane.rs
+++ b/rinkaku-tui/src/ui/detail_pane.rs
@@ -203,7 +203,7 @@ pub(crate) fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
                     Some(Classification::BodyOnly) | None => " ",
                 }
             };
-            // ADR 0013 amendment (2026-07-13, relabeled by ADR 0033): the
+            // ADR 0013 amendment (2026-07-13, relabeled by ADR 0034): the
             // compact fan-in badge matches `row_view::push_badge_spans`'
             // `fan-in:N` labeling so the two panes agree on the badge
             // legend.

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -55,7 +55,7 @@ pub(crate) fn draw_status_line(frame: &mut Frame, app: &App, report: &Report, ar
 /// emoji rendering width is inconsistent enough that a status-line
 /// glyph can push the help hints past the frame edge. The whole suffix
 /// is dropped when the vec is empty (mirrors ADR 0013's "High fan-in
-/// symbols is skipped when empty" rule, named per ADR 0033).
+/// symbols is skipped when empty" rule, named per ADR 0034).
 pub(crate) fn status_line_text(app: &App, report: &Report) -> String {
     let help = match app.screen() {
         Screen::Entry => {


### PR DESCRIPTION
## Summary

PR #100 (TUI splash screen) and PR #101 (hotspot→fan-in vocabulary
rename) both landed on `main` using ADR number 0033 — each branch was
written independently against its own base before the other merged.
Following merge order (#100 first), this PR keeps 0033 for the
splash-screen ADR and renumbers the fan-in-rename ADR to 0034:

- `git mv docs/adr/0033-rename-hotspots-vocabulary-to-fan-in.md` →
  `docs/adr/0034-rename-hotspots-vocabulary-to-fan-in.md`, plus the
  `# 0033.` → `# 0034.` title line.
- Every "ADR 0033" / `adr/0033` reference that points at the fan-in
  rename (not the splash screen) is updated to 0034, across:
  - `docs/adr/0013-hotspots-fan-in-section.md` (supersession note +
    link)
  - `rinkaku-core/src/graph.rs`, `render/mod.rs`, `render/report.rs`,
    `pipeline_tests/mod.rs`, `pipeline_tests/analyze_diff.rs`,
    `render/markdown_tests/sections_skipped_fan_in_filesize.rs`
  - `rinkaku-tui/src/row_view.rs`, `ui/status.rs`, `ui/detail_pane.rs`,
    `row_view_tests/entry_row_line.rs`

References to the splash-screen ADR (progress reporting, `TuiSession`,
`splash.rs`, `spinner.rs`, `main.rs`, experiment round 021, etc.) are
left untouched at 0033.

Note: ADR number 0035 is intentionally left free — a separate
in-progress branch (`feat/tui-tests-sorted-last`) is expected to claim
it.

This is a **mechanical** change (rename + reference relabeling, no
behavior or output-format change), so per CLAUDE.md's "Process weight"
section it does not require the three-angle dogfooding review — the
usual `make test` / `make lint` gate is the applicable bar here.

## Test plan

- [x] `make test` — 549 passed, 0 failed
- [x] `make lint` — clean (fmt + clippy)
- [x] `grep -rn "ADR 0033\|adr/0033"` re-run after the change: only
      splash-related references remain at 0033; all fan-in-rename
      references now read 0034
- [x] No stray references to the old filename
      (`0033-rename-hotspots-vocabulary-to-fan-in.md`) remain anywhere