### PR TITLE
feat(tui): report per-file progress during diff analysis

### DIFF
--- a/docs/adr/0033-tui-splash-screen-with-progress.md
+++ b/docs/adr/0033-tui-splash-screen-with-progress.md
@@ -333,3 +333,40 @@ when the note lands.
   screen, even without remembering to call the explicit teardown method —
   matching the same "belt and braces" precedent `rinkaku_tui::run`'s own
   panic-hook layering already sets.
+
+## Amendment (2026-07-13)
+
+The "fake/animated progress bar" rejection above (Alternatives) listed
+`AnalyzingDiff` alongside `ResolvingPr`/`Diffing` as a phase with "no real
+signal" — true at the time, since `analyze_diff`'s per-file loop had no
+progress port at all. That has changed: `analyze_diff` now takes the same
+`on_progress: Option<rinkaku_core::progress::OnProgress>` port
+`analyze_repo` and `TagsResolver::new` already had, reporting
+`(files_done, total)` as its sequential loop over the diff's changed files
+progresses, gated by the same `should_report_progress` stride rule. `main.rs`
+wires this through `AnalysisProgress::report_file_progress` exactly as it
+already did for the other two phases, so `AnalyzingDiff` now draws a real
+determinate gauge in `--tui` mode instead of a label-only splash — closing
+the one phase this ADR originally could not give real progress to.
+
+This does not change any decision above: it exercises the same
+`OnProgress`/`should_report_progress` port `analyze_repo` established,
+extended to a second, sequential (not rayon-parallel) call site, so no new
+concurrency primitive is introduced (a plain `usize` counter suffices,
+where `analyze_repo` needs `AtomicUsize` for its parallel workers). "Files
+done" counts every changed file the loop looks at, including ones it skips
+(deleted/generated/binary/unsupported-language/pure-rename), matching
+`analyze_repo`'s own "looked at" — not "produced a report for" — convention,
+so a caller watching the callback sees the same meaning regardless of
+which pipeline entry point produced it.
+
+- **Core API**: `rinkaku_core::pipeline::analyze_diff` gains the same
+  `on_progress: Option<OnProgress>` last parameter `analyze_repo` already
+  has. Every existing call site (tests included) is updated to pass
+  `None`; behavior and output are unchanged when it is `None` — same
+  breaking-but-additive signature change class this ADR's original
+  Consequences section already accepted for `analyze_repo`.
+- **UX**: `--base`/`--pr`/stdin modes under `--tui` now show a real gauge
+  during "Analyzing diff..." instead of a static label, matching the
+  whole-repo-outline and dependency-index phases. Every non-TUI display
+  mode is unaffected, same as the original decision.

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -131,6 +131,22 @@ pub enum AnalyzeError {
 /// transient git failure) is treated as "no base content available" for
 /// that one file rather than propagated as an [`AnalyzeError`] or guessed
 /// at.
+///
+/// `on_progress` (ADR 0033, amended), when `Some`, is called with
+/// `(files_done, changed_files.len())` as this function's sequential
+/// per-file loop below works through the diff's changed files —
+/// approximately every [`crate::progress::PROGRESS_REPORT_STRIDE`] files
+/// ([`crate::progress::should_report_progress`]), always including a final
+/// `(total, total)` call. Unlike [`analyze_repo`]'s parallel loop, this
+/// loop is already sequential, so a plain `usize` counter is incremented
+/// in place — no `AtomicUsize` is needed. "Files done" counts every file
+/// the loop looks at, including ones it skips (deleted/generated/binary/
+/// unsupported-language), matching `analyze_repo`'s own "looked at" —not
+/// "produced a report for"— convention so a caller watching the callback
+/// sees the same meaning regardless of which pipeline entry point produced
+/// it. `None` (every caller before this parameter existed) skips all
+/// counting overhead, leaving behavior and output byte-for-byte unchanged.
+#[allow(clippy::too_many_arguments)]
 pub fn analyze_diff(
     diff_text: &str,
     read_file: impl Fn(&str) -> std::io::Result<String>,
@@ -139,8 +155,11 @@ pub fn analyze_diff(
     include_tests: bool,
     generated_paths: &std::collections::HashSet<String>,
     include_generated: bool,
+    on_progress: Option<OnProgress>,
 ) -> Result<Report, AnalyzeError> {
     let changed_files = parse_unified_diff(diff_text)?;
+    let total = changed_files.len();
+    let mut done = 0usize;
 
     let mut files = Vec::new();
     let mut skipped = Vec::new();
@@ -153,58 +172,109 @@ pub fn analyze_diff(
     let mut sized_files: Vec<(String, usize)> = Vec::new();
 
     for changed_file in changed_files {
-        if changed_file.kind == ChangeKind::Deleted {
-            skipped.push(SkippedFile {
-                path: changed_file.path,
-                reason: SkipReason::Deleted,
-            });
-            continue;
-        }
-        if generated_paths.contains(&changed_file.path) {
-            skipped.push(SkippedFile {
-                path: changed_file.path,
-                reason: SkipReason::Generated,
-            });
-            continue;
-        }
-        if changed_file.is_binary {
-            skipped.push(SkippedFile {
-                path: changed_file.path,
-                reason: SkipReason::Binary,
-            });
-            continue;
-        }
-        let Some(lang) = language_for_path(&changed_file.path) else {
-            skipped.push(SkippedFile {
-                path: changed_file.path,
-                reason: SkipReason::UnsupportedLanguage,
-            });
-            continue;
-        };
+        // ADR 0033 (amended): the per-file body is wrapped in a labeled
+        // block so every early exit below (`break 'file`, replacing what
+        // used to be a bare `continue`) still falls through to the single
+        // progress report at the bottom of the loop — "files done" counts
+        // every changed file the loop looks at, including skipped ones,
+        // matching `analyze_repo`'s own "looked at" convention (see this
+        // function's doc comment).
+        'file: {
+            if changed_file.kind == ChangeKind::Deleted {
+                skipped.push(SkippedFile {
+                    path: changed_file.path,
+                    reason: SkipReason::Deleted,
+                });
+                break 'file;
+            }
+            if generated_paths.contains(&changed_file.path) {
+                skipped.push(SkippedFile {
+                    path: changed_file.path,
+                    reason: SkipReason::Generated,
+                });
+                break 'file;
+            }
+            if changed_file.is_binary {
+                skipped.push(SkippedFile {
+                    path: changed_file.path,
+                    reason: SkipReason::Binary,
+                });
+                break 'file;
+            }
+            let Some(lang) = language_for_path(&changed_file.path) else {
+                skipped.push(SkippedFile {
+                    path: changed_file.path,
+                    reason: SkipReason::UnsupportedLanguage,
+                });
+                break 'file;
+            };
 
-        // Base-side content lives at `old_path` for a rename/copy (the
-        // pre-rename path — the new-side `path` never existed on the base
-        // side under a rename, so reading it there would always fail), and
-        // at `path` itself for every other kind.
-        let read_path = changed_file
-            .old_path
-            .as_deref()
-            .unwrap_or(&changed_file.path);
+            // Base-side content lives at `old_path` for a rename/copy (the
+            // pre-rename path — the new-side `path` never existed on the base
+            // side under a rename, so reading it there would always fail), and
+            // at `path` itself for every other kind.
+            let read_path = changed_file
+                .old_path
+                .as_deref()
+                .unwrap_or(&changed_file.path);
 
-        // No new-side hunks means no new-side content change (a pure
-        // rename, a mode-change-only diff, or — ADR 0014's case — a hunk
-        // that only *removes* lines with nothing added back):
-        // extract_changed_symbols would return no symbols for an empty
-        // changed_ranges anyway, so the head-side read is skipped entirely
-        // rather than paying IO for a result already known to be empty.
-        // `old_changed_ranges` can still be non-empty in the removal case,
-        // though, so classification against the base side still runs when
-        // a base reader is available — a whole-function deletion is
-        // exactly the case ADR 0014's `removed` classification exists for.
-        if changed_file.changed_ranges.is_empty() {
-            let mut no_head_symbols: Vec<ExtractedSymbol> = Vec::new();
+            // No new-side hunks means no new-side content change (a pure
+            // rename, a mode-change-only diff, or — ADR 0014's case — a hunk
+            // that only *removes* lines with nothing added back):
+            // extract_changed_symbols would return no symbols for an empty
+            // changed_ranges anyway, so the head-side read is skipped entirely
+            // rather than paying IO for a result already known to be empty.
+            // `old_changed_ranges` can still be non-empty in the removal case,
+            // though, so classification against the base side still runs when
+            // a base reader is available — a whole-function deletion is
+            // exactly the case ADR 0014's `removed` classification exists for.
+            if changed_file.changed_ranges.is_empty() {
+                let mut no_head_symbols: Vec<ExtractedSymbol> = Vec::new();
+                removed.extend(classify_against_base(
+                    &mut no_head_symbols,
+                    read_base_file,
+                    lang,
+                    changed_file.kind,
+                    read_path,
+                    &changed_file.path,
+                    &changed_file.old_changed_ranges,
+                ));
+                files.push(FileReport {
+                    path: changed_file.path,
+                    symbols: Vec::new(),
+                });
+                break 'file;
+            }
+
+            let source =
+                read_file(&changed_file.path).map_err(|source| AnalyzeError::ReadFile {
+                    path: changed_file.path.clone(),
+                    source,
+                })?;
+            // ADR 0011: content-marker detection, checked after the read but
+            // before parsing — a file already excluded by an attribute
+            // (generated_paths, above) never reaches here, so this only ever
+            // adds coverage on top of ADR 0010, never duplicates it.
+            if !include_generated && is_generated_content(&source) {
+                skipped.push(SkippedFile {
+                    path: changed_file.path,
+                    reason: SkipReason::Generated,
+                });
+                break 'file;
+            }
+            // ADR 0028: measure line count once the file's content has cleared
+            // every skip check above. `str::lines()` returns a sensible count
+            // whether or not the final line ends in a newline.
+            sized_files.push((changed_file.path.clone(), source.lines().count()));
+            let mut symbols = extract_changed_symbols(&source, lang, &changed_file.changed_ranges);
+
+            // ADR 0014: classify each symbol's contract impact against the
+            // base side. `ChangeKind::Added` classifies every symbol `Added`
+            // directly (see `classify_against_base`'s doc comment); every other
+            // kind is left at `None`/empty (classify_symbols never runs) when
+            // `read_base_file` is absent or its call fails for this file.
             removed.extend(classify_against_base(
-                &mut no_head_symbols,
+                &mut symbols,
                 read_base_file,
                 lang,
                 changed_file.kind,
@@ -212,53 +282,19 @@ pub fn analyze_diff(
                 &changed_file.path,
                 &changed_file.old_changed_ranges,
             ));
+
             files.push(FileReport {
                 path: changed_file.path,
-                symbols: Vec::new(),
+                symbols,
             });
-            continue;
         }
 
-        let source = read_file(&changed_file.path).map_err(|source| AnalyzeError::ReadFile {
-            path: changed_file.path.clone(),
-            source,
-        })?;
-        // ADR 0011: content-marker detection, checked after the read but
-        // before parsing — a file already excluded by an attribute
-        // (generated_paths, above) never reaches here, so this only ever
-        // adds coverage on top of ADR 0010, never duplicates it.
-        if !include_generated && is_generated_content(&source) {
-            skipped.push(SkippedFile {
-                path: changed_file.path,
-                reason: SkipReason::Generated,
-            });
-            continue;
+        if let Some(on_progress) = on_progress {
+            done += 1;
+            if should_report_progress(done, total) {
+                on_progress(done, total);
+            }
         }
-        // ADR 0028: measure line count once the file's content has cleared
-        // every skip check above. `str::lines()` returns a sensible count
-        // whether or not the final line ends in a newline.
-        sized_files.push((changed_file.path.clone(), source.lines().count()));
-        let mut symbols = extract_changed_symbols(&source, lang, &changed_file.changed_ranges);
-
-        // ADR 0014: classify each symbol's contract impact against the
-        // base side. `ChangeKind::Added` classifies every symbol `Added`
-        // directly (see `classify_against_base`'s doc comment); every other
-        // kind is left at `None`/empty (classify_symbols never runs) when
-        // `read_base_file` is absent or its call fails for this file.
-        removed.extend(classify_against_base(
-            &mut symbols,
-            read_base_file,
-            lang,
-            changed_file.kind,
-            read_path,
-            &changed_file.path,
-            &changed_file.old_changed_ranges,
-        ));
-
-        files.push(FileReport {
-            path: changed_file.path,
-            symbols,
-        });
     }
 
     let mut tests = Vec::new();

--- a/rinkaku-core/src/pipeline_tests/analyze_diff.rs
+++ b/rinkaku-core/src/pipeline_tests/analyze_diff.rs
@@ -28,7 +28,7 @@ fn should_return_empty_report_when_diff_is_empty() {
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff("", read_file, None, None, true, &HashSet::new(), true)
+    let actual = analyze_diff("", read_file, None, None, true, &HashSet::new(), true, None)
         .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
@@ -88,8 +88,17 @@ fn foo(a: i32) -> i32 {
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
 }
@@ -123,8 +132,17 @@ index 4b825dc..0000000
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
 }
@@ -151,8 +169,17 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
 }
@@ -187,8 +214,17 @@ index e69de29..4b825dc 100644
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
 }
@@ -227,8 +263,17 @@ rename to src/new_name.rs
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
 }
@@ -245,7 +290,16 @@ index e69de29..4b825dc 100644
 ";
     let read_file = fake_reader(HashMap::new());
 
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true);
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    );
 
     assert!(matches!(actual, Err(AnalyzeError::Diff(_))));
 }
@@ -264,7 +318,16 @@ index e69de29..4b825dc 100644
     // Map has no entry for src/lib.rs, so the fake reader returns Err.
     let read_file = fake_reader(HashMap::new());
 
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true);
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    );
 
     assert!(matches!(
         actual,
@@ -332,8 +395,17 @@ index e69de29..4b825dc 100644
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
 }
@@ -385,8 +457,17 @@ func (r *repoImpl) Save(id string) error {
 ";
     let read_file = fake_reader(HashMap::from([("repo.go", source)]));
 
-    let report = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
     let markdown = crate::render::render(&report, crate::render::OutputFormat::Markdown)
         .expect("markdown render should succeed");
 
@@ -462,8 +543,17 @@ fn foo(p: Point) -> i32 {
 ";
     let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
-    let report = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     // No resolver was passed, so every symbol's dependencies must stay
     // empty — this is `--deps 0`'s contract (main.rs), not merely "the
@@ -503,6 +593,7 @@ fn foo(p: Point) -> i32 {
         true,
         &HashSet::new(),
         true,
+        None,
     )
     .expect("analyze should succeed");
 
@@ -562,8 +653,17 @@ fn caller_two() -> i32 {
 ";
     let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
-    let report = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected = vec![FanIn {
         id: "src/lib.rs::shared_helper".to_string(),
@@ -596,9 +696,94 @@ fn foo(a: i32) -> i32 {
 ";
     let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
-    let report = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected: Vec<FanIn> = Vec::new();
     assert_eq!(expected, report.fan_ins);
+}
+
+// ADR 0033 (amended): `on_progress` must be called with `(files_done,
+// total)` as the sequential per-file loop works through the diff's
+// changed files — mirroring `analyze_repo`'s own progress contract
+// (`crate::progress::should_report_progress`'s stride-16-plus-final
+// rule). `Mutex` rather than `RefCell`: `OnProgress`'s `Sync` bound
+// applies to the type regardless of how many threads actually call
+// through it, and `analyze_diff`'s loop only ever calls it from one
+// (this test's single-threaded call still has to satisfy the same
+// `&(dyn Fn(usize, usize) + Sync)` type `analyze_repo`'s rayon workers
+// require).
+#[test]
+fn should_report_file_progress_for_every_changed_file_including_skipped_ones() {
+    // Three changed files: one deleted (skipped, no read), one
+    // unsupported-language (skipped, no read), one Rust file actually
+    // analyzed — proves "files done" counts every file the loop looks
+    // at, not just ones that produce a `FileReport`. With only 3 files
+    // and `PROGRESS_REPORT_STRIDE` at 16, `should_report_progress` only
+    // fires on the final file (3 == total), so a single `(3, 3)` call
+    // is the entire expected sequence.
+    let diff = "\
+diff --git a/src/old.rs b/src/old.rs
+deleted file mode 100644
+index 4b825dc..0000000
+--- a/src/old.rs
++++ /dev/null
+@@ -1,2 +0,0 @@
+-fn a() {}
+-fn b() {}
+diff --git a/README.rb b/README.rb
+index e69de29..4b825dc 100644
+--- a/README.rb
++++ b/README.rb
+@@ -1,1 +1,1 @@
+-old
++new
+diff --git a/src/lib.rs b/src/lib.rs
+index e69de29..4b825dc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,3 @@
+ fn foo(a: i32) -> i32 {
+-    a
++    a + 1
+ }
+";
+    let source = "\
+fn foo(a: i32) -> i32 {
+    a + 1
+}
+";
+    let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+    let calls: std::sync::Mutex<Vec<(usize, usize)>> = std::sync::Mutex::new(Vec::new());
+    let on_progress = |done: usize, total: usize| {
+        calls
+            .lock()
+            .expect("lock must not be poisoned")
+            .push((done, total));
+    };
+
+    analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        Some(&on_progress),
+    )
+    .expect("analyze should succeed");
+
+    let expected = vec![(3usize, 3usize)];
+    let actual = calls.into_inner().expect("lock must not be poisoned");
+    assert_eq!(expected, actual);
 }

--- a/rinkaku-core/src/pipeline_tests/classification_wiring.rs
+++ b/rinkaku-core/src/pipeline_tests/classification_wiring.rs
@@ -51,6 +51,7 @@ fn foo(a: i32, b: i32) -> i32 {
         true,
         &HashSet::new(),
         true,
+        None,
     )
     .expect("analyze should succeed");
 
@@ -88,8 +89,17 @@ fn foo(a: i32) -> i32 {
 ";
     let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
-    let report = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let symbol = &report.files[0].symbols[0];
     assert_eq!(None, symbol.classification);
@@ -133,6 +143,7 @@ fn new_name() -> i32 {
         true,
         &HashSet::new(),
         true,
+        None,
     )
     .expect("analyze should succeed");
 
@@ -194,6 +205,7 @@ fn kept() -> i32 {
         true,
         &HashSet::new(),
         true,
+        None,
     )
     .expect("analyze should succeed");
 
@@ -254,6 +266,7 @@ fn foo() -> i32 {
         true,
         &HashSet::new(),
         true,
+        None,
     )
     .expect("analyze should succeed");
 
@@ -297,6 +310,7 @@ fn foo() -> i32 {
         true,
         &HashSet::new(),
         true,
+        None,
     )
     .expect("analyze should succeed");
 
@@ -341,6 +355,7 @@ fn foo(a: i32) -> i32 {
         true,
         &HashSet::new(),
         true,
+        None,
     )
     .expect("analyze should succeed");
 
@@ -393,6 +408,7 @@ fn foo(a: i32, b: i32) -> i32 {
         true,
         &HashSet::new(),
         true,
+        None,
     )
     .expect("analyze should succeed");
 
@@ -457,6 +473,7 @@ fn kept() -> i32 {
         true,
         &HashSet::new(),
         true,
+        None,
     )
     .expect("analyze should succeed");
 

--- a/rinkaku-core/src/pipeline_tests/file_size_warnings.rs
+++ b/rinkaku-core/src/pipeline_tests/file_size_warnings.rs
@@ -50,8 +50,17 @@ index e69de29..4b825dc 100644
         Box::leak(big_source.into_boxed_str()) as &'static str,
     )]));
 
-    let report = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected = vec![FileSizeWarning {
         path: "src/big.rs".to_string(),
@@ -74,8 +83,17 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
 ";
     let read_file = fake_reader(HashMap::new());
 
-    let report = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected: Vec<FileSizeWarning> = vec![];
     assert_eq!(expected, report.file_size_warnings);

--- a/rinkaku-core/src/pipeline_tests/generated_exclusion.rs
+++ b/rinkaku-core/src/pipeline_tests/generated_exclusion.rs
@@ -28,8 +28,17 @@ index e69de29..4b825dc 100644
     let read_file = fake_reader(HashMap::new());
     let generated_paths: HashSet<String> = ["Cargo.lock".to_string()].into_iter().collect();
 
-    let report = analyze_diff(diff, read_file, None, None, true, &generated_paths, true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &generated_paths,
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected = vec![SkippedFile {
         path: "Cargo.lock".to_string(),
@@ -61,8 +70,17 @@ index 4b825dc..0000000
     let read_file = fake_reader(HashMap::new());
     let generated_paths: HashSet<String> = ["Cargo.lock".to_string()].into_iter().collect();
 
-    let report = analyze_diff(diff, read_file, None, None, true, &generated_paths, true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &generated_paths,
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected = vec![SkippedFile {
         path: "Cargo.lock".to_string(),
@@ -91,8 +109,17 @@ fn foo(a: i32) -> i32 {
 ";
     let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
-    let report = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected: Vec<SkippedFile> = Vec::new();
     assert_eq!(expected, report.skipped);
@@ -116,8 +143,17 @@ package models
 ";
     let read_file = fake_reader(HashMap::from([("models/user.go", source)]));
 
-    let report = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), false)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        false,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected_files: Vec<FileReport> = Vec::new();
     let expected_skipped = vec![SkippedFile {
@@ -182,8 +218,17 @@ func Foo() int { return 2 }
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
 }
@@ -242,8 +287,17 @@ fn foo(a: i32) -> i32 {
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), false)
-        .expect("analyze should succeed");
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        false,
+        None,
+    )
+    .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
 }
@@ -312,8 +366,17 @@ index e69de29..4b825dc 100644
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), false)
-        .expect("analyze should succeed");
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        false,
+        None,
+    )
+    .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
 }
@@ -340,8 +403,17 @@ index e69de29..4b825dc 100644
     let read_file = fake_reader(HashMap::new());
     let generated_paths: HashSet<String> = ["Cargo.lock".to_string()].into_iter().collect();
 
-    let report = analyze_diff(diff, read_file, None, None, true, &generated_paths, false)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &generated_paths,
+        false,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected = vec![SkippedFile {
         path: "Cargo.lock".to_string(),

--- a/rinkaku-core/src/pipeline_tests/test_symbol_exclusion.rs
+++ b/rinkaku-core/src/pipeline_tests/test_symbol_exclusion.rs
@@ -33,8 +33,17 @@ fn should_add_two_numbers() {
 ";
     let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
 
-    let report = analyze_diff(diff, read_file, None, None, false, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        false,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected_files: Vec<FileReport> = Vec::new();
     let expected_tests = vec![TestFileSummary {
@@ -101,8 +110,17 @@ fn should_add_two_numbers() {
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff(diff, read_file, None, None, true, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
 }
@@ -131,8 +149,17 @@ func TestFoo(t *testing.T) {
 ";
     let read_file = fake_reader(HashMap::from([("repo_test.go", source)]));
 
-    let report = analyze_diff(diff, read_file, None, None, false, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        false,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected_files: Vec<FileReport> = Vec::new();
     let expected_tests = vec![TestFileSummary {
@@ -160,8 +187,17 @@ rename to src/new_name.rs
 ";
     let read_file = fake_reader(HashMap::new());
 
-    let report = analyze_diff(diff, read_file, None, None, false, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        false,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     let expected_files = vec![FileReport {
         path: "src/new_name.rs".to_string(),
@@ -251,8 +287,17 @@ mod tests {
         file_size_warnings: vec![],
         removed: vec![],
     };
-    let actual = analyze_diff(diff, read_file, None, None, false, &HashSet::new(), true)
-        .expect("analyze should succeed");
+    let actual = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        false,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
 
     assert_eq!(expected, actual);
 }

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -376,6 +376,12 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
         let generated_paths = resolve_generated_paths(cli, &changed_paths, None);
         log::debug!("analyzing diff");
         progress.set_phase(AnalysisPhase::AnalyzingDiff);
+        // ADR 0033 (amended): same `on_file_progress` shape as the
+        // `analyze_repo`/`build_resolver` calls above — reports
+        // `(files_done, total)` back through `progress` as `analyze_diff`'s
+        // sequential per-file loop works through the diff's changed files.
+        let on_file_progress =
+            |done: usize, total: usize| progress.report_file_progress(done, total);
         let report = rinkaku_core::pipeline::analyze_diff(
             &diff_text,
             read_working_tree_file,
@@ -393,6 +399,7 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
             !cli.exclude_tests,
             &generated_paths,
             cli.include_generated,
+            Some(&on_file_progress),
         )?;
         if let Some(note) = garbage_input_note(&diff_text, &report) {
             progress.note(note.to_string());

--- a/rinkaku/src/pipeline.rs
+++ b/rinkaku/src/pipeline.rs
@@ -74,6 +74,12 @@ pub(crate) fn run_base_pipeline(
     let generated_paths = resolve_generated_paths(cli, &changed_paths, cwd);
     log::debug!("analyzing diff");
     progress.set_phase(AnalysisPhase::AnalyzingDiff);
+    // ADR 0033 (amended): reports `(files_done, total)` back through
+    // `progress` as `analyze_diff`'s sequential per-file loop works through
+    // the diff's changed files — same closure shape as `build_resolver`'s
+    // own `on_file_progress` above, since `rinkaku_core::progress::OnProgress`
+    // is exactly the `Fn(usize, usize) + Sync` shape `analyze_diff` expects.
+    let on_file_progress = |done: usize, total: usize| progress.report_file_progress(done, total);
     let report = analyze_diff(
         &diff_text,
         read_file,
@@ -86,6 +92,7 @@ pub(crate) fn run_base_pipeline(
         !cli.exclude_tests,
         &generated_paths,
         cli.include_generated,
+        Some(&on_file_progress),
     )?;
     if let Some(note) = garbage_input_note(&diff_text, &report) {
         progress.note(note.to_string());


### PR DESCRIPTION
## What

`analyze_diff`'s sequential per-file loop now takes the same
`on_progress: Option<OnProgress>` port `analyze_repo` and
`TagsResolver::new` already had (ADR 0033), reporting `(files_done,
total)` gated by `should_report_progress`. `main.rs` wires this through
`AnalysisProgress::report_file_progress` at both the `--base`/`--pr` and
stdin call sites, so the TUI splash's "Analyzing diff..." phase now draws
a real gauge instead of a static label — closing the one phase ADR 0033
originally could not give real progress to (see the ADR's amendment).

## Why

ADR 0033 explicitly rejected a fake/animated bar for `AnalyzingDiff`
because there was no real per-file signal to draw from at the time. This
PR adds that signal by threading the same progress port `analyze_repo`
already has through `analyze_diff`'s own per-file loop (a labeled block
`'file: { ... }` replaces the old bare `continue`s so every skip path
still reaches a single progress-report call site at the bottom of the
loop, keeping "files done" counting every changed file the loop looks
at — including skipped ones — same convention as `analyze_repo`).

## Scope

One PR because it's one logical change: the core parameter, both CLI
call sites that need to pass it, and the ADR amendment that records why
`AnalyzingDiff` is no longer in the "no real signal" bucket are only
meaningful together — landing the parameter without the amendment would
leave the ADR's Alternatives section actively wrong, and landing the ADR
change without the code would document a feature that doesn't exist.

## Test plan

- [x] `make test` — 549 `rinkaku-core`/`rinkaku-tui` tests + 169 `rinkaku`
      tests pass, including a new `should_report_file_progress_for_every_changed_file_including_skipped_ones`
      test asserting the exact `(done, total)` call sequence (a single
      `(3, 3)` call for a 3-file diff, per the stride-16 gate) via a
      `Mutex`-recording closure.
- [x] `make lint` — `cargo fmt --all --check` + `cargo clippy --all-targets
      --all-features -- -D warnings` clean (added `#[allow(clippy::too_many_arguments)]`
      to `analyze_diff`, matching the existing allow on `classify_against_base`).
- [x] Dynamic verification: built the binary and ran it against real
      diffs in non-TTY mode — `git diff origin/main~5 origin/main | rinkaku`
      and `git diff | rinkaku` (dogfooding this PR's own diff) both exit 0
      with no panic; `rinkaku --base HEAD~3 --head HEAD` (exercises the
      `analyze_diff` call site that now passes `Some(on_progress)`)
      completes normally; an empty-stdin run prints the existing
      "diff is empty" note and exits 0. `--tui` mode's non-TTY handling is
      unchanged (still forced on regardless of stdout, per its own
      pre-existing tests) — this PR only feeds real data into
      `SplashProgress::report_file_progress`, which ADR 0033 already
      wired and tested.