### PR TITLE
feat(tui): move test badge before the file label in entry tree

### DIFF
--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -86,28 +86,28 @@ pub fn entry_row_line(
         }
         NodeKind::File => {
             spans.push(Span::raw(format!("{} ", expand_marker(row))));
+            // The `[test] (N symbols)` badge is placed *before* the file
+            // label rather than trailing after the badges below: a long
+            // label plus badges can overflow the pane width, and a
+            // trailing badge is the first thing truncation clips away
+            // (see `crate::ui`'s row-truncation), which would hide the
+            // one signal ("this is a test file") a reviewer most needs
+            // to keep visible at a glance.
+            if let Some(count) = row.node.test_symbol_count {
+                spans.push(test_badge_span(count));
+                spans.push(Span::raw(" "));
+            }
             spans.push(Span::styled(label.to_string(), file_label_style(row.node)));
             spans.push(Span::raw(" "));
             push_badge_spans(&mut spans, &row.node.badges, BadgeContext::File);
             // `skip_reason` is mutually exclusive with `test_symbol_count`
             // (`crate::tree::TreeNode::skip_reason`'s own doc comment: a
             // skipped file has no `FileReport`/`TestFileSummary` entry of
-            // its own), so this `if`/`else if` only ever needs to choose
-            // between "skipped" and "has a test count" — but `test_symbol_count`
-            // is *not* exclusive with real `symbols`/badges shown above (a
-            // mixed file legitimately has both, `TreeNode::test_symbol_count`'s
-            // own doc comment), so the test badge still renders alongside the
-            // ordinary changed-symbol badges for such a row rather than being
-            // hidden by them. The priority (skip reason first, when present)
-            // matches `crate::ui::file_detail_lines`'s own skip-reason-first
-            // early return, so the two panes never disagree about which
-            // explanation wins.
+            // its own), so a skip reason and the test badge never both
+            // need to render for the same row.
             if let Some(reason) = row.node.skip_reason {
                 spans.push(Span::raw(" "));
                 spans.push(skip_reason_span(reason));
-            } else if let Some(count) = row.node.test_symbol_count {
-                spans.push(Span::raw(" "));
-                spans.push(test_badge_span(count));
             }
         }
         NodeKind::Symbol(symbol_ref) => {
@@ -348,7 +348,7 @@ fn severity_color(severity: FileSizeSeverity) -> Color {
 /// extracted from it, so it reads visually as "less relevant" than an
 /// analyzed file, same intent as `symbol_name_style`'s dimming of a removed
 /// symbol), plain otherwise — including a whole-test-file row, which is
-/// still an ordinarily-styled label with its own `[test]` badge appended
+/// still an ordinarily-styled label with its own `[test]` badge rendered
 /// separately (see `test_badge_span`) rather than dimmed, since a test file
 /// is not "uninteresting", just excluded from the default symbol-level view
 /// (ADR 0009).

--- a/rinkaku-tui/src/row_view_tests/entry_row_line.rs
+++ b/rinkaku-tui/src/row_view_tests/entry_row_line.rs
@@ -102,7 +102,12 @@ fn should_not_append_skip_reason_for_an_ordinary_file_row() {
 }
 
 #[test]
-fn should_append_test_badge_with_plural_symbols_noun_for_a_whole_test_file_row() {
+fn should_prepend_test_badge_with_plural_symbols_noun_before_a_whole_test_file_label() {
+    // The test badge sits before the file label (left of the name),
+    // not after the trailing badges — a badge trailing a long label
+    // gets clipped first when the row overflows the pane width, but a
+    // reviewer still needs "this is a test file" to be visible at a
+    // glance, so it must survive truncation.
     let node = test_file_node("src/lib_test.go", 3);
     let row = Row {
         node: &node,
@@ -112,11 +117,11 @@ fn should_append_test_badge_with_plural_symbols_noun_for_a_whole_test_file_row()
 
     let line = entry_row_line(&row, "src/lib_test.go", &HashMap::new(), false);
 
-    assert_eq!("  src/lib_test.go  [test] (3 symbols)", line_text(&line));
+    assert_eq!("  [test] (3 symbols) src/lib_test.go ", line_text(&line));
 }
 
 #[test]
-fn should_append_test_badge_with_singular_symbol_noun_when_count_is_one() {
+fn should_prepend_test_badge_with_singular_symbol_noun_when_count_is_one() {
     let node = test_file_node("src/lib_test.go", 1);
     let row = Row {
         node: &node,
@@ -126,7 +131,7 @@ fn should_append_test_badge_with_singular_symbol_noun_when_count_is_one() {
 
     let line = entry_row_line(&row, "src/lib_test.go", &HashMap::new(), false);
 
-    assert_eq!("  src/lib_test.go  [test] (1 symbol)", line_text(&line));
+    assert_eq!("  [test] (1 symbol) src/lib_test.go ", line_text(&line));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Move the whole-test-file `[test] (N symbols)` badge from the end of the entry tree row to just before the file label.

The entry tree pane renders rows with a non-wrapping `Paragraph`, so rows wider than the pane are clipped at the right edge — trailing badges are the first thing to disappear on long paths. Placing the test badge before the label keeps it visible regardless of row width.

## Before / After

```text
# before
  src/lib_test.go  [test] (3 symbols)
# after
  [test] (3 symbols) src/lib_test.go
```

## Scope

- Only the file-row whole-test-file badge moves. The symbol-row `test` badge stays on the right: symbol rows are short (marker + kind + name) and rarely overflow.
- No output-format (Markdown/JSON/mermaid) change; TUI rendering only.

## QA

- `make test` green (169 core + 372 + 591 tui tests).
- `make lint` green (fmt + clippy `-D warnings`).
- Non-TTY smoke: `echo "" | rinkaku` and `git diff main...HEAD | rinkaku` run without panic; no `## File size warnings` for touched files.
- Reviewed (static + dynamic pass): no blockers.