### PR TITLE
docs(adr): record fan-in test-referrer exclusion and TUI risk encoding (ADR 0042/0043)

### DIFF
--- a/docs/adr/0042-exclude-test-referrers-from-fan-in.md
+++ b/docs/adr/0042-exclude-test-referrers-from-fan-in.md
@@ -1,0 +1,99 @@
+# 0042. Exclude test referrers from fan-in counts
+
+- Status: accepted
+- Date: 2026-07-14
+- Amends: [ADR 0013](0013-hotspots-fan-in-section.md) (fan-in aggregation
+  definition), [ADR 0034](0034-rename-hotspots-vocabulary-to-fan-in.md)
+  (naming, `HIGH_FAN_IN_THRESHOLD`)
+
+## Context
+
+`compute_fan_ins` (ADR 0013, renamed by ADR 0034) aggregates
+`graph.edges` by target node, counting every distinct referrer toward a
+symbol's fan-in without regard to whether the referrer is production
+code or a test. ADR 0025 defaults tests into the same graph as
+production symbols, so a symbol exercised by several `#[test]`/
+`should_...` functions accumulates fan-in from those edges exactly like
+it would from real callers.
+
+Fan-in exists to answer "what breaks if I touch this?" (ADR 0013's
+"question B") — a proxy for production blast radius. Test referrers
+invert that signal instead of reinforcing it: a symbol thoroughly
+covered by its own tests looks *more* dangerous to touch under the
+current aggregation, when in practice the opposite holds — its tests
+are rewritten alongside it as a matter of course when it changes, and
+good coverage is a reason for *less* concern, not more. A symbol with
+zero tests but three production callers is the actually risky case, and
+today it can rank *below* a well-tested leaf symbol purely because the
+latter has more referring test functions.
+
+This does not touch `SymbolGraph::edges` itself or ADR 0035's tree
+placement (whole test files still sort into the trailing "Tests"
+section; mixed-file test symbols are unaffected in the graph). It is
+scoped to the fan-in aggregation step alone.
+
+## Decision
+
+- Add `graph::Node::is_test: bool`, computed in `collect_nodes` from the
+  same rule `pipeline::partition_test_symbols` (ADR 0009) already uses:
+  true if the owning file is a whole test path
+  (`LanguageSupport::is_test_path`) or the symbol's own AST context
+  marks it as a test (`ExtractedSymbol::is_test`). `#[serde(skip)]` —
+  not part of any output shape, same treatment ADR 0009's original
+  `is_test` field on `ExtractedSymbol` already received, for the same
+  reason: it is an internal aggregation input, not a fact the Markdown/
+  JSON/Mermaid consumer needs to see per node.
+- `compute_fan_ins` skips any edge whose referrer (`edge.from`) resolves
+  to an `is_test` node before grouping by target and applying
+  `HIGH_FAN_IN_THRESHOLD`. A target's fan-in count and `used_by` list
+  now reflect only production referrers.
+- `SymbolGraph::edges` is unchanged — every edge, test-referrer or not,
+  is still built and still serialized. The TUI's blast-radius view
+  (`crate::blast_radius`, ADR 0023) walks `edges` directly, so it
+  continues to show "this test exercises the symbol you're viewing,"
+  which is true and useful there; only the fan-in *aggregate* excludes
+  it.
+
+## Alternatives
+
+- **Drop test-referrer edges from `SymbolGraph::edges` entirely**:
+  would fix fan-in for free by construction, but breaks the
+  blast-radius view's ability to show "these tests cover this symbol"
+  — a fact a reviewer legitimately wants when assessing whether a
+  change is safe. Rejected: fan-in and blast-radius answer related but
+  distinct questions (aggregate risk ranking vs. "show me everything
+  that touches this one symbol"), and the fix belongs in the narrower
+  consumer (fan-in), not in the shared data both consumers read.
+- **Filter at render time (Markdown/JSON/Mermaid each skip test
+  `used_by` entries)**: would need the same filter duplicated in three
+  render modules instead of once in `compute_fan_ins`, and would leave
+  the TUI badge aggregate (`Badges.fan_in`, which reads `FanIn` values
+  computed once in `rinkaku-core`) still counting test referrers unless
+  it re-filtered too — same duplication, one more place. Rejected in
+  favor of filtering once at the aggregation source every consumer
+  already shares.
+- **A separate `production_fan_in` field alongside the existing
+  (unfiltered) fan-in**: considered, to preserve both signals. Rejected
+  as solving a problem nobody asked for — no consumer has a use for
+  "fan-in including tests," and carrying both would just require every
+  render surface to pick the right one instead of removing the wrong
+  one.
+
+## Consequences
+
+- **Breaking change** to Markdown ("High fan-in symbols" section
+  membership and `used_by` list), JSON (`fan_ins[].used_by`), Mermaid
+  (`fan-in` node classification and `(in:N)` label suffix, ADR 0039),
+  and the TUI (`fan-in:N` badge, and transitively [ADR 0043](0043-tui-risk-oriented-visual-encoding.md)'s
+  `!` risk marker, which reads the same test-excluded count). Consistent
+  with this project's established pre-1.0 stance on output-format
+  changes (ADR 0013/0034's own precedent).
+- A symbol whose only referrers are tests now has fan-in 0 and never
+  appears in "High fan-in symbols"/`fan_ins`, even if it has many test
+  callers — expected, since "many tests call this" is no longer the
+  question fan-in answers.
+- `Node::is_test` is available for any future aggregation that needs
+  the same production/test split (e.g. a hypothetical "test-only
+  hotspot" metric), without re-deriving the rule a third time; the
+  authoritative rule stays `pipeline::partition_test_symbols` and
+  `LanguageSupport::is_test_path`, per ADR 0009.

--- a/docs/adr/0043-tui-risk-oriented-visual-encoding.md
+++ b/docs/adr/0043-tui-risk-oriented-visual-encoding.md
@@ -1,0 +1,147 @@
+# 0043. Risk-oriented visual encoding for the TUI entry tree
+
+- Status: accepted
+- Date: 2026-07-14
+- Related: [ADR 0035](0035-tests-sorted-last-in-entry-tree.md) (whole-test-file
+  section, per-symbol `test` badge this ADR removes),
+  [ADR 0039](0039-mermaid-visual-encoding-revision.md) (the Mermaid
+  counterpart of this ADR's `!` marker and fold),
+  [ADR 0042](0042-exclude-test-referrers-from-fan-in.md) (the fan-in count
+  this ADR's `!` marker reads)
+
+## Context
+
+`docs/tui.md`'s reading protocol — read bright/marked rows, skim dimmed
+ones — has so far lived only as README prose the reviewer must already
+know before looking at the screen. Two gaps in the entry tree work
+against that protocol once a real diff is loaded:
+
+1. **A mixed file's test symbols compete with production symbols for
+   attention.** ADR 0035 already moved whole test files to a trailing
+   "Tests" section, but a file mixing production and test code (a Rust
+   file with a `#[cfg(test)] mod tests` block is the common case in
+   this very repository) keeps its test symbols as ordinary `Symbol`
+   children, one row each, with a trailing `test` badge (ADR 0035's
+   change 3). A file with a dozen `#[test]` functions floods the tree
+   with a dozen individually-badged rows — exactly the "drowns out the
+   implementation symbols" problem ADR 0009 already solved once for the
+   default output, now recurring one level down inside the TUI tree.
+2. **Fan-in and contract-change are both visible per-row, but their
+   co-occurrence is not.** `chg:`/`api:`/`fan-in:` badges (ADR
+   0013/0034) already surface each count independently, and a reviewer
+   is meant to weight "signature changed" and "widely referenced"
+   together as the highest-risk combination — but nothing on the row
+   itself says "these two co-occur here," so noticing the combination
+   requires reading both numbers and doing the AND in your head, for
+   every row, every time.
+
+[ADR 0042](0042-exclude-test-referrers-from-fan-in.md) lands alongside
+this ADR and changes what the fan-in count itself means (production
+referrers only); this ADR is the TUI-side consequence of that count
+now being a trustworthy risk signal worth encoding directly on the row.
+
+## Decision
+
+Three changes to the entry tree's rendering, in `rinkaku-tui`:
+
+**1. Fold a mixed file's test symbols into one collapsed `TestGroup`
+child.** `tree::NodeKind` gains a `TestGroup { count: usize }` variant,
+built only for the `production` `TreeBuilder` (a whole test file is
+already routed into ADR 0035's "Tests" section and stays flat — folding
+it again one level deeper would be redundant nesting with nothing left
+to distinguish it from). `TreeBuilder::group_test_symbols` (`bool`)
+switches this per builder instance. The group node renders as a single
+`N tests`/`1 test` row, dimmed (`Color::DarkGray`), and starts collapsed
+by default (`Nav::new_collapsing_test_groups`, seeding the initial
+`collapsed` set with every `TestGroup` path) — a reviewer sees the count
+and chooses to expand, rather than scrolling past every test row to
+reach the next production file. Expanding shows the symbols with dimmed
+names and no per-symbol badge; the group label already conveys "this is
+test code," so the per-symbol `test` badge ADR 0035 introduced is
+removed as redundant once its only remaining home (a mixed file) has a
+group label saying the same thing.
+
+**2. A `!` marker (bold red) flags contract-change/fan-in co-occurrence.**
+Prefixes a `Dir`/`File` row when its aggregated `Badges` show both
+`contract_changes > 0` and `fan_in >= HIGH_FAN_IN_THRESHOLD` in the same
+subtree, and a `Symbol` row when it is itself `SignatureChanged` and its
+own fan-in (the test-referrer-excluded count, ADR 0042) clears the same
+threshold. A non-risky row's layout is untouched: the marker and its
+trailing space are only pushed when risky, no reserved gutter column
+holding a blank placeholder on every other row.
+
+**3. Body-only/unclassified symbol names dim to `DarkGray`.** Previously
+only a removed symbol's name carried its own style (dimmed +
+crossed-out); a body-only or unclassified symbol's name rendered in the
+default style, i.e. visually equal to an added or signature-changed
+symbol's name despite carrying materially less review weight. Dimming
+(without strikethrough, since the symbol still exists) makes the "read
+bright, skim dim" protocol legible on the name span itself instead of
+requiring the reviewer to cross-reference the leading marker character.
+
+The help overlay glossary (`rinkaku-tui/src/help.rs`) gains entries for
+`!` and `N tests`, and the existing `chg: / api: / fan-in:` entry is
+reworded to note that fan-in counts production referrers only,
+reflecting ADR 0042.
+
+## Alternatives
+
+- **A reserved gutter column for the risk marker (always-present, blank
+  when not risky)**: keeps every row's label starting at a fixed
+  column, which helps horizontal scanning. Rejected: the entry tree
+  already has no fixed-width columns for its other conditional spans
+  (badges, the `test`/`[test]` markers, the classification marker) —
+  every one of them is push-if-present, consistent with `row_view.rs`'s
+  existing convention — and a gutter reserved for a marker that fires
+  rarely (contract-change AND high-fan-in is meant to be an unusual,
+  attention-worthy combination) would visually widen every ordinary row
+  for a signal most rows never carry.
+- **Keep the per-symbol `test` badge alongside the new `TestGroup`
+  label**: considered, since the badge and the group label both say
+  "this is test code" and could in principle coexist. Rejected as
+  redundant — the group node's very existence and its `N tests` label
+  already convey membership for every child underneath it; repeating
+  the same fact on each child row adds visual noise (an extra span per
+  row) without adding information, the opposite of the fold's own goal
+  of quieting the mixed-file test rows down.
+- **A directory-level `!` aggregate distinct from the file/symbol
+  marker (e.g. counting how many risky subtrees exist)**: rejected for
+  now — a `Dir` row already inherits the `!` marker via the same
+  `Badges` aggregation logic used for `chg:`/`api:`/`fan-in:` roll-ups,
+  so a separate counted variant would duplicate a signal the boolean
+  marker already surfaces at every ancestor level; revisit only if
+  dogfooding shows a reviewer wants to know *how many* risky subtrees
+  sit under a directory, not just whether one exists.
+- **Remove test edges/nodes from the tree entirely instead of folding**:
+  rejected for the same reason ADR 0042 rejected dropping test edges
+  from `SymbolGraph`: "tests were touched" is itself a signal a
+  reviewer wants (did this change come with tests?), which ADR 0009
+  already established as worth preserving even while de-emphasizing the
+  content. Folding preserves the count and lets a reviewer opt into the
+  detail; removing would discard the "were there tests" fact along with
+  the noise.
+
+## Consequences
+
+- `tree::TreeNode::kind` gains a `TestGroup` variant, so every existing
+  exhaustive `match` over `NodeKind` (`row_view.rs`, `order/sort.rs`,
+  `nav.rs`) needs a new arm — compile-time-enforced, same category of
+  churn ADR 0035's `Section` variant already caused.
+- Breaking change to the TUI's row rendering only (no Markdown/JSON/
+  Mermaid output is touched by this ADR); consistent with this
+  project's pre-1.0 stance on TUI presentation changes (ADR 0013's
+  amendments, ADR 0034).
+- The per-symbol `test` badge (`row_view::symbol_test_badge_span`,
+  introduced by ADR 0035) is removed; the whole-file `[test] (N
+  symbols)` badge for a file under the "Tests" section is unchanged —
+  this ADR's fold only affects mixed files, not whole test files.
+- The `!` marker's threshold is entirely derived from
+  `HIGH_FAN_IN_THRESHOLD` (ADR 0034) and `contract_changes`/
+  `Classification::SignatureChanged` (ADR 0014); it introduces no new
+  constant of its own, so a future revisit of the fan-in threshold
+  automatically retunes the marker without a separate change here.
+- `Nav::new_collapsing_test_groups` is additive alongside `Nav::new`;
+  callers that construct a bare `Nav` (e.g. some existing tests) keep
+  every `TestGroup` expanded by default, which is intentional — only
+  the TUI's actual startup path is expected to call the collapsing
+  constructor.


### PR DESCRIPTION
## Summary

Records two decisions already implemented and merged in #137:

- **ADR 0042** — fan-in counts now exclude test referrers, so a
  well-tested production symbol no longer looks artificially
  high-risk (amends ADR 0013/0034).
- **ADR 0043** — TUI entry-tree visual encoding for review risk: a
  `!` risk marker on Dir/File/Symbol rows, mixed-file test symbols
  folded into a collapsed synthetic group per file, and dimmed
  body-only/unclassified symbol names. The TUI counterpart of ADR
  0039's mermaid encoding work.

Doc-only PR, split from the implementation per this repo's
mechanical/logic-change convention.

## Test plan

- [x] Doc-only change, no code touched
- [x] ADR numbers (0042/0043) don't collide with anything merged since branch cut

https://claude.ai/code/session_01DCFocfb1tzn8oYAVGXEAoA