### PR TITLE
ci: build Linux releases as statically linked musl

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -45,6 +45,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # musl targets are statically linked, so the published binary runs
+          # on any Linux regardless of the host glibc version — the gnu
+          # binaries require the builder's glibc (currently 2.39 from
+          # ubuntu-latest) or newer, which broke on older self-hosted runners.
+          # gnu is kept for callers that still pull those asset names directly.
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-latest
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
@@ -67,12 +76,15 @@ jobs:
         run: |
           rustup target add ${{ matrix.target }}
 
-      - name: Install cross-compilation tools
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      # Sets up the cross linker/CC for every Linux target except the native
+      # host (x86_64-gnu): aarch64-gnu (cross) plus both musl targets, whose
+      # C dependency (ring) needs a musl-capable compiler. Replaces the
+      # previous hand-rolled apt step, which only handled aarch64-gnu.
+      - name: Setup cross toolchain
+        if: contains(matrix.target, 'linux') && matrix.target != 'x86_64-unknown-linux-gnu'
+        uses: taiki-e/setup-cross-toolchain-action@3d9770ce98eb7dbcf378563182a5e8031165f75b # v1.41.0
+        with:
+          target: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ caveats on ordering and dependency resolution.
 | Homebrew | `brew install hiro-o918/tap/rinkaku` |
 | Install script | `curl -fsSL https://raw.githubusercontent.com/hiro-o918/rinkaku/main/install.sh \| bash` |
 | From source | `cargo install rinkaku` |
-| Manual | Grab a tarball from the [latest release](https://github.com/hiro-o918/rinkaku/releases/latest) and put `rinkaku` on your `PATH`. Targets: `{x86_64,aarch64}-{unknown-linux-gnu,apple-darwin}`. |
+| Manual | Grab a tarball from the [latest release](https://github.com/hiro-o918/rinkaku/releases/latest) and put `rinkaku` on your `PATH`. Targets: `{x86_64,aarch64}-{unknown-linux-musl,unknown-linux-gnu,apple-darwin}` (Linux tooling picks the statically linked musl build). |
 
 Update with `rinkaku self-update` (see
 [`docs/cli.md#self-update`](docs/cli.md#self-update) for the

--- a/action.yaml
+++ b/action.yaml
@@ -121,9 +121,12 @@ runs:
         # binary (not the binary directly at the archive root) — the
         # `find` below locates it either way rather than assuming the
         # exact nesting.
+        # Linux resolves to the statically linked musl asset so it runs
+        # regardless of the runner's glibc version — the gnu binaries need
+        # the builder's glibc (2.39), which older self-hosted runners lack.
         case "$(uname -s)-$(uname -m)" in
-          Linux-x86_64) target="x86_64-unknown-linux-gnu" ;;
-          Linux-aarch64) target="aarch64-unknown-linux-gnu" ;;
+          Linux-x86_64) target="x86_64-unknown-linux-musl" ;;
+          Linux-aarch64) target="aarch64-unknown-linux-musl" ;;
           Darwin-x86_64) target="x86_64-apple-darwin" ;;
           Darwin-arm64) target="aarch64-apple-darwin" ;;
           *)

--- a/install.sh
+++ b/install.sh
@@ -11,9 +11,10 @@ INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 OS=$(uname -s)
 ARCH=$(uname -m)
 
-# Determine target triple
+# Determine target triple. Linux uses the statically linked musl build so
+# the binary runs regardless of the host's glibc version.
 case $OS in
-  Linux)  OS_SUFFIX="unknown-linux-gnu" ;;
+  Linux)  OS_SUFFIX="unknown-linux-musl" ;;
   Darwin) OS_SUFFIX="apple-darwin" ;;
   *) echo "Error: Unsupported OS: $OS"; exit 1 ;;
 esac


### PR DESCRIPTION
## Summary

Fixes `GLIBC_2.39 not found` when running a release binary on a Linux host with an older glibc — the gnu builds require the builder's glibc (`ubuntu-latest` = 2.39) or newer.

- Add `x86_64-unknown-linux-musl` / `aarch64-unknown-linux-musl` targets to `build-and-publish.yaml`; musl is statically linked, so the binary is independent of the host glibc.
- Replace the hand-rolled apt cross setup with [`taiki-e/setup-cross-toolchain-action`](https://github.com/taiki-e/setup-cross-toolchain-action), covering aarch64-gnu and both musl targets in one step (the C dependency `ring` needs a musl-capable compiler).
- Resolve the Linux target to the musl asset in `action.yaml` and `install.sh`.
- Keep publishing the gnu assets so existing direct consumers keep working.

## Test plan

- [ ] Cut a release (tag push) and confirm `build-and-publish` produces all 6 assets, including the two new `*-unknown-linux-musl` tarballs — the musl cross build (notably compiling `ring`) and the aarch64-musl link can only be verified there.
- [ ] Run the built musl binary on a Linux host with glibc < 2.39 and confirm it starts (no `GLIBC_*` error).
- [x] `python3 -c yaml.safe_load` on the workflow/action YAML, `bash -n install.sh` — syntax clean.