### PR TITLE
docs(experiments): record experiment 0001 round 29 (PR #134)

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/029.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/029.md
@@ -1,0 +1,123 @@
+# Round 29
+
+- Subject: PR #134 — fixes `--tui` splash/entry-screen corruption caused
+  by `log::` records (`env_logger`, default target stderr) being written
+  raw into the same physical terminal ratatui's alternate screen
+  occupies, while analysis is running (symptom: a `log::info!` line —
+  "using the current directory as a clone of ..." — rendered mid-screen
+  over the splash). ADR 0033 had already solved exactly this problem for
+  advisory notes (`AnalysisProgress::note`, buffered and flushed after
+  terminal teardown), but `log::` records bypass `AnalysisProgress`
+  entirely and were never covered. Fix: `DeferredLogSink<W>`
+  (`rinkaku/src/log_writer.rs`) buffers `log::` output while the TUI owns
+  the terminal and drains it to stderr after teardown; `main.rs` is
+  reordered so `Cli::parse`/`display_mode` resolution happens before
+  logger initialization; the sink is released explicitly at the two
+  normal exit points (mirroring the existing `flush_notes` calls); a
+  `ReleaseGuard` RAII type is a second-commit addition (see below) that
+  releases the sink on drop as a safety net for panics/early returns.
+  ADR 0033 amended accordingly.
+- Protocol note: cost-reduced two-agent configuration — one static
+  reviewer combining the map-assisted pass and the independent pass,
+  one separate dynamic-verification agent. The implementation agent had
+  already run its own pty-based dynamic smoke test before review (see
+  its PR description's "Dynamic verification" section), so review-time
+  dynamic verification layered additional adversarial scenarios on top
+  rather than starting from zero.
+- **Map delivery**: the static reviewer built rinkaku from the trusted
+  `main` checkout itself and ran that binary's `rinkaku --base main`
+  inside the branch worktree before reading any code (self-serve map
+  generation, delivery variant (b): reviewer generates its own map
+  rather than receiving a pre-generated one from the orchestrator).
+- **Map-assisted pass**: the dependency graph showed `fn main` depending
+  on `TuiSession`'s `fn drop`, but no edge connecting that drop path to
+  `release_log_sink` — the map's structural view corroborated the same
+  gap the independent pass found by code-path reading (see below), from
+  a different angle: absence of an edge between the terminal-teardown
+  path and the log-release path, rather than tracing early-return
+  branches by hand. No unique findings beyond that corroboration.
+  `## File sizes` showed no warnings for either changed file
+  (`log_writer.rs` at 168 lines, `main.rs` at 474).
+- **Independent pass** (same agent, same session, following the map
+  read): full-diff review of `log_writer.rs`, the `main.rs` reordering,
+  and the ADR 0033 amendment against this repository's conventions.
+  Findings:
+  - Should-fix: `TuiSession::init()?` and the first `draw_splash()?`
+    early-return inside the `DisplayMode::Tui` branch bypass
+    `release_log_sink` entirely (they return before either explicit
+    `release_log_sink` call is reached), so any `log::` record buffered
+    before that point would be silently dropped rather than reaching
+    stderr. Latent at the time of the finding — no `log::` call sites
+    are reachable in that portion of the call graph today — but a
+    structural gap in the release coverage regardless.
+  - Nit: the `release_log_sink` doc comment described its coverage more
+    broadly than the two explicit call sites it actually guarded,
+    overstating what was covered before the guard existed.
+- **Dynamic verification** (separate agent): ran the implementation
+  agent's own pty-based scenario list plus additional adversarial
+  cases, all via a real `tmux` pty, rebuilding after each change —
+  roughly 15 scenarios in total: non-TTY stdin/stdout in every
+  combination, empty stdin, `--tui --format json` (clap-rejected before
+  any logger/TUI setup), a garbage `--base` value in both non-TTY and
+  `--tui` modes (buffered `[DEBUG]`/`Error:` lines print in order after
+  clean terminal restoration), `--entry` matching no symbols (logs
+  drain before the "no symbols under ..." note, confirming logs-before-
+  notes ordering), `RUST_LOG` at `off`/`warn`/`debug`/unset, a 20x5
+  tiny pane, and whole-repo `--tui` mode (no `--base`/`--pr`). All
+  scenarios passed. Its unique finding was reached analytically rather
+  than by reproduction: on a panic unwinding through
+  `run_analysis`/`TuiSession::run`, nothing drains the sink before the
+  process exits — `TuiSession`'s `Drop` restores the terminal, but no
+  `Drop` in the pre-fix code released the log sink, so a panic path
+  would silently lose buffered logs the same way the should-fix above
+  described for early `?` returns.
+- **Convergence**: both agents independently landed on the same
+  underlying design gap — sink release was tied to two explicit call
+  sites in `main`, not to any Drop/unwind mechanism — from different
+  evidence: the static pass from reading the early-return code paths
+  plus the map's missing drop-to-release edge, the dynamic pass from
+  tracing what a panic unwind would and wouldn't touch. Neither
+  observation reproduced an actual symptom (no `log::` call site
+  currently sits inside the gap), so both were framed as latent
+  structural risk rather than an active bug.
+- **Fix applied this round**: `ReleaseGuard<W, F>`, an RAII guard
+  constructed right after the sink and before `TuiSession::init` so
+  Rust's LIFO drop order runs the session's terminal-restoring `Drop`
+  first and the guard's log-release `Drop` second on any unwind past
+  that point — covering both the should-fix's early-return gap and the
+  dynamic pass's panic-path gap in a single mechanism, since
+  `DeferredLogSink::release` is idempotent and the guard is a no-op on
+  the normal paths where the explicit calls already ran. Three new
+  rstest cases cover the guard (`should_release_buffered_bytes_when_
+  guard_is_dropped`, `should_not_release_when_guard_is_defused_by_
+  explicit_release`, plus the existing `DeferredLogSink` suite). ADR
+  0033 amendment extended to document the guard alongside the sink.
+  Landed in a second commit within the same PR.
+- Severity summary: 0 blockers, 1 should-fix (fixed, and doubling as
+  the fix for the dynamic pass's independently-reached panic-path
+  finding), 1 nit (doc comment scope; addressed by the same commit that
+  introduced the guard, since the guard changed what the comment needed
+  to describe). `make test`: 176 + 394 + 605 passed. `make lint`: clean.
+- Cost: implementation agent ~118k + ~168k tokens across two turns
+  (initial fix, then the guard follow-up), static reviewer ~89k tokens,
+  dynamic reviewer ~95k tokens. Not a harness-timed comparison; wall-
+  clock not measured.
+- Takeaway: this round is a case of two passes reaching the same
+  should-fix from genuinely different evidence — graph-structure
+  absence plus early-return code reading on the static side, panic-path
+  tracing on the dynamic side — rather than one pass corroborating a
+  finding the other had already made explicit. That the map's edge-
+  absence observation lined up with the independent pass's early-return
+  reading, on the very PR whose defect class is unmapped write paths,
+  reinforces round 17's standing lesson from the other direction: the
+  map's coverage boundary (here, no signature-level marker for "this
+  Drop order does not include releasing that resource") is something a
+  reviewer must reason about structurally, not something the map states
+  outright. Separately, the bug this PR fixes is itself the same defect
+  shape ADR 0033 had already fixed once for `AnalysisProgress::note` —
+  a second confirmation, after round 17, that a side channel writing
+  straight to stderr (there: a doc-vs-implementation drift in `log::`
+  config; here: `log::` itself) is a recurring failure mode in this
+  codebase's TUI/stderr boundary, worth treating as a class rather than
+  a one-off each time a new call path is found to bypass the existing
+  buffering.


### PR DESCRIPTION
## Summary
- Records round 28 of experiment 0001 (map-assisted LLM review), reviewing PR #134 (buffer `log::` output during `--tui` mode to prevent splash corruption, ADR 0033 amendment).
- Continues the reviewer-cost-reduction configuration: two review agents (static = map-assisted + independent pass merged; dynamic = adversarial execution) instead of three.
- 0 blockers, 1 should-fix (fixed by both passes converging on the same design gap from different evidence), 1 nit (fixed).

## Test plan
- [x] Docs-only change; no code touched, `make test`/`make lint` not applicable.

https://claude.ai/code/session_01HuToEMUD2tRARq9BDU2Jdv