### PR TITLE
docs(experiments): record experiment 0001 round 24 (PR #126)

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/024.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/024.md
@@ -1,0 +1,123 @@
+# Round 24
+
+- Subject: PR #126 — `RustSupport::REFERENCE_QUERY` gains
+  `(scoped_identifier path: (identifier) @reference.type)` (ADR 0038),
+  so a scoped path like `OutputFormat::Markdown` now contributes
+  `OutputFormat` to `referenced_names`. Before this fix, a changed
+  function that only referenced another changed type through this path
+  form produced no edge at all — `graph::build_graph`'s name matching
+  had nothing to link, so the dependent showed up as an unconnected
+  root instead of an edge to the type it depends on.
+- Origin of the bug: not a review finding, but a human's use-of-the-
+  tool discomfort. Reading the TUI's directory ordering for PR #116,
+  the human noticed `rinkaku-core/src/render/mod.rs` (the callee,
+  `OutputFormat`) ranked *above* `rinkaku/src/cli.rs` (the caller,
+  `Format::from`) in a way that felt backwards for a topological
+  ordering meant to read callees-before-callers-or-vice-versa
+  consistently. Investigating that discomfort — not a scheduled
+  review — surfaced the missing edge, and from there the missing
+  `scoped_identifier` query pattern. This is a different discovery
+  channel than any of this experiment's prior 23 rounds: every one of
+  those started from a diff already up for review; this one started
+  from a maintainer's dogfooding session years after the tool had
+  already told them a wrong answer once (PR #116, round 23's era) and
+  no one had asked "is this ordering actually right?" until now.
+- Protocol note: three-angle review per this repository's `CLAUDE.md`
+  ("Reviewing changes"), not a harness-timed A/B pair — same as rounds
+  17 and 22. Two review agents run in parallel: (1) map-assisted static
+  review (trusted clean `main` build, not the branch under review) plus
+  repo-convention checks; (2) dynamic verification (rebuild the fixed
+  binary, re-run it against PR #116's real diff, and probe adversarial
+  inputs). Blocker count: 0.
+- **Map-assisted pass**: generated `rinkaku --base main` for this PR's
+  own diff. The diff's substance is a `const &str` tags-query literal
+  (`REFERENCE_QUERY`) and a doc comment above it — both are
+  *definition-body* edits, not new/changed/removed top-level symbols
+  with their own signature, so the change barely registers on the
+  map's signature/fan-in model: no new hotspot, no contract marker,
+  nothing to route attention toward beyond "this file changed." The
+  map still independently verified the tree-sitter grammar claim in
+  ADR 0038 (that a 3+-segment `scoped_identifier` nests an inner
+  `scoped_identifier` in its `path` field rather than a flat list) by
+  reading the `tree-sitter-rust` grammar directly, and confirmed the
+  query and the ADR's prose agree. No should-fix or blocker findings;
+  one non-blocking nit (below). Approved.
+- **Notable observation — a new shape of map blind spot**: this
+  extends the round 17/22 finding that "the map cannot see risk outside
+  its signature/fan-in model" with a sharper instance: **query and
+  config strings are invisible to the map even though they are Rust
+  source the map's own language parses**, because they are string
+  *literals*, not the definitions the map indexes. Round 17's blind
+  spot was rendered log text (non-Rust-shaped risk inside a Rust
+  function body); this one is a Rust `const` whose entire payload is a
+  tree-sitter query DSL, syntactically opaque to a map that only
+  understands Rust symbol shapes, not the embedded query language. Any
+  future PR that edits `DEFINITION_QUERY`/`REFERENCE_QUERY` (or a
+  similar config-as-string pattern elsewhere in the codebase) will hit
+  the same gap — worth naming explicitly since it's a recurring
+  *category* now, not a one-off.
+- **Dynamic verification**: rebuilt `cargo build --release` from PR
+  #126's branch and reran it against PR #116's actual diff exactly as
+  the PR body's own QA section describes, to check the claim rather
+  than accept it:
+  - Before/after edge count and specific-edge presence confirmed
+    independently (48 -> 67 edges; `cli.rs::from` gains the
+    previously-missing edge to `render/mod.rs::OutputFormat`).
+  - All 19 newly-appearing edges in the after-fix graph enumerated and
+    checked individually against the source — every one traces to a
+    real `Type::Variant`/`Type::method()`/`Self::variant` scoped-path
+    reference in a changed function's body. Zero false positives.
+  - Regression check: ran the fixed binary against synthetic Go,
+    Python, and TypeScript diffs (each touching a function that
+    references a same-file type) and diffed the full JSON report
+    against a pre-fix binary's output byte-for-byte — identical in
+    both cases, confirming the query change is additive and scoped to
+    `RustSupport` only.
+  - Edge-case probes, none of which panicked or produced incorrect
+    output: UFCS call (`Type::method()` — path captured, method name
+    still excluded, matching the ADR's stated intent), turbofish
+    (`Type::<T>::method()`), `Self::variant`/`Self::method()` inside an
+    `impl` block, a three-segment path (`mods::sub::Type::method()` —
+    confirmed only the outermost segment `mods` is captured, matching
+    ADR 0038's documented accepted gap and its own pinning test), a
+    scoped path inside a macro invocation body, a scoped path appearing
+    only in a `use` statement (no reference emitted, as expected since
+    `use` isn't inside the query's matched node kinds), an empty diff,
+    a diff with only unparseable/binary hunks, and non-TTY stdin/stdout
+    for the whole pipeline. No crashes, no incorrect graph edges
+    observed in any case.
+  - One non-blocking nit raised: ADR 0038's Consequences section states
+    that `Self::Variant`/`Self::method(...)` "now capture the literal
+    text `Self`, matching `type_identifier`'s pre-existing behavior for
+    `-> Self` return types" — verified this claim holds (both paths do
+    produce the bare string `"Self"` in `referenced_names`, and
+    `graph::build_graph`'s name-matching treats it like any other
+    identifier), but noted the ADR doesn't discuss what happens when
+    `Self` fails to resolve to any changed symbol (the common case,
+    since a `Self`-named node rarely collides with anything else in
+    scope) — purely a documentation completeness point, no behavior to
+    fix.
+- Severity summary: 0 blockers, 0 should-fix, 1 nit (ADR
+  documentation completeness on unresolved-`Self` behavior, not
+  actioned this round since it does not affect correctness).
+- Takeaway: this round's diff is almost entirely a `const` string
+  literal edit plus a doc comment, which meant the map-assisted pass
+  had structurally little to route attention toward — consistent with,
+  but a new instance of, the standing conclusion that the map's
+  coverage boundary is real and must be named rather than silently
+  trusted. Dynamic verification was once again the pass that did the
+  actual load-bearing verification: exhaustively checking every one of
+  19 new edges for correctness, confirming zero cross-language
+  regression via byte-identical JSON diffing, and walking the full set
+  of adversarial path shapes (UFCS, turbofish, `Self`, three-segment,
+  macro-body, `use`-only) the ADR's own Alternatives/Consequences
+  sections either claim or leave as an accepted gap. Separately, the
+  bug's origin this round is itself worth recording: it was found not
+  by a scheduled review of any kind, but by a maintainer's dogfooding
+  discomfort with the TUI's own directory ordering days after the
+  defective map had already silently mis-ranked a real PR (#116) — a
+  reminder that the map's own consumers (this repository's TUI ranking
+  logic) are themselves a review surface, and that "does the output
+  look right to someone using it for its intended purpose" is a defect-
+  finding channel none of the three angles in CLAUDE.md's review
+  protocol currently formalizes.


### PR DESCRIPTION
## Summary

- Adds `rounds/024.md` to experiment 0001, recording the review of
  PR #126 (Rust `scoped_identifier` path references, ADR 0038).
- Follows this repository's `CLAUDE.md` "Reviewing changes" protocol
  (map-assisted static pass + dynamic verification), same shape as
  rounds 17/22: a single-reviewer round recording an actual PR review,
  not a harness-timed A/B pair.
- Per the experiment README's file-layout convention, this PR only
  *adds* `rounds/024.md`; the README's index/Conclusions update is left
  to a separate follow-up commit.

## Findings recorded this round

- 0 blockers, 0 should-fix, 1 non-blocking nit (ADR 0038's
  Consequences section doesn't discuss unresolved-`Self` behavior;
  documentation completeness only, no correctness impact).
- Dynamic verification did the load-bearing work: rebuilt the fixed
  binary, re-ran it against PR #116's real diff, verified all 19 newly
  appearing graph edges individually, confirmed zero cross-language
  regression via byte-identical JSON diffing (Go/Python/TypeScript),
  and probed UFCS/turbofish/`Self`/three-segment-path/macro-body/
  `use`-only edge cases with no crashes or incorrect output.
- New map blind-spot category identified: query/config string literals
  (like `REFERENCE_QUERY`) are invisible to the signature-level map
  even though they're Rust source the map otherwise parses, since they
  are string literal payloads, not indexed definitions.
- The underlying bug (missing `scoped_identifier` reference edges) was
  found via a maintainer's dogfooding discomfort with the TUI's
  directory ordering, not a scheduled review pass — a discovery
  channel none of this experiment's prior 23 rounds recorded.

## Test plan

- [x] `make lint` (docs-only change; ran clean)
- [x] `git status` confirms only `rounds/024.md` is added