### PR TITLE
feat(tui): highlight the focused pane border

### DIFF
--- a/rinkaku-tui/src/ui/blast_radius.rs
+++ b/rinkaku-tui/src/ui/blast_radius.rs
@@ -4,7 +4,8 @@
 //! computed once per handled key by `crate::run_app` and handed in.
 
 use super::scroll::render_scrollable_pane;
-use crate::app::{App, BlastRadiusSelection};
+use super::style::pane_border_style;
+use crate::app::{App, BlastRadiusSelection, Focus};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
@@ -42,9 +43,12 @@ pub(crate) fn draw_blast_radius_pane(
     selection: &BlastRadiusSelection,
     area: Rect,
 ) -> Option<usize> {
+    let focused = app.focus() == Focus::Right;
     match selection {
         BlastRadiusSelection::NotApplicable => {
-            let block = Block::bordered().title(" Blast radius ");
+            let block = Block::bordered()
+                .title(" Blast radius ")
+                .border_style(pane_border_style(focused));
             let paragraph =
                 Paragraph::new("(select a directory or file row to see its blast radius)")
                     .block(block)
@@ -53,7 +57,9 @@ pub(crate) fn draw_blast_radius_pane(
             None
         }
         BlastRadiusSelection::Empty { path } => {
-            let block = Block::bordered().title(format!(" Blast radius of {path} "));
+            let block = Block::bordered()
+                .title(format!(" Blast radius of {path} "))
+                .border_style(pane_border_style(focused));
             let paragraph = Paragraph::new(format!("(nothing under {path} is reachable)"))
                 .block(block)
                 .wrap(ratatui::widgets::Wrap { trim: false });
@@ -69,6 +75,7 @@ pub(crate) fn draw_blast_radius_pane(
                 &lines,
                 app.right_pane_scroll(),
                 area,
+                focused,
             ))
         }
     }

--- a/rinkaku-tui/src/ui/detail_pane.rs
+++ b/rinkaku-tui/src/ui/detail_pane.rs
@@ -4,7 +4,8 @@
 //! (`DetailView`, `DirDetail`, `FileDetail`) come from `crate::detail`.
 
 use super::scroll::render_scrollable_pane;
-use crate::app::{App, SelectedDetail};
+use super::style::pane_border_style;
+use crate::app::{App, Focus, SelectedDetail};
 use crate::detail::{DetailView, DirDetail, FileDetail, SignatureView};
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -24,8 +25,11 @@ pub(crate) fn draw_detail_pane(
     report: &Report,
     area: Rect,
 ) -> Option<usize> {
+    let focused = app.focus() == Focus::Right;
     let Some(detail) = app.selected_detail(report) else {
-        let block = Block::bordered().title(" Detail ");
+        let block = Block::bordered()
+            .title(" Detail ")
+            .border_style(pane_border_style(focused));
         let paragraph = Paragraph::new("(select a row to see its detail)")
             .block(block)
             .wrap(ratatui::widgets::Wrap { trim: false });
@@ -44,6 +48,7 @@ pub(crate) fn draw_detail_pane(
         &lines,
         app.right_pane_scroll(),
         area,
+        focused,
     ))
 }
 

--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -4,8 +4,8 @@
 //! grouped into per-symbol sections for a file row.
 
 use super::scroll::render_scrollable_pane;
-use super::style::styled_content_spans;
-use crate::app::{App, DiffTarget};
+use super::style::{pane_border_style, styled_content_spans};
+use crate::app::{App, DiffTarget, Focus};
 use crate::diff_shape::DiffSection;
 use crate::diff_view::{DiffLine, DiffLineKind};
 use crate::highlight::{self, HighlightedFile, TokenSpan};
@@ -59,6 +59,7 @@ pub(crate) fn draw_diff_pane(
 ) -> Option<usize> {
     use crate::diff_shape::DiffPaneContent;
 
+    let focused = app.focus() == Focus::Right;
     let target = app.selected_diff_target(report);
     let path: &str = match &target {
         Some(DiffTarget::File { path }) => path.as_str(),
@@ -71,7 +72,9 @@ pub(crate) fn draw_diff_pane(
                 None => "(select a symbol or file row to see its diff)".to_string(),
                 Some(_) => format!("(no diff hunks found for {path})"),
             };
-            let block = Block::bordered().title(" Diff ");
+            let block = Block::bordered()
+                .title(" Diff ")
+                .border_style(pane_border_style(focused));
             let paragraph = Paragraph::new(message)
                 .block(block)
                 .wrap(ratatui::widgets::Wrap { trim: false });
@@ -94,6 +97,7 @@ pub(crate) fn draw_diff_pane(
         &lines,
         app.right_pane_scroll(),
         area,
+        focused,
     ))
 }
 

--- a/rinkaku-tui/src/ui/entry.rs
+++ b/rinkaku-tui/src/ui/entry.rs
@@ -6,8 +6,9 @@ use super::blast_radius::draw_blast_radius_pane;
 use super::detail_pane::draw_detail_pane;
 use super::diff_pane::draw_diff_pane;
 use super::scroll::{scroll_indicator, windowed_rows_with_indicators};
+use super::style::pane_border_style;
 use super::{ENTRY_RIGHT_WIDTH_PERCENT, ENTRY_TREE_WIDTH_PERCENT};
-use crate::app::{App, BlastRadiusSelection, RightPane};
+use crate::app::{App, BlastRadiusSelection, Focus, RightPane};
 use crate::highlight::HighlightedFile;
 use crate::row_view::{entry_row_line, relative_labels};
 use ratatui::Frame;
@@ -117,7 +118,9 @@ pub(crate) fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
         Some(indicator) => format!("{}{indicator} ", " Entry".trim_end()),
         None => " Entry ".to_string(),
     };
-    let block = Block::bordered().title(title);
+    let block = Block::bordered()
+        .title(title)
+        .border_style(pane_border_style(app.focus() == Focus::Tree));
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
 }
@@ -128,6 +131,7 @@ mod tests {
     use crate::ui::draw;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
+    use ratatui::style::{Color, Modifier};
     use rinkaku_core::diff::LineRange;
     use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
     use rinkaku_core::graph::SymbolGraph;
@@ -237,6 +241,79 @@ mod tests {
         // the detail pane actually rendered file-detail content rather than
         // asserting on the placeholder text that used to show here.
         assert!(text.contains("Symbols"));
+    }
+
+    // NOTE: asserts only `fg`/`add_modifier` rather than the whole `Style`
+    // returned by `buffer[..].style()` — a rendered `Cell`'s `Style` always
+    // carries ratatui's own default `bg`/`underline_color` (`Color::Reset`)
+    // filled in, unlike the bare `Style` `pane_border_style` constructs, so
+    // a fully-qualified comparison would fail for a reason unrelated to
+    // this test's actual claim. Mirrors the same partial-comparison
+    // precedent `diff_pane`/`source_screen`'s own `find_cell_style` tests
+    // already use for the identical reason.
+    #[test]
+    fn should_swap_border_emphasis_between_tree_and_right_pane_when_focus_moves_right() {
+        // Dogfooding finding: every pane's `Block` looked identical
+        // regardless of which one currently received motion keys, so a
+        // reviewer had no visual way to tell which pane `j`/`k` would move.
+        // This pins the actual rendered border cell style (not just the
+        // pure `pane_border_style` helper in isolation) swapping sides as
+        // `Focus` changes.
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        assert_eq!(crate::app::Focus::Tree, app.focus());
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    None,
+                );
+            })
+            .expect("draw");
+
+        // Tree pane's own top-left border corner is at (0, 0); the right
+        // pane's 60/40 split (`ENTRY_TREE_WIDTH_PERCENT`) puts its top-left
+        // corner at column 48 of an 80-column terminal.
+        let buffer = terminal.backend().buffer();
+        let tree_border_style = buffer[(0, 0)].style();
+        let right_border_style = buffer[(48, 0)].style();
+        assert_eq!(Some(Color::Cyan), tree_border_style.fg);
+        assert!(tree_border_style.add_modifier.contains(Modifier::BOLD));
+        assert_eq!(Some(Color::DarkGray), right_border_style.fg);
+        assert!(!right_border_style.add_modifier.contains(Modifier::BOLD));
+
+        let app = app.handle_key(crate::app::InputKey::Open);
+        assert_eq!(crate::app::Focus::Right, app.focus());
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    None,
+                );
+            })
+            .expect("draw");
+
+        let buffer = terminal.backend().buffer();
+        let tree_border_style = buffer[(0, 0)].style();
+        let right_border_style = buffer[(48, 0)].style();
+        assert_eq!(Some(Color::DarkGray), tree_border_style.fg);
+        assert!(!tree_border_style.add_modifier.contains(Modifier::BOLD));
+        assert_eq!(Some(Color::Cyan), right_border_style.fg);
+        assert!(right_border_style.add_modifier.contains(Modifier::BOLD));
     }
 
     #[test]

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -74,12 +74,17 @@ pub(crate) fn draw_help_overlay(
 
     let lines = help_overlay_lines();
     let inner_height = overlay_area.height.saturating_sub(2) as usize;
+    // Always drawn as focused: this overlay is modal (composited on top of
+    // whatever screen was already showing) and is always the surface `?`'s
+    // own scroll keys act on while open, so there is no competing pane to
+    // distinguish it from (`render_scrollable_pane`'s own doc comment).
     let scroll = render_scrollable_pane(
         frame,
         " Help (? to close) ",
         &lines,
         requested_scroll,
         overlay_area,
+        true,
     );
     (scroll, inner_height)
 }

--- a/rinkaku-tui/src/ui/scroll.rs
+++ b/rinkaku-tui/src/ui/scroll.rs
@@ -6,6 +6,7 @@
 //! [`render_scrollable_pane`] itself (the one non-pure helper here) has a
 //! single home shared by every pane that scrolls.
 
+use super::style::pane_border_style;
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
@@ -49,12 +50,21 @@ use unicode_width::UnicodeWidthChar;
 /// `App::with_right_pane_scroll` after every draw, so the *next* `k` moves
 /// the visible content immediately instead of first re-tracing the
 /// overshoot.
+///
+/// `focused` selects the pane's border style via
+/// [`pane_border_style`] — dogfooding finding: every bordered pane looked
+/// identical regardless of which one currently received motion keys, so a
+/// reviewer had no visual way to tell which pane `j`/`k` would move. The
+/// Detail/Diff/Blast-radius panes pass `app.focus() == Focus::Right`; the
+/// `?` help overlay and jump popup, which are modal and always the active
+/// surface while shown, pass `true` unconditionally.
 pub(crate) fn render_scrollable_pane(
     frame: &mut Frame,
     title: &str,
     lines: &[Line<'static>],
     requested_scroll: usize,
     area: Rect,
+    focused: bool,
 ) -> usize {
     // 2 columns/rows for the left/right and top/bottom border, matching
     // `draw_source_screen`'s own `saturating_sub(2)` convention for a
@@ -73,7 +83,9 @@ pub(crate) fn render_scrollable_pane(
         None => title.to_string(),
     };
 
-    let block = Block::bordered().title(title);
+    let block = Block::bordered()
+        .title(title)
+        .border_style(pane_border_style(focused));
     let paragraph = Paragraph::new(wrapped)
         .block(block)
         .scroll((scroll as u16, 0));

--- a/rinkaku-tui/src/ui/source_screen.rs
+++ b/rinkaku-tui/src/ui/source_screen.rs
@@ -2,7 +2,7 @@
 //! ADR 0018/0020 for the shared "token foreground + line-level background
 //! tint" composition with the diff pane).
 
-use super::style::{gap_span, styled_content_spans};
+use super::style::{gap_span, pane_border_style, styled_content_spans};
 use crate::source::{HighlightedSourceView, SourceView};
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -53,7 +53,13 @@ pub(crate) fn draw_source_screen(
     area: Rect,
 ) {
     let title = format!(" Source: {symbol_id} ");
-    let block = Block::bordered().title(title);
+    // Always drawn as focused: this screen replaces the whole entry view
+    // (tree + right pane) while open, so there is no sibling pane it needs
+    // to be visually distinguished from (`render_scrollable_pane`'s own doc
+    // comment makes the same call for the `?` help overlay).
+    let block = Block::bordered()
+        .title(title)
+        .border_style(pane_border_style(true));
 
     let highlighted = match source_content {
         Some(Ok(highlighted)) => highlighted,

--- a/rinkaku-tui/src/ui/style.rs
+++ b/rinkaku-tui/src/ui/style.rs
@@ -63,6 +63,34 @@ pub(crate) fn gap_span(text: &str, bg: Option<Color>) -> Span<'static> {
     Span::styled(text.to_string(), style)
 }
 
+/// Border style for a pane's `Block`, keyed only on whether that pane
+/// currently has focus (`crate::app::Focus`) — dogfooding finding: every
+/// pane's `Block::bordered()` looked identical regardless of which one
+/// `Tab`/`h`/`l` had routed motion keys to, so a reviewer had no visual way
+/// to tell which pane `j`/`k` would actually move. Centralized here rather
+/// than matched inline in each of `draw_tree_pane`/`render_scrollable_pane`/
+/// the placeholder `Block`s so the two states can never drift apart between
+/// panes.
+///
+/// Focused uses `Color::Cyan` (the crate's existing accent color — the
+/// splash screen's logo/progress gauge and the tree pane's `chg:`/`fan-in:`
+/// badge counts, `crate::row_view::push_badge_spans`, already use it) plus
+/// `Modifier::BOLD` so the focused border reads as "active" rather than just
+/// a different hue. Unfocused is a plain `Color::DarkGray` with no
+/// `Modifier::DIM` stacked on top — a sibling fix (comment-token styling,
+/// ADR-less color cleanup) is removing that exact double-dimming
+/// combination elsewhere in this crate, so a new call site is deliberately
+/// not reintroducing it.
+pub(crate) fn pane_border_style(focused: bool) -> Style {
+    if focused {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    }
+}
+
 /// Maps a [`PALETTE`] index to its display style — the minimal token
 /// palette ADR 0018 asks for. Falls back to the default (unstyled)
 /// foreground for a palette index this match doesn't special-case (there
@@ -118,6 +146,30 @@ mod tests {
             .enumerate()
             .map(|(index, name)| (*name, palette_style(index)))
             .collect();
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_bold_cyan_style_when_pane_is_focused() {
+        let expected = Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD);
+
+        let actual = pane_border_style(true);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_plain_dark_gray_style_when_pane_is_unfocused() {
+        // Deliberately no `Modifier::DIM` stacked on top of `DarkGray` — a
+        // sibling fix elsewhere in this crate is removing that exact
+        // combination from the comment-token style, so this pane border
+        // must not reintroduce it (`pane_border_style`'s own doc comment).
+        let expected = Style::default().fg(Color::DarkGray);
+
+        let actual = pane_border_style(false);
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
## Summary

- Every pane's `Block` border (Entry tree, Detail/Diff/Blast-radius right
  panes, Source screen, Help overlay) looked identical regardless of which
  one currently received motion keys, so a reviewer had no visual way to
  tell whether `j`/`k` would move the tree cursor or scroll the right pane.
- Adds `pane_border_style(focused: bool) -> Style` in `rinkaku-tui/src/ui/style.rs`,
  centralizing the focused/unfocused border decision in one place instead of
  duplicating a match in every pane's own draw function.
- Focused: bold `Color::Cyan` (the crate's existing accent color — used
  already by the splash screen's logo/progress gauge and the tree pane's
  `chg:`/`fan-in:` badge counts). Unfocused: plain `Color::DarkGray`,
  deliberately *not* stacked with `Modifier::DIM` — a parallel PR
  (`fix/tui-comment-color`) is removing that exact double-dimming
  combination from the comment-token style elsewhere in this crate, so this
  change does not reintroduce it.
- Wired into: the tree pane (`ui/entry.rs`, focused when `Focus::Tree`),
  the Detail/Diff/Blast-radius panes (all three share `render_scrollable_pane`
  in `ui/scroll.rs`, now taking a `focused` parameter; focused when
  `Focus::Right`) including their own placeholder `Block`s, the Source
  screen (`ui/source_screen.rs`, always drawn focused — it fully replaces
  the entry view while open, so there is no sibling pane to contrast
  against) and the `?` help overlay (`ui/overlay.rs`, also always focused —
  it is modal).
- The jump-target popup (`overlay.rs`) is left unchanged: it is a transient
  modal on top of the entry view, not a competing pane in the
  tree/right-pane focus sense this change addresses.

## Before / after

- Before: the tree pane and whichever right pane was showing (Detail/Diff/
  Blast-radius) both rendered with a plain default-style border — visually
  indistinguishable, so pressing `Tab` (or `Enter`/`Esc`/`h`/`l`) to move
  focus had no on-screen confirmation of which side would now respond to
  `j`/`k`.
- After: the focused pane's border is bold cyan; the other side's border is
  plain dark gray. Moving focus (`Enter` on a row, or `Esc`/`FocusLeft` back
  to the tree) visibly swaps which border is highlighted.

## Test plan

- [x] `make test` — all 552 tests pass, including two new ones:
  - `ui::style::tests::should_return_bold_cyan_style_when_pane_is_focused`
    / `should_return_plain_dark_gray_style_when_pane_is_unfocused` (pure
    unit tests pinning `pane_border_style`'s table).
  - `ui::entry::tests::should_swap_border_emphasis_between_tree_and_right_pane_when_focus_moves_right`
    — a `TestBackend` buffer-rendering test that draws a full frame,
    reads back the actual rendered border cell style at both panes'
    top-left corners, and confirms the emphasis swaps sides when focus
    moves from `Focus::Tree` to `Focus::Right` (and stays swapped after
    `Open`).
- [x] `make lint` — `cargo fmt --all --check` + `cargo clippy --all-targets
  --all-features -- -D warnings`, clean.
- [x] `cargo build -p rinkaku` succeeds; `rinkaku --help` still shows
  `--tui` as expected.
- [ ] Interactive TTY run: not available in this sandboxed environment
  (`tty` reports "not a tty" for both stdin/stdout), so the change was not
  visually exercised in a live terminal. Relied on the buffer-based
  rendering test above, which drives the exact same `ratatui` draw path
  (`ui::draw`) end-to-end minus an actual terminal — it reads back real
  rendered `Cell` styles from the `TestBackend` buffer, not just the pure
  helper in isolation.