### PR TITLE
feat: rework mermaid visual encoding and legend (ADR 0039)

### DIFF
--- a/compose_and_post_comment.sh
+++ b/compose_and_post_comment.sh
@@ -118,11 +118,11 @@ if [ -n "${MERMAID_PATH:-}" ] && [ -f "${MERMAID_PATH}" ]; then
   fi
 fi
 
-# No legend appended here (ADR 0038): the diagram itself now carries a
+# No legend appended here (ADR 0039): the diagram itself now carries a
 # self-describing `Legend` subgraph, styled with its own real `classDef`s,
 # so this script has nothing to compose alongside it — a hand-written
 # prose legend risked drifting out of sync with the actual node styles
-# (the exact problem ADR 0038 fixes), which a legend built from those same
+# (the exact problem ADR 0039 fixes), which a legend built from those same
 # `classDef`s cannot do. The oversized-mermaid fallback below has no
 # legend either, since there is no diagram at all in that case.
 mermaid_section=""

--- a/compose_and_post_comment.sh
+++ b/compose_and_post_comment.sh
@@ -73,16 +73,6 @@ MAX_BODY_LENGTH=65536
 # practice diagram and leaving nothing for the digest details.
 MAX_MERMAID_LENGTH=32768
 
-# One line spelling out the mermaid `classDef` colors (ADR 0021/0035) in
-# English, since GitHub's rendered mermaid diagram carries no legend of
-# its own — composed here, not by `render_mermaid`/`render_digest`,
-# because it's prose about this comment's presentation, not data derived
-# from the `Report` (ADR 0036's Decision). No emoji/color swatches (this
-# repository avoids decorative glyphs in rendered output on principle,
-# per ADR 0028's terminal-rendering rationale) — plain text names of the
-# `classDef`s themselves.
-MERMAID_LEGEND="_Legend: green = added · orange = API changed · gray dashed = removed · red heavy border = fan-in_"
-
 # Truncates `text` to at most `budget` bytes, then backs off up to 3 more
 # bytes (bounded: the longest a single UTF-8 character's continuation-byte
 # run can be) until the result is valid UTF-8 on its own — a byte-count
@@ -128,20 +118,23 @@ if [ -n "${MERMAID_PATH:-}" ] && [ -f "${MERMAID_PATH}" ]; then
   fi
 fi
 
+# No legend appended here (ADR 0038): the diagram itself now carries a
+# self-describing `Legend` subgraph, styled with its own real `classDef`s,
+# so this script has nothing to compose alongside it — a hand-written
+# prose legend risked drifting out of sync with the actual node styles
+# (the exact problem ADR 0038 fixes), which a legend built from those same
+# `classDef`s cannot do. The oversized-mermaid fallback below has no
+# legend either, since there is no diagram at all in that case.
 mermaid_section=""
 if [ -n "${mermaid_content}" ] && [ "${mermaid_oversized}" -eq 1 ]; then
   mermaid_section="
 ${mermaid_content}
-
-${MERMAID_LEGEND}
 "
 elif [ -n "${mermaid_content}" ]; then
   mermaid_section="
 \`\`\`mermaid
 ${mermaid_content}
 \`\`\`
-
-${MERMAID_LEGEND}
 "
 fi
 

--- a/docs/adr/0038-mermaid-visual-encoding-revision.md
+++ b/docs/adr/0038-mermaid-visual-encoding-revision.md
@@ -1,0 +1,192 @@
+# 0038. Revise `--format mermaid`'s visual encoding and legend
+
+- Status: accepted
+- Date: 2026-07-14
+
+## Context
+
+ADR 0021 chose `classDef added`/`changed`/`fan-in` (red fill, heavier
+stroke) and ADR 0037 added `removed` (gray fill, dashed stroke). ADR
+0036 added a one-line English legend composed by
+`compose_and_post_comment.sh`, next to the rendered diagram:
+
+```
+_Legend: green = added · orange = API changed · gray dashed = removed · red heavy border = fan-in_
+```
+
+User feedback on this pair, after using it on real PR comments:
+
+1. The legend line itself is hard to parse at a glance — four
+   `color/attribute = meaning` clauses packed into one sentence, read
+   without ever seeing the corresponding node styles next to it.
+2. "Removed" reading as gray-dashed is not the intuitive color for
+   deletion; red is the color most reviewers already associate with
+   "this is gone," and pairing it with a dashed border (already used
+   elsewhere in this format for "not a normal solid thing" — the cycle
+   edge, ADR 0021) would read as more self-explanatory.
+3. `fan-in`'s existing encoding (red fill, heavier stroke) collides
+   with the color reviewers now expect for "removed" once (2) takes
+   red. Fan-in needs its own encoding that doesn't compete for the same
+   color.
+
+This ADR revises the `removed` and `fan-in` `classDef`s and replaces
+the one-line legend with a self-describing `Legend` subgraph rendered
+inside the mermaid diagram itself, styled with the real `classDef`s a
+reader is about to see used for real nodes.
+
+## Decision
+
+### Color/style reassignment
+
+- **`added`**: unchanged — green fill (`#c6f6d5`), solid border.
+- **`changed`** (API/signature changed): unchanged — orange fill
+  (`#feebc8`), solid border.
+- **`removed`**: reassigned to **red**, dashed border — muted red fill
+  (`#fed7d7` — the same fill ADR 0021 originally used for `fan-in`,
+  now free since `fan-in` moves off red) with a red stroke
+  (`#9b2c2c`) and `stroke-dasharray: 5 5` (unchanged dash pattern).
+  Red communicates "gone" on first read without relying on the legend;
+  dashed keeps the "not a normal solid node" vocabulary this format
+  already established for the cycle edge (`-.->`) and, until now,
+  `removed` alone.
+- **`fan-in`**: moved off red entirely to avoid colliding with the new
+  `removed` encoding, onto **a distinct blue/violet stroke plus a
+  label suffix**: fill `#e9d8fd` (light violet), stroke `#553c9a`
+  (deep violet), `stroke-width:3px` (kept — the heavier border is
+  still part of "pay attention to this node," just no longer red).
+  Additionally, a fan-in node's **label gains a `(in:N)` suffix**
+  (`n0["shared (in:3)"]`) where `N` is `fan_ins[i].used_by.len()` —
+  encoding the signal in text as well as color/stroke, not color
+  alone. `render_mermaid` already has `report.fan_ins` in scope (used
+  today only to build `fan_in_ids` for class lookup); this reads
+  `used_by.len()` from the same collection.
+
+  This double-encoding (color *and* text) is deliberate: a reviewer who
+  can't rely on color (colorblindness, a grayscale print of the PR
+  page) still gets "this is a hotspot, referenced by 3 others" from
+  the label text alone, the same way `render_markdown`'s `## Fan-in`
+  section already spells the count out in prose. It also removes the
+  need for a reader to distinguish "heavier red border" from "removed"
+  by stroke weight alone under a quick glance — the label makes the
+  distinction textual, not just visual.
+
+  Precedence when a node is both `changed`/`added` and high-fan-in is
+  unchanged from ADR 0021: `fan-in` styling (now violet + label
+  suffix) wins, for the same reason ADR 0021 gave (blast radius is the
+  more decision-relevant fact for a glance-level view).
+
+### Legend: a `subgraph Legend` inside the diagram, not a prose line
+
+Replace `compose_and_post_comment.sh`'s `MERMAID_LEGEND` prose line
+with a small `subgraph Legend` block appended to `render_mermaid`'s own
+output (and `render_mermaid_file_level`'s, for consistency — the
+fallback path uses the same four `classDef`s), placed after every real
+subgraph/edge/class-assignment line but before the trailing
+`classDef` declarations:
+
+```
+  subgraph Legend
+    legend_added["added"]
+    legend_changed["API changed"]
+    legend_removed["removed"]
+    legend_fan_in["fan-in (in:N)"]
+  end
+  class legend_added added
+  class legend_changed changed
+  class legend_removed removed
+  class legend_fan_in fan-in
+```
+
+- **Always emitted**, including on the empty-graph path and the
+  file-level fallback — a reader who only ever sees a small or
+  aggregated graph still gets the same self-describing key, and a
+  reader who never opens the `<details>` prose still has it inline.
+- **Real `classDef`s, not prose describing them**: a legend built from
+  the same four classes actually used on the graph's real nodes cannot
+  drift out of sync with a future color/style change the way a
+  hand-written English sentence already has (this ADR exists because
+  the sentence and the styles disagreed on what "removed" should look
+  like). Changing a `classDef` automatically re-styles the legend
+  entries too, in the same commit, by construction.
+- **`compose_and_post_comment.sh`'s `MERMAID_LEGEND` line is deleted.**
+  The legend now lives inside the fenced ```` ```mermaid ```` block
+  rendered by `rinkaku-core`, not composed by the comment-assembly
+  script — the same "legend is part of the diagram, not commentary
+  about it" reasoning ADR 0036 used in reverse (there, the legend was
+  explicitly kept *out* of `render_mermaid` because it was "prose about
+  this comment's presentation, not data derived from the `Report`");
+  here the legend is no longer prose, it is graph content (real nodes
+  with real classes), which is exactly the kind of thing
+  `render_mermaid` already owns.
+- **Node ids**: `legend_added`/`legend_changed`/`legend_removed`/
+  `legend_fan_in` are fixed, hand-written ids (not sequential `n{i}`)
+  since the legend is not derived from `report.graph.nodes` — using the
+  `n{i}` sequence could theoretically collide with a real node's id if
+  the legend were appended mid-sequence; fixed, clearly-namespaced ids
+  sidestep that entirely and make the legend block greppable/stable
+  across renders.
+- **No edges in the Legend subgraph.** The legend's job is "what does
+  this color/style mean," not "what talks to what" — adding connecting
+  edges between legend entries would imply a call relationship that
+  does not exist and dilutes the one clear reading (four independent
+  swatches).
+
+## Alternatives
+
+- **Keep the one-line prose legend, just fix the color/dash wording.**
+  Rejected: doesn't address complaint (1) — a corrected sentence is
+  still four clauses a reader has to hold in their head and cross
+  reference against the diagram above it, rather than seeing the exact
+  same rendered style directly.
+- **Fan-in encoded by stroke-width alone (thicker border), no color
+  change, no label suffix.** Considered as a smaller change. Rejected:
+  a heavier border on the *same* red fill as `removed` is exactly the
+  collision complaint (3) describes — a reviewer distinguishing
+  "removed" from "high fan-in" by stroke width alone, at a glance, in a
+  PR comment's small viewport, is not a reliable signal. Moving off
+  red entirely (not just adjusting weight) is what actually removes
+  the collision.
+- **Fan-in label suffix only, no color change (keep red fill).**
+  Rejected for the same collision reason as above — the label suffix
+  alone helps distinguish once a reader is already looking closely, but
+  the *first* glance still reads "red = ambiguous between removed and
+  fan-in" before the label is read. Both the color move and the label
+  suffix are needed; the ADR keeps both.
+- **Drop the in-diagram legend subgraph; keep prose but shorten it to
+  a table.** A Markdown table renders fine inside the PR comment body
+  but not inside the ```` ```mermaid ```` fence itself, so it would
+  still live in `compose_and_post_comment.sh`, inheriting the same
+  "can drift out of sync with the real `classDef`s" risk this ADR is
+  trying to close. Rejected in favor of the self-describing subgraph.
+- **Legend subgraph with emoji/icons per class instead of text
+  labels.** Rejected per this repository's established
+  no-decorative-glyphs convention (ADR 0028's terminal-rendering
+  rationale, reapplied here) — plain text names of the classes
+  themselves, consistent with the (now-deleted) prose legend's own
+  wording style.
+
+## Consequences
+
+- `MERMAID_CLASS_DEFS` changes are a breaking change to this format's
+  *rendered colors* (not its structure): existing consumers reading
+  `--format mermaid` output as text (not just rendering it) that
+  pattern-match on the literal hex values would need updating. No
+  external consumer is known to do this (the format's only shipped
+  consumer is the GitHub Action added alongside ADR 0021), so no
+  compatibility path is added.
+- Every `render_mermaid`/`render_mermaid_file_level` test's expected
+  output grows the trailing `Legend` subgraph block — a mechanical,
+  full-string update per this repository's fully-qualified assert
+  convention, not a partial-comparison exception.
+- `compose_and_post_comment.sh` no longer composes `MERMAID_LEGEND`;
+  the mermaid section becomes exactly the fenced diagram, nothing
+  appended after it. The oversized-mermaid fallback branch (mermaid
+  content past `MAX_MERMAID_LENGTH`) no longer has a legend to show
+  either, since there is no diagram at all in that case — consistent
+  with the legend being part of the diagram, not independent prose.
+- The `(in:N)` label suffix is unique to fan-in-classed nodes; `added`/
+  `changed`/`removed` node labels are unchanged (name only, per ADR
+  0021/0037's "coarse and readable" rule) — this ADR does not extend
+  the suffix convention to any other class.
+- If a future class is added to this format, its legend entry follows
+  the same fixed-id, no-edges pattern established here.

--- a/docs/adr/0039-mermaid-visual-encoding-revision.md
+++ b/docs/adr/0039-mermaid-visual-encoding-revision.md
@@ -1,4 +1,4 @@
-# 0038. Revise `--format mermaid`'s visual encoding and legend
+# 0039. Revise `--format mermaid`'s visual encoding and legend
 
 - Status: accepted
 - Date: 2026-07-14

--- a/rinkaku-core/src/render/mermaid.rs
+++ b/rinkaku-core/src/render/mermaid.rs
@@ -1,4 +1,4 @@
-//! Mermaid `flowchart` rendering (ADR 0021, amended by ADR 0037, ADR 0038).
+//! Mermaid `flowchart` rendering (ADR 0021, amended by ADR 0037, ADR 0039).
 //!
 //! The `--format mermaid` output path: a human-oriented call/dependency
 //! graph aimed at GitHub's native mermaid rendering in PR comments/
@@ -8,7 +8,7 @@
 //! of degrading into a hairball. `report.removed` (ADR 0014) renders as
 //! `removed`-classed nodes in the same graph — see ADR 0037 for why a
 //! merged graph rather than a separate before/after diagram. A trailing
-//! `Legend` subgraph (ADR 0038) renders one real, styled node per class so
+//! `Legend` subgraph (ADR 0039) renders one real, styled node per class so
 //! the diagram explains its own color/style vocabulary without a separate
 //! prose legend.
 
@@ -59,7 +59,7 @@ pub(super) fn render_mermaid(report: &Report) -> String {
 
     let lookup = SymbolLookup::build(&report.files);
     // Fan-in count (`used_by.len()`) per node id, used both for class
-    // selection and the `(in:N)` label suffix (ADR 0038) — a node present
+    // selection and the `(in:N)` label suffix (ADR 0039) — a node present
     // here is by definition a high-fan-in symbol (`compute_fan_ins` only
     // includes nodes with fan-in >= 2, per ADR 0013).
     let fan_in_counts: HashMap<&str, usize> = report
@@ -309,15 +309,15 @@ fn render_mermaid_file_level(report: &Report) -> String {
 /// [`render_mermaid_file_level`]. Colors are chosen with explicit
 /// dark-on-light text (rather than relying on mermaid's theme defaults) so
 /// they stay legible under both GitHub's light and dark PR-comment themes
-/// (ADR 0021). `removed` (ADR 0037, recolored red by ADR 0038) is dashed
+/// (ADR 0021). `removed` (ADR 0037, recolored red by ADR 0039) is dashed
 /// rather than solid-bordered, echoing the cycle-edge convention (`-.->`)
-/// for "no longer normal." `fan-in` (ADR 0038) uses a violet/blue stroke
+/// for "no longer normal." `fan-in` (ADR 0039) uses a violet/blue stroke
 /// distinct from `removed`'s red, plus its own heavier `stroke-width`, so
 /// the two classes cannot be confused for each other at a glance — a node
 /// that is both `changed`/`added` and high-fan-in still gets `fan-in`
 /// styling (see `render_mermaid`'s class-assignment comment for the
 /// precedence rule), and its label additionally carries a `(in:N)` suffix
-/// so the signal survives even without color (ADR 0038).
+/// so the signal survives even without color (ADR 0039).
 const MERMAID_CLASS_DEFS: &str = concat!(
     "  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;\n",
     "  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;\n",
@@ -326,13 +326,13 @@ const MERMAID_CLASS_DEFS: &str = concat!(
 );
 
 /// Fixed-id, real-node `subgraph Legend` block appended by
-/// [`write_legend_and_class_defs`] (ADR 0038): one node per class, styled
+/// [`write_legend_and_class_defs`] (ADR 0039): one node per class, styled
 /// with the same `classDef` a real graph node of that class would use.
 /// Always emitted — including the empty-graph and file-level-fallback
 /// paths — so a reader never sees the diagram without its own key, and a
 /// future `classDef` change re-styles the legend automatically instead of
 /// risking drift against a hand-written prose description (the problem ADR
-/// 0038 replaces). Node ids are fixed rather than drawn from the `n{i}`
+/// 0039 replaces). Node ids are fixed rather than drawn from the `n{i}`
 /// sequence since the legend has no corresponding `report.graph.nodes`
 /// entry to derive one from.
 const MERMAID_LEGEND: &str = concat!(

--- a/rinkaku-core/src/render/mermaid.rs
+++ b/rinkaku-core/src/render/mermaid.rs
@@ -1,4 +1,4 @@
-//! Mermaid `flowchart` rendering (ADR 0021, amended by ADR 0037).
+//! Mermaid `flowchart` rendering (ADR 0021, amended by ADR 0037, ADR 0038).
 //!
 //! The `--format mermaid` output path: a human-oriented call/dependency
 //! graph aimed at GitHub's native mermaid rendering in PR comments/
@@ -7,7 +7,10 @@
 //! would exceed `MERMAID_NODE_BUDGET`, so the output stays legible instead
 //! of degrading into a hairball. `report.removed` (ADR 0014) renders as
 //! `removed`-classed nodes in the same graph — see ADR 0037 for why a
-//! merged graph rather than a separate before/after diagram.
+//! merged graph rather than a separate before/after diagram. A trailing
+//! `Legend` subgraph (ADR 0038) renders one real, styled node per class so
+//! the diagram explains its own color/style vocabulary without a separate
+//! prose legend.
 
 use crate::extract::Classification;
 use crate::graph::Node;
@@ -50,11 +53,20 @@ pub(super) fn render_mermaid(report: &Report) -> String {
 
     if report.graph.nodes.is_empty() && report.removed.is_empty() {
         out.push_str("%% no symbols\n");
+        write_legend_and_class_defs(&mut out);
         return out;
     }
 
     let lookup = SymbolLookup::build(&report.files);
-    let fan_in_ids: HashSet<&str> = report.fan_ins.iter().map(|h| h.id.as_str()).collect();
+    // Fan-in count (`used_by.len()`) per node id, used both for class
+    // selection and the `(in:N)` label suffix (ADR 0038) — a node present
+    // here is by definition a high-fan-in symbol (`compute_fan_ins` only
+    // includes nodes with fan-in >= 2, per ADR 0013).
+    let fan_in_counts: HashMap<&str, usize> = report
+        .fan_ins
+        .iter()
+        .map(|h| (h.id.as_str(), h.used_by.len()))
+        .collect();
 
     // Sequential, mermaid-safe node ids (`n0`, `n1`, ...), mapped from the
     // original `NodeId` — a `NodeId` like `src/lib.rs::foo@10` contains
@@ -105,7 +117,11 @@ pub(super) fn render_mermaid(report: &Report) -> String {
         if let Some(nodes) = nodes_by_path.get(path) {
             for n in nodes {
                 let safe_id = &safe_id_by_node[n.id.as_str()];
-                writeln!(out, "    {safe_id}[\"{}\"]", escape_mermaid_label(&n.name))
+                let label = match fan_in_counts.get(n.id.as_str()) {
+                    Some(count) => format!("{} (in:{count})", n.name),
+                    None => n.name.clone(),
+                };
+                writeln!(out, "    {safe_id}[\"{}\"]", escape_mermaid_label(&label))
                     .expect("writing to a String cannot fail");
             }
         }
@@ -135,7 +151,7 @@ pub(super) fn render_mermaid(report: &Report) -> String {
     // `changed`) and a high-fan-in symbol gets `fan-in` styling, checked
     // first — see this function's doc comment / ADR 0021's Decision on
     // precedence. This overlap is real, not just theoretical: fan-in
-    // (`fan_in_ids`, from `compute_fan_ins`) counts referrers among
+    // (`fan_in_counts`, from `compute_fan_ins`) counts referrers among
     // *changed* symbols regardless of the target's own classification, so
     // a brand-new (`Added`) symbol referenced by two or more other
     // changed symbols is a perfectly ordinary high-fan-in symbol too —
@@ -147,7 +163,7 @@ pub(super) fn render_mermaid(report: &Report) -> String {
     // companion Markdown/JSON output's Definitions section either way.
     for n in &report.graph.nodes {
         let safe_id = &safe_id_by_node[n.id.as_str()];
-        let class = if fan_in_ids.contains(n.id.as_str()) {
+        let class = if fan_in_counts.contains_key(n.id.as_str()) {
             Some("fan-in")
         } else {
             match lookup.get(&n.id).and_then(|(_, s)| s.classification) {
@@ -166,7 +182,7 @@ pub(super) fn render_mermaid(report: &Report) -> String {
         writeln!(out, "  class {safe_id} removed").expect("writing to a String cannot fail");
     }
 
-    out.push_str(MERMAID_CLASS_DEFS);
+    write_legend_and_class_defs(&mut out);
     out
 }
 
@@ -285,7 +301,7 @@ fn render_mermaid_file_level(report: &Report) -> String {
         }
     }
 
-    out.push_str(MERMAID_CLASS_DEFS);
+    write_legend_and_class_defs(&mut out);
     out
 }
 
@@ -293,18 +309,53 @@ fn render_mermaid_file_level(report: &Report) -> String {
 /// [`render_mermaid_file_level`]. Colors are chosen with explicit
 /// dark-on-light text (rather than relying on mermaid's theme defaults) so
 /// they stay legible under both GitHub's light and dark PR-comment themes
-/// (ADR 0021) — `stroke-width` on `fan-in` gives it a heavier outline on
-/// top of its own fill, in addition to `changed`'s (SignatureChanged)
-/// styling, since `fan-in` styling takes precedence over `changed` for a
-/// node that qualifies as both (see `render_mermaid`'s class-assignment
-/// comment). `removed` (ADR 0037) is dashed rather than solid-bordered,
-/// echoing the cycle-edge convention (`-.->`) for "no longer normal."
+/// (ADR 0021). `removed` (ADR 0037, recolored red by ADR 0038) is dashed
+/// rather than solid-bordered, echoing the cycle-edge convention (`-.->`)
+/// for "no longer normal." `fan-in` (ADR 0038) uses a violet/blue stroke
+/// distinct from `removed`'s red, plus its own heavier `stroke-width`, so
+/// the two classes cannot be confused for each other at a glance — a node
+/// that is both `changed`/`added` and high-fan-in still gets `fan-in`
+/// styling (see `render_mermaid`'s class-assignment comment for the
+/// precedence rule), and its label additionally carries a `(in:N)` suffix
+/// so the signal survives even without color (ADR 0038).
 const MERMAID_CLASS_DEFS: &str = concat!(
     "  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;\n",
     "  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;\n",
-    "  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;\n",
-    "  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;\n",
+    "  classDef fan-in fill:#e9d8fd,stroke:#553c9a,stroke-width:3px,color:#1a202c;\n",
+    "  classDef removed fill:#fed7d7,stroke:#9b2c2c,color:#1a202c,stroke-dasharray: 5 5;\n",
 );
+
+/// Fixed-id, real-node `subgraph Legend` block appended by
+/// [`write_legend_and_class_defs`] (ADR 0038): one node per class, styled
+/// with the same `classDef` a real graph node of that class would use.
+/// Always emitted — including the empty-graph and file-level-fallback
+/// paths — so a reader never sees the diagram without its own key, and a
+/// future `classDef` change re-styles the legend automatically instead of
+/// risking drift against a hand-written prose description (the problem ADR
+/// 0038 replaces). Node ids are fixed rather than drawn from the `n{i}`
+/// sequence since the legend has no corresponding `report.graph.nodes`
+/// entry to derive one from.
+const MERMAID_LEGEND: &str = concat!(
+    "  subgraph Legend\n",
+    "    legend_added[\"added\"]\n",
+    "    legend_changed[\"API changed\"]\n",
+    "    legend_removed[\"removed\"]\n",
+    "    legend_fan_in[\"fan-in (in:N)\"]\n",
+    "  end\n",
+    "  class legend_added added\n",
+    "  class legend_changed changed\n",
+    "  class legend_removed removed\n",
+    "  class legend_fan_in fan-in\n",
+);
+
+/// Appends [`MERMAID_LEGEND`] followed by [`MERMAID_CLASS_DEFS`] — every
+/// [`render_mermaid`]/[`render_mermaid_file_level`] return path ends with
+/// this same pair, in this order, so the legend's `class` assignments
+/// above always have a matching `classDef` below them.
+fn write_legend_and_class_defs(out: &mut String) {
+    out.push_str(MERMAID_LEGEND);
+    out.push_str(MERMAID_CLASS_DEFS);
+}
 
 /// Escapes text embedded in a quoted mermaid node/subgraph label
 /// (`id["text"]`): `&` first (so the escape sequences below aren't
@@ -325,685 +376,5 @@ fn escape_mermaid_label(text: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::diff::LineRange;
-    use crate::extract::{Classification, ExtractedSymbol, RemovedSymbol, SymbolKind};
-    use crate::graph::{Edge, FanIn, Node, SymbolGraph};
-    use crate::render::report::{FileReport, ReportOrigin};
-    use crate::render::{OutputFormat, render};
-    use pretty_assertions::assert_eq;
-
-    /// Same shape as the sibling `tests::symbol` helper, plus a
-    /// `classification` parameter these tests need to exercise
-    /// added/changed/fan-in styling.
-    fn symbol(
-        id: &str,
-        name: &str,
-        kind: SymbolKind,
-        classification: Option<Classification>,
-    ) -> ExtractedSymbol {
-        ExtractedSymbol {
-            id: id.to_string(),
-            name: name.to_string(),
-            kind,
-            signature: format!("{name}()"),
-            range: LineRange { start: 1, end: 1 },
-            container: None,
-            referenced_names: vec![],
-            dependencies: vec![],
-            omitted_dependency_matches: 0,
-            is_test: false,
-            classification,
-            previous_signature: None,
-        }
-    }
-
-    fn node(id: &str, path: &str, name: &str) -> Node {
-        Node {
-            id: id.to_string(),
-            path: path.to_string(),
-            name: name.to_string(),
-        }
-    }
-
-    fn empty_report(graph: SymbolGraph, files: Vec<FileReport>) -> Report {
-        Report {
-            origin: ReportOrigin::Diff,
-            files,
-            skipped: vec![],
-            graph,
-            tests: vec![],
-            fan_ins: vec![],
-            file_size_warnings: vec![],
-            file_size_bands: vec![],
-            removed: vec![],
-        }
-    }
-
-    fn removed_symbol(name: &str, path: &str) -> RemovedSymbol {
-        RemovedSymbol {
-            name: name.to_string(),
-            kind: SymbolKind::Function,
-            path: path.to_string(),
-            signature: format!("{name}()"),
-        }
-    }
-
-    #[test]
-    fn should_render_minimal_valid_document_when_graph_is_empty() {
-        let report = empty_report(
-            SymbolGraph {
-                nodes: vec![],
-                edges: vec![],
-                roots: vec![],
-            },
-            vec![],
-        );
-
-        let expected = "\
-flowchart LR
-%% no symbols
-"
-        .to_string();
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_render_subgraph_per_file_with_class_assignments_when_report_has_classified_symbols() {
-        // "foo" is Added, "bar" is SignatureChanged, both in src/lib.rs;
-        // "baz" (unclassified/body-only) lives in src/other.rs and depends
-        // on "foo" — pins subgraph grouping, node labels (name only, no
-        // kind prefix), the edge, and the `added`/`changed` class
-        // assignments together in one full-string comparison.
-        let report = empty_report(
-            SymbolGraph {
-                nodes: vec![
-                    node("src/lib.rs::foo", "src/lib.rs", "foo"),
-                    node("src/lib.rs::bar", "src/lib.rs", "bar"),
-                    node("src/other.rs::baz", "src/other.rs", "baz"),
-                ],
-                edges: vec![Edge {
-                    from: "src/other.rs::baz".to_string(),
-                    to: "src/lib.rs::foo".to_string(),
-                    is_cycle: false,
-                }],
-                roots: vec![
-                    "src/lib.rs::foo".to_string(),
-                    "src/lib.rs::bar".to_string(),
-                    "src/other.rs::baz".to_string(),
-                ],
-            },
-            vec![
-                FileReport {
-                    path: "src/lib.rs".to_string(),
-                    symbols: vec![
-                        symbol(
-                            "src/lib.rs::foo",
-                            "foo",
-                            SymbolKind::Function,
-                            Some(Classification::Added),
-                        ),
-                        symbol(
-                            "src/lib.rs::bar",
-                            "bar",
-                            SymbolKind::Function,
-                            Some(Classification::SignatureChanged),
-                        ),
-                    ],
-                },
-                FileReport {
-                    path: "src/other.rs".to_string(),
-                    symbols: vec![symbol(
-                        "src/other.rs::baz",
-                        "baz",
-                        SymbolKind::Function,
-                        Some(Classification::BodyOnly),
-                    )],
-                },
-            ],
-        );
-
-        let expected = "\
-flowchart LR
-  subgraph sub0[\"src/lib.rs\"]
-    n0[\"foo\"]
-    n1[\"bar\"]
-  end
-  subgraph sub1[\"src/other.rs\"]
-    n2[\"baz\"]
-  end
-  n2 --> n0
-  class n0 added
-  class n1 changed
-  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
-  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
-  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
-  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;
-"
-        .to_string();
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_render_dashed_arrow_when_edge_is_a_cycle() {
-        let report = empty_report(
-            SymbolGraph {
-                nodes: vec![
-                    node("src/lib.rs::foo", "src/lib.rs", "foo"),
-                    node("src/lib.rs::bar", "src/lib.rs", "bar"),
-                ],
-                edges: vec![
-                    Edge {
-                        from: "src/lib.rs::foo".to_string(),
-                        to: "src/lib.rs::bar".to_string(),
-                        is_cycle: false,
-                    },
-                    Edge {
-                        from: "src/lib.rs::bar".to_string(),
-                        to: "src/lib.rs::foo".to_string(),
-                        is_cycle: true,
-                    },
-                ],
-                roots: vec!["src/lib.rs::foo".to_string()],
-            },
-            vec![],
-        );
-
-        let expected = "\
-flowchart LR
-  subgraph sub0[\"src/lib.rs\"]
-    n0[\"foo\"]
-    n1[\"bar\"]
-  end
-  n0 --> n1
-  n1 -.-> n0
-  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
-  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
-  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
-  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;
-"
-        .to_string();
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_escape_label_when_name_contains_quote_and_bracket() {
-        let report = empty_report(
-            SymbolGraph {
-                nodes: vec![node(
-                    "src/lib.rs::weird",
-                    "src/lib.rs",
-                    "weird\"name[with]brackets",
-                )],
-                edges: vec![],
-                roots: vec!["src/lib.rs::weird".to_string()],
-            },
-            vec![],
-        );
-
-        let expected = "\
-flowchart LR
-  subgraph sub0[\"src/lib.rs\"]
-    n0[\"weird&quot;name&#91;with&#93;brackets\"]
-  end
-  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
-  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
-  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
-  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;
-"
-        .to_string();
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_replace_embedded_newline_with_space_when_path_contains_one() {
-        // A path/name is not expected to legitimately contain a newline,
-        // but nothing upstream guarantees it can't — an unescaped `\n`
-        // inside a quoted mermaid label would break the single-line label
-        // syntax, so it is normalized to a space defensively rather than
-        // left as-is or escaped like the other special characters.
-        let report = empty_report(
-            SymbolGraph {
-                nodes: vec![node("src/lib.rs::weird", "src/li\nb.rs", "weird")],
-                edges: vec![],
-                roots: vec!["src/lib.rs::weird".to_string()],
-            },
-            vec![],
-        );
-
-        let expected = "\
-flowchart LR
-  subgraph sub0[\"src/li b.rs\"]
-    n0[\"weird\"]
-  end
-  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
-  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
-  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
-  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;
-"
-        .to_string();
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_prefer_fan_in_class_over_changed_class_when_node_is_both() {
-        // "shared" is SignatureChanged *and* referenced by two other
-        // symbols (fan-in >= 2, so it's also a high-fan-in symbol) —
-        // precedence goes to `fan-in` styling per this module's documented
-        // choice.
-        let report = Report {
-            origin: ReportOrigin::Diff,
-            files: vec![FileReport {
-                path: "src/lib.rs".to_string(),
-                symbols: vec![symbol(
-                    "src/lib.rs::shared",
-                    "shared",
-                    SymbolKind::Function,
-                    Some(Classification::SignatureChanged),
-                )],
-            }],
-            skipped: vec![],
-            graph: SymbolGraph {
-                nodes: vec![node("src/lib.rs::shared", "src/lib.rs", "shared")],
-                edges: vec![],
-                roots: vec!["src/lib.rs::shared".to_string()],
-            },
-            tests: vec![],
-            fan_ins: vec![FanIn {
-                id: "src/lib.rs::shared".to_string(),
-                path: "src/lib.rs".to_string(),
-                name: "shared".to_string(),
-                used_by: vec!["a".to_string(), "b".to_string()],
-            }],
-            file_size_warnings: vec![],
-            file_size_bands: vec![],
-            removed: vec![],
-        };
-
-        let expected = "\
-flowchart LR
-  subgraph sub0[\"src/lib.rs\"]
-    n0[\"shared\"]
-  end
-  class n0 fan-in
-  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
-  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
-  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
-  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;
-"
-        .to_string();
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_prefer_fan_in_class_over_added_class_when_a_new_symbol_has_high_fan_in() {
-        // Fan-in (`compute_fan_ins`) counts referrers among *changed*
-        // symbols regardless of the referenced node's own classification —
-        // a brand-new ("added") symbol referenced by two or more other
-        // changed symbols in the same diff (e.g. a new helper two other
-        // new/changed call sites both use) is a perfectly ordinary
-        // high-fan-in symbol too, not a case that can't occur. Same
-        // precedence as the SignatureChanged sibling test above: `fan-in`
-        // wins.
-        let report = Report {
-            origin: ReportOrigin::Diff,
-            files: vec![FileReport {
-                path: "src/lib.rs".to_string(),
-                symbols: vec![symbol(
-                    "src/lib.rs::new_helper",
-                    "new_helper",
-                    SymbolKind::Function,
-                    Some(Classification::Added),
-                )],
-            }],
-            skipped: vec![],
-            graph: SymbolGraph {
-                nodes: vec![node("src/lib.rs::new_helper", "src/lib.rs", "new_helper")],
-                edges: vec![],
-                roots: vec!["src/lib.rs::new_helper".to_string()],
-            },
-            tests: vec![],
-            fan_ins: vec![FanIn {
-                id: "src/lib.rs::new_helper".to_string(),
-                path: "src/lib.rs".to_string(),
-                name: "new_helper".to_string(),
-                used_by: vec!["a".to_string(), "b".to_string()],
-            }],
-            file_size_warnings: vec![],
-            file_size_bands: vec![],
-            removed: vec![],
-        };
-
-        let expected = "\
-flowchart LR
-  subgraph sub0[\"src/lib.rs\"]
-    n0[\"new_helper\"]
-  end
-  class n0 fan-in
-  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
-  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
-  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
-  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;
-"
-        .to_string();
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_stay_symbol_level_when_node_count_equals_budget_exactly() {
-        // Exactly MERMAID_NODE_BUDGET (30) nodes: the fallback condition
-        // is `> budget`, so this boundary case must still render one
-        // subgraph/node per symbol, not the file-level aggregation — pins
-        // the off-by-one the sibling over-budget test alone can't rule
-        // out (that test only proves 31 falls back, not that 30 doesn't).
-        let mut nodes = Vec::new();
-        let mut symbols = Vec::new();
-        for i in 0..30 {
-            let id = format!("src/lib.rs::s{i}");
-            nodes.push(node(&id, "src/lib.rs", &format!("s{i}")));
-            symbols.push(symbol(&id, &format!("s{i}"), SymbolKind::Function, None));
-        }
-        assert_eq!(30, nodes.len());
-
-        let report = empty_report(
-            SymbolGraph {
-                nodes,
-                edges: vec![],
-                roots: vec!["src/lib.rs::s0".to_string()],
-            },
-            vec![FileReport {
-                path: "src/lib.rs".to_string(),
-                symbols,
-            }],
-        );
-
-        let mut expected = String::from("flowchart LR\n  subgraph sub0[\"src/lib.rs\"]\n");
-        for i in 0..30 {
-            expected.push_str(&format!("    n{i}[\"s{i}\"]\n"));
-        }
-        expected.push_str("  end\n");
-        expected.push_str(MERMAID_CLASS_DEFS);
-
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_fall_back_to_file_level_graph_when_node_count_exceeds_budget() {
-        // 31 nodes (one over MERMAID_NODE_BUDGET's 30) across two files:
-        // 16 in src/a.rs (one classified Added, so a.rs is "changed"), 15
-        // in src/b.rs. Two edges cross from a.rs to b.rs (aggregated with
-        // count 2); one edge stays within a.rs (dropped: an intra-file
-        // edge carries no file-level signal).
-        let mut nodes = Vec::new();
-        let mut files_a_symbols = Vec::new();
-        for i in 0..16 {
-            let id = format!("src/a.rs::a{i}");
-            nodes.push(node(&id, "src/a.rs", &format!("a{i}")));
-            let classification = if i == 0 {
-                Some(Classification::Added)
-            } else {
-                None
-            };
-            files_a_symbols.push(symbol(
-                &id,
-                &format!("a{i}"),
-                SymbolKind::Function,
-                classification,
-            ));
-        }
-        let mut files_b_symbols = Vec::new();
-        for i in 0..15 {
-            let id = format!("src/b.rs::b{i}");
-            nodes.push(node(&id, "src/b.rs", &format!("b{i}")));
-            files_b_symbols.push(symbol(&id, &format!("b{i}"), SymbolKind::Function, None));
-        }
-        assert_eq!(31, nodes.len());
-
-        let edges = vec![
-            Edge {
-                from: "src/a.rs::a0".to_string(),
-                to: "src/b.rs::b0".to_string(),
-                is_cycle: false,
-            },
-            Edge {
-                from: "src/a.rs::a1".to_string(),
-                to: "src/b.rs::b1".to_string(),
-                is_cycle: false,
-            },
-            Edge {
-                from: "src/a.rs::a0".to_string(),
-                to: "src/a.rs::a1".to_string(),
-                is_cycle: false,
-            },
-        ];
-        let roots = vec!["src/a.rs::a0".to_string(), "src/b.rs::b0".to_string()];
-
-        let report = empty_report(
-            SymbolGraph {
-                nodes,
-                edges,
-                roots,
-            },
-            vec![
-                FileReport {
-                    path: "src/a.rs".to_string(),
-                    symbols: files_a_symbols,
-                },
-                FileReport {
-                    path: "src/b.rs".to_string(),
-                    symbols: files_b_symbols,
-                },
-            ],
-        );
-
-        let expected = "\
-flowchart LR
-%% aggregated to file level (31 symbols > budget)
-  n0[\"src/a.rs\"]
-  n1[\"src/b.rs\"]
-  n0 -- 2 --> n1
-  class n0 changed
-  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
-  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
-  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
-  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;
-"
-        .to_string();
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_render_removed_node_in_its_file_subgraph_when_report_has_removed_symbols() {
-        // "foo" survives alongside the removed "old_helper" so the
-        // expected output can pin ordering: removed after surviving.
-        let mut report = empty_report(
-            SymbolGraph {
-                nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
-                edges: vec![],
-                roots: vec!["src/lib.rs::foo".to_string()],
-            },
-            vec![FileReport {
-                path: "src/lib.rs".to_string(),
-                symbols: vec![symbol(
-                    "src/lib.rs::foo",
-                    "foo",
-                    SymbolKind::Function,
-                    Some(Classification::Added),
-                )],
-            }],
-        );
-        report.removed = vec![removed_symbol("old_helper", "src/lib.rs")];
-
-        let expected = "\
-flowchart LR
-  subgraph sub0[\"src/lib.rs\"]
-    n0[\"foo\"]
-    n1[\"old_helper\"]
-  end
-  class n0 added
-  class n1 removed
-  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
-  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
-  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
-  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;
-"
-        .to_string();
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_render_removed_only_file_subgraph_when_file_has_no_surviving_symbols() {
-        let mut report = empty_report(
-            SymbolGraph {
-                nodes: vec![],
-                edges: vec![],
-                roots: vec![],
-            },
-            vec![],
-        );
-        report.removed = vec![removed_symbol("old_only", "src/gone.rs")];
-
-        let expected = "\
-flowchart LR
-  subgraph sub0[\"src/gone.rs\"]
-    n0[\"old_only\"]
-  end
-  class n0 removed
-  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
-  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
-  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
-  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;
-"
-        .to_string();
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_count_removed_symbols_toward_node_budget_when_deciding_fallback() {
-        // 30 head-side nodes alone stay symbol-level (see the sibling
-        // boundary test above); the 1 removed symbol added here must be
-        // what tips this report over budget.
-        let mut nodes = Vec::new();
-        let mut symbols = Vec::new();
-        for i in 0..30 {
-            let id = format!("src/lib.rs::s{i}");
-            nodes.push(node(&id, "src/lib.rs", &format!("s{i}")));
-            symbols.push(symbol(&id, &format!("s{i}"), SymbolKind::Function, None));
-        }
-        let mut report = empty_report(
-            SymbolGraph {
-                nodes,
-                edges: vec![],
-                roots: vec!["src/lib.rs::s0".to_string()],
-            },
-            vec![FileReport {
-                path: "src/lib.rs".to_string(),
-                symbols,
-            }],
-        );
-        report.removed = vec![removed_symbol("old_helper", "src/lib.rs")];
-
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert!(
-            actual.contains("%% aggregated to file level (31 symbols > budget)"),
-            "expected file-level fallback comment in output, got:\n{actual}"
-        );
-    }
-
-    #[test]
-    fn should_render_removed_only_file_as_removed_node_when_fallback_fires() {
-        // src/a.rs (16 nodes) + src/b.rs (15) already exceed the budget;
-        // src/gone.rs adds only a removed symbol, no head-side node.
-        let mut nodes = Vec::new();
-        let mut files_a_symbols = Vec::new();
-        for i in 0..16 {
-            let id = format!("src/a.rs::a{i}");
-            nodes.push(node(&id, "src/a.rs", &format!("a{i}")));
-            let classification = if i == 0 {
-                Some(Classification::Added)
-            } else {
-                None
-            };
-            files_a_symbols.push(symbol(
-                &id,
-                &format!("a{i}"),
-                SymbolKind::Function,
-                classification,
-            ));
-        }
-        let mut files_b_symbols = Vec::new();
-        for i in 0..15 {
-            let id = format!("src/b.rs::b{i}");
-            nodes.push(node(&id, "src/b.rs", &format!("b{i}")));
-            files_b_symbols.push(symbol(&id, &format!("b{i}"), SymbolKind::Function, None));
-        }
-        assert_eq!(31, nodes.len());
-
-        let report = Report {
-            origin: ReportOrigin::Diff,
-            files: vec![
-                FileReport {
-                    path: "src/a.rs".to_string(),
-                    symbols: files_a_symbols,
-                },
-                FileReport {
-                    path: "src/b.rs".to_string(),
-                    symbols: files_b_symbols,
-                },
-            ],
-            skipped: vec![],
-            graph: SymbolGraph {
-                nodes,
-                edges: vec![],
-                roots: vec!["src/a.rs::a0".to_string(), "src/b.rs::b0".to_string()],
-            },
-            tests: vec![],
-            fan_ins: vec![],
-            file_size_warnings: vec![],
-            file_size_bands: vec![],
-            removed: vec![removed_symbol("old_only", "src/gone.rs")],
-        };
-
-        let expected = "\
-flowchart LR
-%% aggregated to file level (32 symbols > budget)
-  n0[\"src/a.rs\"]
-  n1[\"src/b.rs\"]
-  n2[\"src/gone.rs\"]
-  class n0 changed
-  class n2 removed
-  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
-  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
-  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
-  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;
-"
-        .to_string();
-        let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
-
-        assert_eq!(expected, actual);
-    }
-}
+#[path = "mermaid_tests/mod.rs"]
+mod tests;

--- a/rinkaku-core/src/render/mermaid_tests/class_styling.rs
+++ b/rinkaku-core/src/render/mermaid_tests/class_styling.rs
@@ -1,0 +1,315 @@
+//! `added`/`changed`/`fan-in` class assignment, fan-in's `(in:N)` label
+//! suffix (ADR 0038), and the fan-in-vs-changed/added precedence rule.
+
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn should_render_subgraph_per_file_with_class_assignments_when_report_has_classified_symbols() {
+    // "foo" is Added, "bar" is SignatureChanged, both in src/lib.rs; "baz"
+    // (unclassified/body-only) lives in src/other.rs and depends on "foo"
+    // — pins subgraph grouping, node labels (name only, no kind prefix),
+    // the edge, and the `added`/`changed` class assignments together in
+    // one full-string comparison.
+    let report = empty_report(
+        SymbolGraph {
+            nodes: vec![
+                node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                node("src/lib.rs::bar", "src/lib.rs", "bar"),
+                node("src/other.rs::baz", "src/other.rs", "baz"),
+            ],
+            edges: vec![Edge {
+                from: "src/other.rs::baz".to_string(),
+                to: "src/lib.rs::foo".to_string(),
+                is_cycle: false,
+            }],
+            roots: vec![
+                "src/lib.rs::foo".to_string(),
+                "src/lib.rs::bar".to_string(),
+                "src/other.rs::baz".to_string(),
+            ],
+        },
+        vec![
+            FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![
+                    symbol(
+                        "src/lib.rs::foo",
+                        "foo",
+                        SymbolKind::Function,
+                        Some(Classification::Added),
+                    ),
+                    symbol(
+                        "src/lib.rs::bar",
+                        "bar",
+                        SymbolKind::Function,
+                        Some(Classification::SignatureChanged),
+                    ),
+                ],
+            },
+            FileReport {
+                path: "src/other.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/other.rs::baz",
+                    "baz",
+                    SymbolKind::Function,
+                    Some(Classification::BodyOnly),
+                )],
+            },
+        ],
+    );
+
+    let expected = concat!(
+        "flowchart LR\n",
+        "  subgraph sub0[\"src/lib.rs\"]\n",
+        "    n0[\"foo\"]\n",
+        "    n1[\"bar\"]\n",
+        "  end\n",
+        "  subgraph sub1[\"src/other.rs\"]\n",
+        "    n2[\"baz\"]\n",
+        "  end\n",
+        "  n2 --> n0\n",
+        "  class n0 added\n",
+        "  class n1 changed\n",
+    )
+    .to_string()
+        + LEGEND_AND_CLASS_DEFS;
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_render_dashed_arrow_when_edge_is_a_cycle() {
+    let report = empty_report(
+        SymbolGraph {
+            nodes: vec![
+                node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                node("src/lib.rs::bar", "src/lib.rs", "bar"),
+            ],
+            edges: vec![
+                Edge {
+                    from: "src/lib.rs::foo".to_string(),
+                    to: "src/lib.rs::bar".to_string(),
+                    is_cycle: false,
+                },
+                Edge {
+                    from: "src/lib.rs::bar".to_string(),
+                    to: "src/lib.rs::foo".to_string(),
+                    is_cycle: true,
+                },
+            ],
+            roots: vec!["src/lib.rs::foo".to_string()],
+        },
+        vec![],
+    );
+
+    let expected = concat!(
+        "flowchart LR\n",
+        "  subgraph sub0[\"src/lib.rs\"]\n",
+        "    n0[\"foo\"]\n",
+        "    n1[\"bar\"]\n",
+        "  end\n",
+        "  n0 --> n1\n",
+        "  n1 -.-> n0\n",
+    )
+    .to_string()
+        + LEGEND_AND_CLASS_DEFS;
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_append_fan_in_count_suffix_to_label_when_node_is_high_fan_in() {
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol(
+                "src/lib.rs::shared",
+                "shared",
+                SymbolKind::Function,
+                None,
+            )],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![node("src/lib.rs::shared", "src/lib.rs", "shared")],
+            edges: vec![],
+            roots: vec!["src/lib.rs::shared".to_string()],
+        },
+        tests: vec![],
+        fan_ins: vec![FanIn {
+            id: "src/lib.rs::shared".to_string(),
+            path: "src/lib.rs".to_string(),
+            name: "shared".to_string(),
+            used_by: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        }],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+
+    let expected = concat!(
+        "flowchart LR\n",
+        "  subgraph sub0[\"src/lib.rs\"]\n",
+        "    n0[\"shared (in:3)\"]\n",
+        "  end\n",
+        "  class n0 fan-in\n",
+    )
+    .to_string()
+        + LEGEND_AND_CLASS_DEFS;
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_prefer_fan_in_class_over_changed_class_when_node_is_both() {
+    // "shared" is SignatureChanged *and* referenced by two other symbols
+    // (fan-in >= 2, so it's also a high-fan-in symbol) — precedence goes
+    // to `fan-in` styling per this module's documented choice.
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol(
+                "src/lib.rs::shared",
+                "shared",
+                SymbolKind::Function,
+                Some(Classification::SignatureChanged),
+            )],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![node("src/lib.rs::shared", "src/lib.rs", "shared")],
+            edges: vec![],
+            roots: vec!["src/lib.rs::shared".to_string()],
+        },
+        tests: vec![],
+        fan_ins: vec![FanIn {
+            id: "src/lib.rs::shared".to_string(),
+            path: "src/lib.rs".to_string(),
+            name: "shared".to_string(),
+            used_by: vec!["a".to_string(), "b".to_string()],
+        }],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+
+    let expected = concat!(
+        "flowchart LR\n",
+        "  subgraph sub0[\"src/lib.rs\"]\n",
+        "    n0[\"shared (in:2)\"]\n",
+        "  end\n",
+        "  class n0 fan-in\n",
+    )
+    .to_string()
+        + LEGEND_AND_CLASS_DEFS;
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_prefer_fan_in_class_over_added_class_when_a_new_symbol_has_high_fan_in() {
+    // Fan-in (`compute_fan_ins`) counts referrers among *changed* symbols
+    // regardless of the referenced node's own classification — a
+    // brand-new ("added") symbol referenced by two or more other changed
+    // symbols in the same diff (e.g. a new helper two other new/changed
+    // call sites both use) is a perfectly ordinary high-fan-in symbol too,
+    // not a case that can't occur. Same precedence as the SignatureChanged
+    // sibling test above: `fan-in` wins.
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol(
+                "src/lib.rs::new_helper",
+                "new_helper",
+                SymbolKind::Function,
+                Some(Classification::Added),
+            )],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![node("src/lib.rs::new_helper", "src/lib.rs", "new_helper")],
+            edges: vec![],
+            roots: vec!["src/lib.rs::new_helper".to_string()],
+        },
+        tests: vec![],
+        fan_ins: vec![FanIn {
+            id: "src/lib.rs::new_helper".to_string(),
+            path: "src/lib.rs".to_string(),
+            name: "new_helper".to_string(),
+            used_by: vec!["a".to_string(), "b".to_string()],
+        }],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+
+    let expected = concat!(
+        "flowchart LR\n",
+        "  subgraph sub0[\"src/lib.rs\"]\n",
+        "    n0[\"new_helper (in:2)\"]\n",
+        "  end\n",
+        "  class n0 fan-in\n",
+    )
+    .to_string()
+        + LEGEND_AND_CLASS_DEFS;
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_render_removed_and_fan_in_nodes_distinctly_when_both_present_in_one_report() {
+    // Regression pin for the ADR 0038 collision this ADR fixes: before
+    // this change, `removed` and `fan-in` shared the same red fill, so a
+    // report containing both classes rendered two visually-identical node
+    // styles. `hot` (SignatureChanged, fan-in 2) must get the `fan-in`
+    // class/violet styling and an `(in:2)` label suffix; `gone` (removed)
+    // must get the red-dashed `removed` class and no label suffix —
+    // distinct classes, distinct `classDef` colors.
+    let mut report = empty_report(
+        SymbolGraph {
+            nodes: vec![node("src/lib.rs::hot", "src/lib.rs", "hot")],
+            edges: vec![],
+            roots: vec!["src/lib.rs::hot".to_string()],
+        },
+        vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol(
+                "src/lib.rs::hot",
+                "hot",
+                SymbolKind::Function,
+                Some(Classification::SignatureChanged),
+            )],
+        }],
+    );
+    report.fan_ins = vec![FanIn {
+        id: "src/lib.rs::hot".to_string(),
+        path: "src/lib.rs".to_string(),
+        name: "hot".to_string(),
+        used_by: vec!["a".to_string(), "b".to_string()],
+    }];
+    report.removed = vec![removed_symbol("gone", "src/lib.rs")];
+
+    let expected = concat!(
+        "flowchart LR\n",
+        "  subgraph sub0[\"src/lib.rs\"]\n",
+        "    n0[\"hot (in:2)\"]\n",
+        "    n1[\"gone\"]\n",
+        "  end\n",
+        "  class n0 fan-in\n",
+        "  class n1 removed\n",
+    )
+    .to_string()
+        + LEGEND_AND_CLASS_DEFS;
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}

--- a/rinkaku-core/src/render/mermaid_tests/class_styling.rs
+++ b/rinkaku-core/src/render/mermaid_tests/class_styling.rs
@@ -1,5 +1,5 @@
 //! `added`/`changed`/`fan-in` class assignment, fan-in's `(in:N)` label
-//! suffix (ADR 0038), and the fan-in-vs-changed/added precedence rule.
+//! suffix (ADR 0039), and the fan-in-vs-changed/added precedence rule.
 
 use super::*;
 use pretty_assertions::assert_eq;
@@ -267,7 +267,7 @@ fn should_prefer_fan_in_class_over_added_class_when_a_new_symbol_has_high_fan_in
 
 #[test]
 fn should_render_removed_and_fan_in_nodes_distinctly_when_both_present_in_one_report() {
-    // Regression pin for the ADR 0038 collision this ADR fixes: before
+    // Regression pin for the ADR 0039 collision this ADR fixes: before
     // this change, `removed` and `fan-in` shared the same red fill, so a
     // report containing both classes rendered two visually-identical node
     // styles. `hot` (SignatureChanged, fan-in 2) must get the `fan-in`

--- a/rinkaku-core/src/render/mermaid_tests/empty_and_legend.rs
+++ b/rinkaku-core/src/render/mermaid_tests/empty_and_legend.rs
@@ -1,4 +1,4 @@
-//! The empty-graph short-circuit and the ADR 0038 `Legend` subgraph every
+//! The empty-graph short-circuit and the ADR 0039 `Legend` subgraph every
 //! render path shares.
 
 use super::*;

--- a/rinkaku-core/src/render/mermaid_tests/empty_and_legend.rs
+++ b/rinkaku-core/src/render/mermaid_tests/empty_and_legend.rs
@@ -1,0 +1,65 @@
+//! The empty-graph short-circuit and the ADR 0038 `Legend` subgraph every
+//! render path shares.
+
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn should_render_minimal_valid_document_with_legend_when_graph_is_empty() {
+    let report = empty_report(
+        SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        vec![],
+    );
+
+    let expected = format!("flowchart LR\n%% no symbols\n{}", LEGEND_AND_CLASS_DEFS);
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+// NOTE: partial (`contains`) assertions here, not a full-string compare —
+// every other test in this module already pins the exact full document
+// (including this same trailer via `LEGEND_AND_CLASS_DEFS`); this test's
+// purpose is narrower, to have one failure point squarely at the legend
+// block itself if its content changes, independent of whichever
+// class-assignment test happens to also cover it.
+#[test]
+fn should_render_legend_subgraph_with_one_styled_node_per_class_when_graph_has_symbols() {
+    let report = empty_report(
+        SymbolGraph {
+            nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+            edges: vec![],
+            roots: vec!["src/lib.rs::foo".to_string()],
+        },
+        vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol("src/lib.rs::foo", "foo", SymbolKind::Function, None)],
+        }],
+    );
+
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert!(
+        actual.contains(
+            "  subgraph Legend\n\
+             \x20   legend_added[\"added\"]\n\
+             \x20   legend_changed[\"API changed\"]\n\
+             \x20   legend_removed[\"removed\"]\n\
+             \x20   legend_fan_in[\"fan-in (in:N)\"]\n\
+             \x20 end\n"
+        ),
+        "expected Legend subgraph block in output, got:\n{actual}"
+    );
+    assert!(
+        actual.contains("  class legend_added added\n"),
+        "expected legend_added class assignment, got:\n{actual}"
+    );
+    assert!(
+        actual.contains("  class legend_fan_in fan-in\n"),
+        "expected legend_fan_in class assignment, got:\n{actual}"
+    );
+}

--- a/rinkaku-core/src/render/mermaid_tests/escaping.rs
+++ b/rinkaku-core/src/render/mermaid_tests/escaping.rs
@@ -1,0 +1,53 @@
+//! Label escaping for quotes/brackets/ampersands and embedded newlines.
+
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn should_escape_label_when_name_contains_quote_and_bracket() {
+    let report = empty_report(
+        SymbolGraph {
+            nodes: vec![node(
+                "src/lib.rs::weird",
+                "src/lib.rs",
+                "weird\"name[with]brackets",
+            )],
+            edges: vec![],
+            roots: vec!["src/lib.rs::weird".to_string()],
+        },
+        vec![],
+    );
+
+    let expected = format!(
+        "flowchart LR\n  subgraph sub0[\"src/lib.rs\"]\n    n0[\"weird&quot;name&#91;with&#93;brackets\"]\n  end\n{}",
+        LEGEND_AND_CLASS_DEFS
+    );
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_replace_embedded_newline_with_space_when_path_contains_one() {
+    // A path/name is not expected to legitimately contain a newline, but
+    // nothing upstream guarantees it can't — an unescaped `\n` inside a
+    // quoted mermaid label would break the single-line label syntax, so it
+    // is normalized to a space defensively rather than left as-is or
+    // escaped like the other special characters.
+    let report = empty_report(
+        SymbolGraph {
+            nodes: vec![node("src/lib.rs::weird", "src/li\nb.rs", "weird")],
+            edges: vec![],
+            roots: vec!["src/lib.rs::weird".to_string()],
+        },
+        vec![],
+    );
+
+    let expected = format!(
+        "flowchart LR\n  subgraph sub0[\"src/li b.rs\"]\n    n0[\"weird\"]\n  end\n{}",
+        LEGEND_AND_CLASS_DEFS
+    );
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}

--- a/rinkaku-core/src/render/mermaid_tests/mod.rs
+++ b/rinkaku-core/src/render/mermaid_tests/mod.rs
@@ -1,0 +1,106 @@
+//! Tests for [`super::render_mermaid`]/[`super::render_mermaid_file_level`],
+//! split by which behavior each file pins:
+//!
+//! - [`empty_and_legend`] — the empty-graph short-circuit and the ADR 0038
+//!   `Legend` subgraph/`classDef` trailer every render path shares.
+//! - [`class_styling`] — `added`/`changed`/`fan-in` class assignment,
+//!   fan-in's `(in:N)` label suffix, and the fan-in-vs-changed/added
+//!   precedence rule.
+//! - [`escaping`] — label escaping for quotes/brackets/ampersands and
+//!   embedded newlines.
+//! - [`node_budget_fallback`] — the [`super::MERMAID_NODE_BUDGET`] boundary
+//!   and the file-level aggregation fallback.
+//! - [`removed_symbols`] — ADR 0037 `removed`-classed nodes, including the
+//!   removed-only-file case and the node-budget interaction.
+
+use super::*;
+use crate::diff::LineRange;
+use crate::extract::{Classification, ExtractedSymbol, RemovedSymbol, SymbolKind};
+use crate::graph::{Edge, FanIn, Node, SymbolGraph};
+use crate::render::report::{FileReport, ReportOrigin};
+use crate::render::{OutputFormat, render};
+
+mod class_styling;
+mod empty_and_legend;
+mod escaping;
+mod node_budget_fallback;
+mod removed_symbols;
+
+/// Same shape as the sibling `tests::symbol` helper, plus a
+/// `classification` parameter these tests need to exercise
+/// added/changed/fan-in styling.
+fn symbol(
+    id: &str,
+    name: &str,
+    kind: SymbolKind,
+    classification: Option<Classification>,
+) -> ExtractedSymbol {
+    ExtractedSymbol {
+        id: id.to_string(),
+        name: name.to_string(),
+        kind,
+        signature: format!("{name}()"),
+        range: LineRange { start: 1, end: 1 },
+        container: None,
+        referenced_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification,
+        previous_signature: None,
+    }
+}
+
+fn node(id: &str, path: &str, name: &str) -> Node {
+    Node {
+        id: id.to_string(),
+        path: path.to_string(),
+        name: name.to_string(),
+    }
+}
+
+fn empty_report(graph: SymbolGraph, files: Vec<FileReport>) -> Report {
+    Report {
+        origin: ReportOrigin::Diff,
+        files,
+        skipped: vec![],
+        graph,
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    }
+}
+
+fn removed_symbol(name: &str, path: &str) -> RemovedSymbol {
+    RemovedSymbol {
+        name: name.to_string(),
+        kind: SymbolKind::Function,
+        path: path.to_string(),
+        signature: format!("{name}()"),
+    }
+}
+
+/// The exact `Legend` subgraph + `classDef` trailer every render path
+/// appends (ADR 0038) — every test's `expected` string ends with this,
+/// shared here so a future style change is a one-line update instead of a
+/// find/replace across every test file. `concat!`, not a `"\`-continued
+/// literal: the latter strips leading whitespace from the continued line,
+/// which would silently swallow this block's leading indentation.
+const LEGEND_AND_CLASS_DEFS: &str = concat!(
+    "  subgraph Legend\n",
+    "    legend_added[\"added\"]\n",
+    "    legend_changed[\"API changed\"]\n",
+    "    legend_removed[\"removed\"]\n",
+    "    legend_fan_in[\"fan-in (in:N)\"]\n",
+    "  end\n",
+    "  class legend_added added\n",
+    "  class legend_changed changed\n",
+    "  class legend_removed removed\n",
+    "  class legend_fan_in fan-in\n",
+    "  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;\n",
+    "  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;\n",
+    "  classDef fan-in fill:#e9d8fd,stroke:#553c9a,stroke-width:3px,color:#1a202c;\n",
+    "  classDef removed fill:#fed7d7,stroke:#9b2c2c,color:#1a202c,stroke-dasharray: 5 5;\n",
+);

--- a/rinkaku-core/src/render/mermaid_tests/mod.rs
+++ b/rinkaku-core/src/render/mermaid_tests/mod.rs
@@ -1,7 +1,7 @@
 //! Tests for [`super::render_mermaid`]/[`super::render_mermaid_file_level`],
 //! split by which behavior each file pins:
 //!
-//! - [`empty_and_legend`] — the empty-graph short-circuit and the ADR 0038
+//! - [`empty_and_legend`] — the empty-graph short-circuit and the ADR 0039
 //!   `Legend` subgraph/`classDef` trailer every render path shares.
 //! - [`class_styling`] — `added`/`changed`/`fan-in` class assignment,
 //!   fan-in's `(in:N)` label suffix, and the fan-in-vs-changed/added
@@ -83,7 +83,7 @@ fn removed_symbol(name: &str, path: &str) -> RemovedSymbol {
 }
 
 /// The exact `Legend` subgraph + `classDef` trailer every render path
-/// appends (ADR 0038) — every test's `expected` string ends with this,
+/// appends (ADR 0039) — every test's `expected` string ends with this,
 /// shared here so a future style change is a one-line update instead of a
 /// find/replace across every test file. `concat!`, not a `"\`-continued
 /// literal: the latter strips leading whitespace from the continued line,

--- a/rinkaku-core/src/render/mermaid_tests/node_budget_fallback.rs
+++ b/rinkaku-core/src/render/mermaid_tests/node_budget_fallback.rs
@@ -1,0 +1,129 @@
+//! The [`super::MERMAID_NODE_BUDGET`] boundary and the file-level
+//! aggregation fallback.
+
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn should_stay_symbol_level_when_node_count_equals_budget_exactly() {
+    // Exactly MERMAID_NODE_BUDGET (30) nodes: the fallback condition is
+    // `> budget`, so this boundary case must still render one
+    // subgraph/node per symbol, not the file-level aggregation — pins the
+    // off-by-one the sibling over-budget test alone can't rule out (that
+    // test only proves 31 falls back, not that 30 doesn't).
+    let mut nodes = Vec::new();
+    let mut symbols = Vec::new();
+    for i in 0..30 {
+        let id = format!("src/lib.rs::s{i}");
+        nodes.push(node(&id, "src/lib.rs", &format!("s{i}")));
+        symbols.push(symbol(&id, &format!("s{i}"), SymbolKind::Function, None));
+    }
+    assert_eq!(30, nodes.len());
+
+    let report = empty_report(
+        SymbolGraph {
+            nodes,
+            edges: vec![],
+            roots: vec!["src/lib.rs::s0".to_string()],
+        },
+        vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols,
+        }],
+    );
+
+    let mut expected = String::from("flowchart LR\n  subgraph sub0[\"src/lib.rs\"]\n");
+    for i in 0..30 {
+        expected.push_str(&format!("    n{i}[\"s{i}\"]\n"));
+    }
+    expected.push_str("  end\n");
+    expected.push_str(LEGEND_AND_CLASS_DEFS);
+
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_fall_back_to_file_level_graph_when_node_count_exceeds_budget() {
+    // 31 nodes (one over MERMAID_NODE_BUDGET's 30) across two files: 16 in
+    // src/a.rs (one classified Added, so a.rs is "changed"), 15 in
+    // src/b.rs. Two edges cross from a.rs to b.rs (aggregated with count
+    // 2); one edge stays within a.rs (dropped: an intra-file edge carries
+    // no file-level signal).
+    let mut nodes = Vec::new();
+    let mut files_a_symbols = Vec::new();
+    for i in 0..16 {
+        let id = format!("src/a.rs::a{i}");
+        nodes.push(node(&id, "src/a.rs", &format!("a{i}")));
+        let classification = if i == 0 {
+            Some(Classification::Added)
+        } else {
+            None
+        };
+        files_a_symbols.push(symbol(
+            &id,
+            &format!("a{i}"),
+            SymbolKind::Function,
+            classification,
+        ));
+    }
+    let mut files_b_symbols = Vec::new();
+    for i in 0..15 {
+        let id = format!("src/b.rs::b{i}");
+        nodes.push(node(&id, "src/b.rs", &format!("b{i}")));
+        files_b_symbols.push(symbol(&id, &format!("b{i}"), SymbolKind::Function, None));
+    }
+    assert_eq!(31, nodes.len());
+
+    let edges = vec![
+        Edge {
+            from: "src/a.rs::a0".to_string(),
+            to: "src/b.rs::b0".to_string(),
+            is_cycle: false,
+        },
+        Edge {
+            from: "src/a.rs::a1".to_string(),
+            to: "src/b.rs::b1".to_string(),
+            is_cycle: false,
+        },
+        Edge {
+            from: "src/a.rs::a0".to_string(),
+            to: "src/a.rs::a1".to_string(),
+            is_cycle: false,
+        },
+    ];
+    let roots = vec!["src/a.rs::a0".to_string(), "src/b.rs::b0".to_string()];
+
+    let report = empty_report(
+        SymbolGraph {
+            nodes,
+            edges,
+            roots,
+        },
+        vec![
+            FileReport {
+                path: "src/a.rs".to_string(),
+                symbols: files_a_symbols,
+            },
+            FileReport {
+                path: "src/b.rs".to_string(),
+                symbols: files_b_symbols,
+            },
+        ],
+    );
+
+    let expected = concat!(
+        "flowchart LR\n",
+        "%% aggregated to file level (31 symbols > budget)\n",
+        "  n0[\"src/a.rs\"]\n",
+        "  n1[\"src/b.rs\"]\n",
+        "  n0 -- 2 --> n1\n",
+        "  class n0 changed\n",
+    )
+    .to_string()
+        + LEGEND_AND_CLASS_DEFS;
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}

--- a/rinkaku-core/src/render/mermaid_tests/removed_symbols.rs
+++ b/rinkaku-core/src/render/mermaid_tests/removed_symbols.rs
@@ -1,0 +1,172 @@
+//! ADR 0037 `removed`-classed nodes, including the removed-only-file case
+//! and the node-budget interaction.
+
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn should_render_removed_node_in_its_file_subgraph_when_report_has_removed_symbols() {
+    // "foo" survives alongside the removed "old_helper" so the expected
+    // output can pin ordering: removed after surviving.
+    let mut report = empty_report(
+        SymbolGraph {
+            nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+            edges: vec![],
+            roots: vec!["src/lib.rs::foo".to_string()],
+        },
+        vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol(
+                "src/lib.rs::foo",
+                "foo",
+                SymbolKind::Function,
+                Some(Classification::Added),
+            )],
+        }],
+    );
+    report.removed = vec![removed_symbol("old_helper", "src/lib.rs")];
+
+    let expected = concat!(
+        "flowchart LR\n",
+        "  subgraph sub0[\"src/lib.rs\"]\n",
+        "    n0[\"foo\"]\n",
+        "    n1[\"old_helper\"]\n",
+        "  end\n",
+        "  class n0 added\n",
+        "  class n1 removed\n",
+    )
+    .to_string()
+        + LEGEND_AND_CLASS_DEFS;
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_render_removed_only_file_subgraph_when_file_has_no_surviving_symbols() {
+    let mut report = empty_report(
+        SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        vec![],
+    );
+    report.removed = vec![removed_symbol("old_only", "src/gone.rs")];
+
+    let expected = concat!(
+        "flowchart LR\n",
+        "  subgraph sub0[\"src/gone.rs\"]\n",
+        "    n0[\"old_only\"]\n",
+        "  end\n",
+        "  class n0 removed\n",
+    )
+    .to_string()
+        + LEGEND_AND_CLASS_DEFS;
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_count_removed_symbols_toward_node_budget_when_deciding_fallback() {
+    // 30 head-side nodes alone stay symbol-level (see the sibling boundary
+    // test in `node_budget_fallback`); the 1 removed symbol added here
+    // must be what tips this report over budget.
+    let mut nodes = Vec::new();
+    let mut symbols = Vec::new();
+    for i in 0..30 {
+        let id = format!("src/lib.rs::s{i}");
+        nodes.push(node(&id, "src/lib.rs", &format!("s{i}")));
+        symbols.push(symbol(&id, &format!("s{i}"), SymbolKind::Function, None));
+    }
+    let mut report = empty_report(
+        SymbolGraph {
+            nodes,
+            edges: vec![],
+            roots: vec!["src/lib.rs::s0".to_string()],
+        },
+        vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols,
+        }],
+    );
+    report.removed = vec![removed_symbol("old_helper", "src/lib.rs")];
+
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert!(
+        actual.contains("%% aggregated to file level (31 symbols > budget)"),
+        "expected file-level fallback comment in output, got:\n{actual}"
+    );
+}
+
+#[test]
+fn should_render_removed_only_file_as_removed_node_when_fallback_fires() {
+    // src/a.rs (16 nodes) + src/b.rs (15) already exceed the budget;
+    // src/gone.rs adds only a removed symbol, no head-side node.
+    let mut nodes = Vec::new();
+    let mut files_a_symbols = Vec::new();
+    for i in 0..16 {
+        let id = format!("src/a.rs::a{i}");
+        nodes.push(node(&id, "src/a.rs", &format!("a{i}")));
+        let classification = if i == 0 {
+            Some(Classification::Added)
+        } else {
+            None
+        };
+        files_a_symbols.push(symbol(
+            &id,
+            &format!("a{i}"),
+            SymbolKind::Function,
+            classification,
+        ));
+    }
+    let mut files_b_symbols = Vec::new();
+    for i in 0..15 {
+        let id = format!("src/b.rs::b{i}");
+        nodes.push(node(&id, "src/b.rs", &format!("b{i}")));
+        files_b_symbols.push(symbol(&id, &format!("b{i}"), SymbolKind::Function, None));
+    }
+    assert_eq!(31, nodes.len());
+
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![
+            FileReport {
+                path: "src/a.rs".to_string(),
+                symbols: files_a_symbols,
+            },
+            FileReport {
+                path: "src/b.rs".to_string(),
+                symbols: files_b_symbols,
+            },
+        ],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes,
+            edges: vec![],
+            roots: vec!["src/a.rs::a0".to_string(), "src/b.rs::b0".to_string()],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![removed_symbol("old_only", "src/gone.rs")],
+    };
+
+    let expected = concat!(
+        "flowchart LR\n",
+        "%% aggregated to file level (32 symbols > budget)\n",
+        "  n0[\"src/a.rs\"]\n",
+        "  n1[\"src/b.rs\"]\n",
+        "  n2[\"src/gone.rs\"]\n",
+        "  class n0 changed\n",
+        "  class n2 removed\n",
+    )
+    .to_string()
+        + LEGEND_AND_CLASS_DEFS;
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}


### PR DESCRIPTION
## Summary

- User feedback on the current `--format mermaid` output (a one-line prose legend plus `red heavy border = fan-in` / `gray dashed = removed`): the legend is hard to parse, "removed" should read as red (not gray), and "fan-in" needs to move off red since red is now claimed by "removed".
- Adds ADR 0039 (`docs/adr/0039-mermaid-visual-encoding-revision.md`) documenting the new encoding and legend design before implementing it.
- Reworks `rinkaku-core/src/render/mermaid.rs`'s `classDef`s and adds a self-describing `Legend` subgraph rendered inside the diagram itself; removes the prose legend line from `compose_and_post_comment.sh`.

## Style/legend changes

| Class | Before | After |
| --- | --- | --- |
| `added` | green fill | unchanged |
| `changed` (API changed) | orange fill | unchanged |
| `removed` | gray fill, dashed border | **red fill, dashed border** |
| `fan-in` | red fill, heavy border | **violet fill/stroke, heavy border, `(in:N)` label suffix** |
| Legend | one prose line composed by `compose_and_post_comment.sh` | **`subgraph Legend` inside the mermaid diagram, using the real `classDef`s** |

The label suffix (`shared_helper (in:2)`) double-encodes fan-in in text as well as color/stroke, so the signal survives without relying on color at all.

## Before / after (real dogfooding output)

Built a small scratch repo with a diff that exercises all four classes at once (`caller_a`: signature changed, `caller_c`/`new_feature`: added, `old_helper`: removed, `shared_helper`: fan-in 2) and ran `rinkaku --base <before> --format mermaid`.

**After** (this PR):

```mermaid
flowchart LR
  subgraph sub0["src/lib.rs"]
    n0["shared_helper (in:2)"]
    n1["caller_a"]
    n2["caller_c"]
    n3["new_feature"]
    n4["old_helper"]
  end
  n1 --> n0
  n2 --> n0
  n3 --> n2
  class n0 fan-in
  class n1 changed
  class n2 added
  class n3 added
  class n4 removed
  subgraph Legend
    legend_added["added"]
    legend_changed["API changed"]
    legend_removed["removed"]
    legend_fan_in["fan-in (in:N)"]
  end
  class legend_added added
  class legend_changed changed
  class legend_removed removed
  class legend_fan_in fan-in
  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
  classDef fan-in fill:#e9d8fd,stroke:#553c9a,stroke-width:3px,color:#1a202c;
  classDef removed fill:#fed7d7,stroke:#9b2c2c,color:#1a202c,stroke-dasharray: 5 5;
```

Rendered with `@mermaid-js/mermaid-cli` to confirm it's valid mermaid and to eyeball the colors — `removed` (`old_helper`) is red/dashed, `fan-in` (`shared_helper (in:2)`) is violet/thick-bordered, and the two are visually unambiguous even side by side. The `Legend` subgraph itself renders with each swatch styled by its real `classDef`.

**Before** (prior encoding, for comparison — same graph, old styling):

```mermaid
flowchart LR
  subgraph sub0["src/lib.rs"]
    n0["shared_helper"]
    n1["caller_a"]
    n2["caller_c"]
    n3["new_feature"]
    n4["old_helper"]
  end
  n1 --> n0
  n2 --> n0
  n3 --> n2
  class n0 fan-in
  class n1 changed
  class n2 added
  class n3 added
  class n4 removed
  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;
  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;
  classDef fan-in fill:#fed7d7,stroke:#9b2c2c,stroke-width:3px,color:#1a202c;
  classDef removed fill:#e2e8f0,stroke:#4a5568,color:#1a202c,stroke-dasharray: 5 5;
```

_Legend: green = added · orange = API changed · gray dashed = removed · red heavy border = fan-in_

Note `removed` and `fan-in` both render red in the "before" version — that's the collision this PR fixes.

## ADR

[`docs/adr/0039-mermaid-visual-encoding-revision.md`](docs/adr/0039-mermaid-visual-encoding-revision.md) — amends ADR 0021/ADR 0037's `classDef`s, documents the rejected alternatives (stroke-width-only fan-in distinction, label-suffix-only, Markdown-table legend), and records the compose-script/render-layer split for where the legend lives.

## Test plan

- [x] `make test` — all crates pass (169 + 384 + 605 unit tests)
- [x] `make lint` — `cargo fmt --all --check` + `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Split `rinkaku-core/src/render/mermaid.rs`'s test module into `rinkaku-core/src/render/mermaid_tests/{mod,empty_and_legend,class_styling,escaping,node_budget_fallback,removed_symbols}.rs` (file-size discipline: adding the legend/label suffix to every expected string would have pushed the single-file test module well past the 1000-line warn threshold) — production file is 380 lines after the split.
- [x] New tests: legend rendering on the empty-graph path, legend content on a non-empty graph, fan-in `(in:N)` label suffix, and a dedicated regression test asserting `removed` and `fan-in` render with distinct classes/styling when both are present in the same report.
- [x] Dynamic verification: built a scratch git repo exercising all four classes in one diff, ran the release binary with `--base`/`--format mermaid`, rendered the output through `@mermaid-js/mermaid-cli` to confirm valid mermaid syntax and to visually verify the colors (see PNG render, described above).
- [x] `compose_and_post_comment.sh` DRY_RUN with the generated mermaid + digest files — confirmed the comment body no longer duplicates a legend line and the diagram's own `Legend` subgraph is the only legend present.


## Review

Two dogfooding review passes were run per this repository's review policy (map-assisted static pass + dynamic verification pass), with zero blocker/should-fix/nit findings from either.

- **Map-assisted static pass**: built rinkaku's own change map from a trusted `main` checkout and reviewed against it — `write_legend_and_class_defs` (the new shared helper used by both `render_mermaid`/`render_mermaid_file_level`) and the shared test helper module were the high-fan-in read targets the map surfaced; no `## File sizes` warning on the touched files.
- **Independent pass**: covered legend node-ID collision safety (fixed ids, not derived from the `n{i}` sequence, so they cannot collide with a real graph node), node-budget math (the legend is appended after the budget check, so it never counts toward `MERMAID_NODE_BUDGET`), `(in:N)` derivation, label escaping, and confirmed no stale references to the deleted prose legend remained.
- **Dynamic verification**: `make test`/`make lint` green; ran the release binary against real diffs including non-TTY stdin (no panic), an empty diff, and `--exclude-tests` combined with the node-budget fallback (exclusion is applied before the budget check, so excluded test symbols never inflate the fallback decision); validated every generated mermaid diagram's syntax with `@mermaid-js/mermaid-cli`.
- **Out-of-scope note**: dynamic verification also surfaced a pre-existing behavior unrelated to this change — when reading from stdin, symbol classification (added/changed/removed) can be dropped in some cases (root cause not in this PR's diff). Not fixed here to keep this PR's scope to the visual-encoding rework; flagged for a separate follow-up.
