### PR TITLE
docs: add colored SVG logo below README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # rinkaku
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./assets/logo-dark.svg">
+    <img alt="rinkaku logo" src="./assets/logo-light.svg" width="640">
+  </picture>
+</p>
+
 > rinkaku (輪郭, "outline" in Japanese)
 
 **See the shape of a PR before you read it.**
@@ -22,17 +29,6 @@ Two ways to look at it:
 Both share one engine: tree-sitter extraction of changed symbols, 1-hop
 dependency expansion, fan-in / contract-change / entry-point
 summarizers. Rust, Go, Python, and TypeScript out of the box.
-
-The TUI greets you with this on startup, while it scans the diff:
-
-```
-      _       _              _
-     (_)     | |            | |
- _ __ _ _ __ | | ____ _ _ __| |___   _
-| '__| | '_ \| |/ / _` | '__| / / | | |
-| |  | | | | |   < (_| | |  | . \ |_| |
-|_|  |_|_| |_|_|\_\__,_|_|  |_|\_\__,_|
-```
 
 ## Try it in 30 seconds
 

--- a/assets/logo-dark.svg
+++ b/assets/logo-dark.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 190" width="680" height="190" role="img" aria-labelledby="rinkaku-logo-dark-title">
+  <title id="rinkaku-logo-dark-title">rinkaku</title>
+  <defs>
+    <linearGradient id="rinkakuStrokeDark" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5eead4"/>
+      <stop offset="50%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+    <linearGradient id="rinkakuFillDark" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#134e4a"/>
+      <stop offset="50%" stop-color="#0c2f4d"/>
+      <stop offset="100%" stop-color="#2e1065"/>
+    </linearGradient>
+  </defs>
+
+  <text
+    x="340" y="92"
+    text-anchor="middle"
+    font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+    font-size="76"
+    font-weight="700"
+    letter-spacing="6"
+    fill="url(#rinkakuFillDark)"
+    stroke="url(#rinkakuStrokeDark)"
+    stroke-width="2"
+    xml:space="preserve"
+  >rinkaku</text>
+
+  <text
+    x="340" y="132"
+    text-anchor="middle"
+    font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+    font-size="17"
+    letter-spacing="3"
+    fill="#94a3b8"
+    xml:space="preserve"
+  >輪郭 &#8212; condense diffs to their outline</text>
+
+  <line x1="120" y1="152" x2="560" y2="152" stroke="url(#rinkakuStrokeDark)" stroke-width="1.5" stroke-opacity="0.55"/>
+</svg>

--- a/assets/logo-light.svg
+++ b/assets/logo-light.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 190" width="680" height="190" role="img" aria-labelledby="rinkaku-logo-light-title">
+  <title id="rinkaku-logo-light-title">rinkaku</title>
+  <defs>
+    <linearGradient id="rinkakuStrokeLight" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f766e"/>
+      <stop offset="50%" stop-color="#0369a1"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="rinkakuFillLight" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#99f6e4"/>
+      <stop offset="50%" stop-color="#bae6fd"/>
+      <stop offset="100%" stop-color="#ddd6fe"/>
+    </linearGradient>
+  </defs>
+
+  <text
+    x="340" y="92"
+    text-anchor="middle"
+    font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+    font-size="76"
+    font-weight="700"
+    letter-spacing="6"
+    fill="url(#rinkakuFillLight)"
+    stroke="url(#rinkakuStrokeLight)"
+    stroke-width="2"
+    xml:space="preserve"
+  >rinkaku</text>
+
+  <text
+    x="340" y="132"
+    text-anchor="middle"
+    font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+    font-size="17"
+    letter-spacing="3"
+    fill="#475569"
+    xml:space="preserve"
+  >輪郭 &#8212; condense diffs to their outline</text>
+
+  <line x1="120" y1="152" x2="560" y2="152" stroke="url(#rinkakuStrokeLight)" stroke-width="1.5" stroke-opacity="0.55"/>
+</svg>


### PR DESCRIPTION
## Summary

- Adds a theme-aware SVG logo (`assets/logo-light.svg` / `assets/logo-dark.svg`) rendered via `<picture>` + `prefers-color-scheme`, placed centered directly below the README's `# rinkaku` heading.
- Removes the plain-text figlet-style ASCII banner that previously appeared further down the README (before "Try it in 30 seconds"), since the new SVG now covers that role.
- Design intent: keep the monospace "ASCII art" feel (`ui-monospace`/`SFMono`/`Menlo` stack, `xml:space="preserve"`) while adding a teal → sky-blue → violet gradient stroke/fill, echoing rinkaku's own concept (輪郭, "outline") through an outlined wordmark rather than a solid block. A small `輪郭 — condense diffs to their outline` subtitle sits underneath. Light and dark variants swap fill/stroke luminance so both remain readable against GitHub's light and dark backgrounds.

## Scope note

This is a docs-only, mechanical change (per `CLAUDE.md`'s "process weight" section) — no Rust source was touched, so the full three-angle dogfooding review was not run.

## Investigation: possible "rinkarku" misspelling

Grepped the whole repo for the reported "rinkarku" misspelling; found none. There are two copies of the same figlet-style ASCII banner, both correctly spelled "rinkaku":

- `README.md` (removed by this PR, replaced by the new SVG)
- `rinkaku-tui/src/splash.rs` (`LOGO_LINES` const, the TUI's actual startup splash screen) — **left untouched**, out of scope for this docs PR since it's source code, not README content.

## Pre-existing issue found (unrelated, not fixed here)

`make lint` currently fails on `origin/main` (HEAD `30feaf3`, before this branch's changes) with a compile error in `rinkaku-tui/src/ui/style.rs`: `Modifier::BOLD` is used but `Modifier` is not imported (`use ratatui::style::{Color, Style};` is missing `Modifier`). Verified via `git show origin/main:rinkaku-tui/src/ui/style.rs` — this predates this PR and is not caused by it. `cargo fmt --all --check` (the other half of `make lint`) passes cleanly on this branch. Flagging for visibility; not fixed here since it's outside this PR's docs-only scope.

## Test plan

- [x] `xmllint --noout` on both new SVGs — valid XML
- [x] Visually confirmed both SVGs render the text `rinkaku` (not misspelled) via `grep -o '>rinkaku<'`
- [x] `cargo fmt --all --check` passes
- [ ] `cargo clippy` blocked by the pre-existing unrelated compile error noted above