### PR TITLE
feat: diff-style marker prefixes and referenced class for mermaid output (ADR 0041)

### DIFF
--- a/compose_and_post_comment.sh
+++ b/compose_and_post_comment.sh
@@ -121,12 +121,14 @@ fi
 # Hand-maintained class-name -> description text (ADR 0040), the one part
 # of the legend that can't be derived from the diagram itself. `case`, not
 # `declare -A`, for bash 3.2 compatibility (macOS's stock `/bin/bash`).
+# Marker prefixes (+/~/-, ADR 0041) mirror rinkaku-core's own node labels.
 legend_description() {
   case "$1" in
-  added) echo "added — new symbol" ;;
-  changed) echo "API changed — signature changed" ;;
-  removed) echo "removed (dashed border in graph)" ;;
+  added) echo "+ added — new symbol" ;;
+  changed) echo "~ API changed — signature changed" ;;
+  removed) echo "- removed (dashed border in graph)" ;;
   fan-in) echo "fan-in — highly referenced, thick border, label shows (in:N)" ;;
+  referenced) echo "referenced — unchanged dependency (not part of the diff)" ;;
   *) echo "" ;;
   esac
 }

--- a/docs/adr/0041-mermaid-diff-marker-encoding.md
+++ b/docs/adr/0041-mermaid-diff-marker-encoding.md
@@ -1,0 +1,148 @@
+# 0041. Diff-style marker prefixes and a `referenced` class for unchanged dependencies
+
+- Status: accepted
+- Date: 2026-07-14
+
+## Context
+
+`--format mermaid`'s color/style vocabulary (ADR 0021, revised by ADR
+0039, legend moved out by ADR 0040) covers `added`, `changed`,
+`fan-in`, and `removed` nodes. A node in the graph that is none of
+these — a symbol pulled in only because a changed symbol depends on
+it, itself untouched by the diff — gets no `class` assignment at all
+today, so mermaid renders it with the theme's default node color.
+
+User feedback: that default-colored node reads as "undefined," not
+"unchanged" — there is no `classDef` a reader can look up for it, so
+the diagram doesn't actually explain what that color means (unlike
+every other node, which now has a Legend entry per ADR 0040). Separately,
+color alone is a weak signal for "what changed" even for the classes
+that do have one: a reviewer scanning a diagram in grayscale, or
+just skimming quickly, benefits from the same textual reinforcement
+ADR 0039 already gave `fan-in` (its `(in:N)` label suffix) — but
+`added`/`changed`/`removed` currently rely on color and file-level
+prose (the Markdown/JSON "Definitions" section) alone.
+
+## Decision
+
+### `referenced` class for unchanged dependency nodes
+
+Add a fifth `classDef referenced` covering any node that is
+in the graph but has none of `added`/`changed`/`fan-in`/`removed`
+today — i.e. every node ends up with exactly one class, none left
+unstyled. Neutral gray, distinct from the other four colors:
+
+```
+classDef referenced fill:#e2e8f0,stroke:#4a5568,color:#1a202c;
+```
+
+Applied in `render_mermaid`'s existing class-assignment loop as the
+`else` arm of the fan-in/added/changed match (previously "no class"),
+and symmetrically in `render_mermaid_file_level`'s per-path loop as
+the `else` arm of changed/removed-only (previously "no class").
+
+### Diff-style marker prefix on node labels
+
+Prepend a marker character to a node's label based on the same
+classification that drives its `classDef`, ahead of the existing
+name and `(in:N)` fan-in suffix:
+
+| Class | Marker | Example label |
+| --- | --- | --- |
+| `added` | `+ ` | `n0["+ foo"]` |
+| `changed` | `~ ` | `n0["~ bar"]` |
+| `removed` | `- ` | `n0["- old_helper"]` |
+| `fan-in` | *(none — unaffected)* | `n0["shared (in:3)"]` |
+| `referenced` | *(none)* | `n0["baz"]` |
+
+`fan-in` gets no marker of its own: per ADR 0039, `fan-in` styling
+already wins over `added`/`changed` for a node that is both (a new or
+changed symbol also referenced by 2+ other changed symbols), and that
+precedence is unchanged here — the node keeps its own
+added/changed/removed status implicitly (visible in the Markdown/JSON
+Definitions section), while the diagram highlights the fan-in signal
+specifically, same reasoning ADR 0039 gave for why fan-in's color wins.
+Adding a `+`/`~` marker on top of `(in:N)` would double-encode the
+same axis (blast radius vs. contract status) into one label and crowd
+it; the two are kept as separate signals: color/stroke-width for
+fan-in, marker text for contract status, and only one is shown at a
+time on any given node.
+
+Marker characters:
+
+- `+`/`-` are the universal unified-diff convention (`git diff`,
+  `diff -u`) for added/removed lines — reusing them needs no
+  legend lookup for a reader already familiar with diffs, which
+  every user of a diff-summarizing tool is.
+- `~` for "changed" rather than a third diff-alphabet character
+  (unified diff has no single-char "modified" marker) because `~`
+  already reads as "approximately/changed" in common prose and code
+  review shorthand, and is visually distinct from `+`/`-` at a glance
+  (unlike, say, `*` which is easy to misread as an added-with-emphasis
+  marker).
+- No marker for `referenced`/`fan-in`: a marker's job here is to flag
+  "this row is part of the diff's contract change," so its absence is
+  itself informative — "nothing to see here, unchanged" — rather than
+  needing its own dedicated glyph.
+
+### Legend and escaping interaction
+
+- `compose_and_post_comment.sh`'s `legend_description()` gains a
+  `referenced` case arm, and the existing `added`/`changed`/`removed`
+  descriptions are updated to lead with the same marker character, so
+  the Legend table doubles as the marker's own key:
+  `+ added — new symbol`, `~ API changed — signature changed`,
+  `- removed (dashed border in graph)`,
+  `referenced — unchanged dependency (not part of the diff)`.
+- The marker is prepended to the label text *before*
+  `escape_mermaid_label` runs, not after: `+`, `~`, and `-` are not
+  among the characters that function escapes (`&`, `"`, `[`, `]`,
+  newline), so this ordering is behaviorally identical to appending
+  after, but keeps "build the full label, then escape it once" as the
+  single escaping contract the function already documents, rather
+  than adding a second, marker-specific escape path.
+
+## Alternatives
+
+- **Encode "unchanged dependency" via node opacity/no-fill instead of
+  a new `classDef`.** Rejected: mermaid `classDef` doesn't have a
+  reliable "no fill, inherit theme" declarative option that stays
+  legible under both GitHub's light and dark theme (the same
+  constraint ADR 0021 already worked around by hardcoding
+  `color:#1a202c` on every class) — an explicit neutral gray is more
+  predictable than relying on the reader's active theme.
+- **Marker suffix instead of prefix** (`foo +` instead of `+ foo`).
+  Rejected: unified diff's own convention is a leading marker column;
+  a trailing marker is easy to miss once fan-in's `(in:N)` suffix is
+  also present, and a reader scanning top-to-bottom sees the marker
+  before the name either way only if it leads.
+- **Distinct marker for `fan-in` too** (e.g. `* foo (in:3)`).
+  Rejected per the Decision section above — would double-encode two
+  independent signals (contract-change status vs. blast radius) on
+  the same node without adding information the color/stroke-width and
+  `(in:N)` suffix don't already carry, and crowds the label.
+- **Skip the `referenced` classDef, leave unclassified nodes
+  styleless.** Rejected: this is the status quo this ADR fixes — a
+  styleless node still reads as "undefined" rather than "confirmed
+  unchanged," and breaks ADR 0040's "every visible style has a Legend
+  row" property.
+
+## Consequences
+
+- Every graph node now carries exactly one `class` assignment
+  (previously, an unclassified non-fan-in node with no
+  added/changed/removed status had none) — a structural invariant a
+  future class addition should preserve.
+- `render_mermaid`/`render_mermaid_file_level` test expected strings
+  gain the `referenced` class on previously-unclassed nodes/paths and
+  the `+`/`~`/`-` marker prefixes on added/changed/removed node
+  labels — mechanical, full-string updates per this repository's
+  fully-qualified assert convention.
+- `compose_and_post_comment.sh`'s Legend table grows a fifth row and
+  the wording of four existing rows changes (marker prefix); the
+  underlying `classDef`-line parsing logic (ADR 0040) is unchanged —
+  only `legend_description()`'s hand-maintained text changes.
+- No effect on `--format md`/`--format json`/`--format digest` output
+  — this is a `--format mermaid`-only visual encoding, verified by
+  comparing that format's output on this PR's own diff against a
+  `main` build.

--- a/docs/adr/0041-mermaid-diff-marker-encoding.md
+++ b/docs/adr/0041-mermaid-diff-marker-encoding.md
@@ -40,6 +40,11 @@ Applied in `render_mermaid`'s existing class-assignment loop as the
 `else` arm of the fan-in/added/changed match (previously "no class"),
 and symmetrically in `render_mermaid_file_level`'s per-path loop as
 the `else` arm of changed/removed-only (previously "no class").
+`render_mermaid_file_level`'s path labels get a `classDef` (`changed`/
+`removed`/`referenced`) the same way, but never a marker prefix: a
+path node aggregates every symbol in that file, so a single `+`/`~`/
+`-` character can't represent a file that may contain an added symbol
+next to an untouched one.
 
 ### Diff-style marker prefix on node labels
 

--- a/rinkaku-core/src/render/mermaid.rs
+++ b/rinkaku-core/src/render/mermaid.rs
@@ -1,5 +1,5 @@
 //! Mermaid `flowchart` rendering (ADR 0021, amended by ADR 0037, ADR 0039,
-//! ADR 0040).
+//! ADR 0040, ADR 0041).
 //!
 //! The `--format mermaid` output path: a human-oriented call/dependency
 //! graph aimed at GitHub's native mermaid rendering in PR comments/
@@ -29,6 +29,46 @@ use std::fmt::Write as _;
 /// can't dodge the fallback merely because a deleted symbol has no
 /// head-side node.
 const MERMAID_NODE_BUDGET: usize = 30;
+
+/// A node's visual class (ADR 0021/0037/0039, `Referenced` added by ADR
+/// 0041): drives both its `classDef` name and its label's marker prefix,
+/// computed once per node so the two can't drift apart. `FanIn` wins over
+/// `Added`/`Changed` when both apply (ADR 0021: blast radius is more
+/// decision-relevant at a glance than contract status, which is still
+/// visible in the Markdown/JSON Definitions section). `Referenced` is the
+/// catch-all: an unchanged symbol pulled in only as a dependency.
+#[derive(Clone, Copy)]
+enum NodeClass {
+    Added,
+    Changed,
+    Removed,
+    FanIn,
+    Referenced,
+}
+
+impl NodeClass {
+    fn classdef_name(self) -> &'static str {
+        match self {
+            NodeClass::Added => "added",
+            NodeClass::Changed => "changed",
+            NodeClass::Removed => "removed",
+            NodeClass::FanIn => "fan-in",
+            NodeClass::Referenced => "referenced",
+        }
+    }
+
+    /// Diff-style label prefix (ADR 0041) — none for `FanIn`/`Referenced`
+    /// (see this enum's doc comment for why fan-in doesn't also carry an
+    /// added/changed marker).
+    fn marker(self) -> &'static str {
+        match self {
+            NodeClass::Added => "+ ",
+            NodeClass::Changed => "~ ",
+            NodeClass::Removed => "- ",
+            NodeClass::FanIn | NodeClass::Referenced => "",
+        }
+    }
+}
 
 /// Renders a [`Report`] as a mermaid `flowchart LR` document (ADR 0021): a
 /// human-oriented call/dependency graph, opt-in via `--format mermaid`,
@@ -68,6 +108,25 @@ pub(super) fn render_mermaid(report: &Report) -> String {
         .fan_ins
         .iter()
         .map(|h| (h.id.as_str(), h.used_by.len()))
+        .collect();
+    // Computed once, reused for both the label marker below and the
+    // `class` assignment line further down (see `NodeClass`).
+    let class_by_node: HashMap<&str, NodeClass> = report
+        .graph
+        .nodes
+        .iter()
+        .map(|n| {
+            let class = if fan_in_counts.contains_key(n.id.as_str()) {
+                NodeClass::FanIn
+            } else {
+                match lookup.get(&n.id).and_then(|(_, s)| s.classification) {
+                    Some(Classification::Added) => NodeClass::Added,
+                    Some(Classification::SignatureChanged) => NodeClass::Changed,
+                    _ => NodeClass::Referenced,
+                }
+            };
+            (n.id.as_str(), class)
+        })
         .collect();
 
     // Sequential, mermaid-safe node ids (`n0`, `n1`, ...), mapped from the
@@ -119,9 +178,10 @@ pub(super) fn render_mermaid(report: &Report) -> String {
         if let Some(nodes) = nodes_by_path.get(path) {
             for n in nodes {
                 let safe_id = &safe_id_by_node[n.id.as_str()];
+                let class = class_by_node[n.id.as_str()];
                 let label = match fan_in_counts.get(n.id.as_str()) {
-                    Some(count) => format!("{} (in:{count})", n.name),
-                    None => n.name.clone(),
+                    Some(count) => format!("{}{} (in:{count})", class.marker(), n.name),
+                    None => format!("{}{}", class.marker(), n.name),
                 };
                 writeln!(out, "    {safe_id}[\"{}\"]", escape_mermaid_label(&label))
                     .expect("writing to a String cannot fail");
@@ -131,7 +191,8 @@ pub(super) fn render_mermaid(report: &Report) -> String {
             for &i in indices {
                 let safe_id = &safe_id_by_removed[i];
                 let name = &report.removed[i].name;
-                writeln!(out, "    {safe_id}[\"{}\"]", escape_mermaid_label(name))
+                let label = format!("{}{name}", NodeClass::Removed.marker());
+                writeln!(out, "    {safe_id}[\"{}\"]", escape_mermaid_label(&label))
                     .expect("writing to a String cannot fail");
             }
         }
@@ -149,34 +210,12 @@ pub(super) fn render_mermaid(report: &Report) -> String {
         writeln!(out, "  {from} {arrow} {to}").expect("writing to a String cannot fail");
     }
 
-    // Class assignment: a node that is both classified (`added` or
-    // `changed`) and a high-fan-in symbol gets `fan-in` styling, checked
-    // first — see this function's doc comment / ADR 0021's Decision on
-    // precedence. This overlap is real, not just theoretical: fan-in
-    // (`fan_in_counts`, from `compute_fan_ins`) counts referrers among
-    // *changed* symbols regardless of the target's own classification, so
-    // a brand-new (`Added`) symbol referenced by two or more other
-    // changed symbols is a perfectly ordinary high-fan-in symbol too —
-    // e.g. a new helper function two other new/changed call sites both
-    // use in the same diff. `fan-in` wins because fan-in ("how many other
-    // changed symbols depend on this") is the more decision-relevant
-    // signal for a reviewer skimming the graph than "this particular node
-    // is new" — the node's own classification is still visible in the
-    // companion Markdown/JSON output's Definitions section either way.
+    // Reuses `class_by_node` (see its doc comment for precedence rules).
     for n in &report.graph.nodes {
         let safe_id = &safe_id_by_node[n.id.as_str()];
-        let class = if fan_in_counts.contains_key(n.id.as_str()) {
-            Some("fan-in")
-        } else {
-            match lookup.get(&n.id).and_then(|(_, s)| s.classification) {
-                Some(Classification::Added) => Some("added"),
-                Some(Classification::SignatureChanged) => Some("changed"),
-                _ => None,
-            }
-        };
-        if let Some(class) = class {
-            writeln!(out, "  class {safe_id} {class}").expect("writing to a String cannot fail");
-        }
+        let class = class_by_node[n.id.as_str()];
+        writeln!(out, "  class {safe_id} {}", class.classdef_name())
+            .expect("writing to a String cannot fail");
     }
     // No precedence conflict with the loop above: a `RemovedSymbol` never
     // has a `graph.nodes` entry, so `removed` is unconditional here.
@@ -294,13 +333,18 @@ fn render_mermaid_file_level(report: &Report) -> String {
         writeln!(out, "  {from} -- {count} --> {to}").expect("writing to a String cannot fail");
     }
 
+    // `referenced` is the file-level catch-all (ADR 0041), matching
+    // `render_mermaid`'s `NodeClass::Referenced`.
     for path in &path_order {
         let safe_id = &safe_id_by_path[path];
-        if changed_paths.contains(path) {
-            writeln!(out, "  class {safe_id} changed").expect("writing to a String cannot fail");
+        let class = if changed_paths.contains(path) {
+            "changed"
         } else if removed_only_paths.contains(path) {
-            writeln!(out, "  class {safe_id} removed").expect("writing to a String cannot fail");
-        }
+            "removed"
+        } else {
+            "referenced"
+        };
+        writeln!(out, "  class {safe_id} {class}").expect("writing to a String cannot fail");
     }
 
     write_class_defs(&mut out);
@@ -322,11 +366,15 @@ fn render_mermaid_file_level(report: &Report) -> String {
 /// so the signal survives even without color (ADR 0039). Also the source
 /// of truth `compose_and_post_comment.sh` parses for the Markdown legend
 /// (ADR 0040) — a hex value changed here needs no separate update there.
+/// `referenced` (ADR 0041) is a neutral gray for a node/path with none of
+/// the other four classes, so no node is left with the theme's default,
+/// unexplained color.
 const MERMAID_CLASS_DEFS: &str = concat!(
     "  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;\n",
     "  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;\n",
     "  classDef fan-in fill:#e9d8fd,stroke:#553c9a,stroke-width:3px,color:#1a202c;\n",
     "  classDef removed fill:#fed7d7,stroke:#9b2c2c,color:#1a202c,stroke-dasharray: 5 5;\n",
+    "  classDef referenced fill:#e2e8f0,stroke:#4a5568,color:#1a202c;\n",
 );
 
 /// Appends [`MERMAID_CLASS_DEFS`] — every [`render_mermaid`]/

--- a/rinkaku-core/src/render/mermaid_tests/class_styling.rs
+++ b/rinkaku-core/src/render/mermaid_tests/class_styling.rs
@@ -1,5 +1,7 @@
-//! `added`/`changed`/`fan-in` class assignment, fan-in's `(in:N)` label
-//! suffix (ADR 0039), and the fan-in-vs-changed/added precedence rule.
+//! `added`/`changed`/`fan-in`/`referenced` class assignment, the
+//! `+`/`~`/`-` diff-marker label prefixes (ADR 0041), fan-in's `(in:N)`
+//! label suffix (ADR 0039), and the fan-in-vs-changed/added precedence
+//! rule.
 
 use super::*;
 use pretty_assertions::assert_eq;
@@ -8,9 +10,9 @@ use pretty_assertions::assert_eq;
 fn should_render_subgraph_per_file_with_class_assignments_when_report_has_classified_symbols() {
     // "foo" is Added, "bar" is SignatureChanged, both in src/lib.rs; "baz"
     // (unclassified/body-only) lives in src/other.rs and depends on "foo"
-    // — pins subgraph grouping, node labels (name only, no kind prefix),
-    // the edge, and the `added`/`changed` class assignments together in
-    // one full-string comparison.
+    // — pins subgraph grouping, the `+`/`~` marker prefixes, the edge, and
+    // the `added`/`changed`/`referenced` class assignments together in one
+    // full-string comparison.
     let report = empty_report(
         SymbolGraph {
             nodes: vec![
@@ -62,8 +64,8 @@ fn should_render_subgraph_per_file_with_class_assignments_when_report_has_classi
     let expected = concat!(
         "flowchart LR\n",
         "  subgraph sub0[\"src/lib.rs\"]\n",
-        "    n0[\"foo\"]\n",
-        "    n1[\"bar\"]\n",
+        "    n0[\"+ foo\"]\n",
+        "    n1[\"~ bar\"]\n",
         "  end\n",
         "  subgraph sub1[\"src/other.rs\"]\n",
         "    n2[\"baz\"]\n",
@@ -71,6 +73,7 @@ fn should_render_subgraph_per_file_with_class_assignments_when_report_has_classi
         "  n2 --> n0\n",
         "  class n0 added\n",
         "  class n1 changed\n",
+        "  class n2 referenced\n",
     )
     .to_string()
         + CLASS_DEFS;
@@ -112,6 +115,8 @@ fn should_render_dashed_arrow_when_edge_is_a_cycle() {
         "  end\n",
         "  n0 --> n1\n",
         "  n1 -.-> n0\n",
+        "  class n0 referenced\n",
+        "  class n1 referenced\n",
     )
     .to_string()
         + CLASS_DEFS;
@@ -302,7 +307,7 @@ fn should_render_removed_and_fan_in_nodes_distinctly_when_both_present_in_one_re
         "flowchart LR\n",
         "  subgraph sub0[\"src/lib.rs\"]\n",
         "    n0[\"hot (in:2)\"]\n",
-        "    n1[\"gone\"]\n",
+        "    n1[\"- gone\"]\n",
         "  end\n",
         "  class n0 fan-in\n",
         "  class n1 removed\n",

--- a/rinkaku-core/src/render/mermaid_tests/empty_and_legend.rs
+++ b/rinkaku-core/src/render/mermaid_tests/empty_and_legend.rs
@@ -43,6 +43,7 @@ fn should_render_class_defs_with_no_legend_subgraph_when_graph_has_symbols() {
         "  subgraph sub0[\"src/lib.rs\"]\n",
         "    n0[\"foo\"]\n",
         "  end\n",
+        "  class n0 referenced\n",
     )
     .to_string()
         + CLASS_DEFS;

--- a/rinkaku-core/src/render/mermaid_tests/escaping.rs
+++ b/rinkaku-core/src/render/mermaid_tests/escaping.rs
@@ -1,4 +1,5 @@
-//! Label escaping for quotes/brackets/ampersands and embedded newlines.
+//! Label escaping for quotes/brackets/ampersands and embedded newlines,
+//! including its interaction with the ADR 0041 marker prefix.
 
 use super::*;
 use pretty_assertions::assert_eq;
@@ -20,6 +21,41 @@ fn should_escape_label_when_name_contains_quote_and_bracket() {
 
     let expected = format!(
         "flowchart LR\n  subgraph sub0[\"src/lib.rs\"]\n    n0[\"weird&quot;name&#91;with&#93;brackets\"]\n  end\n  class n0 referenced\n{}",
+        CLASS_DEFS
+    );
+    let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_escape_label_when_added_node_name_contains_quote_and_bracket() {
+    // No supported language's identifier grammar can produce these
+    // characters via the CLI; pinned at the unit level via a direct
+    // GraphNode construction instead.
+    let report = empty_report(
+        SymbolGraph {
+            nodes: vec![node(
+                "src/lib.rs::weird",
+                "src/lib.rs",
+                "weird\"name[with]brackets",
+            )],
+            edges: vec![],
+            roots: vec!["src/lib.rs::weird".to_string()],
+        },
+        vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol(
+                "src/lib.rs::weird",
+                "weird\"name[with]brackets",
+                SymbolKind::Function,
+                Some(Classification::Added),
+            )],
+        }],
+    );
+
+    let expected = format!(
+        "flowchart LR\n  subgraph sub0[\"src/lib.rs\"]\n    n0[\"+ weird&quot;name&#91;with&#93;brackets\"]\n  end\n  class n0 added\n{}",
         CLASS_DEFS
     );
     let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");

--- a/rinkaku-core/src/render/mermaid_tests/escaping.rs
+++ b/rinkaku-core/src/render/mermaid_tests/escaping.rs
@@ -19,7 +19,7 @@ fn should_escape_label_when_name_contains_quote_and_bracket() {
     );
 
     let expected = format!(
-        "flowchart LR\n  subgraph sub0[\"src/lib.rs\"]\n    n0[\"weird&quot;name&#91;with&#93;brackets\"]\n  end\n{}",
+        "flowchart LR\n  subgraph sub0[\"src/lib.rs\"]\n    n0[\"weird&quot;name&#91;with&#93;brackets\"]\n  end\n  class n0 referenced\n{}",
         CLASS_DEFS
     );
     let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
@@ -44,7 +44,7 @@ fn should_replace_embedded_newline_with_space_when_path_contains_one() {
     );
 
     let expected = format!(
-        "flowchart LR\n  subgraph sub0[\"src/li b.rs\"]\n    n0[\"weird\"]\n  end\n{}",
+        "flowchart LR\n  subgraph sub0[\"src/li b.rs\"]\n    n0[\"weird\"]\n  end\n  class n0 referenced\n{}",
         CLASS_DEFS
     );
     let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");

--- a/rinkaku-core/src/render/mermaid_tests/mod.rs
+++ b/rinkaku-core/src/render/mermaid_tests/mod.rs
@@ -84,15 +84,17 @@ fn removed_symbol(name: &str, path: &str) -> RemovedSymbol {
     }
 }
 
-/// The exact `classDef` trailer every render path appends (ADR 0040) —
-/// every test's `expected` string ends with this, shared here so a future
-/// style change is a one-line update instead of a find/replace across
-/// every test file. `concat!`, not a `"\`-continued literal: the latter
-/// strips leading whitespace from the continued line, which would
-/// silently swallow this block's leading indentation.
+/// The exact `classDef` trailer every render path appends (ADR 0040,
+/// `referenced` added by ADR 0041) — every test's `expected` string ends
+/// with this, shared here so a future style change is a one-line update
+/// instead of a find/replace across every test file. `concat!`, not a
+/// `"\`-continued literal: the latter strips leading whitespace from the
+/// continued line, which would silently swallow this block's leading
+/// indentation.
 const CLASS_DEFS: &str = concat!(
     "  classDef added fill:#c6f6d5,stroke:#276749,color:#1a202c;\n",
     "  classDef changed fill:#feebc8,stroke:#9c4221,color:#1a202c;\n",
     "  classDef fan-in fill:#e9d8fd,stroke:#553c9a,stroke-width:3px,color:#1a202c;\n",
     "  classDef removed fill:#fed7d7,stroke:#9b2c2c,color:#1a202c,stroke-dasharray: 5 5;\n",
+    "  classDef referenced fill:#e2e8f0,stroke:#4a5568,color:#1a202c;\n",
 );

--- a/rinkaku-core/src/render/mermaid_tests/node_budget_fallback.rs
+++ b/rinkaku-core/src/render/mermaid_tests/node_budget_fallback.rs
@@ -37,6 +37,9 @@ fn should_stay_symbol_level_when_node_count_equals_budget_exactly() {
         expected.push_str(&format!("    n{i}[\"s{i}\"]\n"));
     }
     expected.push_str("  end\n");
+    for i in 0..30 {
+        expected.push_str(&format!("  class n{i} referenced\n"));
+    }
     expected.push_str(CLASS_DEFS);
 
     let actual = render(&report, OutputFormat::Mermaid).expect("mermaid render succeeds");
@@ -120,6 +123,7 @@ fn should_fall_back_to_file_level_graph_when_node_count_exceeds_budget() {
         "  n1[\"src/b.rs\"]\n",
         "  n0 -- 2 --> n1\n",
         "  class n0 changed\n",
+        "  class n1 referenced\n",
     )
     .to_string()
         + CLASS_DEFS;

--- a/rinkaku-core/src/render/mermaid_tests/removed_symbols.rs
+++ b/rinkaku-core/src/render/mermaid_tests/removed_symbols.rs
@@ -29,8 +29,8 @@ fn should_render_removed_node_in_its_file_subgraph_when_report_has_removed_symbo
     let expected = concat!(
         "flowchart LR\n",
         "  subgraph sub0[\"src/lib.rs\"]\n",
-        "    n0[\"foo\"]\n",
-        "    n1[\"old_helper\"]\n",
+        "    n0[\"+ foo\"]\n",
+        "    n1[\"- old_helper\"]\n",
         "  end\n",
         "  class n0 added\n",
         "  class n1 removed\n",
@@ -57,7 +57,7 @@ fn should_render_removed_only_file_subgraph_when_file_has_no_surviving_symbols()
     let expected = concat!(
         "flowchart LR\n",
         "  subgraph sub0[\"src/gone.rs\"]\n",
-        "    n0[\"old_only\"]\n",
+        "    n0[\"- old_only\"]\n",
         "  end\n",
         "  class n0 removed\n",
     )
@@ -162,6 +162,7 @@ fn should_render_removed_only_file_as_removed_node_when_fallback_fires() {
         "  n1[\"src/b.rs\"]\n",
         "  n2[\"src/gone.rs\"]\n",
         "  class n0 changed\n",
+        "  class n1 referenced\n",
         "  class n2 removed\n",
     )
     .to_string()


### PR DESCRIPTION
## Summary

- Implements ADR 0041 (`docs/adr/0041-mermaid-diff-marker-encoding.md`): user feedback on the `--format mermaid` PR-comment diagram was that unchanged dependency nodes (no `classDef`) rendered in the theme's default color with no explanation, and that a more diff-like visual encoding was wanted.
- `rinkaku-core`: node labels now get a diff-style marker prefix based on classification — `+ ` for added, `~ ` for API-changed, `- ` for removed; `fan-in` and unchanged-dependency nodes get no marker (fan-in already has its own `(in:N)` suffix and violet styling; adding a marker on top would double-encode the same signal). A new `referenced` classDef (neutral gray) now covers every node/path that previously had no class at all, so no node is left unstyled. A `NodeClass` enum centralizes class selection so the label marker and the `class` line can never disagree.
- `compose_and_post_comment.sh`: `legend_description()` gains a `referenced` row and the existing `added`/`changed`/`removed` descriptions now lead with the same marker characters, so the Legend table doubles as the marker's key.

## Rendering check

Legend generated by `compose_and_post_comment.sh` from this PR's own dogfooded `--format mermaid` output, pasted verbatim (5 rows, including the new `referenced` row):

### Legend

| | Meaning |
|---|---|
| $`{\color{#c6f6d5}\blacksquare}`$ | + added — new symbol |
| $`{\color{#feebc8}\blacksquare}`$ | ~ API changed — signature changed |
| $`{\color{#e9d8fd}\blacksquare}`$ | fan-in — highly referenced, thick border, label shows (in:N) |
| $`{\color{#fed7d7}\blacksquare}`$ | - removed (dashed border in graph) |
| $`{\color{#e2e8f0}\blacksquare}`$ | referenced — unchanged dependency (not part of the diff) |

## QA / verification

- `make test`: 605 passed, 0 failed.
- `make lint`: `cargo fmt --all --check` + `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `bash -n compose_and_post_comment.sh` and `shellcheck compose_and_post_comment.sh` clean.
- TDD: every `mermaid_tests/*.rs` expectation was updated to a full-string `pretty_assertions::assert_eq!` (existing convention) before touching `mermaid.rs`, confirmed Red, then Green after implementation — including the fan-in-vs-added/changed precedence test (fan-in still wins, still no marker) and the escaping tests (marker is prepended before `escape_mermaid_label` runs, so `+`/`~`/`-` never interact with the escaping logic since none of them are in its escape set).
- File-level fallback (`render_mermaid_file_level`) was updated symmetrically: a path with no changed/removed-only symbol of its own now gets `referenced` instead of no class.
- Dogfooded `--format mermaid` against this PR's own diff (`/tmp/marker_report.mmd`) shows all 5 classes appearing correctly in a real graph (`NodeClass` itself is fan-in with no marker, `classdef_name`/`marker` are `+`-marked added functions, everything else unclassified/test code is `referenced`).
- No effect on `--format md`/`--format json`/`--format digest`: confirmed by inspecting the diff itself — only `rinkaku-core/src/render/mermaid.rs`, `mermaid_tests/*`, `compose_and_post_comment.sh`, and the ADR are touched; `render/markdown.rs`, `render/json.rs`, and `render/digest.rs` are untouched by this PR, so those formats are provably unaffected, not just spot-checked.
- Legend script dynamic verification (`DRY_RUN=1`, standalone): full 5-class `.mmd` → correct 5-row table; missing/empty `MERMAID_PATH` → no mermaid section, no legend, no crash; oversized mermaid → omitted-diagram note only, no legend; unknown `classDef` name → `::warning::` printed, row skipped, known rows still render.

## Note

Base is `main` (PR #131, which this work originally stacked on, has already merged).
