### PR TITLE
feat(tui): widen right pane and show symbol name in diff pane title

### DIFF
--- a/docs/adr/0030-diff-scroll-syncs-tree-selection.md
+++ b/docs/adr/0030-diff-scroll-syncs-tree-selection.md
@@ -258,3 +258,17 @@ ADR needs to touch.
 - No backward-compatibility concern: the TUI has never shipped a
   release (ADR 0015/0016, restated by every TUI-scoped ADR since),
   so this amendment applies in place.
+
+## Amendment (dynamic review, post-acceptance)
+
+Decision 7's claim that re-entering `RightPane::Diff` always resets to
+the current symbol's section top (ADR 0027 decision 2) held only when
+the tree cursor had moved since Diff was last shown: `last_diff_focus`
+survived a Diff -> Detail/BlastRadius -> Diff round trip unchanged, so
+with the cursor untouched across the round trip, `run_app`'s auto-scroll
+gate (`next_focus != last_diff_focus`) saw no change and skipped the
+resync, leaving `right_pane_scroll` at whatever the blanket key-reset
+left it rather than the section start. Fixed by resetting
+`last_diff_focus` to `None` whenever a handled key leaves `RightPane`
+other than `Diff`, so the next re-entry is always treated as a fresh
+selection — restoring decision 7's guarantee for this case too.

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -538,6 +538,22 @@ impl App {
         }
     }
 
+    /// The name [`crate::ui::diff_pane`] should show in the Diff pane's
+    /// title for the row currently under the cursor: a present symbol's own
+    /// name, or a file/skipped-file row's path — mirrors
+    /// [`Self::selected_diff_target`]'s row-kind scoping (present symbol or
+    /// file only) so the title never names a row the pane would not
+    /// actually render a diff for.
+    pub fn selected_diff_title_name(&self) -> Option<&str> {
+        let rows = self.nav.rows(&self.tree);
+        let row = rows.get(self.nav.cursor())?;
+        match &row.node.kind {
+            NodeKind::Symbol(symbol_ref) if !symbol_ref.removed => Some(symbol_ref.name.as_str()),
+            NodeKind::File => Some(row.node.path.as_str()),
+            _ => None,
+        }
+    }
+
     /// Which symbol the tree cursor currently focuses for the diff pane's
     /// auto-scroll (ADR 0027 decision 2 + Consequences): [`DiffFocus`] on a
     /// present symbol row, `None` on file/directory rows, on removed symbol

--- a/rinkaku-tui/src/app/tests/right_pane.rs
+++ b/rinkaku-tui/src/app/tests/right_pane.rs
@@ -428,6 +428,63 @@ fn should_return_file_diff_target_when_cursor_is_on_a_symbol_row() {
 }
 
 #[test]
+fn should_return_symbol_name_for_diff_title_when_cursor_is_on_a_present_symbol_row() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report).handle_key(InputKey::Down);
+
+    let actual = app.selected_diff_title_name();
+
+    assert_eq!(Some("foo"), actual);
+}
+
+#[test]
+fn should_return_file_path_for_diff_title_when_cursor_is_on_a_file_row() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report);
+
+    let actual = app.selected_diff_title_name();
+
+    assert_eq!(Some("lib.rs"), actual);
+}
+
+#[test]
+fn should_return_none_for_diff_title_when_cursor_is_on_a_directory_row() {
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![symbol("src/lib.rs::foo", "foo")],
+        }],
+        ..empty_report()
+    };
+    let app = App::new(&report);
+
+    let actual = app.selected_diff_title_name();
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_return_none_for_diff_title_when_cursor_is_on_a_removed_symbol_row() {
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        removed: vec![rinkaku_core::extract::RemovedSymbol {
+            name: "old_foo".to_string(),
+            kind: rinkaku_core::extract::SymbolKind::Function,
+            path: "lib.rs".to_string(),
+            signature: "fn old_foo()".to_string(),
+        }],
+        ..empty_report()
+    };
+    // Row 0 is the "lib.rs" file row, row 1 is the removed "old_foo" symbol.
+    let app = App::new(&report).handle_key(InputKey::Down);
+
+    let actual = app.selected_diff_title_name();
+
+    assert_eq!(None, actual);
+}
+
+#[test]
 fn should_return_diff_focus_when_cursor_is_on_a_present_symbol_row() {
     let report = Report {
         origin: rinkaku_core::render::ReportOrigin::Diff,

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -327,6 +327,14 @@ pub(crate) fn run_app(
                 app = effects.app;
                 diff_pane_content = effects.diff_pane_content;
                 last_diff_focus = effects.last_diff_focus;
+            } else {
+                // Without this, toggling away from RightPane::Diff and back
+                // with the cursor unchanged left `last_diff_focus` equal to
+                // the still-current symbol, so re-entry skipped both ADR
+                // 0027's auto-scroll and ADR 0030's sync-back branch and
+                // redrew at a stale `right_pane_scroll`. Resetting to `None`
+                // makes re-entry look like a fresh selection.
+                last_diff_focus = None;
             }
         }
     }

--- a/rinkaku-tui/src/lib_tests/diff_scroll_sync.rs
+++ b/rinkaku-tui/src/lib_tests/diff_scroll_sync.rs
@@ -369,3 +369,34 @@ fn should_not_bounce_scroll_back_on_the_next_key_after_a_sync() {
     assert_eq!(6, second.app.right_pane_scroll());
     assert_eq!(Some("lib.rs::bar"), second.app.selected_symbol_id());
 }
+
+// --- apply_diff_pane_selection_effects (re-entering RightPane::Diff with
+// an unchanged cursor: `run_app`'s loop resets `last_diff_focus` to
+// `None` while the right pane is not Diff, so re-entry looks like a
+// fresh selection to the ADR 0027 auto-scroll branch below) ---
+
+#[test]
+fn should_resync_scroll_to_current_symbols_section_when_diff_pane_is_reentered_with_cursor_unchanged()
+ {
+    let report = report_with_two_symbols();
+    let diff_hunks = diff_hunks_with_two_symbol_sections();
+    // Cursor on `bar` (row 2), already inside bar's own section — the
+    // *symbol* did not change, only the right pane's visibility did.
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Open);
+    assert_eq!(Some("lib.rs::bar"), app.selected_symbol_id());
+
+    // `last_diff_focus: None` and `scroll_before_dispatch: 0` are what
+    // `run_app`'s loop passes in after a Diff -> Detail -> Diff toggle
+    // with the cursor untouched, per the fix.
+    let app = app.with_right_pane_scroll(0);
+    let effects = apply_diff_pane_selection_effects(app, &report, &diff_hunks, None, 0);
+
+    // bar's section starts at line 5 (same layout as every other test in
+    // this file); landing at 0 would show foo's section under a title
+    // (this PR's own addition) that still reads "Diff: bar".
+    assert_eq!(5, effects.app.right_pane_scroll());
+    assert_eq!(Some("lib.rs::bar"), effects.app.selected_symbol_id());
+}

--- a/rinkaku-tui/src/ui/blast_radius.rs
+++ b/rinkaku-tui/src/ui/blast_radius.rs
@@ -248,9 +248,9 @@ mod tests {
 
         let text = buffer_text(&terminal);
         assert!(text.contains("Blast radius"));
-        // Not the full placeholder sentence: the pane is narrow enough
-        // (40% of an 80-column terminal) that `Paragraph`'s word-wrapping
-        // splits it across rows, and `buffer_text` joins rows with `\n` —
+        // Not the full placeholder sentence: `Paragraph`'s word-wrapping
+        // can still split it across rows even at this pane's width, and
+        // `buffer_text` joins rows with `\n` —
         // a multi-row substring would never match. "directory" alone fits
         // on one wrapped line and is unique enough to confirm the
         // placeholder rendered, mirroring this module's other coarse
@@ -292,9 +292,8 @@ mod tests {
         let text = buffer_text(&terminal);
         assert!(text.contains("Blast radius of lib.rs"));
         // NOTE: asserting a substring, not the full parenthesized sentence —
-        // the pane is narrow enough (40% of an 80-column terminal) that
-        // `Paragraph`'s word-wrapping can split the sentence across rows,
-        // and `buffer_text` joins rows with `\n`, so a wrapped multi-row
+        // `Paragraph`'s word-wrapping can still split the sentence across
+        // rows, and `buffer_text` joins rows with `\n`, so a wrapped multi-row
         // substring would never match a single-line `contains` check
         // (mirroring `should_draw_blast_radius_placeholder_when_cursor_is_on_a_symbol_row`'s
         // own "directory" fragment check just above, for the same reason).

--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -27,6 +27,18 @@ use rinkaku_core::render::Report;
 pub(crate) const ADDED_BG: Color = Color::Indexed(22);
 pub(crate) const REMOVED_BG: Color = Color::Indexed(52);
 
+/// Builds the Diff pane's base title (before [`super::scroll::scroll_indicator`]'s
+/// suffix is appended): `" Diff: <name> "` when a row is selected, else the
+/// plain `" Diff "` every other pane's placeholder title uses. Extracted so
+/// the narrower tree pane (40% of the entry screen) truncating a long
+/// symbol/file name still leaves the diff pane naming what is on screen.
+pub(crate) fn diff_pane_title(selection_name: Option<&str>) -> String {
+    match selection_name {
+        Some(name) => format!(" Diff: {name} "),
+        None => " Diff ".to_string(),
+    }
+}
+
 /// Draws the diff pane (TUI iteration 2, [`crate::app::RightPane::Diff`]; ADR 0020
 /// reshapes its content): the raw unified-diff hunks touching the row under
 /// the cursor, clipped to a symbol's own line range for a symbol row, or
@@ -65,6 +77,7 @@ pub(crate) fn draw_diff_pane(
         Some(DiffTarget::File { path }) => path.as_str(),
         None => "",
     };
+    let title = diff_pane_title(app.selected_diff_title_name());
 
     let sections: Vec<&crate::diff_shape::DiffSection> = match diff_content {
         DiffPaneContent::Empty => {
@@ -73,7 +86,7 @@ pub(crate) fn draw_diff_pane(
                 Some(_) => format!("(no diff hunks found for {path})"),
             };
             let block = Block::bordered()
-                .title(" Diff ")
+                .title(title)
                 .border_style(pane_border_style(focused));
             let paragraph = Paragraph::new(message)
                 .block(block)
@@ -93,7 +106,7 @@ pub(crate) fn draw_diff_pane(
     let lines = diff_pane_lines(&sections, true, highlighted_file);
     Some(render_scrollable_pane(
         frame,
-        " Diff ",
+        &title,
         &lines,
         app.right_pane_scroll(),
         area,
@@ -249,6 +262,41 @@ mod tests {
     use rinkaku_core::extract::{Classification, ExtractedSymbol, SymbolKind};
     use rinkaku_core::graph::SymbolGraph;
     use rinkaku_core::render::FileReport;
+
+    // --- diff_pane_title (pure helper) ---
+
+    #[test]
+    fn should_return_plain_title_when_no_selection_name() {
+        let actual = diff_pane_title(None);
+
+        assert_eq!(" Diff ".to_string(), actual);
+    }
+
+    #[test]
+    fn should_include_selection_name_in_title_when_present() {
+        let actual = diff_pane_title(Some("foo"));
+
+        assert_eq!(" Diff: foo ".to_string(), actual);
+    }
+
+    #[test]
+    fn should_include_file_path_in_title_when_selection_name_is_a_path() {
+        let actual = diff_pane_title(Some("src/lib.rs"));
+
+        assert_eq!(" Diff: src/lib.rs ".to_string(), actual);
+    }
+
+    #[test]
+    fn should_include_empty_selection_name_verbatim_in_title() {
+        // Defensive: `App::selected_diff_title_name` never actually
+        // returns `Some("")` (a tree row's `name`/`path` is never empty),
+        // but this pins that an empty string is not treated the same as
+        // `None` — the caller decides `Option`-ness, this function only
+        // formats.
+        let actual = diff_pane_title(Some(""));
+
+        assert_eq!(" Diff:  ".to_string(), actual);
+    }
 
     fn symbol(id: &str, name: &str) -> ExtractedSymbol {
         ExtractedSymbol {

--- a/rinkaku-tui/src/ui/entry.rs
+++ b/rinkaku-tui/src/ui/entry.rs
@@ -18,12 +18,14 @@ use ratatui::text::Line;
 use ratatui::widgets::{Block, Paragraph};
 use rinkaku_core::render::Report;
 
-/// Left entry pane (directory tree) + right pane, split 60/40 — this
+/// Left entry pane (directory tree) + right pane, split 40/60 — this
 /// implementation's own choice (ADR 0015/0016 left the exact ratio open):
-/// the tree is the primary navigation surface and typically has more rows
-/// than the right pane has fields, so it gets the larger share. The right
-/// pane itself shows either the detail view or the diff view depending on
-/// `app.right_pane()` (`d`/`D` toggles between them, TUI iteration 2).
+/// the right pane's Diff/Detail/BlastRadius content is code and prose that
+/// needs width to read comfortably, while the tree's rows stay legible
+/// truncated (the Diff pane's title now names the truncated row's symbol/
+/// file, `diff_pane::diff_pane_title`). The right pane itself shows either
+/// the detail view or the diff view depending on `app.right_pane()` (`d`/`D`
+/// toggles between them, TUI iteration 2).
 ///
 /// Returns the clamped right-pane scroll offset actually applied — whichever
 /// of `draw_detail_pane`/`draw_diff_pane`/`draw_blast_radius_pane` ran for
@@ -288,11 +290,11 @@ mod tests {
             .expect("draw");
 
         // Tree pane's own top-left border corner is at (0, 0); the right
-        // pane's 60/40 split (`ENTRY_TREE_WIDTH_PERCENT`) puts its top-left
-        // corner at column 48 of an 80-column terminal.
+        // pane's split (`ENTRY_TREE_WIDTH_PERCENT`) puts its top-left
+        // corner at column 32 of an 80-column terminal.
         let buffer = terminal.backend().buffer();
         let tree_border_style = buffer[(0, 0)].style();
-        let right_border_style = buffer[(48, 0)].style();
+        let right_border_style = buffer[(32, 0)].style();
         assert_eq!(Some(Color::Cyan), tree_border_style.fg);
         assert!(tree_border_style.add_modifier.contains(Modifier::BOLD));
         assert_eq!(Some(Color::DarkGray), right_border_style.fg);
@@ -318,7 +320,7 @@ mod tests {
 
         let buffer = terminal.backend().buffer();
         let tree_border_style = buffer[(0, 0)].style();
-        let right_border_style = buffer[(48, 0)].style();
+        let right_border_style = buffer[(32, 0)].style();
         assert_eq!(Some(Color::DarkGray), tree_border_style.fg);
         assert!(!tree_border_style.add_modifier.contains(Modifier::BOLD));
         assert_eq!(Some(Color::Cyan), right_border_style.fg);
@@ -423,7 +425,7 @@ mod tests {
     }
 
     /// A single-file report whose path overflows an 80-column terminal's
-    /// tree pane (60% width, `ENTRY_TREE_WIDTH_PERCENT`, minus 2 columns
+    /// tree pane (40% width, `ENTRY_TREE_WIDTH_PERCENT`, minus 2 columns
     /// of border).
     fn report_with_long_path_symbol() -> Report {
         Report {

--- a/rinkaku-tui/src/ui/mod.rs
+++ b/rinkaku-tui/src/ui/mod.rs
@@ -194,8 +194,8 @@ pub fn draw(
 }
 
 /// The right pane's inner height (borders excluded), computed from `body`
-/// (the entry screen's full body area) using the same 60/40 horizontal
-/// split and `saturating_sub(2)` border deduction [`draw_entry_screen`]
+/// (the entry screen's full body area) using the same horizontal split and
+/// `saturating_sub(2)` border deduction [`draw_entry_screen`]
 /// itself uses (`ENTRY_TREE_WIDTH_PERCENT`/`ENTRY_RIGHT_WIDTH_PERCENT`
 /// below, referenced both here and there so the two never drift).
 /// Extracted so [`DrawOutcome`]'s `scroll_viewport_height` reflects the
@@ -214,5 +214,5 @@ fn right_pane_viewport_height(body: Rect) -> usize {
 /// [`right_pane_viewport_height`]'s report of that layout to
 /// [`DrawOutcome::scroll_viewport_height`] (ADR 0026) so the two cannot
 /// drift.
-pub(crate) const ENTRY_TREE_WIDTH_PERCENT: u16 = 60;
-pub(crate) const ENTRY_RIGHT_WIDTH_PERCENT: u16 = 40;
+pub(crate) const ENTRY_TREE_WIDTH_PERCENT: u16 = 40;
+pub(crate) const ENTRY_RIGHT_WIDTH_PERCENT: u16 = 60;


### PR DESCRIPTION
## Summary

Two small TUI improvements to the entry screen, plus a resync bug found by dynamic review while verifying the second one.

- **Widen the right pane to 60% of the entry screen** (`ENTRY_TREE_WIDTH_PERCENT`/`ENTRY_RIGHT_WIDTH_PERCENT` flip from 60/40 to 40/60, `rinkaku-tui/src/ui/mod.rs`). The right pane's Diff/Detail/BlastRadius content is code and prose that needs width to read comfortably; the tree pane's rows stay legible even truncated, especially now that the diff pane's title (below) names the truncated symbol/file.
- **Show the selected symbol's name in the Diff pane title** (`Diff: <name>` instead of a plain `Diff`), so a narrower, more-truncated tree pane still tells the reviewer which symbol/file they're looking at. `App::selected_diff_title_name()` mirrors `selected_diff_target`'s existing row-kind scoping: a present symbol row shows its name, a file/skipped-file row shows its path, everything else (directory, removed symbol, no selection) keeps the plain `Diff` title.
- **Fix:** re-entering the Diff pane after toggling away (found during dynamic review of the title feature — see below).

## Judgment call: full path vs. basename for file rows

`selected_diff_title_name` shows a file row's *full* path (e.g. `Diff: rinkaku-tui/src/ui/diff_pane.rs`), not just the basename. Static review confirmed this is correct as-is: it matches the tree pane's own ancestor-relative truncation convention and the diff pane's existing placeholder text (`"(no diff hunks found for {path})"`), both of which already use the full path.

## Bug found by dynamic review, and the fix

**Repro:** `--base HEAD~N`, cursor on a symbol row, diff pane shows the correct title and content. Press `d` (→ Detail) then `d` again (→ Diff), cursor untouched: the title correctly reads the *current* symbol's name (`selected_diff_title_name` is computed live every draw), but the pane *body* still shows the *previous* symbol's diff at a stale scroll position. Same via `r` (→ Blast radius) → `d`. Moving the cursor at any point resyncs correctly.

**Root cause:** `apply_diff_pane_selection_effects` (`rinkaku-tui/src/lib.rs`) only re-syncs the diff pane's scroll (ADR 0027's auto-scroll-to-section, and ADR 0030's mirror-image scroll→cursor sync) when `next_focus != last_diff_focus` — i.e. when the tree cursor's symbol actually changed since the last handled key. Toggling `RightPane` away from `Diff` and back with the cursor unchanged leaves `next_focus == last_diff_focus` (both still the same symbol), so neither sync branch fires, and the pane redraws at whatever `right_pane_scroll` `App::handle_key`'s blanket reset left (0) — landing on whichever symbol happens to sit at that offset in the file, not the currently selected one. This staleness predates this PR (ADR 0027/0030 already had this gap) but was invisible while the title was the generic `Diff`; the per-symbol title turns a silent scroll-offset bug into an actively misleading title/body mismatch.

**Fix:** reset `last_diff_focus` to `None` in `run_app`'s loop whenever a handled key leaves `RightPane` other than `Diff`. The next re-entry into `Diff` then always looks like a fresh selection to the existing ADR 0027 auto-scroll branch, restoring the correct section-start scroll — no new comparison axis, just clearing the "what we last synced to" memory when the pane stops being shown.

**ADR:** ADR 0030 decision 7 explicitly claimed "the diff pane itself resetting to that symbol's own section top on the next re-entry to `RightPane::Diff` ... is the existing, desired behavior" — a factual claim that didn't hold for the unchanged-cursor case. Added a short "Amendment (dynamic review, post-acceptance)" section to `docs/adr/0030-diff-scroll-syncs-tree-selection.md` recording the gap and the fix.

TDD: added a failing test first (`should_resync_scroll_to_current_symbols_section_when_diff_pane_is_reentered_with_cursor_unchanged`, `rinkaku-tui/src/lib_tests/diff_scroll_sync.rs`, alongside the existing `apply_diff_pane_selection_effects`/`sync_target_for_scroll` tests) pinning that the function resyncs to the current symbol's section when called with `last_diff_focus: None` (the shape the loop now produces on re-entry), then implemented the loop-side fix.

## Test results

- `make test`: 176 + 399 + 628 (+1 new) unit tests pass across the workspace, 0 failed.
- `make lint`: `cargo fmt --all --check` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Dynamic verification

All via a real pty (tmux), using the built `target/debug/rinkaku` binary directly:

- **Terminal widths** 120/80/60/40/20 columns × 15 rows: entry screen renders without panic at every width; diff pane title clips gracefully at narrow widths (e.g. `Diff: ren` at 20 cols) via ratatui's native `Block` title clipping — no wrap, no crash.
- **Row kinds**: symbol row → `Diff: <symbol-name>`; file row (including a skipped/unsupported-language file) → `Diff: <full-path>`; directory row → plain `Diff`; removed symbol row → plain `Diff`.
- **Whole-repo mode** (`--tui`, no `--base`) and **`--entry <path>` mode** (opens on Blast radius by default): title/content stay correct after toggling `d`/`r` in both modes.
- **The exact blocker repro** (`d`→`d` and `r`→`d`, cursor untouched, on a symbol whose section does *not* start at the top of the file): before the fix, content showed the wrong symbol's diff under the correct title; after the fix, both title and content consistently show the current symbol at its own section start.
- **Cursor-move case**: moving the cursor to a different symbol (with Diff showing, and with Detail/BlastRadius showing before toggling back) correctly re-syncs title, content, and scroll every time.
- **Focus switching** (`Enter`/`h`/Esc between `Focus::Tree` and `Focus::Right`) and manual scrolling (ADR 0030's scroll→cursor sync direction) verified unaffected.
- **`RUST_LOG=debug`**: no splash-screen corruption, clean exit, no stray log-drain artifacts on screen — unaffected by these changes.

https://claude.ai/code/session_01HuToEMUD2tRARq9BDU2Jdv
