### PR TITLE
feat(tui): truncate overflowing entry tree rows with ellipsis

### DIFF
--- a/rinkaku-tui/src/ui/entry.rs
+++ b/rinkaku-tui/src/ui/entry.rs
@@ -5,7 +5,7 @@
 use super::blast_radius::draw_blast_radius_pane;
 use super::detail_pane::draw_detail_pane;
 use super::diff_pane::draw_diff_pane;
-use super::scroll::{scroll_indicator, windowed_rows_with_indicators};
+use super::scroll::{scroll_indicator, truncate_line_to_width, windowed_rows_with_indicators};
 use super::style::pane_border_style;
 use super::{ENTRY_RIGHT_WIDTH_PERCENT, ENTRY_TREE_WIDTH_PERCENT};
 use crate::app::{App, BlastRadiusSelection, Focus, RightPane};
@@ -80,9 +80,11 @@ pub(crate) fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
     let cursor = app.nav().cursor();
     let ranks = app.ranks();
 
-    // 2 rows for the top/bottom border, matching `render_scrollable_pane`'s
-    // own `saturating_sub(2)` convention for a bordered pane's inner height.
+    // 2 rows/columns for the top/bottom and left/right border, matching
+    // `render_scrollable_pane`'s own `saturating_sub(2)` convention for a
+    // bordered pane's inner height/width.
     let viewport_height = area.height.saturating_sub(2) as usize;
+    let viewport_width = area.width.saturating_sub(2) as usize;
     let (start, end, above, below) =
         windowed_rows_with_indicators(rows.len(), cursor, viewport_height);
 
@@ -108,6 +110,15 @@ pub(crate) fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
             Style::default().add_modifier(Modifier::DIM),
         ));
     }
+
+    // No `.wrap(...)`: `windowed_rows_with_indicators`' one-row-per-item
+    // window math requires each row to stay exactly one rendered row
+    // (`draw_jump_popup`'s doc comment on the same constraint), so an
+    // overflowing row is truncated with `…` rather than wrapped.
+    let lines: Vec<Line<'static>> = lines
+        .iter()
+        .map(|line| truncate_line_to_width(line, viewport_width))
+        .collect();
 
     // `end - start`, not the raw `viewport_height`, is the title
     // indicator's own "how many rows are actually visible" — the two can
@@ -410,5 +421,123 @@ mod tests {
 
         let text = buffer_text(&terminal);
         assert!(text.contains("sym55"), "jump target row not visible");
+    }
+
+    /// A single-file report whose path overflows an 80-column terminal's
+    /// tree pane (60% width, `ENTRY_TREE_WIDTH_PERCENT`, minus 2 columns
+    /// of border).
+    fn report_with_long_path_symbol() -> Report {
+        Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/very/deeply/nested/directory/tree/that/does/not/fit.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/very/deeply/nested/directory/tree/that/does/not/fit.rs::foo",
+                    "foo",
+                )],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            fan_ins: vec![],
+            file_size_warnings: vec![],
+            removed: vec![],
+        }
+    }
+
+    #[test]
+    fn should_truncate_tree_row_with_trailing_ellipsis_when_it_overflows_the_pane_width() {
+        let report = report_with_long_path_symbol();
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    None,
+                );
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(
+            text.contains('…'),
+            "expected an ellipsis-truncated row in:\n{text}"
+        );
+        assert!(
+            !text.contains("src/very/deeply/nested/directory/tree/that/does/not/fit.rs"),
+            "the full overflowing path should not fit on screen:\n{text}"
+        );
+    }
+
+    #[test]
+    fn should_not_truncate_tree_row_when_it_fits_within_the_pane_width() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    None,
+                );
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(
+            text.contains("lib.rs"),
+            "short file row should render in full"
+        );
+        assert!(
+            !text.contains('…'),
+            "no row should need truncation in:\n{text}"
+        );
+    }
+
+    #[test]
+    fn should_preserve_selection_highlight_style_on_a_truncated_cursor_row() {
+        let report = report_with_long_path_symbol();
+        let app = App::new(&report);
+        assert_eq!(0, app.nav().cursor());
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    None,
+                );
+            })
+            .expect("draw");
+
+        // (1, 1): one column/row past the pane's own left/top border.
+        let buffer = terminal.backend().buffer();
+        let cell_style = buffer[(1, 1)].style();
+        assert!(
+            cell_style.add_modifier.contains(Modifier::REVERSED),
+            "cursor row cell should stay reversed after truncation, got {cell_style:?}"
+        );
     }
 }

--- a/rinkaku-tui/src/ui/entry.rs
+++ b/rinkaku-tui/src/ui/entry.rs
@@ -80,9 +80,7 @@ pub(crate) fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
     let cursor = app.nav().cursor();
     let ranks = app.ranks();
 
-    // 2 rows/columns for the top/bottom and left/right border, matching
-    // `render_scrollable_pane`'s own `saturating_sub(2)` convention for a
-    // bordered pane's inner height/width.
+    // 2 rows/columns reserved for the pane's own border.
     let viewport_height = area.height.saturating_sub(2) as usize;
     let viewport_width = area.width.saturating_sub(2) as usize;
     let (start, end, above, below) =
@@ -111,10 +109,8 @@ pub(crate) fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
         ));
     }
 
-    // No `.wrap(...)`: `windowed_rows_with_indicators`' one-row-per-item
-    // window math requires each row to stay exactly one rendered row
-    // (`draw_jump_popup`'s doc comment on the same constraint), so an
-    // overflowing row is truncated with `…` rather than wrapped.
+    // No `.wrap(...)`: `windowed_rows_with_indicators` requires one row
+    // per item, so overflow is truncated with `…` instead.
     let lines: Vec<Line<'static>> = lines
         .iter()
         .map(|line| truncate_line_to_width(line, viewport_width))

--- a/rinkaku-tui/src/ui/scroll.rs
+++ b/rinkaku-tui/src/ui/scroll.rs
@@ -223,24 +223,12 @@ pub(crate) fn truncate_to_width(text: &str, width: usize) -> String {
     result
 }
 
-/// Truncates a styled, possibly multi-[`Span`] [`Line`] to `width` display
-/// columns, the [`Line`]/[`Span`] counterpart of [`truncate_to_width`] —
-/// needed because a tree-pane row (`crate::row_view::entry_row_line`) is
-/// built from several differently-styled spans (indent, marker, label,
-/// badges), so truncating its flattened text would lose which style
-/// belonged to which surviving character. Per-span width accounting
-/// mirrors [`wrap_one_line`] (never splits a wide/CJK character), but
-/// stops at the first overflow and appends one `…` span instead of
-/// starting a new output line, preserving the "one logical row stays one
+/// [`Line`]/[`Span`] counterpart of [`truncate_to_width`] — kept separate
+/// because a tree-pane row is built from several differently-styled spans,
+/// so truncating flattened text would lose which style belonged to which
+/// surviving character. Stops at the first overflow and appends one `…`
+/// span rather than wrapping, preserving the "one logical row stays one
 /// rendered row" invariant [`windowed_rows_with_indicators`] depends on.
-///
-/// The `…` marker takes the style of the span it cuts into, and the
-/// line's own `style` (e.g. `entry_row_line`'s `Modifier::REVERSED` on the
-/// selected row) is preserved unchanged, since it lives outside `spans`.
-///
-/// `line` already fitting within `width` is returned unchanged. `width ==
-/// 0` returns an empty line (`style` preserved), mirroring
-/// `truncate_to_width`'s own `width == 0` case.
 pub(crate) fn truncate_line_to_width(line: &Line<'static>, width: usize) -> Line<'static> {
     if width == 0 {
         return Line::default().style(line.style);
@@ -258,8 +246,7 @@ pub(crate) fn truncate_line_to_width(line: &Line<'static>, width: usize) -> Line
     let mut result_spans: Vec<Span<'static>> = Vec::new();
     let mut used = 0usize;
     let mut last_style = Style::default();
-    // Reserve 1 column for the trailing `…` marker, mirroring
-    // `truncate_to_width`'s own budget reservation.
+    // 1 column reserved for the trailing `…`.
     let budget = width.saturating_sub(1);
 
     'spans: for span in &line.spans {
@@ -287,10 +274,8 @@ pub(crate) fn truncate_line_to_width(line: &Line<'static>, width: usize) -> Line
         last_style = style;
     }
 
-    // Merged into the last span when its style matches, rather than
-    // always pushed separately — otherwise a single-style line would
-    // truncate into a spuriously multi-span `Line`, failing whole-`Line`
-    // `PartialEq` comparisons against an equivalent single-span value.
+    // Merge into the last span when styles match, else a single-style
+    // line would fail `PartialEq` against an equivalent single-span value.
     match result_spans.last_mut() {
         Some(last) if last.style == last_style => {
             let mut content = last.content.to_string();
@@ -860,7 +845,7 @@ mod tests {
         assert_eq!("…".to_string(), actual);
     }
 
-    // --- truncate_line_to_width (styled, multi-span counterpart, tree-pane row truncation) ---
+    // --- truncate_line_to_width (styled, multi-span counterpart) ---
 
     #[test]
     fn should_return_line_unchanged_when_it_fits_within_width() {
@@ -885,8 +870,6 @@ mod tests {
         let red = Style::default().fg(Color::Red);
         let line = Line::from(vec![Span::raw("ab"), Span::styled("cdef", red)]);
 
-        // Budget after reserving 1 column for "…" is 3: "ab" (2, unstyled)
-        // + "c" (1, red) fits, "d" would overflow.
         let actual = truncate_line_to_width(&line, 4);
 
         assert_eq!(
@@ -897,9 +880,6 @@ mod tests {
 
     #[test]
     fn should_preserve_line_level_selected_style_when_truncating_an_overflowing_line() {
-        // `entry_row_line` applies the cursor row's reverse-video highlight
-        // as the `Line`'s own `style`, separate from any span's style —
-        // truncation must not drop it while trimming `spans`.
         let selected_style = Style::default().add_modifier(Modifier::REVERSED);
         let line = Line::from(vec![Span::raw("abcdefgh")]).style(selected_style);
 
@@ -922,11 +902,6 @@ mod tests {
 
     #[test]
     fn should_return_only_the_marker_line_when_width_is_one() {
-        // Mirrors `truncate_to_width`'s own width=1 case: a budget of 0
-        // after reserving 1 column for "…" drops every character of the
-        // input, leaving only the marker — the narrowest width at which
-        // truncation still produces non-empty output (width=0 is the
-        // separate empty-line case covered below).
         let line = Line::raw("abcdef");
 
         let actual = truncate_line_to_width(&line, 1);
@@ -936,12 +911,6 @@ mod tests {
 
     #[test]
     fn should_return_only_the_marker_line_when_width_is_one_and_first_char_is_double_width() {
-        // Same width=1 boundary as above, but the first character is a
-        // 2-column CJK character that would not fit in the 0-column
-        // budget either — pins that the double-width guard and the
-        // width=1 budget-exhaustion guard compose correctly instead of
-        // one masking a bug in the other, same as `truncate_to_width`'s
-        // own symmetric case.
         let line = Line::raw("あいう");
 
         let actual = truncate_line_to_width(&line, 1);

--- a/rinkaku-tui/src/ui/scroll.rs
+++ b/rinkaku-tui/src/ui/scroll.rs
@@ -9,6 +9,7 @@
 use super::style::pane_border_style;
 use ratatui::Frame;
 use ratatui::layout::Rect;
+use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph};
 use unicode_width::UnicodeWidthChar;
@@ -222,6 +223,85 @@ pub(crate) fn truncate_to_width(text: &str, width: usize) -> String {
     result
 }
 
+/// Truncates a styled, possibly multi-[`Span`] [`Line`] to `width` display
+/// columns, the [`Line`]/[`Span`] counterpart of [`truncate_to_width`] —
+/// needed because a tree-pane row (`crate::row_view::entry_row_line`) is
+/// built from several differently-styled spans (indent, marker, label,
+/// badges), so truncating its flattened text would lose which style
+/// belonged to which surviving character. Per-span width accounting
+/// mirrors [`wrap_one_line`] (never splits a wide/CJK character), but
+/// stops at the first overflow and appends one `…` span instead of
+/// starting a new output line, preserving the "one logical row stays one
+/// rendered row" invariant [`windowed_rows_with_indicators`] depends on.
+///
+/// The `…` marker takes the style of the span it cuts into, and the
+/// line's own `style` (e.g. `entry_row_line`'s `Modifier::REVERSED` on the
+/// selected row) is preserved unchanged, since it lives outside `spans`.
+///
+/// `line` already fitting within `width` is returned unchanged. `width ==
+/// 0` returns an empty line (`style` preserved), mirroring
+/// `truncate_to_width`'s own `width == 0` case.
+pub(crate) fn truncate_line_to_width(line: &Line<'static>, width: usize) -> Line<'static> {
+    if width == 0 {
+        return Line::default().style(line.style);
+    }
+    let line_width: usize = line
+        .spans
+        .iter()
+        .flat_map(|span| span.content.chars())
+        .map(|ch| ch.width().unwrap_or(1))
+        .sum();
+    if line_width <= width {
+        return line.clone();
+    }
+
+    let mut result_spans: Vec<Span<'static>> = Vec::new();
+    let mut used = 0usize;
+    let mut last_style = Style::default();
+    // Reserve 1 column for the trailing `…` marker, mirroring
+    // `truncate_to_width`'s own budget reservation.
+    let budget = width.saturating_sub(1);
+
+    'spans: for span in &line.spans {
+        let style = span.style;
+        let mut fragment = String::new();
+        let mut fragment_width = 0usize;
+
+        for ch in span.content.chars() {
+            let char_width = ch.width().unwrap_or(1);
+            if used + fragment_width + char_width > budget {
+                if !fragment.is_empty() {
+                    result_spans.push(Span::styled(fragment, style));
+                }
+                last_style = style;
+                break 'spans;
+            }
+            fragment.push(ch);
+            fragment_width += char_width;
+        }
+
+        if !fragment.is_empty() {
+            result_spans.push(Span::styled(fragment, style));
+            used += fragment_width;
+        }
+        last_style = style;
+    }
+
+    // Merged into the last span when its style matches, rather than
+    // always pushed separately — otherwise a single-style line would
+    // truncate into a spuriously multi-span `Line`, failing whole-`Line`
+    // `PartialEq` comparisons against an equivalent single-span value.
+    match result_spans.last_mut() {
+        Some(last) if last.style == last_style => {
+            let mut content = last.content.to_string();
+            content.push('…');
+            last.content = content.into();
+        }
+        _ => result_spans.push(Span::styled("…", last_style)),
+    }
+    Line::from(result_spans).style(line.style)
+}
+
 /// Clamps a requested scroll offset (lines) to `[0, content_len -
 /// viewport_height]` — the largest offset that still leaves the viewport
 /// full of content rather than trailing off into blank space below the
@@ -372,7 +452,7 @@ pub(crate) fn scroll_indicator(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ratatui::style::{Color, Style};
+    use ratatui::style::{Color, Modifier, Style};
 
     // --- clamp_scroll / scroll_indicator (pure helpers) ---
 
@@ -778,5 +858,104 @@ mod tests {
         let actual = truncate_to_width("あいう", 1);
 
         assert_eq!("…".to_string(), actual);
+    }
+
+    // --- truncate_line_to_width (styled, multi-span counterpart, tree-pane row truncation) ---
+
+    #[test]
+    fn should_return_line_unchanged_when_it_fits_within_width() {
+        let line = Line::from(vec![Span::raw("ab"), Span::styled("cde", Style::default())]);
+
+        let actual = truncate_line_to_width(&line, 5);
+
+        assert_eq!(line, actual);
+    }
+
+    #[test]
+    fn should_truncate_single_span_line_with_trailing_marker_when_it_overflows_width() {
+        let line = Line::raw("abcdefgh");
+
+        let actual = truncate_line_to_width(&line, 5);
+
+        assert_eq!(Line::raw("abcd…"), actual);
+    }
+
+    #[test]
+    fn should_preserve_each_surviving_spans_own_style_when_truncating_a_multi_span_line() {
+        let red = Style::default().fg(Color::Red);
+        let line = Line::from(vec![Span::raw("ab"), Span::styled("cdef", red)]);
+
+        // Budget after reserving 1 column for "…" is 3: "ab" (2, unstyled)
+        // + "c" (1, red) fits, "d" would overflow.
+        let actual = truncate_line_to_width(&line, 4);
+
+        assert_eq!(
+            Line::from(vec![Span::raw("ab"), Span::styled("c…", red)]),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_preserve_line_level_selected_style_when_truncating_an_overflowing_line() {
+        // `entry_row_line` applies the cursor row's reverse-video highlight
+        // as the `Line`'s own `style`, separate from any span's style —
+        // truncation must not drop it while trimming `spans`.
+        let selected_style = Style::default().add_modifier(Modifier::REVERSED);
+        let line = Line::from(vec![Span::raw("abcdefgh")]).style(selected_style);
+
+        let actual = truncate_line_to_width(&line, 5);
+
+        assert_eq!(
+            Line::from(vec![Span::raw("abcd…")]).style(selected_style),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_not_split_a_double_width_character_when_truncating_a_line() {
+        let line = Line::raw("aああb");
+
+        let actual = truncate_line_to_width(&line, 4);
+
+        assert_eq!(Line::raw("aあ…"), actual);
+    }
+
+    #[test]
+    fn should_return_only_the_marker_line_when_width_is_one() {
+        // Mirrors `truncate_to_width`'s own width=1 case: a budget of 0
+        // after reserving 1 column for "…" drops every character of the
+        // input, leaving only the marker — the narrowest width at which
+        // truncation still produces non-empty output (width=0 is the
+        // separate empty-line case covered below).
+        let line = Line::raw("abcdef");
+
+        let actual = truncate_line_to_width(&line, 1);
+
+        assert_eq!(Line::raw("…"), actual);
+    }
+
+    #[test]
+    fn should_return_only_the_marker_line_when_width_is_one_and_first_char_is_double_width() {
+        // Same width=1 boundary as above, but the first character is a
+        // 2-column CJK character that would not fit in the 0-column
+        // budget either — pins that the double-width guard and the
+        // width=1 budget-exhaustion guard compose correctly instead of
+        // one masking a bug in the other, same as `truncate_to_width`'s
+        // own symmetric case.
+        let line = Line::raw("あいう");
+
+        let actual = truncate_line_to_width(&line, 1);
+
+        assert_eq!(Line::raw("…"), actual);
+    }
+
+    #[test]
+    fn should_return_empty_line_when_width_is_zero() {
+        let selected_style = Style::default().add_modifier(Modifier::REVERSED);
+        let line = Line::from(vec![Span::raw("abcdef")]).style(selected_style);
+
+        let actual = truncate_line_to_width(&line, 0);
+
+        assert_eq!(Line::default().style(selected_style), actual);
     }
 }


### PR DESCRIPTION
## Summary

The entry tree pane renders rows with a non-wrapping `Paragraph`, so rows wider than the pane were silently clipped at the right edge with no visual cue. This adds `truncate_line_to_width` (a styled/multi-`Span` counterpart of the existing `&str`-based `truncate_to_width`) and applies it to every tree row in `draw_tree_pane`, so overflowing rows now end with a `…` marker.

- Same Unicode-width accounting as `wrap_one_line`: reserves one column for `…`, never splits a double-width character.
- Per-span styles and the line-level style (cursor row `REVERSED`) survive truncation.
- `Paragraph` stays unwrapped, preserving the one-logical-row-per-rendered-row invariant that `windowed_rows_with_indicators` depends on. Kept separate from the `&str` version because span-style preservation is a responsibility the string version doesn't have.

## Scope

Entry tree pane only; `source_screen.rs`'s similar clipping is left as-is (minimal scope).

## QA

- `make test` green (602 tests), `make lint` green (fmt + clippy `-D warnings`).
- Unit tests: fits-unchanged, single-span truncation, style preservation across the cut, double-width guard, `width == 0` and `width == 1` boundaries.
- `TestBackend` integration tests: overflowing row shows `…`, normal row untouched, cursor-row `REVERSED` style survives.
- Real-PTY verification (tmux, 80x20 down to 3x10): long directory rows truncate with `…`, no panic at extreme widths, reverse-video cursor styling confirmed via `capture-pane -e`.
- Non-TTY smoke: empty stdin and a real diff both run without panic.
- Reviewed (static + dynamic pass): no blockers; review's one suggestion (width == 1 boundary tests) applied.