### PR TITLE
docs(experiments): record experiment 0001 round 27 (PR #131)

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/027.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/027.md
@@ -1,0 +1,104 @@
+# Round 27
+
+- Subject: PR #131 — removes the in-diagram Legend `subgraph` that
+  round 25 (PR #128) had added to `--format mermaid` output, and moves
+  legend generation to CI: `compose_and_post_comment.sh` now parses the
+  `classDef` lines rinkaku emits and builds the Legend as a Markdown
+  table in the sticky PR comment instead (ADR 0040).
+- Protocol note: three-angle review per this repository's `CLAUDE.md`
+  ("Reviewing changes"), continuing the reviewer-cost-reduction
+  variant this experiment has been trying across recent rounds: two
+  reviewer agents instead of three, with the map-assisted pass and the
+  independent/conventions pass merged into a single static-review
+  agent, and dynamic verification run by a separate second agent.
+  Implementation was a third, separate agent. Blocker count: 0. Two
+  should-fix findings, both fixed in this round's follow-up commits
+  before the PR was opened.
+- **Map delivery**: rather than the orchestrator generating the map and
+  handing it to the reviewer, the static reviewer agent built the map
+  itself — `cargo build --release` from a trusted clean `main` checkout
+  (never the branch under review), then ran that binary's
+  `rinkaku --base main` against the PR's diff before reading any code.
+- **Map-assisted pass**: correctly named `write_class_defs`
+  (`rinkaku-core/src/render/mermaid.rs`) as the single high-fan-in
+  symbol in the diff — the crux of the change, since it is the function
+  whose `classDef` line format the new CI-side parser now depends on as
+  an implicit contract. The PR's other high-risk surface,
+  `compose_and_post_comment.sh`'s new `classDef`-parsing logic, is
+  shell and outside rinkaku's supported languages, so it does not
+  appear on the map at all. The reviewer treated this as expected
+  rather than a gap to route around, and read the shell script in full
+  during the independent half of the same pass. No `## File size`
+  warning entry for either changed file.
+- **Independent pass** (same agent, same session, following the map
+  read): full-diff review of the Rust rendering change, the shell
+  parser, and ADR 0040 against this repository's conventions. Findings:
+  - Should-fix: `rinkaku-core/src/render/mermaid_tests/
+    empty_and_legend.rs` asserts on a substring of the rendered output
+    rather than the full string, with no NOTE at the top of the test
+    explaining why the assertion is partial, violating this
+    repository's fully-qualified-assert convention.
+  - Nit: the new Legend Markdown table renders with an empty header
+    cell (the swatch column has no text label), which is visually fine
+    but slightly odd markup.
+- **Dynamic verification** (separate agent, rebuilt the branch's own
+  binary): broad adversarial coverage of both the Rust binary and the
+  shell parsing logic.
+  - `--format md`, `--format json`, and `--format digest` output
+    verified byte-identical to a trusted `main` build's output for the
+    same diffs, confirming this PR's change is scoped to `--format
+    mermaid` and does not perturb the other formats' contracts.
+  - Failure-mode inputs against the binary: empty stdin, non-TTY stdin/
+    stdout, binary/garbage bytes on stdin, and a malformed (truncated/
+    hand-edited) diff — no panics in any case.
+  - `compose_and_post_comment.sh`'s new `classDef`-line parser exercised
+    directly under `DRY_RUN=1`, beyond the normal-path case: an empty
+    mermaid file, a mermaid file with no `classDef` lines at all, an
+    oversized file, a `classDef` referencing a class name the parser
+    doesn't recognize, malformed `classDef` lines (e.g. a 3-digit hex
+    color instead of 6), a 65536-byte input near a truncation boundary,
+    and multibyte characters mixed into class/label text. Found that an
+    unrecognized class name is warned on (visible in CI logs) but a
+    malformed `classDef` line (e.g. bad hex length) is silently
+    skipped instead of warned on — the two failure shapes are handled
+    asymmetrically. Filed as the nit below rather than should-fix,
+    since a malformed line is generator-side (rinkaku itself) breakage
+    that the Rust test suite would already catch, not a shape a
+    correctly-functioning rinkaku binary can actually produce.
+  - Should-fix: the PR branch's merge-base with `origin/main` was stale
+    enough that `git diff`/`rinkaku --base main` against a fresh
+    checkout showed a phantom deletion not actually present in the
+    PR's real changes — recommended rebasing onto current `origin/main`
+    before opening the PR.
+  - Nit: the asymmetric warn-vs-silent-skip behavior for unrecognized
+    vs. malformed `classDef` lines noted above.
+- **Fixes applied**: the implementation agent addressed both should-fix
+  findings before the PR was opened — the partial assert in
+  `empty_and_legend.rs` was converted to a full-string comparison in
+  its own `test:` commit, and the branch was rebased onto current
+  `origin/main` to remove the phantom deletion. Both nits were left
+  as-is (neither blocks merge).
+- **Implementation-side dynamic-verification finding, worth recording
+  separately**: while locally verifying the new shell parser, the
+  implementation agent discovered `compose_and_post_comment.sh`'s
+  original `declare -A` associative-array usage does not work under
+  macOS's bundled bash 3.2 (associative arrays require bash 4+), and
+  replaced it with a `case`-based dispatch. This was caught by running
+  the script for real on a real machine during implementation, not by
+  either review pass — dynamic execution paying off before a change
+  ever reaches review at all, not just during it.
+- Severity summary: 0 blockers, 2 should-fix (both fixed), 2 nits (both
+  left as-is, non-blocking).
+- Takeaway: two threads worth carrying forward. First, the map's
+  blindness to non-Rust files is not just a theoretical gap this round
+  — it is the exact shape of this PR's riskiest surface
+  (`compose_and_post_comment.sh`'s new parsing logic), and the map-
+  assisted pass handled it correctly by falling back to full manual
+  reading rather than under-reading the unmapped file; a map consumer
+  needs to cross-check the diff's file list against the map's coverage,
+  not just trust what the map shows. Second, the dynamic pass again
+  produced the highest-value finding of the round by volume of input
+  permutations tried (bash-version incompatibility, stale merge-base)
+  rather than by any single clever probe — consistent with rounds 22-25's
+  standing conclusion that adversarial input coverage, not cleverness,
+  is what dynamic verification is for.


### PR DESCRIPTION
## Summary
- Records round 26 of experiment 0001 (map-assisted LLM review), reviewing PR #131 (removal of the in-diagram mermaid Legend subgraph in favor of a CI-generated Markdown legend table, ADR 0040).
- Continues the reviewer-cost-reduction variant: two review agents (static = map-assisted + independent pass merged; dynamic = adversarial execution) instead of three.
- 0 blockers, 2 should-fix (both fixed pre-PR), 2 nits (left as-is).

## Test plan
- [x] Docs-only change; no code touched, `make test`/`make lint` not applicable.