### PR TITLE
docs(adr): align ADR 0021 terminology with the fan-in rename (ADR 0034)

### DIFF
--- a/docs/adr/0021-mermaid-output-format.md
+++ b/docs/adr/0021-mermaid-output-format.md
@@ -56,13 +56,14 @@ unchanged.
   way `change_graph_summary`'s "most in ..." line does for Markdown,
   but visually instead of as a sentence.
 - **Styling via `classDef`**: `added` (green-tinted), `changed`
-  (orange-tinted), `hotspot` (red-tinted, heavier stroke). A node that
-  is both `changed` and a hotspot gets the `hotspot` class — precedence
-  documented at the call site in `render.rs` — since "this is a wide
-  blast radius" is the more actionable fact for a glance-level view than
-  "this signature changed," and the node's own subgraph/label already
-  shows it changed via the Definitions/Markdown companion output.
-  Colors are chosen with explicit dark-on-light text so they hold up
+  (orange-tinted), `hotspot` (red-tinted, heavier stroke; renamed to
+  `fan-in` by ADR 0034). A node that is both `changed` and a hotspot
+  gets the `hotspot` class — precedence documented at the call site in
+  `render.rs` — since "this is a wide blast radius" is the more
+  actionable fact for a glance-level view than "this signature
+  changed," and the node's own subgraph/label already shows it changed
+  via the Definitions/Markdown companion output. Colors are chosen with
+  explicit dark-on-light text so they hold up
   under both GitHub's light and dark themes (mermaid's own theming
   otherwise only flips background, not a fixed text color).
 - **Cycle edges** render as `-.->` (dashed) instead of `-->`, mirroring


### PR DESCRIPTION
## Summary

- ADR 0034 renamed the Mermaid `hotspot` `classDef` to `fan-in` in `rinkaku-core` (`rinkaku-core/src/render/mermaid.rs`), but ADR 0021's styling description still describes the now-stale `hotspot` class name as current behavior.
- Adds a parenthetical note ("renamed to `fan-in` by ADR 0034") to that one line, matching the phrasing ADR 0013's own amendment already uses for the same rename.
- ADR 0034 explicitly scopes historical ADR reasoning out of the rename ("past ADR bodies... are a record of what was true at the time and are not rewritten", naming ADR 0021's "hairball" discussion specifically). The "top-N hotspot nodes" rejected-alternative text in ADR 0021's Alternatives section is left untouched for that reason.
- Surveyed all other `docs/` occurrences of "hotspot" (`grep -ri hotspot docs/`); every other hit is historical ADR/experiment-log text describing what was true at time of writing, which ADR 0034 already decided not to rewrite. No code-level `hotspot` references remain (ADR 0034 covered those).

This is a mechanical, docs-only change (CLAUDE.md "Process weight": mechanical/label change, lightweight route — no three-angle dogfooding review).

## Test plan

- [x] `make test` — 552 passed
- [x] `make lint` — clean