### PR TITLE
fix: buffer log:: output during --tui mode to prevent splash corruption

### DIFF
--- a/docs/adr/0033-tui-splash-screen-with-progress.md
+++ b/docs/adr/0033-tui-splash-screen-with-progress.md
@@ -398,17 +398,32 @@ after `TuiSession::run` returns, and after an early-return analysis error
 drops the `TuiSession` — so both drain in order once the terminal has
 actually left the alternate screen.
 
+Those two explicit calls do not cover every exit path: a panic unwinding
+through `run_analysis`/`TuiSession::run`, or an early `?` return from
+`TuiSession::init`/`draw_splash` before either explicit call is reached,
+would silently discard whatever was buffered. `log_writer::ReleaseGuard`
+closes that gap — an RAII guard, constructed right after the sink and
+before `TuiSession::init` so Rust's LIFO drop order runs the session's
+terminal-restoring `Drop` first and the guard's log-release `Drop` second
+on any unwind, releasing the sink to a freshly-built stderr handle
+unconditionally. `DeferredLogSink::release` is idempotent (a no-op once
+already released), so the guard is a pure safety net: it changes nothing
+on the normal paths where the explicit calls already ran.
+
 This does not change any decision above: it is the same buffer-then-flush
 shape decision 8 already established, applied to the one write path that
 bypasses `AnalysisProgress`.
 
 - **`rinkaku` bin API** (all `pub(crate)`, no external surface): adds
   `log_writer::DeferredLogSink<W>` (`new`, `release`, `Write` impl,
-  `Clone`). `main.rs` gains a `logger_builder()` helper (the
-  `env_logger::Builder` construction shared by every display mode) and a
-  `release_log_sink` helper mirroring `flush_notes`.
+  `Clone`) and `log_writer::ReleaseGuard<W, F>` (`new`, `Drop`). `main.rs`
+  gains a `logger_builder()` helper (the `env_logger::Builder`
+  construction shared by every display mode) and a `release_log_sink`
+  helper mirroring `flush_notes`.
 - **Testing**: `DeferredLogSink` is unit tested as a pure `Write` sink
   against an injected in-memory destination (`rstest` +
   `pretty_assertions`) — buffering while deferring, in-order draining on
-  release, passthrough after release, and shared state across clones. No
-  real stderr is touched in tests.
+  release, idempotence on a second release, passthrough after release,
+  and shared state across clones. `ReleaseGuard` is tested the same way:
+  dropping it releases buffered bytes, and dropping it after an explicit
+  release is a no-op. No real stderr is touched in tests.

--- a/docs/adr/0033-tui-splash-screen-with-progress.md
+++ b/docs/adr/0033-tui-splash-screen-with-progress.md
@@ -370,3 +370,45 @@ which pipeline entry point produced it.
   during "Analyzing diff..." instead of a static label, matching the
   whole-repo-outline and dependency-index phases. Every non-TUI display
   mode is unaffected, same as the original decision.
+
+## Amendment: deferring `log::` records too
+
+Decision 8's buffering covers `AnalysisProgress::note`, but not `log::`
+records — `env_logger` writes straight to its configured target (stderr
+by default), bypassing `AnalysisProgress` entirely. `--tui` mode's
+alternate screen is the same physical terminal stderr writes to, so a
+`log::info!`/`log::warn!` fired during analysis (e.g. `workdir.rs`'s
+"using the current directory as a clone of ..." line, or `base_sha.rs`'s
+fallback warning) lands as raw bytes mid-redraw, corrupting the splash or
+entry screen frame — the same failure mode decision 8 fixed for notes,
+for a call path decision 8 did not cover.
+
+`rinkaku`'s bin crate gains a `log_writer` module: `DeferredLogSink<W>`, a
+cheaply cloneable `std::io::Write` sink wrapping `Arc<Mutex<State<W>>>`
+with two states, buffering while deferring and writing straight to `W`
+once released (draining the buffer first, so record order is preserved).
+`main` now resolves `display_mode` *before* initializing `env_logger`
+(reordered ahead of `Cli::parse`'s `SelfUpdate` branch too, which still
+logs directly to stderr since it never touches the alternate screen).
+`DisplayMode::Tui` initializes `env_logger` with
+`.target(env_logger::Target::Pipe(Box::new(sink.clone())))`; every other
+display mode keeps targeting stderr directly, unchanged. The sink is
+released at the same two points `main` already flushes buffered notes —
+after `TuiSession::run` returns, and after an early-return analysis error
+drops the `TuiSession` — so both drain in order once the terminal has
+actually left the alternate screen.
+
+This does not change any decision above: it is the same buffer-then-flush
+shape decision 8 already established, applied to the one write path that
+bypasses `AnalysisProgress`.
+
+- **`rinkaku` bin API** (all `pub(crate)`, no external surface): adds
+  `log_writer::DeferredLogSink<W>` (`new`, `release`, `Write` impl,
+  `Clone`). `main.rs` gains a `logger_builder()` helper (the
+  `env_logger::Builder` construction shared by every display mode) and a
+  `release_log_sink` helper mirroring `flush_notes`.
+- **Testing**: `DeferredLogSink` is unit tested as a pure `Write` sink
+  against an injected in-memory destination (`rstest` +
+  `pretty_assertions`) — buffering while deferring, in-order draining on
+  release, passthrough after release, and shared state across clones. No
+  real stderr is touched in tests.

--- a/rinkaku/src/log_writer.rs
+++ b/rinkaku/src/log_writer.rs
@@ -13,6 +13,15 @@
 //! screen — draining the buffer to the destination first so log order is
 //! preserved, then writing straight through for any record logged after
 //! that point.
+//!
+//! [`ReleaseGuard`] is the panic/early-return safety net for the same
+//! release: `main.rs` calls `release` explicitly at its two normal-flow
+//! points (for deterministic ordering against the buffered notes flush,
+//! see `main.rs`'s own comments), but neither an early `?` return nor a
+//! panic unwinding through `run_analysis`/`TuiSession::run` reaches those
+//! calls. `ReleaseGuard::drop` releases the sink unconditionally, so a
+//! record buffered before either kind of abrupt exit still reaches stderr
+//! instead of being silently discarded.
 
 use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
@@ -51,17 +60,52 @@ impl<W: Write> DeferredLogSink<W> {
     /// Drains any buffered bytes to `destination` (in the order they were
     /// written) and switches to passthrough: every write after this call
     /// goes straight to `destination` instead of being buffered.
+    ///
+    /// A no-op if already in the passthrough state (idempotent): the
+    /// explicit `main.rs` call and [`ReleaseGuard`]'s `Drop`-based call can
+    /// both reach the same sink on a given run, and only the first one
+    /// should have any effect.
     pub(crate) fn release(&self, mut destination: W) -> io::Result<()> {
         let mut guard = self
             .state
             .lock()
             .expect("deferred log sink mutex must not be poisoned");
-        if let State::Deferring(buffered) = &*guard {
-            destination.write_all(buffered)?;
-            destination.flush()?;
-        }
+        let State::Deferring(buffered) = &*guard else {
+            return Ok(());
+        };
+        destination.write_all(buffered)?;
+        destination.flush()?;
         *guard = State::Passthrough(destination);
         Ok(())
+    }
+}
+
+/// RAII safety net for [`DeferredLogSink::release`] (see the module doc
+/// comment): releases the wrapped sink to `destination` when dropped,
+/// covering panics and early `?` returns that never reach `main.rs`'s
+/// explicit `release` calls. `destination` is built lazily (`F: FnOnce() ->
+/// W`) so it is only constructed if `Drop` actually runs the release —
+/// `main.rs` uses this to build a fresh `std::io::Stderr` handle at drop
+/// time rather than holding one for the guard's entire lifetime.
+pub(crate) struct ReleaseGuard<W: Write, F: FnOnce() -> W> {
+    sink: DeferredLogSink<W>,
+    destination: Option<F>,
+}
+
+impl<W: Write, F: FnOnce() -> W> ReleaseGuard<W, F> {
+    pub(crate) fn new(sink: DeferredLogSink<W>, destination: F) -> Self {
+        Self {
+            sink,
+            destination: Some(destination),
+        }
+    }
+}
+
+impl<W: Write, F: FnOnce() -> W> Drop for ReleaseGuard<W, F> {
+    fn drop(&mut self) {
+        if let Some(destination) = self.destination.take() {
+            let _ = self.sink.release(destination());
+        }
     }
 }
 
@@ -132,6 +176,57 @@ mod tests {
 
         let actual = destination.lock().unwrap().clone();
         assert_eq!(b"buffered live".to_vec(), actual);
+    }
+
+    #[rstest]
+    fn should_ignore_second_release_when_already_released() {
+        let mut sink = DeferredLogSink::new();
+        sink.write_all(b"buffered").unwrap();
+
+        let first: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        sink.release(SharedVec(Arc::clone(&first))).unwrap();
+
+        let second: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        sink.release(SharedVec(Arc::clone(&second))).unwrap();
+
+        let actual_first = first.lock().unwrap().clone();
+        let actual_second = second.lock().unwrap().clone();
+        assert_eq!(b"buffered".to_vec(), actual_first);
+        assert_eq!(Vec::<u8>::new(), actual_second);
+    }
+
+    #[rstest]
+    fn should_release_buffered_bytes_when_guard_is_dropped() {
+        let mut sink = DeferredLogSink::new();
+        sink.write_all(b"buffered").unwrap();
+
+        let destination: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let destination_for_guard = Arc::clone(&destination);
+        let guard = ReleaseGuard::new(sink, move || SharedVec(destination_for_guard));
+
+        drop(guard);
+
+        let actual = destination.lock().unwrap().clone();
+        assert_eq!(b"buffered".to_vec(), actual);
+    }
+
+    #[rstest]
+    fn should_not_release_when_guard_is_defused_by_explicit_release() {
+        let mut sink = DeferredLogSink::new();
+        sink.write_all(b"buffered").unwrap();
+
+        let explicit: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        sink.release(SharedVec(Arc::clone(&explicit))).unwrap();
+
+        let guard_destination: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let guard_destination_for_guard = Arc::clone(&guard_destination);
+        let guard = ReleaseGuard::new(sink, move || SharedVec(guard_destination_for_guard));
+        drop(guard);
+
+        let actual_explicit = explicit.lock().unwrap().clone();
+        let actual_guard = guard_destination.lock().unwrap().clone();
+        assert_eq!(b"buffered".to_vec(), actual_explicit);
+        assert_eq!(Vec::<u8>::new(), actual_guard);
     }
 
     #[rstest]

--- a/rinkaku/src/log_writer.rs
+++ b/rinkaku/src/log_writer.rs
@@ -1,0 +1,168 @@
+//! A [`std::io::Write`] sink for `env_logger` that defers writes instead of
+//! printing them immediately (ADR 0033 amendment): `--tui` mode's alternate
+//! screen is the same physical terminal stderr writes to, so a `log::info!`/
+//! `log::warn!` fired while the splash/entry screen is being redrawn lands
+//! as raw bytes mid-frame, corrupting it — the same failure mode ADR 0033
+//! already fixed for `AnalysisProgress::note`, but that fix does not cover
+//! `log::` records, which bypass `AnalysisProgress` entirely and go straight
+//! to `env_logger`'s own configured target.
+//!
+//! [`DeferredLogSink`] starts in the deferring state (bytes are appended to
+//! an internal buffer) and is flipped to passthrough once, via
+//! [`DeferredLogSink::release`], after the terminal has left the alternate
+//! screen — draining the buffer to the destination first so log order is
+//! preserved, then writing straight through for any record logged after
+//! that point.
+
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+enum State<W> {
+    Deferring(Vec<u8>),
+    Passthrough(W),
+}
+
+/// Cheaply cloneable handle around a shared [`Write`] destination `W` that
+/// starts in the deferring state. Clones share the same underlying buffer —
+/// `env_logger::Target::Pipe` takes ownership of one handle to write log
+/// records through, while `main.rs` keeps another to call [`release`] once
+/// the TUI's terminal has torn down.
+///
+/// [`release`]: DeferredLogSink::release
+pub(crate) struct DeferredLogSink<W> {
+    state: Arc<Mutex<State<W>>>,
+}
+
+impl<W> Clone for DeferredLogSink<W> {
+    fn clone(&self) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+impl<W: Write> DeferredLogSink<W> {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(State::Deferring(Vec::new()))),
+        }
+    }
+
+    /// Drains any buffered bytes to `destination` (in the order they were
+    /// written) and switches to passthrough: every write after this call
+    /// goes straight to `destination` instead of being buffered.
+    pub(crate) fn release(&self, mut destination: W) -> io::Result<()> {
+        let mut guard = self
+            .state
+            .lock()
+            .expect("deferred log sink mutex must not be poisoned");
+        if let State::Deferring(buffered) = &*guard {
+            destination.write_all(buffered)?;
+            destination.flush()?;
+        }
+        *guard = State::Passthrough(destination);
+        Ok(())
+    }
+}
+
+impl<W: Write> Write for DeferredLogSink<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut guard = self
+            .state
+            .lock()
+            .expect("deferred log sink mutex must not be poisoned");
+        match &mut *guard {
+            State::Deferring(buffered) => buffered.extend_from_slice(buf),
+            State::Passthrough(destination) => return destination.write(buf),
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut guard = self
+            .state
+            .lock()
+            .expect("deferred log sink mutex must not be poisoned");
+        if let State::Passthrough(destination) = &mut *guard {
+            return destination.flush();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    #[rstest]
+    fn should_buffer_writes_when_deferring() {
+        let mut sink = DeferredLogSink::new();
+        sink.write_all(b"first ").unwrap();
+        sink.write_all(b"second").unwrap();
+
+        let destination = Vec::new();
+        sink.release(destination.clone()).unwrap();
+
+        assert_eq!(Vec::<u8>::new(), destination);
+    }
+
+    #[rstest]
+    fn should_drain_buffered_bytes_in_order_when_released() {
+        let mut sink = DeferredLogSink::new();
+        sink.write_all(b"first ").unwrap();
+        sink.write_all(b"second").unwrap();
+
+        let destination: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        sink.release(SharedVec(Arc::clone(&destination))).unwrap();
+
+        let actual = destination.lock().unwrap().clone();
+        assert_eq!(b"first second".to_vec(), actual);
+    }
+
+    #[rstest]
+    fn should_pass_writes_through_when_released() {
+        let mut sink = DeferredLogSink::new();
+        sink.write_all(b"buffered ").unwrap();
+
+        let destination: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        sink.release(SharedVec(Arc::clone(&destination))).unwrap();
+        sink.write_all(b"live").unwrap();
+
+        let actual = destination.lock().unwrap().clone();
+        assert_eq!(b"buffered live".to_vec(), actual);
+    }
+
+    #[rstest]
+    fn should_share_state_across_clones() {
+        let sink = DeferredLogSink::new();
+        let mut handle_a = sink.clone();
+        let mut handle_b = sink.clone();
+        handle_a.write_all(b"from a, ").unwrap();
+        handle_b.write_all(b"from b").unwrap();
+
+        let destination: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        sink.release(SharedVec(Arc::clone(&destination))).unwrap();
+
+        let actual = destination.lock().unwrap().clone();
+        assert_eq!(b"from a, from b".to_vec(), actual);
+    }
+
+    /// A [`Write`] destination that appends to a shared buffer, so a test
+    /// can both hand ownership to [`DeferredLogSink::release`] and inspect
+    /// what was written afterward.
+    #[derive(Clone)]
+    struct SharedVec(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedVec {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+}

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -44,6 +44,7 @@ mod display;
 mod generated_paths;
 mod git;
 mod github;
+mod log_writer;
 mod notes;
 mod pipeline;
 mod progress;
@@ -66,6 +67,7 @@ use github::base_sha::{
 use github::pr_arg::parse_pr_arg;
 use github::pr_info::fetch_pr_info;
 use github::workdir::resolve_pr_workdir;
+use log_writer::DeferredLogSink;
 use notes::{
     apply_entry_pivot, entry_pivot_empty_note, garbage_input_note, repo_outline_empty_note,
 };
@@ -80,24 +82,28 @@ use splash_progress::SplashProgress;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
+/// Shared `env_logger` setup for every display mode: `info`-level default
+/// (env_logger's own default is error-only, which meant `--pr`/`--base`
+/// runs — the ones slow enough to want a heartbeat, see the
+/// dependency-index build below — gave no feedback at all while running;
+/// `RUST_LOG` still overrides this). Timestamp and module path are
+/// dropped: this is a short-lived one-shot CLI, so there is nothing to
+/// correlate a timestamp against, and the binary is a single crate, making
+/// the module path redundant.
+fn logger_builder() -> env_logger::Builder {
+    let mut builder =
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"));
+    builder.format_timestamp(None).format_target(false);
+    builder
+}
+
 fn main() -> anyhow::Result<()> {
-    // Default to `info`-level progress output on stderr (env_logger's own
-    // default is error-only, which meant `--pr`/`--base` runs — the ones
-    // slow enough to want a heartbeat, see the dependency-index build
-    // below — gave no feedback at all while running). `RUST_LOG` still
-    // overrides this, same as any other `env_logger::Builder::from_env`
-    // setup.
-    //
-    // Timestamp and module path are dropped: this is a short-lived
-    // one-shot CLI, so there is nothing to correlate a timestamp against,
-    // and the binary is a single crate, making the module path redundant.
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
-        .format_timestamp(None)
-        .format_target(false)
-        .init();
     let cli = Cli::parse();
 
     if let Some(Command::SelfUpdate { yes }) = cli.command {
+        // Non-TUI: logs straight to stderr like every other subcommand did
+        // before display-mode resolution was moved ahead of logger init.
+        logger_builder().init();
         return self_update::run_self_update(yes);
     }
 
@@ -108,12 +114,27 @@ fn main() -> anyhow::Result<()> {
     // and is what lets the `DisplayMode::Tui` branch below enter the
     // alternate screen and start drawing a splash screen before the
     // pipeline's first byte of work runs, instead of only after it
-    // finishes.
+    // finishes. Determining `display_mode` before `logger_builder().init()`
+    // (ADR 0033 amendment) is what lets the `Tui` branch route the logger
+    // through a deferring sink from the very first log call, instead of
+    // racing the alternate-screen switch against whichever log record
+    // fires first.
     let stdout_is_tty = std::io::stdout().is_terminal();
     let display_mode = resolve_display_mode(cli.tui, cli.format, stdout_is_tty);
 
     match display_mode {
         DisplayMode::Tui => {
+            // ADR 0033 amendment: `log::` records bypass `AnalysisProgress`
+            // entirely, so they need their own deferral mechanism — a
+            // `DeferredLogSink` buffers every record until `release` is
+            // called below, once the alternate screen has actually torn
+            // down, mirroring `SplashProgress`'s buffered-notes handling
+            // for the same underlying bug (raw bytes landing mid-redraw).
+            let log_sink = DeferredLogSink::new();
+            logger_builder()
+                .target(env_logger::Target::Pipe(Box::new(log_sink.clone())))
+                .init();
+
             // No stderr spinner in this branch (ADR 0033 decision 1): the
             // splash screen drawn on the alternate screen is this run's
             // only progress feedback, replacing it rather than layering on
@@ -155,6 +176,7 @@ fn main() -> anyhow::Result<()> {
                     // warning, ADR 0033) is not silently lost on an
                     // early-return failure.
                     drop(session);
+                    release_log_sink(&log_sink);
                     flush_notes(buffered_notes);
                     return Err(err);
                 }
@@ -172,10 +194,15 @@ fn main() -> anyhow::Result<()> {
             // fallback) now reaches stderr as clean, ordinary text once
             // the alternate screen is gone, instead of corrupting a splash
             // or entry-screen frame mid-redraw.
+            release_log_sink(&log_sink);
             flush_notes(buffered_notes);
             result
         }
         DisplayMode::Output(format) => {
+            // Non-TUI: no alternate screen ever opens, so `log::` output
+            // goes straight to stderr, same as it always has.
+            logger_builder().init();
+
             // Started before any branch below runs and cleared right after
             // the pipeline finishes (`spinner.finish_and_clear()`), so the
             // whole synchronous analysis phase — the only part of a run
@@ -216,6 +243,19 @@ fn flush_notes(notes: Vec<String>) {
     for note in notes {
         eprintln!("{note}");
     }
+}
+
+/// Releases a `--tui`-mode [`DeferredLogSink`] to stderr — the `log::`
+/// counterpart of [`flush_notes`], called at the same two points (both of
+/// this function's call sites in `main` are positioned identically; see
+/// each one's own comment) so buffered log records drain in order once the
+/// terminal has actually left the alternate screen.
+fn release_log_sink(sink: &DeferredLogSink<std::io::Stderr>) {
+    // A failed `write_all`/`flush` to stderr here has nowhere left to be
+    // reported (the process is already on its way out in every call site),
+    // so it is dropped rather than propagated — same judgment call
+    // `flush_notes`'s own `eprintln!` already makes implicitly.
+    let _ = sink.release(std::io::stderr());
 }
 
 /// The result of [`run_analysis`]: a built [`Report`], the raw diff text

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -134,6 +134,17 @@ fn main() -> anyhow::Result<()> {
             logger_builder()
                 .target(env_logger::Target::Pipe(Box::new(log_sink.clone())))
                 .init();
+            // Declared before `TuiSession::init` so Rust's drop order (LIFO)
+            // runs `session`'s terminal-restoring `Drop` before this guard's
+            // log-release `Drop`, on *any* unwind past this point — a panic
+            // inside `run_analysis`/`TuiSession::run`, or an early `?`
+            // return from `TuiSession::init`/`draw_splash` below, neither of
+            // which reaches the explicit `release_log_sink` calls further
+            // down. Those explicit calls still run first on the normal exit
+            // paths (`release` is idempotent, see `DeferredLogSink::release`),
+            // giving deterministic logs-before-notes ordering there; this
+            // guard is purely the safety net for the paths that skip them.
+            let _log_sink_guard = log_writer::ReleaseGuard::new(log_sink.clone(), std::io::stderr);
 
             // No stderr spinner in this branch (ADR 0033 decision 1): the
             // splash screen drawn on the alternate screen is this run's
@@ -246,10 +257,13 @@ fn flush_notes(notes: Vec<String>) {
 }
 
 /// Releases a `--tui`-mode [`DeferredLogSink`] to stderr — the `log::`
-/// counterpart of [`flush_notes`], called at the same two points (both of
-/// this function's call sites in `main` are positioned identically; see
-/// each one's own comment) so buffered log records drain in order once the
-/// terminal has actually left the alternate screen.
+/// counterpart of [`flush_notes`]. Called explicitly at `main`'s two normal
+/// exit points, in the same position as each `flush_notes` call, so logs
+/// drain before notes in a fixed order on those paths (`release` is
+/// idempotent, so this is safe even though `_log_sink_guard`'s `Drop` will
+/// also release the same sink later). Paths that skip these explicit calls
+/// (a panic, or an early `?` return before either is reached) still get
+/// their buffered records drained by that guard.
 fn release_log_sink(sink: &DeferredLogSink<std::io::Stderr>) {
     // A failed `write_all`/`flush` to stderr here has nowhere left to be
     // reported (the process is already on its way out in every call site),


### PR DESCRIPTION
## Problem

In `--tui` mode, `env_logger` wrote log records straight to stderr, which is the same physical terminal ratatui's alternate screen occupies. A `log::info!`/`log::warn!` fired during analysis landed as raw bytes mid-redraw, corrupting the splash or entry screen frame. Screenshot evidence showed the text "the current directory as a clone of hiro-o918/rinkaku" wrapped at a random screen position over the splash.

## Root cause

`env_logger` was initialized once in `main()`, targeting stderr, before ADR 0033's `TuiSession::init()` enters the alternate screen. ADR 0033 already solved exactly this problem for advisory notes (`AnalysisProgress::note` buffers messages, flushed to stderr only after the terminal tears down), but `log::` records bypass `AnalysisProgress` entirely and go straight to `env_logger`'s configured target — so call sites like `github/workdir.rs`'s `log::info!("using the current directory as a clone of ...")` and `github/base_sha.rs`'s fallback warning were never covered.

## Fix design

1. **`DeferredLogSink<W>`** (`rinkaku/src/log_writer.rs`): a cheaply cloneable `std::io::Write` sink (`Arc<Mutex<State<W>>>`) with two states — buffering while deferring, passthrough to `W` after `release()` (idempotent: a no-op if already released), draining buffered bytes first so record order is preserved.
2. **`main()`** now resolves `display_mode` *before* initializing `env_logger` (reordered ahead of the `SelfUpdate` subcommand branch too, which still logs directly to stderr since it never touches the alternate screen). `DisplayMode::Tui` routes `env_logger` through `.target(env_logger::Target::Pipe(Box::new(sink.clone())))`; every other display mode targets stderr directly, unchanged.
3. The sink is released explicitly at the same two points `main` already flushes buffered notes (after `TuiSession::run` returns, and after an early-return analysis error drops the `TuiSession`), giving deterministic logs-before-notes ordering on those normal paths.
4. **`ReleaseGuard<W, F>`** (found by review, see below): an RAII safety net. The two explicit `release_log_sink` calls don't cover every exit path — a panic unwinding through `run_analysis`/`TuiSession::run`, or an early `?` return from `TuiSession::init`/`draw_splash`, would silently discard whatever was buffered. The guard is constructed right after the sink and before `TuiSession::init`, so Rust's LIFO drop order runs the session's terminal-restoring `Drop` first and the guard's log-release `Drop` second on any unwind. Since `release` is idempotent, the guard changes nothing on the normal paths where the explicit calls already ran.

This extends [ADR 0033](docs/adr/0033-tui-splash-screen-with-progress.md)'s note-deferral decision (amended twice in this PR: once for the sink itself, once for the guard).

## Tests

`log_writer.rs` unit tests (rstest + pretty_assertions, whole-value asserts, injected in-memory `Write` destination — no real stderr touched): buffering while deferring, in-order draining on release, idempotence on a second release, passthrough after release, shared state across clones, guard releases on drop, and dropping the guard after an explicit release is a no-op.

`make test`: 176 (rinkaku) + 394 (rinkaku-core) + 605 (rinkaku-tui) passed, 0 failed.
`make lint`: clean (`cargo fmt --all --check` + `cargo clippy --all-targets --all-features -- -D warnings`).

## Dynamic verification

All via a real pty (`tmux`), rebuilding after each change:

- **Non-TTY stdin/stdout, empty diff**: `echo "" | rinkaku` — clean `note: diff is empty, nothing to analyze` on stderr, exit 0.
- **Conflicting flags**: `--tui --format json` — rejected by clap before any logger/TUI setup (`error: the argument '--tui' cannot be used with '--format <FORMAT>'`).
- **Garbage `--base` (non-TTY)**: buffered debug log line printed before the `git diff` error, in order.
- **Garbage `--base` in `--tui`**: splash never corrupts; on the early-return error path, terminal restores cleanly and the buffered `[DEBUG] diffing ...` line + `Error: ...` print in order afterward — this exercises the exact `Err(err)` branch the should-fix targeted.
- **`--entry` matching nothing, in `--tui`**: all three `[DEBUG]` analysis lines drain before the `note: no symbols under ...` note, confirming logs-before-notes ordering.
- **`RUST_LOG` = `off` / `warn` / `debug` / unset (default)**: all four run clean in a pty, exit 0, no corruption.
- **Tiny pane (30x8)**: splash and entry screen render correctly clipped, log lines still drain cleanly on quit.
- **Whole-repo `--tui` mode** (no `--base`/`--pr`, stdin is a terminal): renders cleanly, `[DEBUG] no diff input and stdin is a terminal; building a whole-repo outline` drains after quit.

The panic-path log-loss gap (item 4 above) was found by review (both an independent pass and the map-assisted pass converged on it) and fixed with `ReleaseGuard` in the second commit of this PR.

https://claude.ai/code/session_01HuToEMUD2tRARq9BDU2Jdv