### PR TITLE
docs(experiments): record experiment 0001 round 28 (PR #133)

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/028.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/028.md
@@ -1,0 +1,100 @@
+# Round 28
+
+- Subject: PR #133 — `--format mermaid` node labels gain a diff-style
+  marker prefix (`+ ` added, `~ ` API-changed, `- ` removed; `fan-in`
+  and unchanged-dependency nodes get no marker, since `fan-in` already
+  carries its own `(in:N)` suffix and violet styling), a new
+  `referenced` classDef (neutral gray) covers every previously-
+  unstyled node so no node is left without a class, and a new
+  `NodeClass` enum centralizes class selection so the label marker and
+  the `class` line can never disagree. `compose_and_post_comment.sh`'s
+  CI-generated Legend grows to 5 rows (ADR 0041).
+- Protocol note: three-angle review per this repository's `CLAUDE.md`
+  ("Reviewing changes"), continuing the same cost-reduced two-agent
+  configuration as the previous round: one static reviewer combining
+  the map-assisted pass and the independent/conventions pass, one
+  separate dynamic-verification agent, with implementation handled by
+  a third, separate agent. The static reviewer again built the map
+  itself — `cargo build --release` from a trusted `main` checkout, not
+  the branch under review — rather than the orchestrator generating it
+  and handing it over. Blocker count: 0.
+- **Map-assisted pass**: correctly named the new `NodeClass` enum as a
+  high-fan-in symbol — the enum is the crux of this PR's design, since
+  it is what makes marker selection and `classDef` selection share one
+  source of priority truth rather than two independently-maintained
+  branches that could drift apart. Routing attention there matched
+  where the static reviewer's independent read also concluded the
+  real risk lived (precedence order between `fan-in` and the marker
+  classes).
+- **Trusted-checkout hygiene finding**: before generating the map, the
+  reviewer found the trusted `main` checkout was not clean — leftover
+  uncommitted changes to three `is_test`-related files from unrelated
+  prior work. Restored a clean `HEAD` before building and generating
+  the map, rather than risk the map reflecting an unintended local
+  diff instead of `origin/main`. Recorded as a process lesson rather
+  than a finding against this PR: **the trusted `main` checkout's
+  cleanliness should be verified as an explicit step before it is
+  built from, not assumed.**
+- **Static findings** (map-assisted + independent, combined): 0
+  blockers, 0 should-fix, 1 nit — ADR 0041 does not explicitly state
+  that the file-level fallback path (`render_mermaid_file_level`)
+  never emits a marker (only the `referenced`/other classes, no
+  `+`/`~`/`-` prefix), leaving a reader to infer this from the
+  implementation rather than the ADR's own text. Also confirmed, as a
+  regression check on the prior round's finding rather than a new
+  finding: the partial (non-fully-qualified) assert that round 27
+  (PR #131) had flagged in `mermaid_tests/empty_and_legend.rs` is gone
+  in this PR's branch, converted to a full-string comparison as
+  expected.
+- **Dynamic verification**: broad, and the highest-confidence part of
+  this round by construction rather than by any single clever probe.
+  Three diff shapes were built — a historical real-world diff, a
+  synthetic diff, and a diff engineered to hit all 5 node classes at
+  once — and for each, the rendered mermaid output was run through a
+  small Python parser that mechanically cross-checked every node's
+  label-marker prefix against its `class` assignment. Zero mismatches
+  across all three diffs. Other checks, all PASS: the `fan-in`-over-
+  `added`/`changed` precedence rule (a node that is both fan-in and
+  newly-added shows the violet fan-in styling with `(in:N)` and no
+  `+`/`~` marker, confirmed by direct construction of such a node
+  rather than by reading the precedence code) held under live
+  execution; the file-level fallback was forced and confirmed to
+  assign `referenced` (not leave nodes unstyled) with no marker
+  prefix; `--format md`/`--format json`/`--format digest` output
+  verified byte-identical against a fresh `main` build across all
+  three diffs (6/6 comparisons matching, confirming this PR's change
+  is fully scoped to `--format mermaid`); a pre-ADR-0041 `.mmd` fixture
+  (4 classes, no `referenced`, no markers) still parses and renders
+  correctly, confirming backward compatibility with diagrams generated
+  before this change; and the usual failure-mode sweep (empty stdin,
+  non-TTY, garbage/binary stdin, malformed diffs) produced no panics.
+  One **nit**: no unit test exercises the combination of a marker-
+  bearing classified node whose symbol name itself needs mermaid label
+  escaping (e.g. a name containing a character in
+  `escape_mermaid_label`'s escape set) — flagged as a coverage gap
+  rather than should-fix, since Rust identifier syntax makes such a
+  name unreachable through any real CLI invocation; the gap is
+  theoretical, not exploitable.
+- **Fixes applied**: the implementation agent addressed both nits —
+  ADR 0041 was amended to state the file-level fallback never emits a
+  marker, and a unit test covering marker-plus-escaping was added to
+  `mermaid_tests/`.
+- Severity summary: 0 blockers, 0 should-fix, 2 nits (both fixed).
+- Takeaway: three threads worth carrying forward. First, this is the
+  second consecutive round (after round 27/PR #131) where the dynamic
+  pass's highest-confidence result came from mechanical, exhaustive
+  verification — a parser cross-checking every node in every test diff
+  — rather than from spot-checking a handful of cases by hand; this is
+  becoming a repeatable pattern for this class of rendering change,
+  not a one-off. Second, the map continues to earn its keep on diffs
+  that introduce a new centralizing type (`NodeClass` here, echoing
+  `write_class_defs` in round 27): naming the new abstraction as
+  high-fan-in correctly routes a reviewer to the one place two
+  previously-separate concerns (marker text, `classDef` selection) now
+  live together and could silently diverge. Third, the trusted-
+  checkout hygiene lesson is new to this experiment's process notes:
+  nothing in the review protocol up to this point had flagged that the
+  map-generation step depends on an assumption (`main` checkout is
+  clean) that this round's reviewer found false in practice — worth
+  folding into the standing map-assisted-pass procedure rather than
+  treating as a one-off surprise.


### PR DESCRIPTION
## Summary
- Records round 28 of experiment 0001 (map-assisted LLM review), reviewing PR #133 (mermaid diff-style marker prefixes on node labels, new `referenced` classDef, `NodeClass` enum, 5-row CI legend; ADR 0041).
- Same cost-reduced two-agent configuration as round 27: static reviewer (map-assisted + independent, self-builds the map from a trusted `main` checkout) plus a separate dynamic-verification agent.
- 0 blockers, 0 should-fix, 2 nits (both fixed pre-PR): ADR gap on file-level fallback marker behavior, and a marker+escaping unit test coverage gap.
- New process lesson recorded: the trusted `main` checkout was found dirty before map generation this round and had to be restored to a clean `HEAD` first — cleanliness should be an explicit pre-check, not an assumption.

## Test plan
- [x] Docs-only change; no code touched, `make test`/`make lint` not applicable.