### PR TITLE
feat: classify Rust *_tests/ directories as test paths

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/026.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/026.md
@@ -1,0 +1,89 @@
+# Round 26
+
+- Subject: PR #130 — extends Rust's `LanguageSupport::is_test_path` to
+  treat any path segment (directory name or file stem) ending in
+  `_tests` as a test path, in addition to the existing exact `tests`
+  match, closing issue #114 (surfaced in round 22: a `nav_tests/mod.rs`
+  fixture helper outranked real production hotspots because this
+  repo's own ADR 0028 split-test-file convention was misclassified as
+  production code). One function changed, plus new rstest cases
+  covering `_tests/` directory segments (top-level and nested), a
+  `_tests` file stem, and near-miss non-test paths (`latest_stats.rs`,
+  `contests/mod.rs`) that must stay `false`.
+- Protocol note: cost-reduced single-reviewer configuration — one
+  static reviewer combining the map-assisted pass and the independent
+  pass, plus one separate dynamic-verification agent. The map was built
+  from a trusted `main` checkout and the branch diff piped through it
+  (delivery variant (a): map generated once, diff handed to the
+  reviewer alongside it), no A/B pairing. Not a harness-timed
+  comparison; recorded in this format for continuity with rounds 17-25.
+- **Static pass (map-assisted + independent, combined)**: the map was
+  near-inert this round. The diff touches exactly one leaf function
+  with zero in-diff callers, so `## Change graph` / `## High fan-in
+  symbols` rendered essentially nothing distinguishing — the same
+  shape round 17 already recorded for a single-function, zero-fan-in
+  diff. Routing toward the two findings below came from the PR
+  description itself (which named the exact heuristic and its rationale)
+  and from round 22's own write-up pointing at a `nav_tests/mod.rs`-
+  shaped fixture as the concrete replay case to check by hand, not from
+  the map's fan-in ranking. This is the second data point (after round
+  17) reinforcing that single-function, zero-fan-in diffs render the
+  map nearly inert as an attention-routing tool; value on this shape of
+  diff comes from hand-tracing the function's callers and running the
+  real report generator against real fixtures, not from the map's
+  computed rankings. Findings: one **should-fix** — a bare `src/tests.rs`
+  file stem (no underscore) is newly classified as a test path (the
+  pre-PR code only matched a directory segment literally `tests`), but
+  no rstest case exercised that combination; confirmed this broadening
+  is intended (it matches ADR 0028's canonical split pattern, precedent
+  `rinkaku-tui/src/app/tests.rs`) rather than an accidental side effect,
+  so the fix is a locking-in test case, not a behavior change. One
+  **nit** — the function's doc comment described the bare `tests` match
+  only in terms of a directory segment; extended by half a sentence to
+  state it applies to a file stem too. No blockers.
+- **Dynamic verification**: `make test` and `make lint` both pass
+  before and after the fix. Methodology note worth recording: the first
+  dynamic-verification attempt was a **false negative** — running the
+  branch and `main` builds against a plain diff produced byte-identical
+  output, because the sample diff didn't touch any path shaped like
+  this PR's actual change. The gap was traced back to `--exclude-tests`
+  (an opt-in flag per ADR 0025) being the mode that actually exercises
+  `is_test_path`'s output; once identified from `deps.rs`/`pipeline.rs`/
+  `--help`, a proper A/B repro was constructed. **Lesson**: "run the
+  binary" is not sufficient on its own — dynamic verification must
+  first identify which flag or mode actually exercises the changed
+  code path, or a real regression (or, as here, a real fix) can look
+  like a no-op. With `--exclude-tests` identified, verification covered:
+  A/B repro of issue #114's original symptom (`main` shows
+  `fn sample_tree ... used by 2` under `## High fan-in symbols`; the
+  branch build collapses it into the Tests section as designed);
+  near-miss names (`latest_stats.rs`, `contests.rs`, `protests/`) stay
+  classified as production on both builds; no panics across empty
+  stdin, garbage stdin, diffs referencing nonexistent files, every
+  `--format` value combined with `--exclude-tests`, and non-TTY
+  `--tui`; a Go `foo_tests.go` fixture is byte-identical between branch
+  and `main` (confirming the fix is scoped to Rust, as the PR describes
+  — Go/Python/TypeScript each implement `is_test_path` independently);
+  a Cargo integration `tests/` directory is still classified as Tests
+  on both builds (the original exact-match case, unaffected by the
+  broadening). All PASS.
+- **Fix applied this round**: added the `src/tests.rs` rstest case
+  (`should_return_true_when_tests_is_the_bare_file_stem`) and extended
+  the doc comment, per the static pass's should-fix and nit above.
+- Severity summary: one **should-fix** (fixed), one **nit** (fixed), no
+  blockers from the static pass; all dynamic checks PASS, with one
+  methodology near-miss (false-negative first attempt) corrected before
+  being recorded as a result.
+- Takeaway: this round adds a second data point that a change confined
+  to one leaf function with zero in-diff callers makes the map's
+  hotspot/fan-in view render as near-inert noise rather than a useful
+  routing signal — consistent with round 17, and worth treating as a
+  recognizable diff shape (not a map defect) rather than re-litigating
+  each time it recurs. Separately, the false-negative dynamic-
+  verification attempt is a new, generalizable methodology lesson for
+  this experiment: mandatory dynamic verification (CLAUDE.md's rule
+  since round 3) means *running the binary*, but running it against an
+  input that doesn't exercise the changed code path produces a
+  confident-looking PASS that verifies nothing. Identifying the
+  exercising flag/mode is a prerequisite step dynamic verification must
+  budget for explicitly, not an incidental detail.

--- a/rinkaku-core/src/language/rust.rs
+++ b/rinkaku-core/src/language/rust.rs
@@ -84,13 +84,22 @@ impl LanguageSupport for RustSupport {
         REFERENCE_QUERY
     }
 
-    /// Rust's `tests/` directory convention: integration test crates
-    /// (`tests/*.rs`, each compiled as its own binary by `cargo test`).
-    /// Unit tests (`#[cfg(test)] mod tests { ... }`) live colocated with
-    /// production code instead, so they are not caught by path alone — see
-    /// `is_test_definition`.
+    /// Rust's `tests/` directory convention (integration test crates,
+    /// compiled as their own binary by `cargo test`), plus this repo's
+    /// ADR 0028 split-test-file convention: a `#[cfg(test)] #[path =
+    /// "foo_tests/mod.rs"] mod tests;` include, where the split file itself
+    /// has no `#[cfg(test)] mod` wrapper and would otherwise be
+    /// misclassified as production code. Matched by path *segment*
+    /// (directory name or file stem), not substring, so `latest_stats.rs`
+    /// and `contests/mod.rs` stay production while `nav_tests/mod.rs` and
+    /// `foo_tests.rs` are recognized. Unit tests colocated in an inline
+    /// `#[cfg(test)] mod tests { ... }` block are not caught by path at
+    /// all — see `is_test_definition`.
     fn is_test_path(&self, path: &str) -> bool {
-        path.split('/').any(|segment| segment == "tests")
+        path.split('/').any(|segment| {
+            let stem = segment.strip_suffix(".rs").unwrap_or(segment);
+            stem == "tests" || stem.ends_with("_tests")
+        })
     }
 
     /// Whether `node` (a captured `@definition` node) is a Rust unit test:
@@ -349,6 +358,23 @@ mod tests {
     #[case::should_return_false_when_path_is_ordinary_module("src/lib.rs", false)]
     #[case::should_return_false_when_filename_merely_contains_test_substring(
         "src/contest.rs",
+        false
+    )]
+    #[case::should_return_true_when_path_has_underscore_tests_directory_segment(
+        "rinkaku-tui/src/nav_tests/mod.rs",
+        true
+    )]
+    #[case::should_return_true_when_underscore_tests_directory_is_deeply_nested(
+        "rinkaku-tui/src/tree/tree_tests/tests_section.rs",
+        true
+    )]
+    #[case::should_return_true_when_underscore_tests_is_the_file_stem("src/foo_tests.rs", true)]
+    #[case::should_return_false_when_filename_merely_ends_in_tests_substring(
+        "src/latest_stats.rs",
+        false
+    )]
+    #[case::should_return_false_when_directory_merely_contains_tests_substring(
+        "src/contests/mod.rs",
         false
     )]
     fn is_test_path_cases(#[case] path: &str, #[case] expected: bool) {

--- a/rinkaku-core/src/language/rust.rs
+++ b/rinkaku-core/src/language/rust.rs
@@ -84,19 +84,11 @@ impl LanguageSupport for RustSupport {
         REFERENCE_QUERY
     }
 
-    /// Rust's `tests/` directory convention (integration test crates,
-    /// compiled as their own binary by `cargo test`), plus this repo's
-    /// ADR 0028 split-test-file convention: a `#[cfg(test)] #[path =
-    /// "foo_tests/mod.rs"] mod tests;` include, where the split file itself
-    /// has no `#[cfg(test)] mod` wrapper and would otherwise be
-    /// misclassified as production code. Matched by path *segment*
-    /// (directory name or file stem), not substring, so `latest_stats.rs`
-    /// and `contests/mod.rs` stay production while `nav_tests/mod.rs` and
-    /// `foo_tests.rs` are recognized; the bare `tests` match applies equally
-    /// to a directory segment (`tests/it.rs`) and a file stem
-    /// (`src/tests.rs`, ADR 0028's own split-file example). Unit tests
-    /// colocated in an inline `#[cfg(test)] mod tests { ... }` block are not
-    /// caught by path at all — see `is_test_definition`.
+    /// Covers Rust's `tests/` integration-test convention and ADR 0028
+    /// split test files (`#[cfg(test)] #[path = "foo_tests/mod.rs"] mod
+    /// tests;`): the split file carries no `#[cfg(test)]` wrapper, so its
+    /// path is the only classification signal. Inline `#[cfg(test)] mod
+    /// tests` blocks are handled by `is_test_definition` instead.
     fn is_test_path(&self, path: &str) -> bool {
         path.split('/').any(|segment| {
             let stem = segment.strip_suffix(".rs").unwrap_or(segment);

--- a/rinkaku-core/src/language/rust.rs
+++ b/rinkaku-core/src/language/rust.rs
@@ -92,9 +92,11 @@ impl LanguageSupport for RustSupport {
     /// misclassified as production code. Matched by path *segment*
     /// (directory name or file stem), not substring, so `latest_stats.rs`
     /// and `contests/mod.rs` stay production while `nav_tests/mod.rs` and
-    /// `foo_tests.rs` are recognized. Unit tests colocated in an inline
-    /// `#[cfg(test)] mod tests { ... }` block are not caught by path at
-    /// all — see `is_test_definition`.
+    /// `foo_tests.rs` are recognized; the bare `tests` match applies equally
+    /// to a directory segment (`tests/it.rs`) and a file stem
+    /// (`src/tests.rs`, ADR 0028's own split-file example). Unit tests
+    /// colocated in an inline `#[cfg(test)] mod tests { ... }` block are not
+    /// caught by path at all — see `is_test_definition`.
     fn is_test_path(&self, path: &str) -> bool {
         path.split('/').any(|segment| {
             let stem = segment.strip_suffix(".rs").unwrap_or(segment);
@@ -369,6 +371,7 @@ mod tests {
         true
     )]
     #[case::should_return_true_when_underscore_tests_is_the_file_stem("src/foo_tests.rs", true)]
+    #[case::should_return_true_when_tests_is_the_bare_file_stem("src/tests.rs", true)]
     #[case::should_return_false_when_filename_merely_ends_in_tests_substring(
         "src/latest_stats.rs",
         false


### PR DESCRIPTION
## Problem

Rust's `LanguageSupport::is_test_path` in `rinkaku-core` recognizes an exact `tests` path segment (integration test crates under `tests/`), but not this repo's own ADR 0028 split-test-file convention: files under `*_tests/` directories (e.g. `nav_tests/mod.rs`, `tree_tests/…`) included via `#[cfg(test)] #[path = "nav_tests/mod.rs"] mod tests;`.

Because the split file itself has no `#[cfg(test)] mod` wrapper, helper functions defined there (e.g. a `sample_tree`-style fixture builder) were misclassified as production code: they stayed in the production tree / `## Definitions` instead of being summarized under the "Tests" section, and could pollute `## High fan-in symbols`.

Closes #114.

## Fix

Extended `RustSupport::is_test_path` to treat any path *segment* (directory name or file stem) ending in `_tests` as a test path, in addition to the existing exact `tests` match:

```rust
fn is_test_path(&self, path: &str) -> bool {
    path.split('/').any(|segment| {
        let stem = segment.strip_suffix(".rs").unwrap_or(segment);
        stem == "tests" || stem.ends_with("_tests")
    })
}
```

Segment match rather than substring match, so `latest_stats.rs` and `contests/mod.rs` correctly stay classified as production code — only `nav_tests/mod.rs`, `foo_tests.rs`, etc. match.

Scoped to Rust only: Go, Python, and TypeScript each implement `is_test_path` independently for their own toolchain conventions (`_test.go` suffix, `test_*.py`/`*_test.py`, `.test.ts`/`.spec.ts`), with no shared helper — this change does not touch their behavior.

ADR 0035's Tests-section semantics (a whole-file test classification feeding a summarized "Tests" bucket instead of the production tree) are unchanged; this is purely a heuristic extension of the existing path convention, not a new concept.

## Verified

- New `rstest` cases in `is_test_path_cases` cover: `_tests/` dir segment (top-level and nested), `_tests` as a file stem, and near-miss non-test paths (`latest_stats.rs`, `contests/mod.rs`) that must stay `false`. Existing `tests/` cases pass unchanged (regression).
- `make test` (1167 tests) and `make lint` both pass.
- End-to-end: built the release binary from this branch and from `origin/main`, then ran both against a synthetic diff that adds a helper function to `rinkaku-tui/src/nav_tests/mod.rs` (an existing ADR 0028 split-test file), with `--exclude-tests --format json`:
  - **Before (main)**: the symbol stayed in `files` (production), `tests: []`.
  - **After (this branch)**: the symbol moved to `tests: [{"path": "rinkaku-tui/src/nav_tests/mod.rs", "symbol_count": 1}]`, and `files` no longer lists the file. Markdown output correspondingly changed from listing it under "Other changed files" to a "Tests" section entry (`rinkaku-tui/src/nav_tests/mod.rs: 1 changed test symbol`).

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] Manual end-to-end comparison against a pre-fix build (see above)

## Review process

Reviewed with a cost-reduced 2-agent setup: one static reviewer (map-assisted pass + independent pass combined) and one dynamic-verification agent.

- Static review found one should-fix (a bare `src/tests.rs` file stem wasn't covered by a test case, even though the code already classified it as a test path) and one nit (doc comment wording). Both fixed in this PR: added `should_return_true_when_tests_is_the_bare_file_stem`, and extended the doc comment to state the bare `tests` match applies to a file stem as well as a directory segment.
- Dynamic verification re-confirmed the original issue #114 symptom fix via `--exclude-tests` A/B comparison against `main`, checked near-miss names (`latest_stats.rs`, `contests.rs`, `protests/`) stay production, ran panic checks across empty/garbage/nonexistent-file inputs and all `--format` values, and confirmed the fix is scoped to Rust only (Go's `_test.go` handling is untouched).
- Recorded as round 26 of the map-assisted-review experiment (`docs/experiments/0001-map-assisted-llm-review/rounds/026.md`).
