### PR TITLE
fix(tui): restore Modifier import broken by concurrent merges

### DIFF
--- a/rinkaku-tui/src/ui/style.rs
+++ b/rinkaku-tui/src/ui/style.rs
@@ -5,7 +5,7 @@
 //! background tint" composition (ADR 0018).
 
 use crate::highlight::{PALETTE, TokenSpan};
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
 
 /// Splits `content` into styled spans per `spans` (byte-offset [`TokenSpan`]s


### PR DESCRIPTION
## Summary

`main` currently fails to build (`cargo build -p rinkaku-tui`, `cargo run -- --pr <N>`):

```
error[E0433]: cannot find type `Modifier` in this scope
  --> rinkaku-tui/src/ui/style.rs:88:27
   |
88 |             .add_modifier(Modifier::BOLD)
```

Root cause: two PRs each independently green on their own CI run combined into a broken `main`.

- #104 removed `Modifier` from `ui/style.rs`'s import (`use ratatui::style::{Color, Modifier, Style};` → `use ratatui::style::{Color, Style};`) because it dropped the file's only `Modifier::DIM` usage.
- #106 was developed against a base predating #104 and added a new `Modifier::BOLD` usage (`pane_border_style`, for the focused-pane border) without re-adding the import.
- The two diffs don't overlap on any line, so the merge was textually clean — this is a semantic merge conflict, not a textual one. Each PR's own CI run only compiled against its own base branch; neither run ever built the combination of both changes, so nothing caught it before merge.

This PR re-adds `Modifier` to the import line. One-line fix, no behavior change.

## Test plan

- [x] `cargo build` (whole workspace) succeeds
- [x] `cargo check --all-targets --all-features` succeeds
- [x] `make test` — 552 passed, 0 failed
- [x] `make lint` (fmt --check + clippy --all-targets --all-features -D warnings) — clean