### PR TITLE
docs(experiments): record experiment 0001 round 30 (PR #144)

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/030.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/030.md
@@ -1,0 +1,121 @@
+# Round 30
+
+- Subject: PR #144 — two small TUI improvements to the entry screen,
+  plus a resync fix found by dynamic review while verifying the
+  second one. **Widen the right pane** (`ENTRY_TREE_WIDTH_PERCENT`/
+  `ENTRY_RIGHT_WIDTH_PERCENT` flip from 60/40 to 40/60,
+  `rinkaku-tui/src/ui/mod.rs`): the right pane's Diff/Detail/
+  BlastRadius content is code and prose that needs width, while the
+  tree pane's rows stay legible even truncated, especially now that
+  the diff pane names the truncated symbol/file. **Show the selected
+  symbol's name in the Diff pane title** (`Diff: <name>` instead of a
+  plain `Diff`) via a new pure helper `diff_pane_title`
+  (`rinkaku-tui/src/ui/diff_pane.rs`) and `App::
+  selected_diff_title_name()`, which mirrors the existing
+  `selected_diff_target`'s row-kind scoping (symbol row -> name,
+  file/skipped-file row -> full path, everything else -> plain
+  `Diff`). **Fix** (third commit): re-entering the Diff pane after
+  toggling away left stale content under a fresh title — found during
+  dynamic review of the title feature, not proposed by either static
+  pass.
+- Protocol note: same cost-reduced two-agent configuration as rounds
+  27-29 — one static reviewer combining the map-assisted pass and the
+  independent pass, one separate dynamic-verification agent. The
+  implementation agent had already run its own pty-based dynamic smoke
+  test before review (terminal widths 120/80/60/40/20, all four row
+  kinds, whole-repo and `--entry` modes), so review-time dynamic
+  verification started from a working baseline rather than zero.
+- **Map delivery**: self-serve, variant (b) — the static reviewer
+  built rinkaku from a trusted clean `main` checkout itself and ran
+  that binary's `rinkaku --base main` inside the branch worktree
+  before reading any code.
+- **Map-assisted pass**: no unique defects. Confirmed `diff_pane_title`
+  as a small, fully-tested pure function (four cases: `None`, a
+  symbol name, a path-shaped name, and a defensive empty-string case),
+  and observed that `selected_diff_title_name` and the pre-existing
+  `selected_diff_target` are convention-mirrored match arms with no
+  shared helper between them — fed directly into the independent
+  pass's first judgment call below.
+- **Independent pass** (same agent, same session, following the map
+  read): full-diff review of the width-percent flip, the title helper,
+  and the row-kind scoping against this repository's conventions.
+  Fully clean — zero blockers, zero should-fix. Two judgment
+  confirmations, not findings:
+  1. `selected_diff_title_name` duplicating `selected_diff_target`'s
+     match-arm structure instead of sharing a helper was judged
+     acceptable: both accessors are pinned by their own unit tests, so
+     the duplication cannot silently drift without a test catching it,
+     and the two functions return different types (a display name vs.
+     a `DiffTarget`) that don't obviously factor into one shared
+     branch.
+  2. File rows showing the *full* path in the title (`Diff:
+     rinkaku-tui/src/ui/diff_pane.rs`), not the basename, was confirmed
+     correct as-is: it matches the tree pane's own ancestor-relative
+     truncation convention and the diff pane's existing placeholder
+     text (`"(no diff hunks found for {path})"`), both of which
+     already use the full path.
+- **Dynamic verification** (separate agent, real pty via tmux,
+  rebuilding after the fix): the round's only finding, and the only
+  one of the three angles positioned to catch it. Repro: `--base
+  HEAD~N`, cursor on a symbol row, Diff pane shows correct title and
+  content. Press `d` (-> Detail) then `d` again (-> Diff), cursor
+  untouched — the title correctly re-reads the current symbol's name
+  (computed live every draw), but the pane *body* still shows the
+  *previous* symbol's diff at a stale scroll position. Same via `r`
+  (-> BlastRadius) -> `d`. Moving the cursor at any point resyncs
+  correctly. **BLOCKER.**
+- **Root cause**: `apply_diff_pane_selection_effects`
+  (`rinkaku-tui/src/lib.rs`) only re-syncs the diff pane's scroll (ADR
+  0027's auto-scroll-to-section, ADR 0030's mirror-image scroll-to-
+  cursor sync) when `next_focus != last_diff_focus` — i.e. when the
+  tree cursor's symbol actually changed since the last handled key.
+  Toggling `RightPane` away from `Diff` and back with the cursor
+  unchanged leaves `next_focus == last_diff_focus` (both still the
+  same symbol), so neither sync branch fires and the pane redraws at
+  whatever `right_pane_scroll` the blanket key-reset left (0) — the
+  section that happens to sit at that offset, not the currently
+  selected symbol's own section. This staleness predates this PR
+  (ADR 0027/0030 already had the gap); it was invisible while the
+  title read the generic `Diff`, and this PR's own title feature is
+  what converted a silent scroll-offset quirk into an actively
+  misleading title/body mismatch.
+- **Fix**: reset `last_diff_focus` to `None` in `run_app`'s loop
+  whenever a handled key leaves `RightPane` other than `Diff`, so the
+  next re-entry always looks like a fresh selection to the existing
+  ADR 0027 auto-scroll branch. TDD: a failing test was added first
+  (`should_resync_scroll_to_current_symbols_section_when_diff_pane_is_
+  reentered_with_cursor_unchanged`,
+  `rinkaku-tui/src/lib_tests/diff_scroll_sync.rs`) pinning that
+  `apply_diff_pane_selection_effects` resyncs to the current symbol's
+  section when called with `last_diff_focus: None` — the shape the
+  loop now produces on re-entry — then the loop-side fix landed.
+  Amended ADR 0030's decision 7, which had explicitly claimed
+  re-entry to `RightPane::Diff` always resets to that symbol's own
+  section top; a new "Amendment (dynamic review, post-acceptance)"
+  section records the unchanged-cursor gap and the fix.
+- Severity summary: 1 blocker (dynamic, fixed same round), 0
+  should-fix, 0 nits. `make test`: 176 + 399 + 628 (+1 new) passed
+  across the workspace. `make lint`: clean.
+- Cost: implementation agent ~222k + ~321k tokens across two turns
+  (the two features, then the fix), static reviewer ~97k tokens,
+  dynamic reviewer ~142k tokens. Not a harness-timed comparison;
+  wall-clock not measured.
+- Takeaway: a feature that surfaces previously hidden state can
+  promote a pre-existing, purely cosmetic staleness bug into an
+  actively misleading one, and the pass that catches this class is
+  dynamic interaction sweeps that toggle *mode* without moving the
+  cursor — a state transition neither the map (which has no notion of
+  interactive state at all) nor a diff-focused static read (which
+  reasons about code paths, not runtime key sequences) is positioned
+  to try unprompted. This sharpens round 22's "map defeated by its own
+  coverage heuristics being wrong" one level further: here nothing in
+  the map or the diff was wrong, but the diff's own premise (a title
+  that always matches its body) depended on an interaction-order
+  invariant that predates this PR and that no reading pass, however
+  careful, was going to reconstruct by inspection. It reinforces this
+  experiment's standing conclusion, unbroken since round 5: dynamic
+  verification remains the strongest single predictor of finding real
+  behavioral defects, and this round's defect specifically required
+  the "toggle away and back with cursor unchanged" permutation rather
+  than any cursor-movement or width-sweep case the implementation
+  agent's own pre-review smoke test had already covered.


### PR DESCRIPTION
## Summary

- Records round 30 of experiment 0001, reviewing PR #144 (`feat(tui): widen right pane and show symbol name in diff pane title`).
- Same cost-reduced two-agent configuration as rounds 27-29: one static reviewer (map-assisted + independent passes, self-serve map build from trusted `main`), one dynamic-verification agent.
- Only the round file is added; the experiment README's index/conclusions are updated separately per the experiment's own file-layout convention.

## Round highlights

- Static pass: fully clean (0 blockers, 0 should-fix). Confirmed the new `diff_pane_title` helper is small and well-tested, and validated two judgment calls (duplicated-but-tested match arms; full-path vs. basename title text) rather than filing findings.
- Dynamic pass: found the round's only blocker — toggling Detail/BlastRadius back to Diff with the cursor unchanged left stale diff content under a freshly-computed, now-misleading per-symbol title. Fixed via `ReleaseGuard`-style focus reset (`last_diff_focus = None` on leaving `RightPane::Diff`) plus an ADR 0030 amendment.
- Takeaway: a feature that surfaces previously-hidden state (naming the symbol on screen) promoted a pre-existing cosmetic staleness bug into an actively misleading one — only a dynamic mode-toggle sweep with the cursor held still could catch it.

## Test plan

- [x] `docs/experiments/0001-map-assisted-llm-review/rounds/030.md` added, no other files touched
- [x] Round number checked against both `origin/main`'s `rounds/` directory (up to 029) and open PRs (`gh pr list --state open`, no other in-flight round record)

https://claude.ai/code/session_01HuToEMUD2tRARq9BDU2Jdv