### PR TITLE
docs: rewrite TUI reading guide around an annotated ASCII mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,42 +60,25 @@ aid, not a verifier, and we have the experiment rounds to prove it.
 
 ## How to read the TUI
 
-The tree pane orders sibling directories topologically over the change
-graph, not alphabetically: entry-point directories (nothing else
-depends on them) sort first, heavily-depended-upon foundations sort
-last. Tests are excluded from that ranking entirely and pinned into a
-trailing `Tests` section instead. Files within a directory are
-alphabetical; symbols keep source order. When a diff has no
-cross-directory references, ranking has nothing to work with and the
-order silently falls back to alphabetical — don't over-read ordering
-in that case, and remember the underlying dependency edges come from
-syntactic tree-sitter resolution, not a type checker, so a reference
-can occasionally be missed.
+```
+v ! auth chg:4 api:2 fan-in:3   <- contract change + high fan-in
+    ! token.rs api:1 fan-in:2   <- same, rolled up to the file
+      ~ fn ! verify_token       <- changed + high fan-in itself
+      + fn rotate_secret        <- added
+        fn log_attempt          <- body-only, dimmed: skim
+    > 6 tests                   <- folded tests, dimmed
+v tui                           <- no risk marker here
+    render.rs lines:812         <- file-size watch badge
+  legacy  (cycle)               <- dependency cycle
+```
 
-Badges on a row: `chg:N` changed symbols, `api:N` (yellow) contract/
-signature changes, `fan-in:N` symbols that reference this one — i.e.
-this row's *blast radius*, not a measure of its importance —
-`lines:`/`warn:`/`split:` file-size discipline, and `(cycle)` for a
-directory-level dependency cycle. A symbol's leading marker is `+`
-added, `~` signature-changed, `x` removed, or blank for body-only.
+Top-down = callers before callees: entry points sort first, foundations
+last. `fan-in:` counts other *production* symbols referencing this one,
+never tests. Press `r`/`R` on any row to pivot the right pane to its
+blast radius; `?` opens the full keymap.
 
-A reading protocol that uses those signals instead of scrolling
-top-to-bottom through the diff:
-
-1. Read the tree top-down — callers appear before the callees they
-   depend on.
-2. Deep-read any row where `api:` and a high `fan-in:` co-occur: a
-   changed contract with many referrers is the highest-risk zone in the
-   PR.
-3. Skim blank-marker (body-only) symbols — their signature didn't
-   change, so they're locally contained.
-4. Press `r`/`R` on a row you're suspicious of to pivot the right pane
-   to its blast-radius tree and see everything downstream of it.
-5. Treat `(cycle)` markers and file-size warnings as structural
-   findings worth calling out separately, not as line-level bugs.
-
-See [`docs/tui.md`](docs/tui.md) for the full layout and key-binding
-reference.
+See [`docs/tui.md`](docs/tui.md) for the full layout, key bindings, and
+caveats on ordering and dependency resolution.
 
 ## Install
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -17,17 +17,41 @@ only becomes load-bearing when the output would otherwise not be TUI
 ## Layout
 
 - **Tree pane (left)** — a directory tree of *changed files*, mirroring
-  your repository layout. Rows carry badges: `chg:N` changed symbols,
-  `api:N` contract changes (added / removed / signature-changed),
-  `fan-in:N` symbols referenced by 2+ other changed symbols. `chg:`/
-  `fan-in:` numbers are cyan (informational); `api:` is yellow, the same
-  warning color as the file-size `warn:` badge, flagging it as the one
-  badge worth a second look. Directories in a dependency cycle are
-  marked `(cycle)`. Symbol rows show a kind abbreviation (`fn`,
-  `struct`, ...) and a classification marker: `+` added, `~`
-  signature-changed, `x` removed. Files rinkaku couldn't analyze appear
+  your repository layout. Sibling directories order topologically over
+  the change graph: entry-point directories (nothing else depends on
+  them) sort first, heavily-depended-upon foundations sort last. Files
+  within a directory are alphabetical; symbols keep source order. When
+  a diff has no cross-directory references, ranking has nothing to
+  work with and the order silently falls back to alphabetical — don't
+  over-read ordering in that case. The underlying dependency edges come
+  from syntactic tree-sitter resolution, not a type checker, so a
+  reference can occasionally be missed.
+
+  Rows carry badges: `chg:N` changed symbols, `api:N` contract changes
+  (added / removed / signature-changed), `fan-in:N` other *production*
+  symbols referencing this one — tests exercising it don't count, so
+  the number reflects blast radius among changed code, not test
+  coverage. `chg:`/`fan-in:` numbers are cyan (informational);
+  `api:` is yellow, the same warning color as the file-size `warn:`
+  badge, flagging it as the one badge worth a second look. A row whose
+  badges show both a contract change and a high-fan-in symbol in its
+  subtree gets a leading `!` (red, bold) — the combination that makes a
+  change both hard to miss and wide-reaching; a signature-changed
+  symbol with high fan-in of its own gets the same marker. Directories
+  in a dependency cycle are marked `(cycle)`.
+
+  Symbol rows show a kind abbreviation (`fn`, `struct`, ...) and a
+  classification marker: `+` added, `~` signature-changed, `x` removed,
+  or blank for body-only/unclassified — a blank-marker symbol's name
+  also dims to DarkGray, since its signature didn't change and it
+  carries less review weight. Files rinkaku couldn't analyze appear
   dimmed as `(skipped: <reason>)`; whole-test files as
-  `[test] (N symbols)`.
+  `[test] (N symbols)`. A *mixed* file's test symbols (real code
+  alongside `#[cfg(test)]`-style tests in the same file) fold into a
+  trailing `N tests` row (`1 test` singular), collapsed by default —
+  expand it with `space`/`enter` to see them individually, dimmed and
+  without any per-symbol badge, since group membership already says
+  "this is test code".
 - **Diff pane (right, default)** — the raw unified-diff hunks touching
   the selected row, syntax-highlighted for the four built-in languages
   ([ADR 0018](adr/0018-syntax-highlight-diff-pane-via-tree-sitter.md)).
@@ -77,7 +101,8 @@ Press `?` in the TUI for the always-up-to-date table.
 | `?` | Toggle the help overlay |
 | `q` / `ctrl-c` | Quit (from the entry view); `esc`/`q` also returns from the source view |
 
-Glyphs are plain ASCII (`~`/`!`/`^`/`+`/`x`, `v`/`>` for expand state).
+Glyphs are plain ASCII: `+` added, `~` signature-changed, `x` removed,
+blank for body-only, `!` for the risk marker, `v`/`>` for expand state.
 
 ## Jump navigation (`gd` / `gr`)
 


### PR DESCRIPTION
## Summary

Documents the review-risk visual encoding merged in #137 (ADRs 0042/0043):

- Replaces the README's "How to read the TUI" prose + 5-step protocol
  with a single annotated tree-pane mock showing the risk marker,
  folded test group, and dimmed body-only symbols in context. Each row
  in the mock was verified byte-for-byte against the actual renderer
  output.
- Moves the ordering-fallback and tree-sitter caveats into
  `docs/tui.md`, and updates that doc's badge/glyph reference for the
  new encoding (risk marker, `N tests` fold, dimmed body-only,
  fan-in as production-referrers-only).

## Test plan

- [x] `make test` — 619 passed
- [x] `make lint` — clean
- [x] Doc-only change (README.md, docs/tui.md)

https://claude.ai/code/session_01DCFocfb1tzn8oYAVGXEAoA