### PR TITLE
feat: tighten file size thresholds and always show per-file line counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,10 +133,10 @@ one context window.
 
 - **Thresholds** (mirror the `pub const`s in `rinkaku-core/src/file_size.rs`;
   changing them is an ADR amendment):
-  - ≤ 1000 lines — normal, no action.
-  - 1000–1500 lines — watch; a follow-up split is on the horizon.
-  - > 1500 lines — warn; start planning the split now.
-  - > 2000 lines — split it, or write down in the PR body why not.
+  - ≤ 600 lines — normal, no action.
+  - 600–1000 lines — watch; a follow-up split is on the horizon.
+  - > 1000 lines — warn; start planning the split now.
+  - > 1500 lines — split it, or write down in the PR body why not.
 - **Co-locate tests, but move them out when they push the file over.**
   Default to `#[cfg(test)] mod tests { ... }` in the same file. When
   production + test lines together exceed a threshold, switch to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ one context window.
   Don't wait for a line count to force the obvious split.
 - **rinkaku's own warning is authoritative.** When
   `rinkaku --base main` (from a trusted `main` build, per the
-  dogfooding rule above) prints a `## File size warnings` entry for a
+  dogfooding rule above) prints a warn/split entry in `## File sizes` for a
   file this PR touches, treat it as a review-blocker hint: either
   perform the split in the same PR, or justify the continued growth
   in the PR body. Do not merge past the warning silently.

--- a/docs/adr/0028-file-size-warnings.md
+++ b/docs/adr/0028-file-size-warnings.md
@@ -223,3 +223,163 @@ each other without either silently working around the other.
 - CI enforcement, CLI configurability, and a dedicated Mermaid /
   Change-graph annotation for file size are all out of scope; each
   can arrive as its own ADR when there is concrete demand.
+
+## Amendment (2026-07-14, feat/tighten-file-size-thresholds)
+
+The original thresholds (`WARN_LINE_THRESHOLD: 1500`,
+`SPLIT_LINE_THRESHOLD: 2000`) were calibrated against PR #82's
+outlier files (3000-4800+ lines). In practice they proved too loose
+for rinkaku's primary use case — reviewing LLM-generated diffs, which
+tend to grow a single file past a healthy size well before either
+number is crossed. The `#[path = "tests.rs"]` test-extraction
+convention this ADR's Decision section already establishes (point 8)
+means a file over `WARN_LINE_THRESHOLD` on production code alone is
+already a responsibility-mixing signal, not just a size one — the old
+1500/2000 pair let that signal go unraised for too long.
+
+Change: lower both constants by 500 lines, keeping the 500-line gap
+between them:
+
+- `WARN_LINE_THRESHOLD: usize = 1000` (was `1500`)
+- `SPLIT_LINE_THRESHOLD: usize = 1500` (was `2000`)
+
+CLAUDE.md's "File size discipline" table is updated to match: normal
+≤600, watch 600-1000, warn >1000, split >1500. The `≤600` "normal" and
+"600-1000" "watch" bands are descriptive only (no corresponding
+consts) and shift down by the same 500 lines, keeping every band's
+width unchanged.
+
+A one-tier shift, rather than a more aggressive drop, is a deliberate
+compromise against alert fatigue: tightening further would start
+flagging files that are legitimately at rest, not drifting, and repeat
+warnings a reviewer learns to ignore defeat the whole point of ADR
+0028. The existing escape hatch (justify continued growth in the PR
+body instead of splitting) is unchanged.
+
+No change to `FileSizeWarning`, `FileSizeSeverity`, or the sort order —
+this amendment is a constant-value change only. The always-present
+per-file line count/band surface described below is a separate
+amendment landing in the same PR, not a consequence of the threshold
+change itself.
+
+## Amendment (2026-07-14, feat/tighten-file-size-thresholds, part 2)
+
+Decision 2 above only reports files that already cross
+`WARN_LINE_THRESHOLD`. Dogfooding this PR itself surfaced the gap: a
+file sitting just under the threshold gives a reviewer no signal at
+all, even though "how close is this file to the line" is exactly the
+kind of drift-over-time question ADR 0028's Context section is about.
+
+**1. Four-tier classification, always computed.** New
+`FileSizeBand { Normal, Watch, Warn, Split }` in `file_size.rs`,
+alongside a new `NORMAL_LINE_THRESHOLD: usize = 600` (the boundary
+CLAUDE.md's table already described informally but had no constant
+for) and `classify_file_size(line_count) -> FileSizeBand`, the single
+function both the existing `compute_file_size_warnings` (refactored to
+call it) and the new `compute_file_size_bands` build on — one threshold
+ladder, not two independently-maintained ones. `compute_file_size_bands`
+returns a `FileSizeEntry { path, line_count, band }` for *every* file in
+its input, sorted by path ascending (there is no "most attention-worthy
+first" concern the way `compute_file_size_warnings` has — every file is
+listed, not just the ones worth flagging).
+
+**2. `Report.file_size_bands: Vec<FileSizeEntry>`, additive.** Same
+`(path, line_count)` pairs `analyze_diff`/`analyze_repo` already collect
+for `file_size_warnings`, so no new IO. `file_size_warnings` and
+`FileSizeSeverity` are unchanged and still drive nothing new — kept
+because `Badges.file_size_warn_count`/`file_size_split_count` (the
+directory-level aggregate badges) intentionally stay Warn/Split-only
+(see point 4).
+
+**3. Markdown: `## File size warnings` becomes `## File sizes`.**
+Renamed and widened to list every analyzed file, not only Warn/Split
+ones — the two sections would otherwise show overlapping information
+for exactly the files a reviewer most wants to see (a Warn/Split file
+would appear twice under the old scheme: once in the warnings section,
+once if a future "always show" section were added alongside it).
+Format, one line per file in `file_size_bands`'s order:
+
+```markdown
+## File sizes
+
+- `path/to/normal.rs` (80 lines)
+- `path/to/watch.rs` (700 lines, watch)
+- `path/to/warn.rs` (1200 lines, warn)
+- `path/to/split.rs` (2500 lines, split)
+```
+
+`Normal` gets no suffix (nothing to flag); every other band appends
+`, {band}`. The `⚠`/`🚨` glyphs the old section used are dropped: with
+four bands instead of two, a growing zoo of glyphs was worse than a
+plain word, and the TUI surface (point 4) already establishes
+"text label, no emoji" as this feature's house style. Section placement
+(after `## High fan-in symbols`, before `## Definitions`) is unchanged
+from the original decision. Skipped entirely when `file_size_bands` is
+empty, same "skip when empty" rule as every other optional section.
+
+**4. TUI: the file-row `lines:N` badge is now unconditional.**
+`Badges.own_file_size_severity: Option<FileSizeSeverity>` becomes
+`own_file_size_band: Option<FileSizeBand>`, populated from
+`file_size_bands` (every file) rather than `file_size_warnings`
+(Warn/Split only) — so `lines:N` renders on every file row, not only
+oversized ones. Color follows the band: `Normal` unstyled, `Watch`
+yellow, `Warn`/`Split` red with `Split` additionally bold, so the two
+red bands remain visually distinguishable. `Badges.file_size_warn_count`
+/ `file_size_split_count` (the directory-level `warn:N split:N`
+aggregate) are deliberately **not** widened to count `Watch` files —
+those two counts exist to answer "how many files need action", and a
+`Watch` file needs none yet; widening them would dilute a signal that
+today means "these directories have Warn/Split files in them" into a
+vaguer "these directories have some files that are somewhat large."
+No emoji, matching the crate's established TUI convention (this ADR's
+original decision 6, reaffirmed after PR #104 removed `DIM` from
+`DarkGray` text for the same "keep it legible across terminals" reason).
+
+**5. JSON: `file_size_bands` is a new additive top-level field**,
+always present (empty array when `files` is empty), mirroring how
+`file_size_warnings`/`fan_ins` are always present. `file_size_warnings`
+is untouched — this is a pure addition, not a replacement, at the JSON
+level (unlike the Markdown section, which does replace the old one).
+
+## Alternatives (amendment)
+
+- **Fold the new field into `file_size_warnings` by adding
+  `FileSizeSeverity::Normal`/`Watch` variants** — rejected.
+  `FileSizeSeverity` is deliberately the Warn/Split-only type the
+  directory aggregate badges (`file_size_warn_count`/
+  `file_size_split_count`) and the Markdown warnings label depend on;
+  widening it would force every existing match over `FileSizeSeverity`
+  to grow two new arms it has no use for, whereas a sibling
+  `FileSizeBand` type keeps each concept's match exhaustive over only
+  the variants it actually cares about.
+- **Keep `## File size warnings` alongside a new, separate "## File
+  sizes" section** — rejected as the redundant-information outcome
+  point 3 above already argues against: a Warn/Split file would appear
+  in both sections with the same line count, just formatted two ways.
+- **Show the line count in the Detail pane's per-file view unconditionally
+  too** (today: only when `size_warning` is `Some`) — deferred. The
+  Detail pane's dedicated warning line answers "why is this file
+  flagged", which only makes sense for Warn/Split; showing an
+  unconditional "N lines, normal" line there as well was judged noise
+  for the common case (most files are Normal) without a concrete
+  request driving it. Can follow later if it turns out to matter.
+
+## Consequences (amendment)
+
+- Markdown output for every repository with at least one analyzed file
+  now includes a `## File sizes` section (previously only shown when a
+  file crossed `WARN_LINE_THRESHOLD`) — a bigger, but purely additive
+  (in the "more information, not less accurate" sense), change to the
+  default Markdown surface than decision 2's threshold shift alone.
+  Downstream Markdown parsers pinning section presence/absence need to
+  account for `## File sizes` now appearing on ordinary diffs, not only
+  large-file ones.
+- JSON gains one new field (`file_size_bands`); no existing field
+  changes shape.
+- TUI file rows always show `lines:N`; directory rows are unchanged
+  (still Warn/Split-only aggregates).
+- `docs/experiments/0001-map-assisted-llm-review/rounds/021.md` and
+  `022.md` reference the old `## File size warnings` heading as
+  historical fact about those specific review rounds — left unedited,
+  same "historical record, not rewritten" rule this ADR's own
+  Consequences section already applies to itself.

--- a/rinkaku-core/src/file_size.rs
+++ b/rinkaku-core/src/file_size.rs
@@ -1,29 +1,43 @@
-//! File-size warnings (ADR 0028): flag source files that have grown past
-//! empirical readability thresholds, so a reviewer skimming rinkaku's
-//! output sees oversized files at a glance rather than discovering the
-//! drift only when a multi-thousand-line file finally needs a mechanical
-//! split.
+//! File-size warnings and bands (ADR 0028, amended to add always-present
+//! per-file bands): flag source files that have grown past empirical
+//! readability thresholds, so a reviewer skimming rinkaku's output sees
+//! oversized files at a glance rather than discovering the drift only when
+//! a multi-thousand-line file finally needs a mechanical split.
 //!
 //! Pure over plain `(path, line_count)` pairs — [`crate::pipeline`]
 //! collects the pairs while it already holds each file's content in scope
 //! for parsing (skipped files — binary, generated, deleted,
-//! unsupported-language — are excluded there, not here), then this module
-//! turns them into [`FileSizeWarning`]s. Two thresholds
-//! ([`WARN_LINE_THRESHOLD`], [`SPLIT_LINE_THRESHOLD`]) are fixed by ADR
-//! 0028 as part of the spec: changing them is an ADR amendment, not a
-//! silent tune, so downstream consumers (LLM reviewers, human review
-//! policy) can rely on the meaning of "warn" vs "split" staying stable.
+//! unsupported-language — are excluded there, not here). This module then
+//! classifies each pair into a [`FileSizeBand`] via [`classify_file_size`],
+//! the single source of truth both [`compute_file_size_warnings`] (the
+//! Warn/Split-only subset, historically the whole of this module) and
+//! [`compute_file_size_bands`] (every file, all four bands) build on. Three
+//! thresholds ([`NORMAL_LINE_THRESHOLD`], [`WARN_LINE_THRESHOLD`],
+//! [`SPLIT_LINE_THRESHOLD`]) are fixed by ADR 0028 as part of the spec:
+//! changing them is an ADR amendment, not a silent tune, so downstream
+//! consumers (LLM reviewers, human review policy) can rely on the meaning
+//! of each band staying stable.
 
 use serde::Serialize;
 
+/// Line-count threshold above which a file leaves [`FileSizeBand::Normal`]
+/// and enters [`FileSizeBand::Watch`] (ADR 0028 amendment). Strictly
+/// greater, same convention as [`WARN_LINE_THRESHOLD`] /
+/// [`SPLIT_LINE_THRESHOLD`]. Descriptive only — unlike the other two
+/// thresholds, no dedicated Markdown/JSON warning was ever built around
+/// this boundary; it exists so [`FileSizeBand`] can classify every file,
+/// not just the ones already worth a warning.
+pub const NORMAL_LINE_THRESHOLD: usize = 600;
+
 /// Line-count threshold above which a file is reported as
-/// [`FileSizeSeverity::Warn`] (ADR 0028). The check is strictly greater:
-/// a file at exactly [`WARN_LINE_THRESHOLD`] lines is not warned about.
+/// [`FileSizeSeverity::Warn`] / [`FileSizeBand::Warn`] (ADR 0028). The
+/// check is strictly greater: a file at exactly [`WARN_LINE_THRESHOLD`]
+/// lines is not warned about.
 pub const WARN_LINE_THRESHOLD: usize = 1000;
 
 /// Line-count threshold above which a file is reported as
-/// [`FileSizeSeverity::Split`] (ADR 0028). Strictly greater, same as
-/// [`WARN_LINE_THRESHOLD`].
+/// [`FileSizeSeverity::Split`] / [`FileSizeBand::Split`] (ADR 0028).
+/// Strictly greater, same as [`WARN_LINE_THRESHOLD`].
 pub const SPLIT_LINE_THRESHOLD: usize = 1500;
 
 /// Severity of a [`FileSizeWarning`] (ADR 0028): `Warn` = the file has
@@ -47,6 +61,60 @@ pub struct FileSizeWarning {
     pub severity: FileSizeSeverity,
 }
 
+/// The four-tier line-count classification every analyzed file falls into
+/// (ADR 0028 amendment), unlike [`FileSizeSeverity`] which only names the
+/// two bands worth a dedicated warning. Serializes as `"normal"` /
+/// `"watch"` / `"warn"` / `"split"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileSizeBand {
+    Normal,
+    Watch,
+    Warn,
+    Split,
+}
+
+impl FileSizeBand {
+    /// The [`FileSizeSeverity`] a [`FileSizeWarning`] would carry for this
+    /// band, or `None` for [`FileSizeBand::Normal`] / [`FileSizeBand::Watch`]
+    /// — bands below the warning thresholds have no `FileSizeSeverity`
+    /// equivalent, since that type only exists to name the two bands worth
+    /// a dedicated warning.
+    pub fn severity(self) -> Option<FileSizeSeverity> {
+        match self {
+            FileSizeBand::Normal | FileSizeBand::Watch => None,
+            FileSizeBand::Warn => Some(FileSizeSeverity::Warn),
+            FileSizeBand::Split => Some(FileSizeSeverity::Split),
+        }
+    }
+}
+
+/// One file's line count and band (ADR 0028 amendment), reported on
+/// [`crate::render::Report::file_size_bands`] for every analyzed file —
+/// unlike [`FileSizeWarning`], which only covers the Warn/Split subset.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FileSizeEntry {
+    pub path: String,
+    pub line_count: usize,
+    pub band: FileSizeBand,
+}
+
+/// Classifies a single `line_count` into a [`FileSizeBand`] (ADR 0028
+/// amendment) — the one place the four threshold comparisons live, so
+/// [`compute_file_size_warnings`] and [`compute_file_size_bands`] can't
+/// drift apart on where a boundary falls.
+pub fn classify_file_size(line_count: usize) -> FileSizeBand {
+    if line_count > SPLIT_LINE_THRESHOLD {
+        FileSizeBand::Split
+    } else if line_count > WARN_LINE_THRESHOLD {
+        FileSizeBand::Warn
+    } else if line_count > NORMAL_LINE_THRESHOLD {
+        FileSizeBand::Watch
+    } else {
+        FileSizeBand::Normal
+    }
+}
+
 /// Computes the per-file size warnings for a `(path, line_count)` list,
 /// following ADR 0028's thresholds and ordering:
 ///
@@ -64,13 +132,7 @@ pub fn compute_file_size_warnings(files: &[(String, usize)]) -> Vec<FileSizeWarn
     let mut warnings: Vec<FileSizeWarning> = files
         .iter()
         .filter_map(|(path, line_count)| {
-            let severity = if *line_count > SPLIT_LINE_THRESHOLD {
-                FileSizeSeverity::Split
-            } else if *line_count > WARN_LINE_THRESHOLD {
-                FileSizeSeverity::Warn
-            } else {
-                return None;
-            };
+            let severity = classify_file_size(*line_count).severity()?;
             Some(FileSizeWarning {
                 path: path.clone(),
                 line_count: *line_count,
@@ -90,6 +152,28 @@ pub fn compute_file_size_warnings(files: &[(String, usize)]) -> Vec<FileSizeWarn
             .then_with(|| a.path.cmp(&b.path))
     });
     warnings
+}
+
+/// Computes every analyzed file's [`FileSizeEntry`] (ADR 0028 amendment),
+/// unlike [`compute_file_size_warnings`] which drops everything at or
+/// below [`WARN_LINE_THRESHOLD`]. Sorted by `path` ascending — there is no
+/// "most attention-worthy first" ordering here the way
+/// [`compute_file_size_warnings`] has, since the point of this function is
+/// a complete per-file listing (the Markdown/TUI callers already know
+/// which of their own rows are Watch/Warn/Split from the `band` field, and
+/// render each file in their own existing order — this function does not
+/// need to pre-sort attention).
+pub fn compute_file_size_bands(files: &[(String, usize)]) -> Vec<FileSizeEntry> {
+    let mut entries: Vec<FileSizeEntry> = files
+        .iter()
+        .map(|(path, line_count)| FileSizeEntry {
+            path: path.clone(),
+            line_count: *line_count,
+            band: classify_file_size(*line_count),
+        })
+        .collect();
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+    entries
 }
 
 /// Numeric weight used to sort [`FileSizeSeverity`] descending
@@ -244,6 +328,104 @@ mod tests {
             },
         ];
         let actual = compute_file_size_warnings(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_classify_normal_when_line_count_is_at_normal_threshold() {
+        // Strictly-greater convention: exactly NORMAL_LINE_THRESHOLD stays
+        // Normal, matching how WARN/SPLIT are strictly-greater too.
+        let expected = FileSizeBand::Normal;
+        let actual = classify_file_size(NORMAL_LINE_THRESHOLD);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_classify_watch_when_line_count_is_above_normal_threshold() {
+        let expected = FileSizeBand::Watch;
+        let actual = classify_file_size(NORMAL_LINE_THRESHOLD + 1);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_classify_watch_when_line_count_is_at_warn_threshold() {
+        let expected = FileSizeBand::Watch;
+        let actual = classify_file_size(WARN_LINE_THRESHOLD);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_classify_warn_when_line_count_is_above_warn_threshold() {
+        let expected = FileSizeBand::Warn;
+        let actual = classify_file_size(WARN_LINE_THRESHOLD + 1);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_classify_split_when_line_count_is_above_split_threshold() {
+        let expected = FileSizeBand::Split;
+        let actual = classify_file_size(SPLIT_LINE_THRESHOLD + 1);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_none_severity_when_band_is_normal_or_watch() {
+        assert_eq!(None, FileSizeBand::Normal.severity());
+        assert_eq!(None, FileSizeBand::Watch.severity());
+    }
+
+    #[test]
+    fn should_return_matching_severity_when_band_is_warn_or_split() {
+        assert_eq!(Some(FileSizeSeverity::Warn), FileSizeBand::Warn.severity());
+        assert_eq!(
+            Some(FileSizeSeverity::Split),
+            FileSizeBand::Split.severity()
+        );
+    }
+
+    #[test]
+    fn should_include_every_file_when_computing_bands_regardless_of_band() {
+        let files = vec![
+            ("normal.rs".to_string(), 10),
+            ("watch.rs".to_string(), NORMAL_LINE_THRESHOLD + 1),
+            ("warn.rs".to_string(), WARN_LINE_THRESHOLD + 1),
+            ("split.rs".to_string(), SPLIT_LINE_THRESHOLD + 1),
+        ];
+
+        let expected = vec![
+            FileSizeEntry {
+                path: "normal.rs".to_string(),
+                line_count: 10,
+                band: FileSizeBand::Normal,
+            },
+            FileSizeEntry {
+                path: "split.rs".to_string(),
+                line_count: SPLIT_LINE_THRESHOLD + 1,
+                band: FileSizeBand::Split,
+            },
+            FileSizeEntry {
+                path: "warn.rs".to_string(),
+                line_count: WARN_LINE_THRESHOLD + 1,
+                band: FileSizeBand::Warn,
+            },
+            FileSizeEntry {
+                path: "watch.rs".to_string(),
+                line_count: NORMAL_LINE_THRESHOLD + 1,
+                band: FileSizeBand::Watch,
+            },
+        ];
+        let actual = compute_file_size_bands(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_empty_when_computing_bands_over_an_empty_file_list() {
+        let files: Vec<(String, usize)> = vec![];
+
+        let expected: Vec<FileSizeEntry> = vec![];
+        let actual = compute_file_size_bands(&files);
 
         assert_eq!(expected, actual);
     }

--- a/rinkaku-core/src/file_size.rs
+++ b/rinkaku-core/src/file_size.rs
@@ -19,12 +19,12 @@ use serde::Serialize;
 /// Line-count threshold above which a file is reported as
 /// [`FileSizeSeverity::Warn`] (ADR 0028). The check is strictly greater:
 /// a file at exactly [`WARN_LINE_THRESHOLD`] lines is not warned about.
-pub const WARN_LINE_THRESHOLD: usize = 1500;
+pub const WARN_LINE_THRESHOLD: usize = 1000;
 
 /// Line-count threshold above which a file is reported as
 /// [`FileSizeSeverity::Split`] (ADR 0028). Strictly greater, same as
 /// [`WARN_LINE_THRESHOLD`].
-pub const SPLIT_LINE_THRESHOLD: usize = 2000;
+pub const SPLIT_LINE_THRESHOLD: usize = 1500;
 
 /// Severity of a [`FileSizeWarning`] (ADR 0028): `Warn` = the file has
 /// crossed the "start planning the split" watch threshold, `Split` = the

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -12,7 +12,7 @@ use crate::diff::{ChangeKind, parse_unified_diff};
 use crate::extract::{
     ExtractedSymbol, RemovedSymbol, classify_symbols, extract_all_symbols, extract_changed_symbols,
 };
-use crate::file_size::compute_file_size_warnings;
+use crate::file_size::{compute_file_size_bands, compute_file_size_warnings};
 use crate::graph::{build_graph, compute_fan_ins, stamp_ids};
 use crate::language::{LanguageSupport, language_for_path};
 use crate::progress::{OnProgress, should_report_progress};
@@ -321,6 +321,8 @@ pub fn analyze_diff(
     // ADR 0028: file-size warnings from the `(path, line_count)` pairs
     // collected inline above during the per-file read loop.
     let file_size_warnings = compute_file_size_warnings(&sized_files);
+    // ADR 0028 amendment: every file's band, from the same pairs.
+    let file_size_bands = compute_file_size_bands(&sized_files);
 
     Ok(Report {
         origin: ReportOrigin::Diff,
@@ -330,6 +332,7 @@ pub fn analyze_diff(
         tests,
         fan_ins,
         file_size_warnings,
+        file_size_bands,
         removed,
     })
 }
@@ -526,6 +529,7 @@ pub fn analyze_repo(
     stamp_ids(&mut files, &graph);
     let fan_ins = compute_fan_ins(&graph);
     let file_size_warnings = compute_file_size_warnings(&sized_files);
+    let file_size_bands = compute_file_size_bands(&sized_files);
 
     Report {
         origin: ReportOrigin::RepoOutline,
@@ -535,6 +539,7 @@ pub fn analyze_repo(
         tests: Vec::new(),
         fan_ins,
         file_size_warnings,
+        file_size_bands,
         removed: Vec::new(),
     }
 }

--- a/rinkaku-core/src/pipeline_tests/analyze_diff.rs
+++ b/rinkaku-core/src/pipeline_tests/analyze_diff.rs
@@ -8,6 +8,7 @@
 use super::{empty_graph, fake_reader};
 use crate::diff::LineRange;
 use crate::extract::{ExtractedSymbol, SymbolKind};
+use crate::file_size::{FileSizeBand, FileSizeEntry};
 use crate::graph::FanIn;
 use crate::pipeline::{AnalyzeError, analyze_diff};
 use crate::render::{FileReport, Report, ReportOrigin, SkipReason, SkippedFile};
@@ -26,6 +27,7 @@ fn should_return_empty_report_when_diff_is_empty() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     let actual = analyze_diff("", read_file, None, None, true, &HashSet::new(), true, None)
@@ -86,6 +88,11 @@ fn foo(a: i32) -> i32 {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![FileSizeEntry {
+            path: "src/lib.rs".to_string(),
+            line_count: 3,
+            band: FileSizeBand::Normal,
+        }],
         removed: vec![],
     };
     let actual = analyze_diff(
@@ -130,6 +137,7 @@ index 4b825dc..0000000
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     let actual = analyze_diff(
@@ -167,6 +175,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     let actual = analyze_diff(
@@ -212,6 +221,7 @@ index e69de29..4b825dc 100644
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     let actual = analyze_diff(
@@ -261,6 +271,7 @@ rename to src/new_name.rs
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     let actual = analyze_diff(
@@ -393,6 +404,11 @@ index e69de29..4b825dc 100644
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![FileSizeEntry {
+            path: "src/lib.rs".to_string(),
+            line_count: 1,
+            band: FileSizeBand::Normal,
+        }],
         removed: vec![],
     };
     let actual = analyze_diff(

--- a/rinkaku-core/src/pipeline_tests/analyze_diff.rs
+++ b/rinkaku-core/src/pipeline_tests/analyze_diff.rs
@@ -495,6 +495,10 @@ func (r *repoImpl) Save(id string) error {
 - interface Repo (repo.go)
   - fn Save (repo.go)
 
+## File sizes
+
+- `repo.go` (11 lines)
+
 ## Definitions
 
 ### interface Repo (repo.go)

--- a/rinkaku-core/src/pipeline_tests/analyze_repo.rs
+++ b/rinkaku-core/src/pipeline_tests/analyze_repo.rs
@@ -7,6 +7,7 @@
 use super::{empty_graph, fake_reader};
 use crate::diff::LineRange;
 use crate::extract::{ExtractedSymbol, SymbolKind};
+use crate::file_size::{FileSizeBand, FileSizeEntry};
 use crate::pipeline::analyze_repo;
 use crate::render::{FileReport, Report, ReportOrigin};
 use pretty_assertions::assert_eq;
@@ -24,6 +25,7 @@ fn should_return_empty_report_when_paths_is_empty() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     let actual = analyze_repo(&[], read_file, true, &HashSet::new(), true, None);
@@ -107,6 +109,11 @@ struct Point {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![FileSizeEntry {
+            path: "src/lib.rs".to_string(),
+            line_count: 7,
+            band: FileSizeBand::Normal,
+        }],
         removed: vec![],
     };
     let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
@@ -148,6 +155,7 @@ fn should_skip_path_without_registered_language_support() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
@@ -171,6 +179,7 @@ fn should_skip_path_when_read_file_fails() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
@@ -198,6 +207,7 @@ fn should_skip_path_in_generated_paths_set_without_reading_it() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     let actual = analyze_repo(&paths, read_file, true, &generated_paths, true, None);
@@ -219,6 +229,7 @@ fn should_skip_file_with_generated_content_marker_when_include_generated_is_fals
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), false, None);
@@ -257,6 +268,7 @@ func TestFoo(t *testing.T) {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     let actual = analyze_repo(&paths, read_file, false, &HashSet::new(), true, None);

--- a/rinkaku-core/src/pipeline_tests/generated_exclusion.rs
+++ b/rinkaku-core/src/pipeline_tests/generated_exclusion.rs
@@ -7,6 +7,7 @@
 use super::fake_reader;
 use crate::diff::LineRange;
 use crate::extract::{ExtractedSymbol, SymbolKind};
+use crate::file_size::{FileSizeBand, FileSizeEntry};
 use crate::pipeline::analyze_diff;
 use crate::render::{FileReport, Report, ReportOrigin, SkipReason, SkippedFile};
 use pretty_assertions::assert_eq;
@@ -216,6 +217,11 @@ func Foo() int { return 2 }
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![FileSizeEntry {
+            path: "models/user.go".to_string(),
+            line_count: 3,
+            band: FileSizeBand::Normal,
+        }],
         removed: vec![],
     };
     let actual = analyze_diff(
@@ -285,6 +291,11 @@ fn foo(a: i32) -> i32 {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![FileSizeEntry {
+            path: "src/lib.rs".to_string(),
+            line_count: 3,
+            band: FileSizeBand::Normal,
+        }],
         removed: vec![],
     };
     let actual = analyze_diff(
@@ -364,6 +375,11 @@ index e69de29..4b825dc 100644
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![FileSizeEntry {
+            path: "src/lib.rs".to_string(),
+            line_count: 3,
+            band: FileSizeBand::Normal,
+        }],
         removed: vec![],
     };
     let actual = analyze_diff(

--- a/rinkaku-core/src/pipeline_tests/test_symbol_exclusion.rs
+++ b/rinkaku-core/src/pipeline_tests/test_symbol_exclusion.rs
@@ -6,6 +6,7 @@
 use super::fake_reader;
 use crate::diff::LineRange;
 use crate::extract::{ExtractedSymbol, SymbolKind};
+use crate::file_size::{FileSizeBand, FileSizeEntry};
 use crate::pipeline::analyze_diff;
 use crate::render::{FileReport, Report, ReportOrigin, TestFileSummary};
 use pretty_assertions::assert_eq;
@@ -108,6 +109,11 @@ fn should_add_two_numbers() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![FileSizeEntry {
+            path: "src/lib.rs".to_string(),
+            line_count: 4,
+            band: FileSizeBand::Normal,
+        }],
         removed: vec![],
     };
     let actual = analyze_diff(
@@ -285,6 +291,11 @@ mod tests {
         }],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![FileSizeEntry {
+            path: "src/lib.rs".to_string(),
+            line_count: 11,
+            band: FileSizeBand::Normal,
+        }],
         removed: vec![],
     };
     let actual = analyze_diff(

--- a/rinkaku-core/src/render/digest.rs
+++ b/rinkaku-core/src/render/digest.rs
@@ -189,6 +189,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed,
         }
     }

--- a/rinkaku-core/src/render/markdown.rs
+++ b/rinkaku-core/src/render/markdown.rs
@@ -8,9 +8,7 @@
 //! output for each section shape.
 
 use crate::extract::{Classification, ExtractedSymbol, RemovedSymbol, SymbolKind};
-use crate::file_size::{
-    FileSizeSeverity, FileSizeWarning, SPLIT_LINE_THRESHOLD, WARN_LINE_THRESHOLD,
-};
+use crate::file_size::{FileSizeBand, FileSizeEntry};
 use crate::graph::{FanIn, Node, NodeId, SymbolGraph};
 use crate::render::RenderError;
 use crate::render::report::{Report, ReportOrigin, SkipReason, SkippedFile, skip_reason_label};
@@ -105,11 +103,11 @@ pub(super) fn render_markdown(report: &Report) -> Result<String, RenderError> {
             writeln!(out)?;
         }
 
-        if !report.file_size_warnings.is_empty() {
-            writeln!(out, "## File size warnings")?;
+        if !report.file_size_bands.is_empty() {
+            writeln!(out, "## File sizes")?;
             writeln!(out)?;
-            for warning in &report.file_size_warnings {
-                writeln!(out, "- {}", file_size_warning_label(warning))?;
+            for entry in &report.file_size_bands {
+                writeln!(out, "- {}", file_size_entry_label(entry))?;
             }
             writeln!(out)?;
         }
@@ -528,23 +526,15 @@ fn fan_in_label(fan_in: &FanIn, lookup: &SymbolLookup) -> String {
     }
 }
 
-/// Builds the "File size warnings" line label for a [`FileSizeWarning`]
-/// (ADR 0028): `⚠` for [`FileSizeSeverity::Warn`] / `🚨` for
-/// [`FileSizeSeverity::Split`], followed by the path (in `code span`), the
-/// line count, and a short explanation naming the threshold crossed. The
-/// threshold numbers are pulled from [`WARN_LINE_THRESHOLD`] and
-/// [`SPLIT_LINE_THRESHOLD`] rather than duplicated inline, so the Markdown
-/// text stays in sync with the file_size module's single source of truth.
-fn file_size_warning_label(warning: &FileSizeWarning) -> String {
-    match warning.severity {
-        FileSizeSeverity::Warn => format!(
-            "⚠ `{}` ({} lines) — over the {}-line watch threshold; consider splitting",
-            warning.path, warning.line_count, WARN_LINE_THRESHOLD,
-        ),
-        FileSizeSeverity::Split => format!(
-            "🚨 `{}` ({} lines) — over the {}-line split threshold",
-            warning.path, warning.line_count, SPLIT_LINE_THRESHOLD,
-        ),
+/// Builds the "File sizes" line label for a [`FileSizeEntry`] (ADR 0028
+/// amendment): `path (N lines)` for [`FileSizeBand::Normal`], with a
+/// `, {band}` suffix for every other band.
+fn file_size_entry_label(entry: &FileSizeEntry) -> String {
+    match entry.band {
+        FileSizeBand::Normal => format!("`{}` ({} lines)", entry.path, entry.line_count),
+        FileSizeBand::Watch => format!("`{}` ({} lines, watch)", entry.path, entry.line_count),
+        FileSizeBand::Warn => format!("`{}` ({} lines, warn)", entry.path, entry.line_count),
+        FileSizeBand::Split => format!("`{}` ({} lines, split)", entry.path, entry.line_count),
     }
 }
 

--- a/rinkaku-core/src/render/markdown_tests/change_graph_summary.rs
+++ b/rinkaku-core/src/render/markdown_tests/change_graph_summary.rs
@@ -32,6 +32,7 @@ fn should_render_change_graph_and_definitions_when_report_has_one_symbol() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -86,6 +87,7 @@ fn should_render_summary_with_hotspot_when_report_has_multiple_symbols_and_files
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -136,6 +138,7 @@ fn should_render_repository_graph_heading_and_drop_changed_wording_when_origin_i
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -174,6 +177,7 @@ fn should_omit_hotspot_suffix_when_all_symbols_are_in_one_file() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -220,6 +224,7 @@ fn should_break_hotspot_tie_by_first_seen_path_order_when_counts_are_equal() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -286,6 +291,7 @@ fn should_include_start_line_in_label_when_node_id_is_disambiguated_by_line() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 

--- a/rinkaku-core/src/render/markdown_tests/change_graph_tree.rs
+++ b/rinkaku-core/src/render/markdown_tests/change_graph_tree.rs
@@ -53,6 +53,7 @@ fn should_nest_callee_under_caller_in_change_graph_when_symbol_references_anothe
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -137,6 +138,7 @@ fn should_order_definitions_in_true_pre_order_when_first_child_has_its_own_child
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -227,6 +229,7 @@ fn should_mark_see_above_when_symbol_reachable_from_multiple_roots() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -297,6 +300,7 @@ fn should_render_cycle_warning_when_edge_is_marked_as_cycle() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -409,6 +413,7 @@ fn should_render_full_cycle_example_with_two_root_functions_and_a_dependency_cyc
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -524,6 +529,7 @@ fn should_inline_two_leaf_struct_children_as_uses_annotation_on_method_line() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -621,6 +627,7 @@ fn should_disambiguate_folded_names_when_duplicate_symbols_fold_under_same_paren
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -705,6 +712,7 @@ fn should_repeat_folded_struct_annotation_on_every_referencing_parent() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -770,6 +778,7 @@ fn should_render_childless_non_function_root_as_top_level_line_when_it_would_oth
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -848,6 +857,7 @@ fn should_render_nested_line_when_non_function_child_has_its_own_children() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -930,6 +940,7 @@ fn should_not_fold_non_function_child_when_its_only_children_are_cycle_edges() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 

--- a/rinkaku-core/src/render/markdown_tests/classification_and_removed.rs
+++ b/rinkaku-core/src/render/markdown_tests/classification_and_removed.rs
@@ -33,6 +33,7 @@ fn should_append_new_marker_to_tree_and_definition_when_symbol_is_added() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -83,6 +84,7 @@ fn should_render_diff_block_and_marker_when_symbol_is_signature_changed() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -139,6 +141,7 @@ fn should_render_container_comment_above_diff_lines_when_signature_changed_symbo
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -190,6 +193,7 @@ fn should_render_unmarked_tree_and_definition(#[case] classification: Option<Cla
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -245,6 +249,7 @@ fn should_append_marker_to_fan_in_line_before_used_by() {
             used_by: vec!["caller_one".to_string(), "caller_two".to_string()],
         }],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -291,6 +296,7 @@ fn should_render_removed_symbols_section_between_definitions_and_tests() {
         }],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![RemovedSymbol {
             name: "old_helper".to_string(),
             kind: SymbolKind::Function,
@@ -350,6 +356,7 @@ fn should_render_removed_symbols_section_alone_when_graph_is_empty() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![RemovedSymbol {
             name: "old_helper".to_string(),
             kind: SymbolKind::Function,
@@ -391,6 +398,7 @@ fn should_deduplicate_identical_removed_symbol_lines() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![
             RemovedSymbol {
                 name: "save".to_string(),
@@ -452,6 +460,7 @@ fn should_omit_removed_symbols_section_when_removed_is_empty() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -493,6 +502,7 @@ fn should_widen_fence_when_previous_signature_contains_a_backtick_run() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 

--- a/rinkaku-core/src/render/markdown_tests/definition_body.rs
+++ b/rinkaku-core/src/render/markdown_tests/definition_body.rs
@@ -35,6 +35,7 @@ fn should_render_container_comment_when_symbol_has_container() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -89,6 +90,7 @@ fn should_render_depends_on_list_when_symbol_has_dependencies() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -151,6 +153,7 @@ fn should_render_multiple_depends_on_entries_when_symbol_has_several_dependencie
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -209,6 +212,7 @@ fn should_render_omitted_matches_note_when_dependency_matches_were_capped() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -269,6 +273,7 @@ fn should_widen_fence_when_signature_contains_a_backtick_run() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -322,6 +327,7 @@ fn should_widen_fence_when_container_contains_a_backtick_run() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 

--- a/rinkaku-core/src/render/markdown_tests/empty_and_ordering.rs
+++ b/rinkaku-core/src/render/markdown_tests/empty_and_ordering.rs
@@ -24,6 +24,7 @@ fn should_render_empty_markdown_when_report_has_no_files_and_no_skips() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -59,6 +60,7 @@ fn should_list_file_with_no_symbols_under_other_changed_files_when_report_has_no
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -106,6 +108,7 @@ fn should_list_file_with_no_symbols_after_definitions_when_report_has_graph_node
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -155,6 +158,7 @@ fn should_render_other_changed_files_before_skipped_files_when_report_has_both()
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -190,6 +194,7 @@ fn should_render_tests_section_with_singular_symbol_noun_when_count_is_one() {
         }],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -222,6 +227,7 @@ fn should_render_tests_section_with_plural_symbols_noun_when_count_is_greater_th
         }],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -263,6 +269,7 @@ fn should_render_tests_section_between_definitions_and_other_changed_files_when_
         }],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -317,6 +324,7 @@ fn should_omit_generated_skip_entry_from_markdown_output() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -352,6 +360,7 @@ fn should_omit_only_generated_entries_when_skipped_has_other_reasons_too() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 

--- a/rinkaku-core/src/render/markdown_tests/lookup_miss_defenses.rs
+++ b/rinkaku-core/src/render/markdown_tests/lookup_miss_defenses.rs
@@ -33,6 +33,7 @@ fn should_skip_definitions_entry_when_visit_order_id_has_no_matching_symbol() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -69,6 +70,7 @@ fn should_render_nothing_for_root_when_root_id_has_no_matching_symbol() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -123,6 +125,7 @@ fn should_omit_cycle_warning_line_when_cycle_target_id_has_no_matching_symbol() 
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 

--- a/rinkaku-core/src/render/markdown_tests/mod.rs
+++ b/rinkaku-core/src/render/markdown_tests/mod.rs
@@ -11,7 +11,7 @@
 //! - [`definition_body`] — one symbol's "### ..." entry: container
 //!   comment, `Depends on:` list, and the fence-widening rules.
 //! - [`sections_skipped_fan_in_filesize`] — the "Skipped files",
-//!   "High fan-in symbols", and "File size warnings" sections plus the
+//!   "High fan-in symbols", and "File sizes" sections plus the
 //!   ADR 0028 JSON shape.
 //! - [`lookup_miss_defenses`] — defensive branches for a `graph` node
 //!   with no matching `ExtractedSymbol` in `files`.

--- a/rinkaku-core/src/render/markdown_tests/sections_skipped_fan_in_filesize.rs
+++ b/rinkaku-core/src/render/markdown_tests/sections_skipped_fan_in_filesize.rs
@@ -39,6 +39,7 @@ fn should_render_skipped_files_section_when_report_has_skips() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -80,6 +81,7 @@ fn should_render_change_graph_then_skipped_section_when_report_has_both() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -130,6 +132,7 @@ fn should_omit_high_fan_in_symbols_section_when_fan_ins_is_empty() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -226,6 +229,7 @@ fn should_render_high_fan_in_symbols_section_between_change_graph_and_definition
             used_by: vec!["HandleBar".to_string(), "HandleFoo".to_string()],
         }],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -298,6 +302,7 @@ fn should_render_fan_in_line_for_symbol_with_no_matching_definition() {
             used_by: vec!["a".to_string(), "b".to_string()],
         }],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -357,6 +362,7 @@ fn should_render_file_size_warnings_section_when_warnings_are_present() {
                 severity: crate::file_size::FileSizeSeverity::Warn,
             },
         ],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -411,6 +417,7 @@ fn should_omit_file_size_warnings_section_when_report_has_no_warnings() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -490,6 +497,7 @@ fn should_place_file_size_warnings_between_high_fan_in_symbols_and_definitions()
             line_count: 2500,
             severity: crate::file_size::FileSizeSeverity::Split,
         }],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -565,6 +573,7 @@ fn should_include_file_size_warnings_in_json_output() {
                 severity: crate::file_size::FileSizeSeverity::Warn,
             },
         ],
+        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -591,6 +600,7 @@ fn should_include_file_size_warnings_in_json_output() {
       \"severity\": \"warn\"
     }
   ],
+  \"file_size_bands\": [],
   \"removed\": []
 }"
     .to_string();

--- a/rinkaku-core/src/render/markdown_tests/sections_skipped_fan_in_filesize.rs
+++ b/rinkaku-core/src/render/markdown_tests/sections_skipped_fan_in_filesize.rs
@@ -369,8 +369,8 @@ fn should_render_file_size_warnings_section_when_warnings_are_present() {
 
 ## File size warnings
 
-- 🚨 `b.rs` (2500 lines) — over the 2000-line split threshold
-- ⚠ `a.rs` (1600 lines) — over the 1500-line watch threshold; consider splitting
+- 🚨 `b.rs` (2500 lines) — over the 1500-line split threshold
+- ⚠ `a.rs` (1600 lines) — over the 1000-line watch threshold; consider splitting
 
 ## Definitions
 
@@ -507,7 +507,7 @@ fn should_place_file_size_warnings_between_high_fan_in_symbols_and_definitions()
 
 ## File size warnings
 
-- 🚨 `store/items.go` (2500 lines) — over the 2000-line split threshold
+- 🚨 `store/items.go` (2500 lines) — over the 1500-line split threshold
 
 ## Definitions
 

--- a/rinkaku-core/src/render/markdown_tests/sections_skipped_fan_in_filesize.rs
+++ b/rinkaku-core/src/render/markdown_tests/sections_skipped_fan_in_filesize.rs
@@ -1,6 +1,6 @@
 //! The three optional post-graph sections — "## Skipped files",
 //! "## High fan-in symbols" (ADR 0013, named per ADR 0034), and
-//! "## File size warnings" (ADR 0028) — plus the ADR 0028 shape of
+//! "## File sizes" (ADR 0028, amended) — plus the ADR 0028 shape of
 //! `file_size_warnings` in JSON output. Pins that each section is
 //! emitted only when its list is non-empty and that they land in the
 //! correct order relative to "Change graph" / "Definitions".
@@ -326,11 +326,7 @@ fn should_render_fan_in_line_for_symbol_with_no_matching_definition() {
 }
 
 #[test]
-fn should_render_file_size_warnings_section_when_warnings_are_present() {
-    // Two warnings across both severities: the `Split` entry must come
-    // first (ADR 0028 orders `Split` before `Warn`), each glyph and the
-    // threshold-numbered explanation pinned exactly as the ADR spec
-    // shows.
+fn should_render_file_sizes_section_in_report_order_across_all_bands() {
     let report = Report {
         origin: ReportOrigin::Diff,
         files: vec![FileReport {
@@ -350,19 +346,29 @@ fn should_render_file_size_warnings_section_when_warnings_are_present() {
         },
         tests: vec![],
         fan_ins: vec![],
-        file_size_warnings: vec![
-            crate::file_size::FileSizeWarning {
-                path: "b.rs".to_string(),
-                line_count: 2500,
-                severity: crate::file_size::FileSizeSeverity::Split,
-            },
-            crate::file_size::FileSizeWarning {
+        file_size_warnings: vec![],
+        file_size_bands: vec![
+            crate::file_size::FileSizeEntry {
                 path: "a.rs".to_string(),
-                line_count: 1600,
-                severity: crate::file_size::FileSizeSeverity::Warn,
+                line_count: 80,
+                band: crate::file_size::FileSizeBand::Normal,
+            },
+            crate::file_size::FileSizeEntry {
+                path: "b.rs".to_string(),
+                line_count: 700,
+                band: crate::file_size::FileSizeBand::Watch,
+            },
+            crate::file_size::FileSizeEntry {
+                path: "c.rs".to_string(),
+                line_count: 1200,
+                band: crate::file_size::FileSizeBand::Warn,
+            },
+            crate::file_size::FileSizeEntry {
+                path: "d.rs".to_string(),
+                line_count: 2500,
+                band: crate::file_size::FileSizeBand::Split,
             },
         ],
-        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -373,10 +379,12 @@ fn should_render_file_size_warnings_section_when_warnings_are_present() {
 
 - fn foo (src/lib.rs)
 
-## File size warnings
+## File sizes
 
-- 🚨 `b.rs` (2500 lines) — over the 1500-line split threshold
-- ⚠ `a.rs` (1600 lines) — over the 1000-line watch threshold; consider splitting
+- `a.rs` (80 lines)
+- `b.rs` (700 lines, watch)
+- `c.rs` (1200 lines, warn)
+- `d.rs` (2500 lines, split)
 
 ## Definitions
 
@@ -394,9 +402,7 @@ fn foo()
 }
 
 #[test]
-fn should_omit_file_size_warnings_section_when_report_has_no_warnings() {
-    // Empty `file_size_warnings` must drop the whole section — no bare
-    // "## File size warnings" heading with nothing under it.
+fn should_omit_file_sizes_section_when_report_has_no_bands() {
     let report = Report {
         origin: ReportOrigin::Diff,
         files: vec![FileReport {
@@ -423,15 +429,11 @@ fn should_omit_file_size_warnings_section_when_report_has_no_warnings() {
 
     let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
 
-    assert!(!actual.contains("## File size warnings"));
+    assert!(!actual.contains("## File sizes"));
 }
 
 #[test]
-fn should_place_file_size_warnings_between_high_fan_in_symbols_and_definitions() {
-    // A report with both a high-fan-in symbol and a file-size warning:
-    // the `## File size warnings` section must land after
-    // `## High fan-in symbols` and before `## Definitions`, matching
-    // ADR 0028's placement decision.
+fn should_place_file_sizes_between_high_fan_in_symbols_and_definitions() {
     let report = Report {
         origin: ReportOrigin::Diff,
         files: vec![FileReport {
@@ -492,12 +494,12 @@ fn should_place_file_size_warnings_between_high_fan_in_symbols_and_definitions()
             name: "UpsertItemsRequest".to_string(),
             used_by: vec!["HandleBar".to_string(), "HandleFoo".to_string()],
         }],
-        file_size_warnings: vec![crate::file_size::FileSizeWarning {
+        file_size_warnings: vec![],
+        file_size_bands: vec![crate::file_size::FileSizeEntry {
             path: "store/items.go".to_string(),
             line_count: 2500,
-            severity: crate::file_size::FileSizeSeverity::Split,
+            band: crate::file_size::FileSizeBand::Split,
         }],
-        file_size_bands: vec![],
         removed: vec![],
     };
 
@@ -513,9 +515,9 @@ fn should_place_file_size_warnings_between_high_fan_in_symbols_and_definitions()
 
 - struct UpsertItemsRequest (store/items.go) — used by 2: HandleBar, HandleFoo
 
-## File size warnings
+## File sizes
 
-- 🚨 `store/items.go` (2500 lines) — over the 1500-line split threshold
+- `store/items.go` (2500 lines, split)
 
 ## Definitions
 

--- a/rinkaku-core/src/render/mermaid.rs
+++ b/rinkaku-core/src/render/mermaid.rs
@@ -984,6 +984,7 @@ flowchart LR
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![removed_symbol("old_only", "src/gone.rs")],
         };
 

--- a/rinkaku-core/src/render/mermaid.rs
+++ b/rinkaku-core/src/render/mermaid.rs
@@ -376,6 +376,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }
@@ -626,6 +627,7 @@ flowchart LR
                 used_by: vec!["a".to_string(), "b".to_string()],
             }],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         };
 
@@ -681,6 +683,7 @@ flowchart LR
                 used_by: vec!["a".to_string(), "b".to_string()],
             }],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         };
 

--- a/rinkaku-core/src/render/report.rs
+++ b/rinkaku-core/src/render/report.rs
@@ -59,6 +59,15 @@ pub struct Report {
     /// consumers get it as an always-present top-level field, matching how
     /// `fan_ins` above is already exposed.
     pub file_size_warnings: Vec<crate::file_size::FileSizeWarning>,
+    /// Every analyzed file's line count and [`crate::file_size::FileSizeBand`]
+    /// (ADR 0028 amendment) — unlike `file_size_warnings` above, which only
+    /// covers the Warn/Split subset, this covers every file so Markdown/TUI
+    /// can show a line count next to every file, not only the ones already
+    /// worth a dedicated warning. Derived from the same `(path, line_count)`
+    /// pairs as `file_size_warnings`, via
+    /// [`crate::file_size::compute_file_size_bands`], sorted by path
+    /// ascending (see that function's doc comment for why).
+    pub file_size_bands: Vec<crate::file_size::FileSizeEntry>,
     /// Symbols present on the base side of a diff but absent from the head
     /// side entirely (ADR 0014's `removed` classification) — reported
     /// separately from `files` since a removed symbol has no head-side
@@ -208,6 +217,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         };
 
@@ -228,6 +238,7 @@ mod tests {
   \"tests\": [],
   \"fan_ins\": [],
   \"file_size_warnings\": [],
+  \"file_size_bands\": [],
   \"removed\": []
 }"
         .to_string();
@@ -257,6 +268,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         };
 
@@ -273,6 +285,7 @@ mod tests {
   \"tests\": [],
   \"fan_ins\": [],
   \"file_size_warnings\": [],
+  \"file_size_bands\": [],
   \"removed\": []
 }"
         .to_string();
@@ -306,6 +319,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         };
 
@@ -353,6 +367,7 @@ mod tests {
   \"tests\": [],
   \"fan_ins\": [],
   \"file_size_warnings\": [],
+  \"file_size_bands\": [],
   \"removed\": []
 }"
         .to_string();
@@ -386,6 +401,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![RemovedSymbol {
                 name: "old_helper".to_string(),
                 kind: SymbolKind::Function,
@@ -435,6 +451,7 @@ mod tests {
   \"tests\": [],
   \"fan_ins\": [],
   \"file_size_warnings\": [],
+  \"file_size_bands\": [],
   \"removed\": [
     {
       \"name\": \"old_helper\",

--- a/rinkaku-tui/src/app/tests/mod.rs
+++ b/rinkaku-tui/src/app/tests/mod.rs
@@ -74,6 +74,7 @@ pub(super) fn empty_report() -> Report {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     }
 }

--- a/rinkaku-tui/src/blast_radius.rs
+++ b/rinkaku-tui/src/blast_radius.rs
@@ -289,6 +289,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/detail_tests/mod.rs
+++ b/rinkaku-tui/src/detail_tests/mod.rs
@@ -60,6 +60,7 @@ pub(super) fn empty_report() -> Report {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     }
 }

--- a/rinkaku-tui/src/diff_shape_tests/mod.rs
+++ b/rinkaku-tui/src/diff_shape_tests/mod.rs
@@ -53,6 +53,7 @@ pub(super) fn empty_report() -> Report {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     }
 }

--- a/rinkaku-tui/src/lib_tests/mod.rs
+++ b/rinkaku-tui/src/lib_tests/mod.rs
@@ -45,6 +45,7 @@ pub(super) fn empty_report() -> Report {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     }
 }

--- a/rinkaku-tui/src/order/rank_tests/mod.rs
+++ b/rinkaku-tui/src/order/rank_tests/mod.rs
@@ -57,6 +57,7 @@ pub(super) fn report_with_graph(nodes: Vec<Node>, edges: Vec<Edge>) -> Report {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     }
 }

--- a/rinkaku-tui/src/order/sort_tests/mod.rs
+++ b/rinkaku-tui/src/order/sort_tests/mod.rs
@@ -31,6 +31,7 @@ pub(super) fn report_with_graph(nodes: Vec<Node>, edges: Vec<Edge>) -> Report {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     }
 }

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -18,7 +18,7 @@ use crate::tree::{Badges, NodeKind, SymbolRef};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use rinkaku_core::extract::{Classification, SymbolKind};
-use rinkaku_core::file_size::FileSizeSeverity;
+use rinkaku_core::file_size::FileSizeBand;
 use std::collections::HashMap;
 
 /// Indent width per tree depth level, in columns.
@@ -251,13 +251,13 @@ enum BadgeContext {
 ///   removed symbol) is the one badge that flags something a caller
 ///   should double-check, restoring in color the "pay attention" signal
 ///   the original `!` glyph carried on its own.
-/// - The file-size warnings (ADR 0028) deliberately use **text labels
-///   plus color** rather than an emoji glyph (`⚠` / `🚨`): terminal
-///   emoji rendering width is inconsistent enough to distort the tree
-///   column layout, and the color already encodes severity. Only the
-///   numeric N portion is colored (yellow for Warn, red for Split); the
-///   `lines:` / `warn:` / `split:` label stays default so the eye lands
-///   on the number.
+/// - The file-size badges (ADR 0028, amended to always show a line count)
+///   deliberately use **text labels plus color** rather than an emoji
+///   glyph (`⚠` / `🚨`): terminal emoji rendering width is inconsistent
+///   enough to distort the tree column layout. The per-file `lines:N`
+///   badge's color follows [`band_style`]'s 4-band scale, independent of
+///   the directory-level `warn:N split:N` aggregate, which only ever
+///   counts `Warn`/`Split` files (see `Badges`' doc comment).
 fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: BadgeContext) {
     let cyan = Style::default().fg(Color::Cyan);
     let mut wrote_any_ascii_badge = false;
@@ -286,13 +286,10 @@ fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: Ba
         wrote_any_ascii_badge = true;
     }
 
-    // File-size warning badges (ADR 0028) — text label + color, no
-    // emoji. Rendered as separate spans so only the numeric N picks up
-    // the severity color.
     match context {
         BadgeContext::File => {
-            if let (Some(severity), Some(line_count)) =
-                (badges.own_file_size_severity, badges.own_file_line_count)
+            if let (Some(band), Some(line_count)) =
+                (badges.own_file_size_band, badges.own_file_line_count)
             {
                 // Leading space only when a preceding badge wrote
                 // something — otherwise the row would gain a stray gap.
@@ -300,10 +297,7 @@ fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: Ba
                     spans.push(Span::raw(" "));
                 }
                 spans.push(Span::raw("lines:"));
-                spans.push(Span::styled(
-                    line_count.to_string(),
-                    Style::default().fg(severity_color(severity)),
-                ));
+                spans.push(Span::styled(line_count.to_string(), band_style(band)));
             }
         }
         BadgeContext::Dir => {
@@ -333,14 +327,15 @@ fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: Ba
     }
 }
 
-/// Maps a [`FileSizeSeverity`] to its display color — yellow for `Warn`,
-/// red for `Split`. Shared by the file-row `lines:N` badge and the
-/// directory-row `warn:N` / `split:N` aggregates so both surfaces agree
-/// on the color legend.
-fn severity_color(severity: FileSizeSeverity) -> Color {
-    match severity {
-        FileSizeSeverity::Warn => Color::Yellow,
-        FileSizeSeverity::Split => Color::Red,
+/// File-row `lines:N` badge style per [`FileSizeBand`] (ADR 0028
+/// amendment). `Split` is additionally bold so it doesn't read
+/// identically to `Warn`, which shares its red foreground.
+fn band_style(band: FileSizeBand) -> Style {
+    match band {
+        FileSizeBand::Normal => Style::default(),
+        FileSizeBand::Watch => Style::default().fg(Color::Yellow),
+        FileSizeBand::Warn => Style::default().fg(Color::Red),
+        FileSizeBand::Split => Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
     }
 }
 

--- a/rinkaku-tui/src/row_view_tests/file_size_badges.rs
+++ b/rinkaku-tui/src/row_view_tests/file_size_badges.rs
@@ -1,19 +1,64 @@
-// File-size warning badges (ADR 0028): a file row carrying a warning
-// renders `lines:{N}` with the numeric N colored by severity (yellow
-// for Warn, red for Split), and a directory row aggregates the
-// per-severity counts as `warn:N split:N` with the numbers colored
-// the same way. No emoji glyphs — the color already conveys severity
-// and emoji rendering width is inconsistent across terminals.
-
 use super::*;
 
 #[test]
-fn should_render_lines_count_in_yellow_when_file_has_warn_severity() {
+fn should_render_lines_count_unstyled_when_file_has_normal_band() {
+    let node = TreeNode {
+        kind: NodeKind::File,
+        path: "src/small.rs".to_string(),
+        badges: Badges {
+            own_file_size_band: Some(FileSizeBand::Normal),
+            own_file_line_count: Some(80),
+            ..Badges::default()
+        },
+        children: vec![],
+        skip_reason: None,
+        test_symbol_count: None,
+    };
+    let row = Row {
+        node: &node,
+        depth: 0,
+        expanded: false,
+    };
+
+    let line = entry_row_line(&row, "small.rs", &HashMap::new(), false);
+
+    assert_eq!("  small.rs lines:80", line_text(&line));
+    assert_eq!(None, fg_of_span_with_content(&line, "80"));
+}
+
+#[test]
+fn should_render_lines_count_in_yellow_when_file_has_watch_band() {
+    let node = TreeNode {
+        kind: NodeKind::File,
+        path: "src/mid.rs".to_string(),
+        badges: Badges {
+            own_file_size_band: Some(FileSizeBand::Watch),
+            own_file_line_count: Some(700),
+            ..Badges::default()
+        },
+        children: vec![],
+        skip_reason: None,
+        test_symbol_count: None,
+    };
+    let row = Row {
+        node: &node,
+        depth: 0,
+        expanded: false,
+    };
+
+    let line = entry_row_line(&row, "mid.rs", &HashMap::new(), false);
+
+    assert_eq!("  mid.rs lines:700", line_text(&line));
+    assert_eq!(Some(Color::Yellow), fg_of_span_with_content(&line, "700"));
+}
+
+#[test]
+fn should_render_lines_count_in_red_when_file_has_warn_band() {
     let node = TreeNode {
         kind: NodeKind::File,
         path: "src/big.rs".to_string(),
         badges: Badges {
-            own_file_size_severity: Some(FileSizeSeverity::Warn),
+            own_file_size_band: Some(FileSizeBand::Warn),
             own_file_line_count: Some(1734),
             ..Badges::default()
         },
@@ -30,19 +75,17 @@ fn should_render_lines_count_in_yellow_when_file_has_warn_severity() {
     let line = entry_row_line(&row, "big.rs", &HashMap::new(), false);
 
     assert_eq!("  big.rs lines:1734", line_text(&line));
-    // The numeric 1734 span carries the severity color; the leading
-    // "lines:" label stays uncolored so the eye lands on the number.
-    assert_eq!(Some(Color::Yellow), fg_of_span_with_content(&line, "1734"));
+    assert_eq!(Some(Color::Red), fg_of_span_with_content(&line, "1734"));
     assert_eq!(None, fg_of_span_with_content(&line, "lines:"));
 }
 
 #[test]
-fn should_render_lines_count_in_red_when_file_has_split_severity() {
+fn should_render_lines_count_in_bold_red_when_file_has_split_band() {
     let node = TreeNode {
         kind: NodeKind::File,
         path: "src/huge.rs".to_string(),
         badges: Badges {
-            own_file_size_severity: Some(FileSizeSeverity::Split),
+            own_file_size_band: Some(FileSizeBand::Split),
             own_file_line_count: Some(4837),
             ..Badges::default()
         },
@@ -60,6 +103,12 @@ fn should_render_lines_count_in_red_when_file_has_split_severity() {
 
     assert_eq!("  huge.rs lines:4837", line_text(&line));
     assert_eq!(Some(Color::Red), fg_of_span_with_content(&line, "4837"));
+    let span = line
+        .spans
+        .iter()
+        .find(|span| span.content.as_ref() == "4837")
+        .expect("line_count span must be present");
+    assert!(span.style.add_modifier.contains(Modifier::BOLD));
 }
 
 #[test]
@@ -82,9 +131,6 @@ fn should_render_warn_and_split_labels_side_by_side_on_dir_row() {
     let line = entry_row_line(&row, "src", &HashMap::new(), false);
 
     assert_eq!("v src warn:2 split:1", line_text(&line));
-    // The numeric part of each half picks up its own severity color;
-    // the "warn:" / "split:" labels themselves stay uncolored so the
-    // eye lands on the counts.
     assert_eq!(Some(Color::Yellow), fg_of_span_with_content(&line, "2"));
     assert_eq!(Some(Color::Red), fg_of_span_with_content(&line, "1"));
     assert_eq!(None, fg_of_span_with_content(&line, "warn:"));
@@ -92,7 +138,7 @@ fn should_render_warn_and_split_labels_side_by_side_on_dir_row() {
 }
 
 #[test]
-fn should_not_render_file_size_badge_when_file_node_has_no_warning() {
+fn should_not_render_file_size_badge_when_file_node_has_no_band() {
     let node = file_node("lib.rs", Badges::default());
     let row = Row {
         node: &node,
@@ -110,9 +156,6 @@ fn should_not_render_file_size_badge_when_file_node_has_no_warning() {
 
 #[test]
 fn should_render_only_warn_label_on_dir_row_when_no_split_files() {
-    // When only one severity is present under a directory, only that
-    // half of the badge shows — the other half is omitted rather
-    // than rendered as "warn:0" or "split:0".
     let node = dir_node(
         "src",
         Badges {

--- a/rinkaku-tui/src/source.rs
+++ b/rinkaku-tui/src/source.rs
@@ -326,6 +326,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/tree/mod.rs
+++ b/rinkaku-tui/src/tree/mod.rs
@@ -7,7 +7,7 @@
 //! separate concern, see `crate::order`).
 
 use rinkaku_core::extract::{Classification, SymbolKind};
-use rinkaku_core::file_size::FileSizeSeverity;
+use rinkaku_core::file_size::FileSizeBand;
 use rinkaku_core::render::{Report, SkipReason};
 use std::collections::{BTreeMap, HashMap};
 
@@ -129,33 +129,22 @@ impl SectionKind {
 ///   nothing to any ancestor directory's `fan_in` badge here — expected,
 ///   not a bug, since the badge's whole purpose is to flag high-fan-in
 ///   symbols specifically, not fan-in in general.
-/// - `own_file_size_severity`: the severity of this file node's own
-///   [`FileSizeWarning`] (ADR 0028), or `None` when the file is under
-///   the watch threshold and for every non-file node. Paired with
-///   `own_file_line_count`. Deliberately **not** merged upward: a
-///   directory has no single severity of its own, only the aggregated
-///   counts below (which are split by severity, so a mixed subtree of
-///   `Warn` and `Split` files reads as `warn:N split:M` rather than
-///   collapsing into one meaningless total).
-/// - `own_file_line_count`: this file node's own line count, matching
-///   the [`FileSizeWarning`] it carries. `None` when the file is under
-///   the watch threshold and for every non-file node. Kept alongside
-///   `own_file_size_severity` so the file row can render `lines:{N}`
-///   without a second lookup back into the report.
-/// - `file_size_warn_count`: bottom-up **count** of file nodes in this
-///   subtree whose own severity is `FileSizeSeverity::Warn`. A directory
-///   row displays this as `warn:N` (colored yellow) when nonzero — same
-///   aggregation pattern as `fan_in` — and severity is kept split from
-///   `file_size_split_count` so the reader sees "how many yellow" and
-///   "how many red" separately.
-/// - `file_size_split_count`: same as above for `FileSizeSeverity::Split`;
-///   renders as `split:N` (colored red) on directory rows.
+/// - `own_file_size_band`/`own_file_line_count`: this file node's own
+///   [`FileSizeBand`] and line count (ADR 0028 amendment), `None` for
+///   every non-file node. Deliberately **not** merged upward — a
+///   directory has no single band of its own, only the aggregates below.
+/// - `file_size_warn_count`/`file_size_split_count`: bottom-up count of
+///   file nodes in this subtree at [`FileSizeBand::Warn`]/`Split`
+///   respectively, rendered as `warn:N`/`split:N` on directory rows.
+///   `Normal`/`Watch` files contribute to neither — those two bands are
+///   shown per-file only, not aggregated, since they are not
+///   "attention-worthy" the way `Warn`/`Split` are.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Badges {
     pub changed_symbols: usize,
     pub contract_changes: usize,
     pub fan_in: usize,
-    pub own_file_size_severity: Option<FileSizeSeverity>,
+    pub own_file_size_band: Option<FileSizeBand>,
     pub own_file_line_count: Option<usize>,
     pub file_size_warn_count: usize,
     pub file_size_split_count: usize,
@@ -168,10 +157,6 @@ impl Badges {
         self.fan_in += other.fan_in;
         self.file_size_warn_count += other.file_size_warn_count;
         self.file_size_split_count += other.file_size_split_count;
-        // `own_file_size_severity` / `own_file_line_count` are per-file
-        // attributes, not aggregates — see this struct's doc comment.
-        // The aggregates live in `file_size_warn_count` /
-        // `file_size_split_count` above, split by severity.
     }
 }
 
@@ -279,15 +264,14 @@ pub fn build_tree(report: &Report) -> Tree {
         .map(|fan_in| (fan_in.id.as_str(), fan_in.used_by.len()))
         .collect();
 
-    let file_size_by_path: HashMap<&str, (FileSizeSeverity, usize)> = report
-        .file_size_warnings
+    // ADR 0028 amendment: built from `file_size_bands` (every analyzed
+    // file), not `file_size_warnings` (the Warn/Split subset) — so a
+    // file row can always show its line count, not only when it crosses
+    // the warn threshold.
+    let file_size_by_path: HashMap<&str, (FileSizeBand, usize)> = report
+        .file_size_bands
         .iter()
-        .map(|warning| {
-            (
-                warning.path.as_str(),
-                (warning.severity, warning.line_count),
-            )
-        })
+        .map(|entry| (entry.path.as_str(), (entry.band, entry.line_count)))
         .collect();
 
     let mut production = TreeBuilder::new(fan_in_by_id.clone(), file_size_by_path.clone());
@@ -340,14 +324,10 @@ struct TreeBuilder<'a> {
     /// `report.files` — built once in `build_tree` rather than per-symbol,
     /// since `report.fan_ins` doesn't change during one `build_tree` call.
     fan_in_by_id: HashMap<&'a str, usize>,
-    /// `report.file_size_warnings`, keyed by path — the value is
-    /// `(severity, line_count)` so a file node can populate both
-    /// `own_file_size_severity` and `own_file_line_count` (and its
-    /// per-severity contribution to the aggregate `file_size_warn_count` /
-    /// `file_size_split_count`) in one lookup, while walking every source
-    /// of file rows (`report.files`, `report.tests`, `report.skipped`).
-    /// Built once in `build_tree`, same reasoning as `fan_in_by_id`.
-    file_size_by_path: HashMap<&'a str, (FileSizeSeverity, usize)>,
+    /// `report.file_size_bands` keyed by path (ADR 0028 amendment):
+    /// covers every analyzed file, not only `Warn`/`Split` as the
+    /// pre-amendment `file_size_warnings`-derived map did.
+    file_size_by_path: HashMap<&'a str, (FileSizeBand, usize)>,
 }
 
 #[derive(Default)]
@@ -374,7 +354,7 @@ struct FileBuilder {
 impl<'a> TreeBuilder<'a> {
     fn new(
         fan_in_by_id: HashMap<&'a str, usize>,
-        file_size_by_path: HashMap<&'a str, (FileSizeSeverity, usize)>,
+        file_size_by_path: HashMap<&'a str, (FileSizeBand, usize)>,
     ) -> Self {
         Self {
             root: DirBuilder::default(),
@@ -519,15 +499,12 @@ impl DirBuilder {
     /// order, applying single-child directory collapsing (see
     /// `build_tree`'s doc comment) and computing bottom-up [`Badges`] as it
     /// goes. `fan_in_by_id` is threaded through to leaf symbols unchanged —
-    /// see `symbol_badges`. `file_size_by_path` is threaded to file nodes,
-    /// where a match seeds `own_file_size_severity` /
-    /// `own_file_line_count` and the per-severity contribution to the
-    /// aggregated `file_size_warn_count` / `file_size_split_count`.
+    /// see `symbol_badges`.
     fn into_nodes(
         self,
         prefix: String,
         fan_in_by_id: &HashMap<&str, usize>,
-        file_size_by_path: &HashMap<&str, (FileSizeSeverity, usize)>,
+        file_size_by_path: &HashMap<&str, (FileSizeBand, usize)>,
     ) -> Vec<TreeNode> {
         let DirBuilder {
             mut dirs,
@@ -575,7 +552,7 @@ fn build_dir_node(
     prefix: &str,
     mut dir: DirBuilder,
     fan_in_by_id: &HashMap<&str, usize>,
-    file_size_by_path: &HashMap<&str, (FileSizeSeverity, usize)>,
+    file_size_by_path: &HashMap<&str, (FileSizeBand, usize)>,
 ) -> TreeNode {
     let mut label = name;
     loop {
@@ -615,29 +592,21 @@ fn build_file_node(
     prefix: &str,
     file: FileBuilder,
     fan_in_by_id: &HashMap<&str, usize>,
-    file_size_by_path: &HashMap<&str, (FileSizeSeverity, usize)>,
+    file_size_by_path: &HashMap<&str, (FileSizeBand, usize)>,
 ) -> TreeNode {
     let path = join_path(prefix, &name);
-    let (own_file_size_severity, own_file_line_count) = match file_size_by_path.get(path.as_str()) {
-        Some((severity, line_count)) => (Some(*severity), Some(*line_count)),
+    let (own_file_size_band, own_file_line_count) = match file_size_by_path.get(path.as_str()) {
+        Some((band, line_count)) => (Some(*band), Some(*line_count)),
         None => (None, None),
     };
-    // A file with its own warning contributes 1 to the matching aggregate
-    // count so an ancestor directory's `Badges::merge` sums the correct
-    // per-severity totals (which `Badges::merge` does — the aggregate
-    // fields — while it deliberately does not merge
-    // `own_file_size_severity` / `own_file_line_count`, see `Badges`'
-    // doc comment).
-    let file_size_warn_count = usize::from(matches!(
-        own_file_size_severity,
-        Some(FileSizeSeverity::Warn)
-    ));
-    let file_size_split_count = usize::from(matches!(
-        own_file_size_severity,
-        Some(FileSizeSeverity::Split)
-    ));
+    // A Warn/Split file contributes 1 to the matching aggregate count so
+    // an ancestor directory's `Badges::merge` sums the correct per-band
+    // totals — see `Badges`' doc comment.
+    let file_size_warn_count = usize::from(matches!(own_file_size_band, Some(FileSizeBand::Warn)));
+    let file_size_split_count =
+        usize::from(matches!(own_file_size_band, Some(FileSizeBand::Split)));
     let mut badges = Badges {
-        own_file_size_severity,
+        own_file_size_band,
         own_file_line_count,
         file_size_warn_count,
         file_size_split_count,
@@ -689,10 +658,10 @@ fn symbol_badges(symbol_ref: &SymbolRef, fan_in_by_id: &HashMap<&str, usize>) ->
             .get(symbol_ref.id.as_str())
             .copied()
             .unwrap_or(0),
-        // File-size warnings are a per-file attribute (ADR 0028), not a
-        // per-symbol one, so a symbol never contributes to any of the
-        // file-size fields.
-        own_file_size_severity: None,
+        // File size is a per-file attribute (ADR 0028), not a per-symbol
+        // one, so a symbol never contributes to any of the file-size
+        // fields.
+        own_file_size_band: None,
         own_file_line_count: None,
         file_size_warn_count: 0,
         file_size_split_count: 0,

--- a/rinkaku-tui/src/tree/tree_tests/file_size_warnings.rs
+++ b/rinkaku-tui/src/tree/tree_tests/file_size_warnings.rs
@@ -1,23 +1,18 @@
 use super::*;
 use pretty_assertions::assert_eq;
 
-// File-size warning badge tests (ADR 0028): a file rinkaku measured as
-// oversized must carry its own severity + line count on the file node,
-// and its containing directories must aggregate the count split by
-// severity so `row_view` can render the pair (`warn:N split:M`).
-
 #[test]
-fn should_populate_own_file_line_count_when_report_has_warning_for_that_path() {
+fn should_populate_own_file_line_count_when_report_has_band_for_that_path() {
     let report = Report {
         origin: rinkaku_core::render::ReportOrigin::Diff,
         files: vec![FileReport {
             path: "src/big.rs".to_string(),
             symbols: vec![],
         }],
-        file_size_warnings: vec![rinkaku_core::file_size::FileSizeWarning {
+        file_size_bands: vec![rinkaku_core::file_size::FileSizeEntry {
             path: "src/big.rs".to_string(),
             line_count: 1734,
-            severity: FileSizeSeverity::Warn,
+            band: FileSizeBand::Warn,
         }],
         ..empty_report()
     };
@@ -27,7 +22,7 @@ fn should_populate_own_file_line_count_when_report_has_warning_for_that_path() {
     // Root is the "src" Dir; file node is its only child.
     let file_node = &tree.roots[0].children[0];
     let expected = Badges {
-        own_file_size_severity: Some(FileSizeSeverity::Warn),
+        own_file_size_band: Some(FileSizeBand::Warn),
         own_file_line_count: Some(1734),
         file_size_warn_count: 1,
         file_size_split_count: 0,
@@ -38,10 +33,6 @@ fn should_populate_own_file_line_count_when_report_has_warning_for_that_path() {
 
 #[test]
 fn should_aggregate_warn_and_split_counts_separately_on_parent_dir() {
-    // src/warn.rs = Warn, src/split.rs = Split, src/ok.rs = under
-    // threshold. The parent "src" dir must show warn_count=1,
-    // split_count=1 — kept split by severity so the row can render
-    // `warn:1 split:1` rather than merging into one meaningless total.
     let report = Report {
         origin: rinkaku_core::render::ReportOrigin::Diff,
         files: vec![
@@ -58,16 +49,21 @@ fn should_aggregate_warn_and_split_counts_separately_on_parent_dir() {
                 symbols: vec![],
             },
         ],
-        file_size_warnings: vec![
-            rinkaku_core::file_size::FileSizeWarning {
+        file_size_bands: vec![
+            rinkaku_core::file_size::FileSizeEntry {
                 path: "src/warn.rs".to_string(),
                 line_count: 1600,
-                severity: FileSizeSeverity::Warn,
+                band: FileSizeBand::Warn,
             },
-            rinkaku_core::file_size::FileSizeWarning {
+            rinkaku_core::file_size::FileSizeEntry {
                 path: "src/split.rs".to_string(),
                 line_count: 2500,
-                severity: FileSizeSeverity::Split,
+                band: FileSizeBand::Split,
+            },
+            rinkaku_core::file_size::FileSizeEntry {
+                path: "src/ok.rs".to_string(),
+                line_count: 10,
+                band: FileSizeBand::Normal,
             },
         ],
         ..empty_report()
@@ -79,9 +75,7 @@ fn should_aggregate_warn_and_split_counts_separately_on_parent_dir() {
     let expected = Badges {
         file_size_warn_count: 1,
         file_size_split_count: 1,
-        // Directories deliberately never carry per-node severity /
-        // line_count of their own — those live only on file rows.
-        own_file_size_severity: None,
+        own_file_size_band: None,
         own_file_line_count: None,
         ..Badges::default()
     };
@@ -89,20 +83,17 @@ fn should_aggregate_warn_and_split_counts_separately_on_parent_dir() {
 }
 
 #[test]
-fn should_leave_own_file_size_severity_none_on_dir_node() {
-    // Even when a directory aggregates a nonzero warn/split count
-    // from below, its own_file_size_severity / own_file_line_count
-    // must stay None — those two fields are per-file attributes only.
+fn should_leave_own_file_size_band_none_on_dir_node() {
     let report = Report {
         origin: rinkaku_core::render::ReportOrigin::Diff,
         files: vec![FileReport {
             path: "src/big.rs".to_string(),
             symbols: vec![],
         }],
-        file_size_warnings: vec![rinkaku_core::file_size::FileSizeWarning {
+        file_size_bands: vec![rinkaku_core::file_size::FileSizeEntry {
             path: "src/big.rs".to_string(),
             line_count: 3000,
-            severity: FileSizeSeverity::Split,
+            band: FileSizeBand::Split,
         }],
         ..empty_report()
     };
@@ -110,8 +101,48 @@ fn should_leave_own_file_size_severity_none_on_dir_node() {
     let tree = build_tree(&report);
 
     let dir_node = &tree.roots[0];
-    assert_eq!(None, dir_node.badges.own_file_size_severity);
+    assert_eq!(None, dir_node.badges.own_file_size_band);
     assert_eq!(None, dir_node.badges.own_file_line_count);
-    // Aggregates still count the descendant.
     assert_eq!(1, dir_node.badges.file_size_split_count);
+}
+
+#[test]
+fn should_not_aggregate_warn_or_split_count_when_band_is_normal_or_watch() {
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![
+            FileReport {
+                path: "src/normal.rs".to_string(),
+                symbols: vec![],
+            },
+            FileReport {
+                path: "src/watch.rs".to_string(),
+                symbols: vec![],
+            },
+        ],
+        file_size_bands: vec![
+            rinkaku_core::file_size::FileSizeEntry {
+                path: "src/normal.rs".to_string(),
+                line_count: 10,
+                band: FileSizeBand::Normal,
+            },
+            rinkaku_core::file_size::FileSizeEntry {
+                path: "src/watch.rs".to_string(),
+                line_count: 700,
+                band: FileSizeBand::Watch,
+            },
+        ],
+        ..empty_report()
+    };
+
+    let tree = build_tree(&report);
+
+    let expected = Badges {
+        own_file_size_band: None,
+        own_file_line_count: None,
+        file_size_warn_count: 0,
+        file_size_split_count: 0,
+        ..Badges::default()
+    };
+    assert_eq!(expected, tree.roots[0].badges);
 }

--- a/rinkaku-tui/src/tree/tree_tests/mod.rs
+++ b/rinkaku-tui/src/tree/tree_tests/mod.rs
@@ -65,6 +65,7 @@ pub(super) fn empty_report() -> Report {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     }
 }

--- a/rinkaku-tui/src/ui/blast_radius.rs
+++ b/rinkaku-tui/src/ui/blast_radius.rs
@@ -157,6 +157,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/ui/detail_pane_tests/content_by_row_kind.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/content_by_row_kind.rs
@@ -14,6 +14,7 @@ fn should_draw_placeholder_message_when_there_are_no_rows_at_all() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     // ADR 0020 defaults the right pane to Diff, whose own placeholder
@@ -57,6 +58,7 @@ fn should_draw_dir_detail_content_when_cursor_is_on_a_directory_row() {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     // ADR 0020 defaults the right pane to Diff; `ToggleDiff` switches to
@@ -110,6 +112,7 @@ fn should_draw_symbols_label_without_changed_wording_when_origin_is_repo_outline
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     // See the sibling test above for why `ToggleDiff` is needed to
@@ -233,6 +236,7 @@ fn should_draw_both_test_note_and_real_symbols_in_detail_pane_when_file_is_mixed
         }],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     // Row 0 is the "app.rs" file row itself.

--- a/rinkaku-tui/src/ui/detail_pane_tests/mod.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/mod.rs
@@ -63,6 +63,7 @@ pub(super) fn report_with_one_symbol() -> Report {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     }
 }
@@ -99,6 +100,7 @@ pub(super) fn report_with_one_skipped_file() -> Report {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     }
 }
@@ -121,6 +123,7 @@ pub(super) fn report_with_one_test_file() -> Report {
         }],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     }
 }
@@ -150,6 +153,7 @@ pub(super) fn report_with_many_symbols(count: usize) -> Report {
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     }
 }

--- a/rinkaku-tui/src/ui/detail_pane_tests/size_warning.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/size_warning.rs
@@ -41,7 +41,7 @@ fn should_render_size_warning_line_when_file_detail_has_size_warning() {
     assert!(
         rendered
             .iter()
-            .any(|line| line == "Warn: 1734 lines \u{2014} consider splitting (>1500 watch)"),
+            .any(|line| line == "Warn: 1734 lines \u{2014} consider splitting (>1000 watch)"),
         "expected watch-severity warning line among: {rendered:?}",
     );
 }
@@ -77,7 +77,7 @@ fn should_render_split_severity_label_when_file_detail_size_warning_is_split() {
     assert!(
         rendered
             .iter()
-            .any(|line| line == "Split: 4837 lines \u{2014} over the 2000-line split threshold"),
+            .any(|line| line == "Split: 4837 lines \u{2014} over the 1500-line split threshold"),
         "expected split-severity warning line among: {rendered:?}",
     );
 }

--- a/rinkaku-tui/src/ui/detail_pane_tests/wrap_reachability.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/wrap_reachability.rs
@@ -28,6 +28,7 @@ fn should_reach_the_last_wrapped_line_of_content_via_scrolling_when_a_logical_li
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     // ADR 0020 defaults the right pane to Diff, whose own placeholder
@@ -88,6 +89,7 @@ fn should_report_indicator_total_as_wrapped_row_count_not_logical_line_count_whe
         tests: vec![],
         fan_ins: vec![],
         file_size_warnings: vec![],
+        file_size_bands: vec![],
         removed: vec![],
     };
     // ADR 0020 defaults the right pane to Diff; `ToggleDiff` switches to

--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -283,6 +283,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }
@@ -397,6 +398,7 @@ index e69de29..4b825dc 100644
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
             files: vec![],
         };
@@ -461,6 +463,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
             files: vec![],
         };
@@ -528,6 +531,7 @@ index e69de29..4b825dc 100644
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         };
         let app = App::new(&report);
@@ -591,6 +595,7 @@ index e69de29..4b825dc 100644
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         };
         // Row 0 is the "lib.rs" file row, row 1 is the "foo" symbol.
@@ -827,6 +832,7 @@ index e69de29..4b825dc 100644
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         };
         // ADR 0020 defaults the right pane to Diff already, so no

--- a/rinkaku-tui/src/ui/entry.rs
+++ b/rinkaku-tui/src/ui/entry.rs
@@ -177,6 +177,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }
@@ -199,6 +200,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/ui/entry.rs
+++ b/rinkaku-tui/src/ui/entry.rs
@@ -443,6 +443,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -238,6 +238,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }

--- a/rinkaku-tui/src/ui/source_screen.rs
+++ b/rinkaku-tui/src/ui/source_screen.rs
@@ -203,6 +203,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }
@@ -362,6 +363,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         };
         let app = App::new(&report)
@@ -431,6 +433,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         };
         let app = App::new(&report)

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -164,6 +164,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }
@@ -194,6 +195,7 @@ mod tests {
             tests: vec![],
             fan_ins: vec![],
             file_size_warnings: vec![],
+            file_size_bands: vec![],
             removed: vec![],
         }
     }
@@ -346,6 +348,7 @@ mod tests {
                     severity: rinkaku_core::file_size::FileSizeSeverity::Split,
                 },
             ],
+            file_size_bands: vec![],
             ..empty_report_for_status_line()
         };
         let app = App::new(&report);
@@ -369,6 +372,7 @@ mod tests {
                 line_count: 1734,
                 severity: rinkaku_core::file_size::FileSizeSeverity::Warn,
             }],
+            file_size_bands: vec![],
             ..empty_report_for_status_line()
         };
         let app = App::new(&report);

--- a/rinkaku/src/notes.rs
+++ b/rinkaku/src/notes.rs
@@ -115,6 +115,7 @@ mod tests {
                 tests: vec![],
                 fan_ins: vec![],
                 file_size_warnings: vec![],
+                file_size_bands: vec![],
                 removed: vec![],
             }
         }
@@ -131,6 +132,7 @@ mod tests {
                 tests: vec![],
                 fan_ins: vec![],
                 file_size_warnings: vec![],
+                file_size_bands: vec![],
                 removed: vec![],
             }
         }
@@ -179,6 +181,7 @@ mod tests {
                 tests: vec![],
                 fan_ins: vec![],
                 file_size_warnings: vec![],
+                file_size_bands: vec![],
                 removed: vec![],
             };
 
@@ -206,6 +209,7 @@ mod tests {
                 }],
                 fan_ins: vec![],
                 file_size_warnings: vec![],
+                file_size_bands: vec![],
                 removed: vec![],
             };
 
@@ -245,6 +249,7 @@ mod tests {
                 tests: vec![],
                 fan_ins: vec![],
                 file_size_warnings: vec![],
+                file_size_bands: vec![],
                 removed: vec![],
             };
 
@@ -304,6 +309,7 @@ mod tests {
                 tests: vec![],
                 fan_ins: vec![],
                 file_size_warnings: vec![],
+                file_size_bands: vec![],
                 removed: vec![],
             }
         }
@@ -363,6 +369,7 @@ mod tests {
                 tests: vec![],
                 fan_ins: vec![],
                 file_size_warnings: vec![],
+                file_size_bands: vec![],
                 removed: vec![],
             };
 
@@ -393,6 +400,7 @@ mod tests {
                 tests: vec![],
                 fan_ins: vec![],
                 file_size_warnings: vec![],
+                file_size_bands: vec![],
                 removed: vec![],
             }
         }

--- a/rinkaku/src/pipeline.rs
+++ b/rinkaku/src/pipeline.rs
@@ -47,6 +47,7 @@ pub(crate) fn run_base_pipeline(
                 tests: Vec::new(),
                 fan_ins: Vec::new(),
                 file_size_warnings: Vec::new(),
+                file_size_bands: vec![],
                 removed: Vec::new(),
             },
             diff_text,
@@ -343,6 +344,7 @@ mod tests {
                 tests: Vec::new(),
                 fan_ins: Vec::new(),
                 file_size_warnings: Vec::new(),
+                file_size_bands: vec![],
                 removed: Vec::new(),
             },
             actual_report


### PR DESCRIPTION
## Summary

- Lower file-size thresholds one tier: `WARN_LINE_THRESHOLD` 1500→1000, `SPLIT_LINE_THRESHOLD` 2000→1500 (new: normal ≤600 / watch 600-1000 / warn >1000 / split >1500). Rationale and alternatives in ADR 0028's first amendment.
- Add `Report.file_size_bands`: every analyzed file's line count + 4-band classification (`Normal`/`Watch`/`Warn`/`Split`), reusing the existing threshold logic (`classify_file_size` is now the single source of truth for both `compute_file_size_warnings` and the new `compute_file_size_bands`).
- TUI: every file row now always shows `lines:N`, colored by band (`Normal` unstyled, `Watch` yellow, `Warn`/`Split` red with `Split` additionally bold). Directory-level `warn:N split:N` aggregate is unchanged (still Warn/Split only).
- Markdown: `## File size warnings` (Warn/Split only) is replaced by `## File sizes`, listing every file as `` `path` (N lines) `` with a `, {band}` suffix for Watch/Warn/Split.
- JSON: additive `file_size_bands` field; `file_size_warnings` unchanged.
- ADR 0028 gets two amendments documenting both changes.

## Self-dogfooding

With the new thresholds, `rinkaku-tui/src/lib.rs` (1038 lines) is the only file in the repo crossing into `warn`; nothing crosses `split`. No splits performed in this PR.

## Follow-ups

- Detail pane's dedicated file-size warning line stays Warn/Split-only (not widened to always show a line for Normal/Watch) — deferred, no concrete need yet.

## Test plan

- [x] `make test` (all 3 crates green)
- [x] `make lint`
- [x] Built the CLI from this branch and ran it against real diffs (`--format md` and `--format json`) confirming `## File sizes` and `file_size_bands` render correctly for Normal/Watch bands live; Warn/Split covered by unit tests.