### PR TITLE
docs(experiments): record experiment 0001 round 22 (PR #112)

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/README.md
+++ b/docs/experiments/0001-map-assisted-llm-review/README.md
@@ -1,7 +1,8 @@
 # Experiment 0001: rinkaku change maps as an entry point for LLM code review
 
-- Status: 17 rounds complete (index/conclusions cover rounds 1-10 and
-  17; rounds 11-16 are recorded under `rounds/` but not yet folded in)
+- Status: 22 rounds complete (index/conclusions cover rounds 1-10, 17,
+  and 22; rounds 11-16 and 18-21 are recorded under `rounds/` but not
+  yet folded in)
 - Date: 2026-07-13
 
 ## Hypothesis
@@ -68,9 +69,11 @@ that file so future rounds are conflict-free:
 | [009](rounds/009.md) | TUI entry tree: skipped/test-only files | Zero overlap, zero shared theme — the cleanest complementary-findings round yet |
 | [010](rounds/010.md) | This PR's own diff: `--format mermaid` + GitHub Action | Mostly non-Rust surface; map's best signal was naming its own blind spot; neither arm caught a first-PR bootstrap bug the orchestrator found post-merge |
 | [017](rounds/017.md) | Minimal `env_logger` config change in `fn main` (PR #79) | Map was correctly silent on a body-only diff whose entire risk lives in rendered log text, not any signature; reviewer fell back to manual consumer tracing, dynamic verification carried the confirmation |
+| [022](rounds/022.md) | Tests excluded from entry-tree ranking + trailing Tests section (ADR 0035, PR #112) | Map caught two review-blockers as pure bookkeeping (stale ADR status, a mid-PR file-size warning); dynamic verification found a pre-existing bug (`is_test_path` blind to this repo's own `*_tests/` convention) that no unit test in the PR's 1121-test suite could reach |
 
-Rounds 11-16 are recorded under `rounds/` but not yet folded into this
-index; that backlog is tracked separately from this round's follow-up.
+Rounds 11-16 and 18-21 are recorded under `rounds/` but not yet folded
+into this index; that backlog is tracked separately from this round's
+follow-up.
 
 ## Threats to validity
 
@@ -89,8 +92,11 @@ index; that backlog is tracked separately from this round's follow-up.
   tool-call/wall-clock metrics collected); it records the review this
   PR actually received before merge, in the per-round format used for
   continuity, not as comparable experimental data.
+- Round 22, like round 17, was a single-reviewer session recording the
+  review a PR actually received before merge, not a harness-timed A/B
+  pair; no token/tool-call/wall-clock metrics were collected.
 
-## Conclusions (after rounds 1-10 and 17)
+## Conclusions (after rounds 1-10, 17, and 22)
 
 - The map is a **complement, not a substitute**. Across ten rounds,
   neither arm has ever produced a superset of the other's findings;
@@ -151,6 +157,27 @@ index; that backlog is tracked separately from this round's follow-up.
   what neither review arm's prompt currently does: quantitative
   measurement, distrust of self-reported compliance, and verifying
   a merged workflow's actual first live run.
+- **The map's value extends to mechanical compliance checks, not just
+  logic-level attention routing** (round 22): a stale ADR status field
+  and a file-size warning crossing this repo's own warn threshold
+  mid-PR were both caught as pure bookkeeping the report already
+  tracks, resolved without any deep code reading — consistent with
+  CLAUDE.md's own framing of the file-size warning as "authoritative,"
+  not merely advisory.
+- **The map can be defeated by its own coverage heuristics being
+  wrong, not just incomplete** (round 22, sharpening rounds 7-9's
+  "wrong value on a data-flow wire" one level further): a test-only
+  helper function outranked real production hotspots in the fan-in
+  report because the underlying `is_test_path` classification silently
+  misclassified an entire directory convention (`*_tests/`) as
+  production code — a defect in what feeds the map, not in how the map
+  presents what it's given. No unit test in the PR's own 1121-test
+  suite could have caught this, because every test fixture in that
+  suite hand-sets its `is_test` flags rather than deriving them from a
+  real path through `is_test_path`; only running the actual report
+  generator against the repository's own real directory layout
+  exercised the gap, reinforcing dynamic verification's role as the
+  check no amount of unit testing substitutes for.
 
 ## Next
 
@@ -190,3 +217,9 @@ index; that backlog is tracked separately from this round's follow-up.
   isolate whether the attention-routing benefit this round attributes
   to the map specifically requires the full report or would come from
   just knowing the coverage boundary.
+- Round 22's `is_test_path` gap (issue #114 — the Rust `LanguageSupport`
+  impl doesn't recognize this repo's own `*_tests/` directory
+  convention as test code) is itself a candidate future subject: once
+  fixed, a follow-up round could confirm the fan-in hotspot list no
+  longer surfaces `nav_tests`/`tree_tests`/`order_tests` helper
+  functions ahead of real production hotspots.

--- a/docs/experiments/0001-map-assisted-llm-review/rounds/022.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/022.md
@@ -1,0 +1,164 @@
+# Round 22
+
+- Subject: PR #112 — the entry tree stops letting test symbols/files
+  distort production directory ranking and gains a trailing "Tests"
+  section (ADR 0035, amending ADR 0016 decision 4). Phase A:
+  `order::rank::DirCondensation::build` now drops any graph node/edge
+  whose owning symbol is test code before condensing to directories, so
+  an inbound test→production edge can no longer shift a production
+  directory's rank; `tree::SymbolRef` gains `is_test: bool` and
+  `row_view::entry_row_line` renders a magenta `test` badge on a mixed-
+  file test symbol's row. Phase B: `tree::NodeKind` gains a
+  `Section(SectionKind)` variant; `build_tree` appends a synthetic,
+  always-A-Z "Tests" root after every production root, holding every
+  *whole* test file (a *mixed* production+test file stays in the
+  production tree, badge-only); `order::sort::order_siblings` gains a
+  three-tier sort key (Dir < File < Section) so a Section always sorts
+  last regardless of topological/alphabetical mode; `nav.rs` required no
+  behavior changes (its path/children-generic logic already handled the
+  new variant, confirmed by new boundary-crossing tests); `app`/
+  `ui::entry` got exhaustive-match updates so a Section row acts like a
+  directory row for expand/collapse and returns `None`/`NotApplicable`
+  for detail/diff-target/blast-radius. A same-PR refactor round then
+  split `order.rs` into `order/{mod,rank,sort}.rs`, `tree.rs` into
+  `tree/{mod.rs,tests_section.rs}`, and `app/mod.rs`'s key-dispatch
+  (~700 lines) into `app/handle_key.rs`. 27 files touched (net ~2,500
+  lines across `rinkaku-tui/src/{app,nav,nav_tests,order,order_tests,
+  row_view,row_view_tests,tree,tree_tests,ui}` plus
+  `docs/adr/0035-tests-sorted-last-in-entry-tree.md`); no changes
+  outside `rinkaku-tui` (`Report`'s shape and Markdown/JSON output are
+  untouched).
+- Protocol note: single-reviewer session covering all three angles, same
+  format as rounds 17-21 for continuity — not a harness-timed A/B pair.
+- **Map-assisted pass**: `rinkaku --base main` (trusted `main` build,
+  never the branch under review) reported 139 changed symbols across 27
+  files, most concentrated in `rinkaku-tui/src/order/rank.rs` (14) —
+  correctly the file with the actual new ranking algorithm (`build`,
+  `tarjan_sccs`, `cycle_partners`/`cycle_edges`/`cycle_explanation`).
+  The hotspot/fan-in view routed deep reading to `rank_directories`
+  (used by 4 new tests plus `DirCondensation`/`DirRank`) and to
+  `sample_tree`/`deep_tree`/`tree_with_section` in `nav_tests/mod.rs`
+  (fanning out to 20+ new `nav_tests` cases), correctly flagging both as
+  the load-bearing shared fixtures worth reading before their consumers.
+  No contract-marker (`removed`) fired, consistent with this being an
+  additive TUI-only feature. Two review-blocker-shaped hints came
+  directly from the map's own bookkeeping rather than from reading
+  logic: (1) ADR 0035's own front matter still said `Status: proposed`
+  at the point this pass ran, one commit before the PR's own "Status:
+  proposed → accepted" fix — a mechanical doc-state check the map
+  doesn't perform itself but which the CLAUDE.md convention it's read
+  alongside requires; (2) `app/mod.rs`'s file-size trajectory
+  (1504 → 1527 lines mid-PR, after the Phase A/B exhaustive-match
+  additions but before the `handle_key.rs` split) tripped this repo's
+  own `## File size warnings` entry in the rinkaku report — exactly the
+  "review-blocker hint" CLAUDE.md's file-size-discipline section
+  describes, and exactly what it was designed to catch: growth crossing
+  the warn threshold mid-PR, before a human reviewer would otherwise
+  notice a diff-relative line count. Neither of these two findings
+  needed logic-level reading; the map surfaced them as bookkeeping
+  facts, and the fix round (ADR status flip, `handle_key.rs` extraction
+  bringing `app/mod.rs` to 797 lines) resolved both directly.
+- **Independent pass** (map-free re-read of the diff): zero blockers.
+  One genuine new finding neither the map nor a first read of the PR's
+  own "Verification" section surfaced: `tree_tests/tests_section.rs`'s
+  initial test bodies used partial, field-by-field assertions (checking
+  individual `NodeKind`/`is_test` values rather than the whole
+  `Tree`/`TreeNode`) — a direct violation of this repo's "assert fully
+  qualified, compare whole structs" convention (CLAUDE.md's Test
+  strategy section), not a functional bug. Fixed by rewriting 5 of 6
+  cases to whole-value `pretty_assertions::assert_eq!` comparisons
+  against the complete expected `Tree`/`TreeNode`. This pass also
+  independently re-derived the same two findings the map surfaced
+  mechanically (ADR status still `proposed`; `app/mod.rs` past the
+  file-size warn threshold), confirming both were real rather than
+  map-only artifacts — but arrived at them by manually diffing ADR
+  front matter and running `wc -l`, not from the report's own bookkeeping.
+- **Dynamic verification — this is where the round's most interesting
+  finding came from, and it could not have come from either static
+  pass.** `make test` (1121 tests: 169 `rinkaku` + 361 `rinkaku-core` +
+  591 `rinkaku-tui`) and `make lint` both clean pre- and post-fix.
+  Six input patterns (whole-test-file-only tree, mixed-file tree,
+  no-test tree, topological vs. alphabetical mode, cycle-containing
+  graph, empty graph) were re-run through the CLI/Markdown path from a
+  release build and diffed byte-for-byte against the pre-PR baseline
+  output for the same inputs outside the entry-tree feature — confirmed
+  unchanged, since this PR's `Report`/Markdown/JSON surface is
+  untouched by design. All attempted failure-mode invocations (non-TTY
+  stdin, empty diff, conflicting flags, a nonexistent `--base`) failed
+  cleanly with no panics, consistent with this PR touching no argument
+  parsing or IO boundary. The PR's own body flagged a real gap in its
+  own verification — no TTY in its authoring sandbox meant the actual
+  interactive TUI had never been eyeballed, only unit/snapshot-tested —
+  so this round drove the real binary under `expect`+PTY
+  (`rinkaku --tui --base main` against a synthetic repo with mixed and
+  whole test files) and confirmed the Tests section renders, sorts A-Z,
+  and carries the magenta `test` badge on mixed-file rows as designed.
+  **The actual finding**: while navigating that PTY session's entry
+  tree with `High fan-in` sorted to the top, `nav_tests/mod.rs`'s own
+  `sample_tree` builder function rose to the single highest fan-in
+  entry in the *rinkaku's own report of this very PR's diff* — a
+  surprising result for a test-only helper. Tracing it back: Rust's
+  `LanguageSupport::is_test_path` recognizes `#[cfg(test)] mod tests`
+  and a literal `tests.rs` filename via AST context, but not this repo's
+  own `*_tests/` directory convention (`nav_tests/`, `tree_tests/`,
+  `order_tests/`, populated via `#[cfg(test)] #[path = "..."] mod
+  tests;`), so every file under `nav_tests/` is classified as
+  production code by Phase A's own test-filtering pass — the exact
+  mechanism this PR just built, defeated by a pre-existing gap in the
+  language-level test detection it depends on. Confirmed the same
+  misclassification survives `--exclude-tests` (ADR 0009's older,
+  separate mechanism has the identical blind spot, since both rely on
+  `is_test_path`). This is a **pre-existing bug this PR did not
+  introduce**, but its symptom (a helper function outranking real
+  production hotspots) is only visible once the actual feature runs
+  against the actual report render — no unit test in the PR's own suite
+  could have caught it, because every `nav_tests`/`tree_tests` fixture
+  in the PR's own test suite manually constructs its `is_test` flags
+  by hand rather than deriving them from `is_test_path` against a real
+  file path, which is structurally incapable of exercising this gap.
+- **Fix applied this round**: none to the shipped code — this is
+  recorded as issue #114 ("classify Rust `*_tests/` directories as test
+  paths for the Tests section"), scoped as a follow-up to
+  `LanguageSupport::is_test_path` rather than blocking this PR, since
+  fixing it requires a judgment call (is a bare `*_tests` path segment
+  match generic enough for OSS use, or does it risk misclassifying a
+  legitimately-named production directory) that the PR's own author
+  flagged as open in its "Known limitations" section rather than
+  resolving unilaterally.
+- Other fixes applied this round (all from the map-assisted and
+  independent passes above, not dynamic verification): `handle_key.rs`
+  extraction from `app/mod.rs` (1527 → 797 lines, resolving the file-
+  size warning); ADR 0035 status flipped `proposed` → `accepted`;
+  comment trimming across the new Section-handling code down to
+  WHY/constraint-only content, per CLAUDE.md's comment rule (also
+  freshly codified in #113 during this PR's own rebase window); 5 of 6
+  `tree_tests/tests_section.rs` tests rewritten to whole-value asserts.
+- Severity summary: no **blocker** findings from either static pass. One
+  **should-fix** each from the map-assisted pass (file-size warning) and
+  the independent pass (partial-assert convention violation), both
+  fixed in this round. ADR-status drift was a **minor** doc-hygiene
+  catch, also fixed. One **pre-existing bug surfaced but out of scope**
+  (issue #114) found only via dynamic verification.
+- Takeaway: this round is the sharpest illustration yet that the map's
+  value is not limited to routing attention toward *logic* — twice this
+  round it functioned as a **mechanical compliance check** (ADR status
+  text, file-size threshold arithmetic) that a reviewer could in
+  principle perform by hand but is exactly the kind of bookkeeping a
+  tool should catch instead, matching CLAUDE.md's own framing of the
+  file-size warning as "authoritative" and a "review-blocker hint," not
+  merely advisory. At the same time, the round's most consequential
+  finding (`nav_tests`'s helper function usurping real hotspots) is a
+  fresh instance of this experiment's standing conclusion that **the
+  map cannot see defects in code paths its own coverage heuristics
+  misclassify** (rounds 5, 7-9's "wrong value on a data-flow wire"
+  generalized one level further: here the wire is the report's own
+  `is_test` classification, and the map faithfully reports fan-in
+  computed from data that is itself wrong) — and, sharper still, that
+  **no unit test in the PR's own extensive suite (1121 passing) could
+  have caught it**, because every fixture in that suite hand-sets
+  `is_test` rather than deriving it from a real path through
+  `is_test_path`, making this a defect class dynamic verification is
+  uniquely positioned to surface: running the real report generator
+  against this repository's own real directory layout is the only path
+  that exercises `is_test_path` against genuine `*_tests/` paths at
+  all.


### PR DESCRIPTION
## Summary

- Adds `docs/experiments/0001-map-assisted-llm-review/rounds/022.md`,
  recording the three-angle review PR #112 (tests excluded from
  entry-tree ranking + trailing Tests section, ADR 0035) actually
  received before merge.
- Folds round 22 into the experiment README: status line, round index,
  threats-to-validity note, two new Conclusions bullets (the map as a
  mechanical compliance check; the map defeated by its own coverage
  heuristics being wrong), and a Next item pointing at issue #114 as a
  candidate follow-up subject.

This is a docs-only, mechanical record of a review that already
happened — no code changes, no new three-angle review needed for this
PR itself (per CLAUDE.md's process-weight section).

## Test plan

- [x] `make test` (1121 tests passing, no changes to source)
- [x] `make lint` clean