### PR TITLE
fix(core): resolve Rust scoped_identifier path references (e.g. enum variant paths)

### DIFF
--- a/docs/adr/0038-rust-scoped-identifier-path-references.md
+++ b/docs/adr/0038-rust-scoped-identifier-path-references.md
@@ -1,0 +1,84 @@
+# 0038. Capture the path side of Rust `scoped_identifier` as a type reference
+
+- Status: accepted
+- Date: 2026-07-14
+
+## Context
+
+`RustSupport::REFERENCE_QUERY` (ADR 0003's tags-based, name-only
+resolution) has no pattern for `scoped_identifier` at all — the node
+tree-sitter produces for `Type::Thing` (enum-variant construction,
+associated-item access, or a UFCS call's callee). A changed function whose
+body only references another changed type through this path form (for
+example `OutputFormat::Markdown`) produces no `referenced_names` entry for
+`OutputFormat`, so `graph::build_graph`'s name matching never links the
+two symbols — the dependent shows up as an unconnected root instead of an
+edge to the type it depends on.
+
+The existing `call_expression function: (identifier)` pattern deliberately
+excludes `scoped_identifier` callees (`Type::method()`) because resolving
+a method name to its defining type needs type information v1 doesn't have.
+That exclusion is about the *name* (right-hand) side of the path — it says
+nothing about the *path* (left-hand) side, which names a real type/enum
+and is exactly the kind of reference `type_identifier` already captures
+elsewhere.
+
+## Decision
+
+Add `(scoped_identifier path: (identifier) @reference.type)` to
+`REFERENCE_QUERY`. This captures the left-hand identifier of any scoped
+path — `OutputFormat` in `OutputFormat::Markdown`, `Type` in
+`Type::method(1)`'s UFCS callee, `Self` in `Self::Default` — without
+capturing the right-hand `name` field (method/variant/associated-item
+name), so the UFCS-callee exclusion is unchanged: only the type-shaped
+side is added.
+
+Because a `scoped_identifier`'s `path` field can itself be a nested
+`scoped_identifier` rather than a bare `identifier` (`a::b::Type::method`
+parses as `path: (path: (path: identifier "a") name: "b") name: "Type")
+name: "method"`), the query only matches when a path segment's own `path`
+is a bare identifier. For a two-segment path (`Type::method`) this
+captures `Type` as wanted; for a three-or-more-segment path
+(`a::b::Type::method`), the type-shaped segment (`Type`) sits one level
+too deep and is missed — only the outermost module segment (`a`) is
+captured by the query, and `extract::is_noise_name`'s existing
+single-character filter drops it anyway when it is that short. This is a
+known, accepted gap in the syntax-only approach (module-qualified paths
+are rare in practice compared to the direct `Type::variant`/
+`Type::method` form this fixes) and is pinned by a test rather than
+silently left unspecified.
+
+## Alternatives
+
+- **Match `scoped_identifier` unconditionally (both `path` and `name`
+  fields)**: would also capture the UFCS method/variant name as a
+  reference, re-introducing the exact ambiguity ADR 0003's exclusion
+  comment rules out (an unresolvable bare method/variant name matched
+  against unrelated same-named definitions). Rejected.
+- **Recursively unwrap nested `scoped_identifier` paths to always reach
+  the innermost type-shaped segment**: would fix the 3+-segment case but
+  requires distinguishing "the last path segment before the final `name`"
+  from "a module segment," which the grammar doesn't mark — segments look
+  identical whether they are modules (`a`, `b`) or the type (`Type`).
+  Deferred; not worth the complexity for a form uncommon in the codebases
+  rinkaku targets.
+- **Do nothing (leave `scoped_identifier` unhandled)**: keeps the current
+  silent gap, where a large and common Rust idiom (returning/constructing
+  another changed enum by its variant path) never produces a dependency
+  edge. Rejected — this was the motivating bug.
+
+## Consequences
+
+- Enum-variant and associated-item path references (`Type::Variant`,
+  `Type::CONST`, a UFCS call's `Type::method(...)`) now contribute their
+  left-hand type name to `referenced_names`, so `graph::build_graph` can
+  link a changed function to a changed type it only references this way.
+  This is what restores cross-file/cross-directory edges the TUI's
+  topological ordering depends on.
+- `Self::Variant`/`Self::method(...)` also now capture the literal text
+  `"Self"`, matching `type_identifier`'s pre-existing behavior for
+  `-> Self` return types (already unfiltered before this change) — no new
+  special-casing needed.
+- Deeply nested module-qualified paths (`a::b::Type::method`) still don't
+  resolve their type segment; if this proves common enough to matter,
+  revisit with a recursive-unwrap approach then.

--- a/rinkaku-core/src/extract_tests/rust.rs
+++ b/rinkaku-core/src/extract_tests/rust.rs
@@ -108,6 +108,71 @@ fn foo() -> i32 {
     assert_eq!(expected, actual);
 }
 
+#[rstest]
+#[case::should_capture_path_type_when_enum_variant_constructed_via_scoped_path(
+    "\
+fn build() -> Format {
+    OutputFormat::Markdown
+}
+",
+    vec!["Format".to_string(), "OutputFormat".to_string()],
+)]
+#[case::should_capture_path_type_but_not_method_name_for_ufcs_call(
+    "\
+fn build() -> Format {
+    Format::default()
+}
+",
+    vec!["Format".to_string()],
+)]
+#[case::should_capture_self_when_used_as_scoped_path(
+    "\
+fn build() -> Format {
+    Self::Default
+}
+",
+    vec!["Format".to_string(), "Self".to_string()],
+)]
+#[case::should_capture_only_the_outermost_module_segment_for_a_three_segment_path(
+    // A three-segment scoped path parses as nested `scoped_identifier`s,
+    // each layer's `path` field holding the next one out; the query only
+    // matches a `scoped_identifier` whose own `path` field is a bare
+    // `identifier`, true only for the innermost `mods::sub` pair.
+    // `Format` sits one level too deep and is not captured — a known,
+    // accepted gap, not an oversight.
+    "\
+fn build() -> Format {
+    mods::sub::Format::default()
+}
+",
+    vec!["Format".to_string(), "mods".to_string()],
+)]
+fn should_collect_scoped_identifier_path_references(
+    #[case] source: &str,
+    #[case] referenced_names: Vec<String>,
+) {
+    let lang = RustSupport;
+    let changed_ranges = vec![LineRange { start: 1, end: 1 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "build".to_string(),
+        kind: SymbolKind::Function,
+        signature: "fn build() -> Format".to_string(),
+        range: LineRange { start: 1, end: 3 },
+        container: None,
+        referenced_names,
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
 #[test]
 fn should_mark_symbol_as_test_when_nested_inside_cfg_test_mod() {
     let source = "\

--- a/rinkaku-core/src/language/rust.rs
+++ b/rinkaku-core/src/language/rust.rs
@@ -23,8 +23,7 @@ const DEFINITION_QUERY: &str = "\
 /// - `call_expression function: (identifier)` captures free function calls
 ///   (`helper(x)`) and tuple-struct/enum-variant constructors used as
 ///   calls. Method/UFCS calls (`function: (field_expression ...)` for
-///   `x.bar()`, `function: (scoped_identifier ...)` for `Type::method()`)
-///   are intentionally not captured: their callee is not a bare
+///   `x.bar()`) are intentionally not captured: their callee is not a bare
 ///   identifier, and resolving them would need type information v1 does
 ///   not have (ADR 0003).
 /// - `type_identifier` captures every named type reference (parameter
@@ -35,6 +34,15 @@ const DEFINITION_QUERY: &str = "\
 ///   pattern. Rust's primitive types (`i32`, `str`, `bool`, ...) parse as
 ///   the distinct `primitive_type` node kind, so they are already excluded
 ///   by construction rather than needing an explicit exclusion list.
+/// - `scoped_identifier path: (identifier)` captures the left-hand type of
+///   a scoped path — `OutputFormat` in `OutputFormat::Markdown`, `Type` in
+///   a UFCS call's `Type::method()` — without capturing the `name` field
+///   (the method/variant/associated-item on the right), which stays
+///   unresolved for the same reason UFCS callees are excluded above. A
+///   path with three or more segments nests an inner `scoped_identifier`
+///   in `path` instead of a bare identifier, so only its outermost
+///   segment is reached this way; deeper segments are a known, accepted
+///   gap rather than a resolved case.
 /// - `trait_item body: (declaration_list (function_signature_item name:
 ///   (identifier)))` and the same shape for `function_item` capture a
 ///   trait's method names — both the common bodiless `fn name(...);` form
@@ -52,6 +60,7 @@ const REFERENCE_QUERY: &str = "\
 [
   (call_expression function: (identifier) @reference.call)
   (type_identifier) @reference.type
+  (scoped_identifier path: (identifier) @reference.type)
   (trait_item body: (declaration_list (function_signature_item name: (identifier) @reference.call)))
   (trait_item body: (declaration_list (function_item name: (identifier) @reference.call)))
 ]";


### PR DESCRIPTION
## Summary

- `RustSupport::REFERENCE_QUERY` had no pattern for `scoped_identifier` at all, so a changed function that only references another changed type through a scoped path (e.g. `OutputFormat::Markdown`) produced no `referenced_names` entry for `OutputFormat`. `graph::build_graph`'s name-based matching never linked the two symbols, so the dependent showed up as an unconnected root instead of an edge to the type it depends on — losing cross-file/cross-directory edges that the TUI's topological ordering relies on.
- Root cause found while investigating why `rinkaku/src/cli.rs`'s `Format::from` (in PR #116's diff) had no edge to `rinkaku-core/src/render/mod.rs`'s `OutputFormat`, even though the function's body constructs `OutputFormat::Markdown`/`OutputFormat::Json` directly.
- See ADR [0038](docs/adr/0038-rust-scoped-identifier-path-references.md) for the full decision, alternatives considered, and the accepted gap (module-qualified 3+-segment paths only resolve their outermost segment).

## Fix

Add `(scoped_identifier path: (identifier) @reference.type)` to `REFERENCE_QUERY`. This captures the left-hand type-shaped side of a scoped path (`OutputFormat` in `OutputFormat::Markdown`, `Type` in a UFCS call's `Type::method()`, `Self` in `Self::Default`) without capturing the right-hand `name` field (method/variant/associated-item), which stays unresolved — unchanged from the existing UFCS-callee exclusion (ADR 0003).

## Tests

Added `should_collect_scoped_identifier_path_references` (rstest, 4 cases) in `rinkaku-core/src/extract_tests/rust.rs`:
- enum-variant construction via scoped path (`OutputFormat::Markdown`)
- UFCS call (`Format::default()`) — path side captured, method name still excluded
- `Self::Default` — `Self` captured, matching `type_identifier`'s pre-existing behavior for `-> Self` return types
- three-segment path (`mods::sub::Format::default()`) — pins the known, accepted gap where only the outermost segment is reachable

All assertions compare the full `ExtractedSymbol` struct (fully qualified, per repo convention). `make test` (605 tests) and `make lint` pass.

## QA (dynamic verification)

Built `cargo build --release` and ran the fixed binary against PR #116's real diff:

```
gh pr diff 116 | ./target/release/rinkaku --format json
```

- **Before fix** (main @ 68dd683): graph has 48 edges; `rinkaku/src/cli.rs::from` only edges to `rinkaku/src/cli.rs::Format` (same-file, already worked via the return-type `type_identifier`). No edge to `OutputFormat`.
- **After fix**: graph has 67 edges; `rinkaku/src/cli.rs::from` now also edges to `rinkaku-core/src/render/mod.rs::OutputFormat` — the missing cross-directory edge is present.
- Confirmed `rinkaku-tui`'s `order::rank::rank_directories` (which computes directory topological rank purely from `report.graph.edges` via Kahn's algorithm, per its own doc comment) will pick up this edge automatically — no changes needed there, and its existing test suite (605 tests, unchanged) still passes.

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] Dynamic verification against a real PR diff (before/after edge-count and specific-edge comparison, see QA section above)