### PR TITLE
ci: exclude test symbols from the PR-comment mermaid graph

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -200,7 +200,16 @@ runs:
         markdown_only=false
 
         if echo "${help_output}" | grep -q -- 'mermaid'; then
-          if run_rinkaku --format mermaid > "${mermaid_path}" 2>/dev/null; then
+          # The mermaid graph is for at-a-glance structure, where test-symbol
+          # nodes are noise; `--exclude-tests` is opt-in itself (ADR 0025),
+          # so guard it the same way as the mermaid/digest formats above —
+          # older binaries may support `--format mermaid` but predate
+          # `--exclude-tests`.
+          mermaid_args=(--format mermaid)
+          if echo "${help_output}" | grep -q -- 'exclude-tests'; then
+            mermaid_args+=(--exclude-tests)
+          fi
+          if run_rinkaku "${mermaid_args[@]}" > "${mermaid_path}" 2>/dev/null; then
             echo "mermaid-path=${mermaid_path}" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::rinkaku --format mermaid failed even though --help mentions --format; falling back to a Markdown-only report"


### PR DESCRIPTION
## Summary

- The `Run rinkaku` step's `--format mermaid` invocation now passes `--exclude-tests`, so the graph posted to PR comments no longer includes test-symbol nodes as noise. The `--format md` and `--format digest` invocations are unchanged and keep including tests, per ADR 0025's default.
- `--exclude-tests` is guarded the same way the step already guards `--format mermaid`/`--format digest` support: it's only added when `--exclude-tests` literally appears in the resolved binary's `--help` output, so a caller-provided binary that predates the flag still runs (falls back to tests included in the mermaid graph rather than failing).

## Why this doesn't need a new ADR

This only changes a CI-side flag choice for one existing, already-documented CLI flag (`--exclude-tests`, ADR 0025) in one of the three formats the action already runs. It doesn't change any output format's shape or introduce a new default — the `--format md`/`--format digest` paths, and rinkaku's own CLI default, are untouched.

## Test plan

- [x] `cargo build --release` in a worktree, then ran the extracted `Run rinkaku` shell block directly against a real diff (added a temporary probe function + test function, reverted after). Confirmed:
  - The mermaid report excludes the temporary test symbol.
  - The markdown report still includes it (tests included by default, ADR 0025 unaffected).
- [x] Confirmed `--exclude-tests` literally appears in `rinkaku --help` output, so the new `--help` guard correctly enables the flag.
- [x] `make test` — 605 passed.
- [x] `make lint` — clean.