### PR TITLE
docs(experiments): record experiment 0001 round 25 (PR #128)

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/025.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/025.md
@@ -1,0 +1,120 @@
+# Round 25
+
+- Subject: PR #128 — reworks `--format mermaid`'s `classDef` visual
+  encoding (ADR 0039, originally numbered 0038 and renumbered after a
+  clash with round 24's PR #126 was found still open): `removed`
+  reassigned to red/dashed (previously gray/dashed), `fan-in` moved off
+  red entirely onto a violet stroke plus an `(in:N)` label suffix
+  (previously red/heavy-border, which collided with the new `removed`
+  color), and the one-line prose legend `compose_and_post_comment.sh`
+  used to compose is replaced with a self-describing `Legend` subgraph
+  rendered inside the diagram by `render_mermaid`/
+  `render_mermaid_file_level` themselves, styled with the same real
+  `classDef`s a graph node of that class would use.
+- Protocol note: three-angle review per this repository's `CLAUDE.md`
+  ("Reviewing changes"), not a harness-timed A/B pair — same shape as
+  rounds 17/22/23/24. Two passes run: (1) map-assisted static review
+  (trusted clean `main` build, not the branch under review) plus
+  repo-convention checks; (2) dynamic verification (rebuild the
+  branch's binary, exercise it against real diffs and adversarial
+  inputs, validate every generated mermaid diagram's syntax). Blocker
+  count: 0. This round is a clean-bill calibration round — zero
+  findings across both passes, the first such round since round 19 to
+  post an unqualified zero on every axis (blocker, should-fix, and
+  nit).
+- **Map-assisted pass**: `rinkaku --base main` (trusted build) flagged
+  `write_legend_and_class_defs` — the new shared helper both
+  `render_mermaid` and `render_mermaid_file_level` call — and the new
+  `rinkaku-core/src/render/mermaid_tests/mod.rs` shared test-helper
+  module as the two high-fan-in read targets, correctly routing
+  attention to the render-layer core of the diff. No `## File sizes`
+  warning entry: `mermaid.rs` itself shrank from 1009 to 380 lines this
+  round (the test module was split out into
+  `rinkaku-core/src/render/mermaid_tests/{mod,empty_and_legend,
+  class_styling,escaping,node_budget_fallback,removed_symbols}.rs` per
+  this repository's file-size discipline, since growing every existing
+  test's expected string with the new legend/label-suffix trailer would
+  otherwise have pushed the single-file module well past the
+  1000-line warn threshold).
+- **Independent pass**: full diff review covering legend node-ID
+  collision safety (the four `legend_*` ids are fixed strings, not
+  drawn from the `n{i}` sequence real graph nodes use, so they cannot
+  collide with a real node regardless of graph size), node-budget math
+  (`write_legend_and_class_defs` is called *after*
+  `MERMAID_NODE_BUDGET`'s check on every return path, so the legend
+  itself never counts toward the budget it would otherwise be able to
+  trip), `(in:N)` derivation (`fan_in_counts`, built from
+  `report.fan_ins[i].used_by.len()`, feeding both the `classDef`
+  selection and the label suffix from one map so the two can't drift
+  apart), label escaping (the suffix is appended before
+  `escape_mermaid_label` runs, so a fan-in symbol whose name itself
+  needs escaping is still escaped correctly), and a stale-reference
+  check confirming no remaining mention of the deleted prose legend
+  line (`MERMAID_LEGEND` in `compose_and_post_comment.sh`) survived
+  anywhere in the diff. No findings.
+- **Dynamic verification**: `make test` (605 `rinkaku-core`/
+  `rinkaku-tui`/`rinkaku` unit tests combined) and `make lint`
+  (`cargo fmt --all --check` + `cargo clippy --all-targets
+  --all-features -- -D warnings`) both green. Ran the release binary
+  against real diffs built from scratch git repos:
+  - Non-TTY stdin/stdout for the whole pipeline (`git diff | rinkaku
+    --format mermaid`, redirected stdout) — no panic, same failure
+    mode round 1 first flagged as a risk class still holds clean here.
+  - An empty diff — renders the minimal `flowchart LR` / `%% no
+    symbols` document plus the Legend subgraph (the ADR's "always
+    emitted, including the empty-graph path" decision holds under a
+    real invocation, not just the unit test that pins it).
+  - `--exclude-tests` combined with the node-budget fallback: verified
+    exclusion is applied *before* `MERMAID_NODE_BUDGET`'s count, i.e.
+    a diff whose total symbol count only exceeds the budget once test
+    symbols are included does *not* trip the file-level fallback when
+    `--exclude-tests` is passed — the budget check counts the same
+    post-exclusion symbol set the rest of the render path already
+    walks, not a pre-exclusion total.
+  - Constructed a single diff exercising all four classes at once
+    (a signature-changed symbol, two added symbols, one removed
+    symbol, and a fan-in-2 symbol) and rendered it through
+    `@mermaid-js/mermaid-cli` (`mmdc`) to confirm valid mermaid syntax
+    end to end, then rendered to PNG to visually confirm `removed`
+    renders red/dashed and `fan-in` renders violet/thick with no color
+    collision between the two, and that the Legend subgraph's four
+    swatches match the real nodes' styling exactly. All cases passed
+    `mmdc` syntax validation with no parse errors.
+  - `compose_and_post_comment.sh` exercised via `DRY_RUN=1` against the
+    generated mermaid + digest files — confirmed the composed comment
+    body carries the diagram's own Legend subgraph and no longer
+    duplicates a legend line from the shell script.
+- **Out-of-scope observation**: while constructing scratch-repo
+  fixtures for the dynamic pass above, noticed that piping a diff via
+  stdin (`git diff | rinkaku ...`) does not always populate symbol
+  classification (`Added`/`SignatureChanged`) or `report.removed` the
+  way `--base <ref>` mode does for an equivalent change — a doc-comment
+  -only touch to an otherwise-untouched dependency, and a same-hunk
+  deletion adjacent to an addition, both failed to classify under
+  piped-diff mode in ways that succeeded once the same change was
+  fed through `--base`. This is a pre-existing behavior unrelated to
+  this PR's diff (the classification pipeline this round's `mermaid.rs`
+  change reads from, not writes to) and reproducing/isolating it
+  further was out of scope for this round's time budget — not fixed or
+  filed as an issue here, flagged for a separate follow-up
+  investigation into stdin-mode classification coverage.
+- Severity summary: 0 blockers, 0 should-fix, 0 nits — nothing fixed
+  this round because nothing was found; the out-of-scope stdin
+  observation above is a flag for future investigation, not a finding
+  against this PR's diff.
+- Takeaway: this round pairs with round 24 as a second consecutive
+  clean-bill result, but for a different reason. Round 24's diff was a
+  `const` string literal the map had structurally little to route
+  attention toward; this round's diff is a normal render-layer
+  change the map's signature/fan-in model handles well (correctly
+  identifying the new shared helper and test module as the fan-in
+  core), and the zero-findings result reflects the change itself
+  being clean rather than either pass having a blind spot to name.
+  The out-of-scope stdin-vs-`--base` classification-coverage gap
+  found while building dynamic-verification fixtures is the one
+  new thread worth carrying forward — it surfaced from the same
+  "construct a repo and run the real tool" instinct round 23 credited
+  for its sharpest finding (the whole-file-deletion gap), reinforcing
+  that building throwaway fixtures for one round's verification keeps
+  paying off as a discovery channel even on rounds where the PR under
+  review itself has nothing wrong with it.


### PR DESCRIPTION
## Summary

- Adds `rounds/025.md` to experiment 0001, recording the review of
  PR #128 (mermaid `--format mermaid` visual encoding rework, ADR
  0039).
- Follows this repository's `CLAUDE.md` "Reviewing changes" protocol
  (map-assisted static pass + dynamic verification), same shape as
  rounds 17/22/23/24: a single-reviewer round recording an actual PR
  review, not a harness-timed A/B pair.
- Per the experiment README's file-layout convention (see round 24 /
  PR #127), this PR only *adds* `rounds/025.md`; the README's
  index/Conclusions update is left to a separate follow-up commit.

## Findings recorded this round

- 0 blockers, 0 should-fix, 0 nits — a clean-bill calibration round,
  the first unqualified zero-across-the-board result since round 19.
- Map-assisted pass correctly routed attention to
  `write_legend_and_class_defs` (the new shared helper both mermaid
  renderers call) and the new shared test-helper module as the
  high-fan-in core of the diff; no file-size warning (`mermaid.rs`
  shrank from 1009 to 380 lines this round via a test-module split).
- Independent pass covered legend node-ID collision safety, node-budget
  math (legend appended after the budget check), `(in:N)` label
  derivation and escaping order, and confirmed no stale references to
  the deleted prose legend remained.
- Dynamic verification: `make test`/`make lint` green; non-TTY stdin,
  empty diff, `--exclude-tests` + node-budget-fallback interaction
  (exclusion applied before the budget count), and `@mermaid-js/
  mermaid-cli` syntax validation of every generated diagram (plus a
  PNG render to visually confirm no removed/fan-in color collision).
- Out-of-scope observation: piped-diff (stdin) mode can fail to
  classify some added/changed/removed symbols in cases where `--base`
  mode succeeds for the equivalent change — noticed while building
  dynamic-verification fixtures, not investigated further this round
  (unrelated to PR #128's own diff), flagged as a follow-up.

## Test plan

- [x] `make lint` (docs-only change; ran clean)
- [x] `git status` confirms only `rounds/025.md` is added
