### PR TITLE
docs: add a "How to read the TUI" guide to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ aid, not a verifier, and we have the experiment rounds to prove it.
 The tree pane orders sibling directories topologically over the change
 graph, not alphabetically: entry-point directories (nothing else
 depends on them) sort first, heavily-depended-upon foundations sort
-last (ADR 0016). Tests are excluded from that ranking entirely and
-pinned into a trailing `Tests` section instead (ADR 0035). Files within
-a directory are alphabetical; symbols keep source order. When a diff
-has no cross-directory references, ranking has nothing to work with and
-the order silently falls back to alphabetical — don't over-read
-ordering in that case, and remember the underlying dependency edges
-come from syntactic tree-sitter resolution, not a type checker, so a
-reference can occasionally be missed (ADR 0003).
+last. Tests are excluded from that ranking entirely and pinned into a
+trailing `Tests` section instead. Files within a directory are
+alphabetical; symbols keep source order. When a diff has no
+cross-directory references, ranking has nothing to work with and the
+order silently falls back to alphabetical — don't over-read ordering
+in that case, and remember the underlying dependency edges come from
+syntactic tree-sitter resolution, not a type checker, so a reference
+can occasionally be missed.
 
 Badges on a row: `chg:N` changed symbols, `api:N` (yellow) contract/
 signature changes, `fan-in:N` symbols that reference this one — i.e.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,45 @@ Feeding it to an LLM reviewer? Read
 [`docs/llm-review.md`](docs/llm-review.md) first — it's an attention
 aid, not a verifier, and we have the experiment rounds to prove it.
 
+## How to read the TUI
+
+The tree pane orders sibling directories topologically over the change
+graph, not alphabetically: entry-point directories (nothing else
+depends on them) sort first, heavily-depended-upon foundations sort
+last (ADR 0016). Tests are excluded from that ranking entirely and
+pinned into a trailing `Tests` section instead (ADR 0035). Files within
+a directory are alphabetical; symbols keep source order. When a diff
+has no cross-directory references, ranking has nothing to work with and
+the order silently falls back to alphabetical — don't over-read
+ordering in that case, and remember the underlying dependency edges
+come from syntactic tree-sitter resolution, not a type checker, so a
+reference can occasionally be missed (ADR 0003).
+
+Badges on a row: `chg:N` changed symbols, `api:N` (yellow) contract/
+signature changes, `fan-in:N` symbols that reference this one — i.e.
+this row's *blast radius*, not a measure of its importance —
+`lines:`/`warn:`/`split:` file-size discipline, and `(cycle)` for a
+directory-level dependency cycle. A symbol's leading marker is `+`
+added, `~` signature-changed, `x` removed, or blank for body-only.
+
+A reading protocol that uses those signals instead of scrolling
+top-to-bottom through the diff:
+
+1. Read the tree top-down — callers appear before the callees they
+   depend on.
+2. Deep-read any row where `api:` and a high `fan-in:` co-occur: a
+   changed contract with many referrers is the highest-risk zone in the
+   PR.
+3. Skim blank-marker (body-only) symbols — their signature didn't
+   change, so they're locally contained.
+4. Press `r`/`R` on a row you're suspicious of to pivot the right pane
+   to its blast-radius tree and see everything downstream of it.
+5. Treat `(cycle)` markers and file-size warnings as structural
+   findings worth calling out separately, not as line-level bugs.
+
+See [`docs/tui.md`](docs/tui.md) for the full layout and key-binding
+reference.
+
 ## Install
 
 | Method | Command |


### PR DESCRIPTION
## Summary

- Adds a "How to read the TUI" section to the README, right after the
  "Try it in 30 seconds" quickstart: explains the tree pane's
  topological directory ordering (ADR 0016), the trailing `Tests`
  section (ADR 0035), the alphabetical fallback when a diff has no
  cross-directory references, and the syntactic (not type-aware)
  nature of dependency resolution (ADR 0003).
- Documents the row badges (`chg:`, `api:`, `fan-in:`, file-size
  badges, `(cycle)`) and the symbol classification markers
  (`+`/`~`/`x`/blank).
- Gives a 5-step reading protocol (top-down read order, prioritize
  `api:` + high `fan-in:` rows, skim body-only symbols, pivot with
  `r`/`R` for blast radius, treat cycles/size warnings as structural
  findings) and points to `docs/tui.md` for the full layout/keymap
  reference.

Docs-only, mechanical route per CLAUDE.md's process weight section —
no behavior change, so the three-angle dogfooding review isn't
required; `make lint` was run to confirm formatting.

## Test plan

- [x] `make lint` passes
- [x] `git status` confirms only `README.md` changed
- [ ] Reviewer eyeballs the new section for tone/accuracy against
      `docs/tui.md` and the cited ADRs (0003, 0016, 0034, 0035)