### PR TITLE
ci: run lint and test on push to main

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -3,6 +3,13 @@ name: Lint and Test
 on:
   pull_request:
     branches: [main]
+  # Catches semantic merge conflicts that individually-green PRs can
+  # introduce once merged (e.g. #104 and #106 each passed CI alone but
+  # together broke main's build, undetected until #108). `branches:
+  # [main]` only matches branch pushes, not tag pushes, so this does not
+  # overlap with build-and-publish.yaml's `push: tags: - "v*"` trigger.
+  push:
+    branches: [main]
 
 jobs:
   rust-test:


### PR DESCRIPTION
## Summary

- Add a `push: branches: [main]` trigger to `lint-and-test.yaml` alongside the existing `pull_request` trigger, so the same checks re-run right after a merge to `main`.

## Motivation

PR #104 and PR #106 each passed CI independently, but merging both introduced a semantic merge conflict that left `main` in a non-compiling state. Nothing caught it because `lint-and-test.yaml` only triggers on `pull_request`, and `main` itself was never re-checked after the merge. The break was only found and fixed forward in #108.

## Why `push: branches: [main]` and not something broader

- `branches: [main]` only matches pushes to a branch named `main`; it does **not** match tag pushes (e.g. `v0.2.0`), so this does not overlap with `build-and-publish.yaml`'s `push: tags: - "v*"` trigger, per the requirement to not fire this workflow on tag pushes.
- Considered wiring this into the `release-please` workflow (`release-main.yaml`) instead, but that workflow's job is release orchestration (PR-merge triggered `release-please-action` / manual `workflow_dispatch`), not verification — mixing lint/test into it would blur that responsibility. Keeping it in `lint-and-test.yaml` keeps "verify the code" and "cut a release" as separate concerns, and reuses the existing `wc-rust-test.yaml` reusable workflow as-is.

## Verification

- `actionlint .github/workflows/lint-and-test.yaml` passes.
- No Rust code changed, so `make test` / `make lint` are not applicable to this diff.

## Test plan

- [ ] After merging, confirm the "Lint and Test" workflow run appears on the resulting push to `main` (not just on the PR itself).
- [ ] Confirm a tag push (e.g. next release) does not additionally trigger "Lint and Test".