### PR TITLE
feat(tui): add a markers legend section to the help overlay

### DIFF
--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -199,6 +199,10 @@ const MARKER_LEGEND: &[MarkerLegendEntry] = &[
         explanation: "Expand marker: children shown / hidden (blank = leaf, nothing to expand)",
     },
     MarkerLegendEntry {
+        swatch: "fn struct enum trait class iface type",
+        explanation: "Symbol row's kind prefix, abbreviated from the language's own keyword",
+    },
+    MarkerLegendEntry {
         swatch: "+",
         explanation: "Added symbol",
     },
@@ -233,6 +237,10 @@ const MARKER_LEGEND: &[MarkerLegendEntry] = &[
     MarkerLegendEntry {
         swatch: "N tests",
         explanation: "Collapsed group of a file's test symbols",
+    },
+    MarkerLegendEntry {
+        swatch: "(skipped: ...)",
+        explanation: "Reason a file was not analyzed (parse failure, unsupported language, ...)",
     },
     MarkerLegendEntry {
         swatch: "chg:N",
@@ -280,18 +288,6 @@ const GLOSSARY: &[GlossaryEntry] = &[
     GlossaryEntry {
         term: "jumplist",
         explanation: "The history of gd/gr jump locations — ctrl-o/ctrl-i move back/forward through it",
-    },
-    GlossaryEntry {
-        term: "chg: / api: / fan-in:",
-        explanation: "Tree row badges: changed symbols, contract changes (signature-changed or deleted, shown in yellow), and fan-in (symbols referenced by 2+ other changed production symbols — tests exercising a symbol don't count toward its fan-in)",
-    },
-    GlossaryEntry {
-        term: "!",
-        explanation: "Risk marker: this row has both a contract change and a high-fan-in symbol in the same subtree — a change that is both hard to miss and wide-reaching",
-    },
-    GlossaryEntry {
-        term: "N tests",
-        explanation: "A collapsed group of a file's test symbols — expand it to see them individually, dimmed to show they carry less review weight than production code",
     },
 ];
 
@@ -368,6 +364,7 @@ mod tests {
         assert_eq!(
             vec![
                 "v / >",
+                "fn struct enum trait class iface type",
                 "+",
                 "~",
                 "(dimmed name)",
@@ -377,6 +374,7 @@ mod tests {
                 "!",
                 "[test] (N symbols)",
                 "N tests",
+                "(skipped: ...)",
                 "chg:N",
                 "api:N",
                 "fan-in:N",
@@ -433,29 +431,6 @@ mod tests {
             .collect();
 
         assert!(terms.contains(&"jumplist"));
-    }
-
-    #[test]
-    fn should_include_a_glossary_entry_for_tree_row_badges() {
-        let terms: Vec<&str> = HELP_CONTENT
-            .glossary
-            .iter()
-            .map(|entry| entry.term)
-            .collect();
-
-        assert!(terms.contains(&"chg: / api: / fan-in:"));
-    }
-
-    #[test]
-    fn should_include_a_glossary_entry_for_the_risk_marker_and_test_group() {
-        let terms: Vec<&str> = HELP_CONTENT
-            .glossary
-            .iter()
-            .map(|entry| entry.term)
-            .collect();
-
-        assert!(terms.contains(&"!"));
-        assert!(terms.contains(&"N tests"));
     }
 
     #[test]

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -26,6 +26,18 @@ pub struct GlossaryEntry {
     pub explanation: &'static str,
 }
 
+/// One marker-legend entry: a tree row marker/badge's display text paired
+/// with a short explanation of what it means — the visual-encoding
+/// counterpart to [`GlossaryEntry`]'s concept glossary. `crate::ui::overlay`
+/// renders `swatch` with the row's *real* style, looked up from
+/// `crate::row_view`'s own style producers rather than duplicated here, so
+/// this struct only needs to carry the text half.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkerLegendEntry {
+    pub swatch: &'static str,
+    pub explanation: &'static str,
+}
+
 /// One named group of [`KeyBinding`]s — "Tree focus", "Right focus", or
 /// "Global" (ADR 0020's own focus/global split).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,10 +47,12 @@ pub struct KeyBindingGroup {
 }
 
 /// The whole help overlay's content: every keymap group in display order,
-/// then the glossary. A `const`, not a function — the content is fixed at
-/// compile time, so there is nothing to compute per call.
+/// then the markers legend, then the glossary. A `const`, not a function —
+/// the content is fixed at compile time, so there is nothing to compute per
+/// call.
 pub struct HelpContent {
     pub keymap_groups: &'static [KeyBindingGroup],
+    pub markers: &'static [MarkerLegendEntry],
     pub glossary: &'static [GlossaryEntry],
 }
 
@@ -173,6 +187,79 @@ const KEYMAP_GROUPS: &[KeyBindingGroup] = &[
     },
 ];
 
+/// The tree pane's marker/badge legend, in the same added-like →
+/// changed-like → removed-like → aggregates reading order as the mermaid
+/// legend (ADR 0039/0040) — the visual-encoding reference for every marker
+/// `crate::row_view::entry_row_line` can draw. `swatch` is the display text
+/// only; `crate::ui::overlay` pairs each with its real style from
+/// `crate::row_view`.
+const MARKER_LEGEND: &[MarkerLegendEntry] = &[
+    MarkerLegendEntry {
+        swatch: "v / >",
+        explanation: "Expand marker: children shown / hidden (blank = leaf, nothing to expand)",
+    },
+    MarkerLegendEntry {
+        swatch: "+",
+        explanation: "Added symbol",
+    },
+    MarkerLegendEntry {
+        swatch: "~",
+        explanation: "Signature-changed symbol",
+    },
+    MarkerLegendEntry {
+        swatch: "(dimmed name)",
+        explanation: "Body-only, unclassified, or test symbol — exists, but carries less review weight",
+    },
+    MarkerLegendEntry {
+        swatch: "x",
+        explanation: "Removed symbol",
+    },
+    MarkerLegendEntry {
+        swatch: "(dimmed + struck-through name)",
+        explanation: "Removed symbol's name",
+    },
+    MarkerLegendEntry {
+        swatch: "(cycle)",
+        explanation: "Directory contains a dependency cycle",
+    },
+    MarkerLegendEntry {
+        swatch: "!",
+        explanation: "Risk marker: a contract change and a high-fan-in symbol in the same subtree",
+    },
+    MarkerLegendEntry {
+        swatch: "[test] (N symbols)",
+        explanation: "Whole-test-file badge",
+    },
+    MarkerLegendEntry {
+        swatch: "N tests",
+        explanation: "Collapsed group of a file's test symbols",
+    },
+    MarkerLegendEntry {
+        swatch: "chg:N",
+        explanation: "Changed, non-removed symbols in this subtree",
+    },
+    MarkerLegendEntry {
+        swatch: "api:N",
+        explanation: "Contract changes in this subtree: signature-changed symbols plus removed symbols",
+    },
+    MarkerLegendEntry {
+        swatch: "fan-in:N",
+        explanation: "Sum of used_by counts over every high-fan-in symbol in this subtree",
+    },
+    MarkerLegendEntry {
+        swatch: "lines:N",
+        explanation: "This file's own line count, colored by file-size band (normal/watch/warn/split)",
+    },
+    MarkerLegendEntry {
+        swatch: "warn:N",
+        explanation: "Directory rows: count of Warn-band files in this subtree",
+    },
+    MarkerLegendEntry {
+        swatch: "split:N",
+        explanation: "Directory rows: count of Split-band files in this subtree",
+    },
+];
+
 const GLOSSARY: &[GlossaryEntry] = &[
     GlossaryEntry {
         term: "topological order",
@@ -211,6 +298,7 @@ const GLOSSARY: &[GlossaryEntry] = &[
 /// The whole help overlay's content (module doc comment).
 pub const HELP_CONTENT: HelpContent = HelpContent {
     keymap_groups: KEYMAP_GROUPS,
+    markers: MARKER_LEGEND,
     glossary: GLOSSARY,
 };
 
@@ -267,6 +355,61 @@ mod tests {
                 group.title
             );
         }
+    }
+
+    #[test]
+    fn should_order_marker_legend_added_changed_removed_then_aggregates() {
+        let swatches: Vec<&str> = HELP_CONTENT
+            .markers
+            .iter()
+            .map(|entry| entry.swatch)
+            .collect();
+
+        assert_eq!(
+            vec![
+                "v / >",
+                "+",
+                "~",
+                "(dimmed name)",
+                "x",
+                "(dimmed + struck-through name)",
+                "(cycle)",
+                "!",
+                "[test] (N symbols)",
+                "N tests",
+                "chg:N",
+                "api:N",
+                "fan-in:N",
+                "lines:N",
+                "warn:N",
+                "split:N",
+            ],
+            swatches
+        );
+    }
+
+    #[test]
+    fn should_describe_api_badge_as_signature_changed_plus_removed_symbols() {
+        let entry = HELP_CONTENT
+            .markers
+            .iter()
+            .find(|entry| entry.swatch == "api:N")
+            .expect("api:N entry present");
+
+        assert!(entry.explanation.contains("removed"));
+        assert!(entry.explanation.contains("signature-changed"));
+    }
+
+    #[test]
+    fn should_describe_fan_in_badge_as_a_sum_over_high_fan_in_symbols() {
+        let entry = HELP_CONTENT
+            .markers
+            .iter()
+            .find(|entry| entry.swatch == "fan-in:N")
+            .expect("fan-in:N entry present");
+
+        assert!(entry.explanation.contains("Sum"));
+        assert!(entry.explanation.contains("high-fan-in"));
     }
 
     #[test]

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -265,11 +265,13 @@ enum BadgeContext {
 ///   the directory-level `warn:N split:N` aggregate, which only ever
 ///   counts `Warn`/`Split` files (see `Badges`' doc comment).
 fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: BadgeContext) {
-    let cyan = Style::default().fg(Color::Cyan);
     let mut wrote_any_ascii_badge = false;
     if badges.changed_symbols > 0 {
         spans.push(Span::raw("chg:"));
-        spans.push(Span::styled(badges.changed_symbols.to_string(), cyan));
+        spans.push(Span::styled(
+            badges.changed_symbols.to_string(),
+            cyan_badge_style(),
+        ));
         wrote_any_ascii_badge = true;
     }
     if badges.contract_changes > 0 {
@@ -279,7 +281,7 @@ fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: Ba
         spans.push(Span::raw("api:"));
         spans.push(Span::styled(
             badges.contract_changes.to_string(),
-            Style::default().fg(Color::Yellow),
+            warning_badge_style(),
         ));
         wrote_any_ascii_badge = true;
     }
@@ -288,7 +290,7 @@ fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: Ba
             spans.push(Span::raw(" "));
         }
         spans.push(Span::raw("fan-in:"));
-        spans.push(Span::styled(badges.fan_in.to_string(), cyan));
+        spans.push(Span::styled(badges.fan_in.to_string(), cyan_badge_style()));
         wrote_any_ascii_badge = true;
     }
 
@@ -316,7 +318,7 @@ fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: Ba
                 spans.push(Span::raw("warn:"));
                 spans.push(Span::styled(
                     badges.file_size_warn_count.to_string(),
-                    Style::default().fg(Color::Yellow),
+                    warning_badge_style(),
                 ));
             }
             if has_warn && has_split {
@@ -326,17 +328,43 @@ fn push_badge_spans(spans: &mut Vec<Span<'static>>, badges: &Badges, context: Ba
                 spans.push(Span::raw("split:"));
                 spans.push(Span::styled(
                     badges.file_size_split_count.to_string(),
-                    Style::default().fg(Color::Red),
+                    split_badge_style(),
                 ));
             }
         }
     }
 }
 
+/// Style for the `chg:`/`fan-in:` badge numbers (cyan, informational
+/// counts — see [`push_badge_spans`]'s badge encoding rationale).
+///
+/// `pub(crate)`: also reused by `crate::ui::overlay`'s Markers legend.
+pub(crate) fn cyan_badge_style() -> Style {
+    Style::default().fg(Color::Cyan)
+}
+
+/// Style for the `api:`/`warn:` badge numbers (yellow — the "pay
+/// attention" color, see [`push_badge_spans`]'s badge encoding rationale).
+///
+/// `pub(crate)`: also reused by `crate::ui::overlay`'s Markers legend.
+pub(crate) fn warning_badge_style() -> Style {
+    Style::default().fg(Color::Yellow)
+}
+
+/// Style for the `split:` badge number (red).
+///
+/// `pub(crate)`: also reused by `crate::ui::overlay`'s Markers legend.
+pub(crate) fn split_badge_style() -> Style {
+    Style::default().fg(Color::Red)
+}
+
 /// File-row `lines:N` badge style per [`FileSizeBand`] (ADR 0028
 /// amendment). `Split` is additionally bold so it doesn't read
 /// identically to `Warn`, which shares its red foreground.
-fn band_style(band: FileSizeBand) -> Style {
+///
+/// `pub(crate)`: also reused by `crate::ui::overlay`'s Markers legend, the
+/// single source of truth for that legend's swatch styles.
+pub(crate) fn band_style(band: FileSizeBand) -> Style {
     match band {
         FileSizeBand::Normal => Style::default(),
         FileSizeBand::Watch => Style::default().fg(Color::Yellow),
@@ -396,7 +424,9 @@ fn test_badge_span(symbol_count: usize) -> Span<'static> {
 /// `x` removed. Kept as its own single-character span (rather than folded
 /// into `symbol_name_style`) so it reads as a consistent left-aligned
 /// column across rows regardless of name length.
-fn symbol_marker_span(symbol_ref: &SymbolRef) -> Span<'static> {
+///
+/// `pub(crate)`: also reused by `crate::ui::overlay`'s Markers legend.
+pub(crate) fn symbol_marker_span(symbol_ref: &SymbolRef) -> Span<'static> {
     if symbol_ref.removed {
         return Span::styled("x", Style::default().fg(Color::Red));
     }
@@ -421,7 +451,9 @@ fn symbol_marker_span(symbol_ref: &SymbolRef) -> Span<'static> {
 /// dimmed the same way — group membership already conveys "this is test
 /// code", so the name itself only needs to read as lower review priority,
 /// not carry its own badge anymore.
-fn symbol_name_style(symbol_ref: &SymbolRef) -> Style {
+///
+/// `pub(crate)`: also reused by `crate::ui::overlay`'s Markers legend.
+pub(crate) fn symbol_name_style(symbol_ref: &SymbolRef) -> Style {
     if symbol_ref.removed {
         Style::default()
             .fg(Color::DarkGray)
@@ -466,12 +498,16 @@ fn is_high_risk_symbol(symbol_ref: &SymbolRef, badges: &Badges) -> bool {
 /// layout is untouched (no reserved gutter column).
 fn push_risk_marker_span(spans: &mut Vec<Span<'static>>, is_risky: bool) {
     if is_risky {
-        spans.push(Span::styled(
-            "!",
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-        ));
+        spans.push(Span::styled("!", risk_marker_style()));
         spans.push(Span::raw(" "));
     }
+}
+
+/// The `!` risk marker's style (bold red), factored out of
+/// [`push_risk_marker_span`] so `crate::ui::overlay`'s Markers legend can
+/// reuse it too.
+pub(crate) fn risk_marker_style() -> Style {
+    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
 }
 
 /// A short, fixed-width kind abbreviation for a symbol row (mirrors

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -415,8 +415,15 @@ fn test_badge_span(symbol_count: usize) -> Span<'static> {
     };
     Span::styled(
         format!("[test] ({symbol_count} {noun})"),
-        Style::default().fg(Color::Magenta),
+        test_badge_style(),
     )
+}
+
+/// Style for the `[test] (N symbols)` whole-test-file badge (magenta).
+///
+/// `pub(crate)`: also reused by `crate::ui::overlay`'s Markers legend.
+pub(crate) fn test_badge_style() -> Style {
+    Style::default().fg(Color::Magenta)
 }
 
 /// A symbol row's leading classification marker: `+` added, `~`

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -74,10 +74,7 @@ fn legend_symbol(
     }
 }
 
-/// Column width the swatch is padded to before the explanation starts —
-/// wide enough for the longest swatch text (`"(dimmed + struck-through
-/// name)"`, 31 chars) plus at least one separating space.
-const MARKER_SWATCH_COLUMN_WIDTH: usize = 32;
+const MARKER_SWATCH_COLUMN_WIDTH: usize = 40;
 
 /// Builds the Markers section's lines: one row per
 /// [`crate::help::HELP_CONTENT`]'s `markers` legend entry, its swatch
@@ -110,11 +107,7 @@ fn markers_legend_lines() -> Vec<Line<'static>> {
 
 /// Looks up the real style(s) for one [`crate::help::MarkerLegendEntry::swatch`]
 /// value, reusing `crate::row_view`'s own style producers so the legend can
-/// never drift from what the tree pane actually renders. A `chg:`/`api:`/
-/// `fan-in:`/`warn:`/`split:` swatch splits into a plain label span plus a
-/// colored number span, mirroring `row_view::push_badge_spans`'s own
-/// label/number split. Falls back to a single unstyled span for the
-/// remaining swatches, which are plain text on the tree row itself.
+/// never drift from what the tree pane actually renders.
 fn marker_swatch_spans(swatch: &'static str) -> Vec<Span<'static>> {
     match swatch {
         "+" => vec![symbol_marker_span(&legend_symbol(
@@ -136,6 +129,12 @@ fn marker_swatch_spans(swatch: &'static str) -> Vec<Span<'static>> {
             swatch,
             symbol_name_style(&legend_symbol(None, true, false)),
         )],
+        "(cycle)" => vec![Span::styled(
+            swatch,
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )],
         "!" => vec![Span::styled(swatch, risk_marker_style())],
         "lines:N" => vec![Span::styled(swatch, band_style(FileSizeBand::Watch))],
         "chg:N" => badge_swatch_spans("chg:", cyan_badge_style()),
@@ -144,6 +143,7 @@ fn marker_swatch_spans(swatch: &'static str) -> Vec<Span<'static>> {
         "warn:N" => badge_swatch_spans("warn:", warning_badge_style()),
         "split:N" => badge_swatch_spans("split:", split_badge_style()),
         "N tests" => vec![Span::styled(swatch, Style::default().fg(Color::DarkGray))],
+        "(skipped: ...)" => vec![Span::styled(swatch, Style::default().fg(Color::DarkGray))],
         _ => vec![Span::raw(swatch)],
     }
 }
@@ -361,6 +361,76 @@ mod tests {
 
         let number_span = line_span(fan_in_line, "N");
         assert_eq!(Style::default().fg(Color::Cyan), number_span.style);
+    }
+
+    #[test]
+    fn should_render_warn_badge_swatch_with_yellow_number_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let warn_line = lines
+            .iter()
+            .find(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.as_ref() == "warn:")
+            })
+            .expect("warn: line present");
+
+        let number_span = line_span(warn_line, "N");
+        assert_eq!(Style::default().fg(Color::Yellow), number_span.style);
+    }
+
+    #[test]
+    fn should_render_split_badge_swatch_with_red_number_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let split_line = lines
+            .iter()
+            .find(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.as_ref() == "split:")
+            })
+            .expect("split: line present");
+
+        let number_span = line_span(split_line, "N");
+        assert_eq!(Style::default().fg(Color::Red), number_span.style);
+    }
+
+    #[test]
+    fn should_render_signature_changed_marker_swatch_with_yellow_tilde_when_building_markers_legend()
+     {
+        let lines = markers_legend_lines();
+
+        let changed_line = lines
+            .iter()
+            .find(|line| line.spans.iter().any(|span| span.content.as_ref() == "~"))
+            .expect("~ line present");
+
+        let swatch_span = line_span(changed_line, "~");
+        assert_eq!(Style::default().fg(Color::Yellow), swatch_span.style);
+    }
+
+    #[test]
+    fn should_render_cycle_marker_swatch_bold_yellow_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let cycle_line = lines
+            .iter()
+            .find(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.as_ref() == "(cycle)")
+            })
+            .expect("(cycle) line present");
+
+        let swatch_span = line_span(cycle_line, "(cycle)");
+        assert_eq!(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+            swatch_span.style
+        );
     }
 
     #[test]

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -5,7 +5,7 @@
 use super::scroll::{render_scrollable_pane, truncate_to_width, windowed_rows_with_indicators};
 use crate::row_view::{
     band_style, cyan_badge_style, risk_marker_style, split_badge_style, symbol_marker_span,
-    symbol_name_style, warning_badge_style,
+    symbol_name_style, test_badge_style, warning_badge_style,
 };
 use crate::tree::SymbolRef;
 use ratatui::Frame;
@@ -142,6 +142,7 @@ fn marker_swatch_spans(swatch: &'static str) -> Vec<Span<'static>> {
         "fan-in:N" => badge_swatch_spans("fan-in:", cyan_badge_style()),
         "warn:N" => badge_swatch_spans("warn:", warning_badge_style()),
         "split:N" => badge_swatch_spans("split:", split_badge_style()),
+        "[test] (N symbols)" => vec![Span::styled(swatch, test_badge_style())],
         "N tests" => vec![Span::styled(swatch, Style::default().fg(Color::DarkGray))],
         "(skipped: ...)" => vec![Span::styled(swatch, Style::default().fg(Color::DarkGray))],
         _ => vec![Span::raw(swatch)],
@@ -515,6 +516,23 @@ mod tests {
             crate::row_view::band_style(FileSizeBand::Watch),
             swatch_span.style
         );
+    }
+
+    #[test]
+    fn should_render_test_badge_swatch_with_magenta_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let line = lines
+            .iter()
+            .find(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.as_ref() == "[test] (N symbols)")
+            })
+            .expect("[test] (N symbols) line present");
+
+        let swatch_span = line_span(line, "[test] (N symbols)");
+        assert_eq!(Style::default().fg(Color::Magenta), swatch_span.style);
     }
 
     #[test]

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -3,11 +3,18 @@
 //! after the pane split has drawn everything else.
 
 use super::scroll::{render_scrollable_pane, truncate_to_width, windowed_rows_with_indicators};
+use crate::row_view::{
+    band_style, cyan_badge_style, risk_marker_style, split_badge_style, symbol_marker_span,
+    symbol_name_style, warning_badge_style,
+};
+use crate::tree::SymbolRef;
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Modifier, Style};
-use ratatui::text::Line;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Clear, Paragraph};
+use rinkaku_core::extract::{Classification, SymbolKind};
+use rinkaku_core::file_size::FileSizeBand;
 
 /// The `?` help overlay's content laid out once, independent of the pane's
 /// rendered size — extracted from [`draw_help_overlay`] so tests can pin
@@ -29,6 +36,12 @@ fn help_overlay_lines() -> Vec<Line<'static>> {
         lines.push(Line::raw(""));
     }
     lines.push(Line::styled(
+        "Markers",
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+    lines.extend(markers_legend_lines());
+    lines.push(Line::raw(""));
+    lines.push(Line::styled(
         "Glossary",
         Style::default().add_modifier(Modifier::BOLD),
     ));
@@ -39,6 +52,107 @@ fn help_overlay_lines() -> Vec<Line<'static>> {
         )));
     }
     lines
+}
+
+/// One [`SymbolRef`] per marker case the Markers legend needs a real
+/// [`crate::row_view::symbol_marker_span`]/[`crate::row_view::symbol_name_style`]
+/// swatch for — fields left at their "no signal" default except the one
+/// this case is about, mirroring the minimal fixtures `row_view`'s own
+/// tests already build (`row_view_tests::plain_symbol`).
+fn legend_symbol(
+    classification: Option<Classification>,
+    removed: bool,
+    is_test: bool,
+) -> SymbolRef {
+    SymbolRef {
+        id: "legend".to_string(),
+        name: "legend".to_string(),
+        kind: SymbolKind::Function,
+        classification,
+        removed,
+        is_test,
+    }
+}
+
+/// Column width the swatch is padded to before the explanation starts —
+/// wide enough for the longest swatch text (`"(dimmed + struck-through
+/// name)"`, 31 chars) plus at least one separating space.
+const MARKER_SWATCH_COLUMN_WIDTH: usize = 32;
+
+/// Builds the Markers section's lines: one row per
+/// [`crate::help::HELP_CONTENT`]'s `markers` legend entry, its swatch
+/// rendered with the exact [`ratatui::style::Style`]
+/// `crate::row_view::entry_row_line` itself would use — a real style, not a
+/// prose color name — followed by the entry's explanation. Extracted as its
+/// own pure function, mirroring [`help_overlay_lines`]'s own split, so a
+/// test can assert on the built `Vec<Line>` without a live `Frame`.
+fn markers_legend_lines() -> Vec<Line<'static>> {
+    crate::help::HELP_CONTENT
+        .markers
+        .iter()
+        .map(|entry| {
+            let swatch = marker_swatch_spans(entry.swatch);
+            let swatch_width: usize = swatch.iter().map(|span| span.content.len()).sum();
+            let padding = MARKER_SWATCH_COLUMN_WIDTH
+                .saturating_sub(swatch_width)
+                .max(1);
+            let mut spans = vec![Span::raw("  ")];
+            spans.extend(swatch);
+            spans.push(Span::raw(format!(
+                "{}{}",
+                " ".repeat(padding),
+                entry.explanation
+            )));
+            Line::from(spans)
+        })
+        .collect()
+}
+
+/// Looks up the real style(s) for one [`crate::help::MarkerLegendEntry::swatch`]
+/// value, reusing `crate::row_view`'s own style producers so the legend can
+/// never drift from what the tree pane actually renders. A `chg:`/`api:`/
+/// `fan-in:`/`warn:`/`split:` swatch splits into a plain label span plus a
+/// colored number span, mirroring `row_view::push_badge_spans`'s own
+/// label/number split. Falls back to a single unstyled span for the
+/// remaining swatches, which are plain text on the tree row itself.
+fn marker_swatch_spans(swatch: &'static str) -> Vec<Span<'static>> {
+    match swatch {
+        "+" => vec![symbol_marker_span(&legend_symbol(
+            Some(Classification::Added),
+            false,
+            false,
+        ))],
+        "~" => vec![symbol_marker_span(&legend_symbol(
+            Some(Classification::SignatureChanged),
+            false,
+            false,
+        ))],
+        "x" => vec![symbol_marker_span(&legend_symbol(None, true, false))],
+        "(dimmed name)" => vec![Span::styled(
+            swatch,
+            symbol_name_style(&legend_symbol(Some(Classification::BodyOnly), false, false)),
+        )],
+        "(dimmed + struck-through name)" => vec![Span::styled(
+            swatch,
+            symbol_name_style(&legend_symbol(None, true, false)),
+        )],
+        "!" => vec![Span::styled(swatch, risk_marker_style())],
+        "lines:N" => vec![Span::styled(swatch, band_style(FileSizeBand::Watch))],
+        "chg:N" => badge_swatch_spans("chg:", cyan_badge_style()),
+        "api:N" => badge_swatch_spans("api:", warning_badge_style()),
+        "fan-in:N" => badge_swatch_spans("fan-in:", cyan_badge_style()),
+        "warn:N" => badge_swatch_spans("warn:", warning_badge_style()),
+        "split:N" => badge_swatch_spans("split:", split_badge_style()),
+        "N tests" => vec![Span::styled(swatch, Style::default().fg(Color::DarkGray))],
+        _ => vec![Span::raw(swatch)],
+    }
+}
+
+/// A `label:N` badge swatch split into a plain label span and an `N`
+/// numeral span styled with `number_style` — the same label/number split
+/// [`crate::row_view::push_badge_spans`] renders on the real tree row.
+fn badge_swatch_spans(label: &'static str, number_style: Style) -> Vec<Span<'static>> {
+    vec![Span::raw(label), Span::styled("N", number_style)]
 }
 
 /// Draws the `?` help overlay (ADR 0020, scrolling added post-hoc once the
@@ -196,14 +310,166 @@ pub(crate) fn draw_jump_popup(frame: &mut Frame, popup: &crate::app::JumpPopup, 
 
 #[cfg(test)]
 mod tests {
+    use super::{FileSizeBand, markers_legend_lines};
     use crate::app::{App, BlastRadiusSelection};
     use crate::ui::draw;
+    use pretty_assertions::assert_eq;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
+    use ratatui::style::{Color, Modifier, Style};
+    use ratatui::text::Span;
     use rinkaku_core::diff::LineRange;
     use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
     use rinkaku_core::graph::SymbolGraph;
     use rinkaku_core::render::{FileReport, Report};
+
+    #[test]
+    fn should_render_api_badge_swatch_with_yellow_number_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let api_line = lines
+            .iter()
+            .find(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.as_ref() == "api:")
+            })
+            .expect("api: line present");
+
+        // NOTE: partial assert — a `Line` built from `format!` interpolation
+        // doesn't have one clean expected `Line` value to compare as a
+        // whole (the explanation half is plain, unstyled text pulled
+        // straight from `help::MARKER_LEGEND`), so this only pins the
+        // swatch's number span style, which is the thing this test exists
+        // to guard.
+        let number_span = line_span(api_line, "N");
+        assert_eq!(Style::default().fg(Color::Yellow), number_span.style);
+    }
+
+    #[test]
+    fn should_render_fan_in_badge_swatch_with_cyan_number_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let fan_in_line = lines
+            .iter()
+            .find(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.as_ref() == "fan-in:")
+            })
+            .expect("fan-in: line present");
+
+        let number_span = line_span(fan_in_line, "N");
+        assert_eq!(Style::default().fg(Color::Cyan), number_span.style);
+    }
+
+    #[test]
+    fn should_render_added_marker_swatch_with_green_plus_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let added_line = lines
+            .iter()
+            .find(|line| line.spans.iter().any(|span| span.content.as_ref() == "+"))
+            .expect("+ line present");
+
+        let swatch_span = line_span(added_line, "+");
+        assert_eq!(Style::default().fg(Color::Green), swatch_span.style);
+    }
+
+    #[test]
+    fn should_render_removed_marker_swatch_with_red_x_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let removed_line = lines
+            .iter()
+            .find(|line| line.spans.iter().any(|span| span.content.as_ref() == "x"))
+            .expect("x line present");
+
+        let swatch_span = line_span(removed_line, "x");
+        assert_eq!(Style::default().fg(Color::Red), swatch_span.style);
+    }
+
+    #[test]
+    fn should_render_risk_marker_swatch_bold_red_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let risk_line = lines
+            .iter()
+            .find(|line| line.spans.iter().any(|span| span.content.as_ref() == "!"))
+            .expect("! line present");
+
+        let swatch_span = line_span(risk_line, "!");
+        assert_eq!(
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            swatch_span.style
+        );
+    }
+
+    #[test]
+    fn should_render_dimmed_and_crossed_out_removed_name_swatch_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let line = lines
+            .iter()
+            .find(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.as_ref() == "(dimmed + struck-through name)")
+            })
+            .expect("removed-name swatch line present");
+
+        let swatch_span = line_span(line, "(dimmed + struck-through name)");
+        assert_eq!(
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::CROSSED_OUT),
+            swatch_span.style
+        );
+    }
+
+    #[test]
+    fn should_reuse_row_view_band_style_for_lines_swatch_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let line = lines
+            .iter()
+            .find(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.as_ref() == "lines:N")
+            })
+            .expect("lines:N line present");
+
+        let swatch_span = line_span(line, "lines:N");
+        assert_eq!(
+            crate::row_view::band_style(FileSizeBand::Watch),
+            swatch_span.style
+        );
+    }
+
+    #[test]
+    fn should_render_test_group_swatch_dark_gray_when_building_markers_legend() {
+        let lines = markers_legend_lines();
+
+        let line = lines
+            .iter()
+            .find(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.as_ref() == "N tests")
+            })
+            .expect("N tests line present");
+
+        let swatch_span = line_span(line, "N tests");
+        assert_eq!(Style::default().fg(Color::DarkGray), swatch_span.style);
+    }
+
+    fn line_span<'a>(line: &'a ratatui::text::Line<'static>, content: &str) -> &'a Span<'static> {
+        line.spans
+            .iter()
+            .find(|span| span.content.as_ref() == content)
+            .unwrap_or_else(|| panic!("span {content:?} not found in line"))
+    }
 
     fn symbol(id: &str, name: &str) -> ExtractedSymbol {
         ExtractedSymbol {
@@ -257,20 +523,18 @@ mod tests {
     }
 
     #[test]
-    fn should_draw_help_overlay_with_keymap_and_glossary_when_help_is_open() {
+    fn should_draw_help_overlay_with_keymap_markers_and_glossary_when_help_is_open() {
         let report = report_with_one_symbol();
         let app = App::new(&report).handle_key(crate::app::InputKey::ToggleHelp);
-        // A 100x50 terminal (up from 100x40 before ADR 0026) so the
-        // overlay's 80% x 90% area (about 80x45 inner) fits every keymap
-        // group *and* the trailing Glossary section without the last
-        // section being pushed off the bottom. ADR 0026 added the
-        // "Source view" group and three extra "Right focus" entries
-        // (gg/G, Ctrl-d/u), which grew the pre-glossary content past
-        // the old 36-row overlay ceiling. Grown here rather than
-        // narrowing the keymap itself since discoverability of the new
-        // bindings is the whole point of adding them to the overlay in
-        // the first place.
-        let mut terminal = Terminal::new(TestBackend::new(100, 50)).expect("terminal");
+        // A 150x70 terminal (up from 100x50): wider so the Markers
+        // section's longest explanation line doesn't wrap onto a second
+        // row, taller so the overlay's 80% x 90% area fits every keymap
+        // group, the Markers legend, *and* the trailing Glossary section
+        // without the last section being pushed off the bottom. Grown here
+        // rather than narrowing the content itself, same rationale as the
+        // 100x40 -> 100x50 growth this test already went through for ADR
+        // 0026's keymap additions.
+        let mut terminal = Terminal::new(TestBackend::new(150, 70)).expect("terminal");
 
         terminal
             .draw(|frame| {
@@ -292,6 +556,8 @@ mod tests {
         assert!(text.contains("Right focus"));
         assert!(text.contains("Source view"));
         assert!(text.contains("Global"));
+        assert!(text.contains("Markers"));
+        assert!(text.contains("fan-in:N"));
         assert!(text.contains("Glossary"));
         assert!(text.contains("blast radius"));
     }


### PR DESCRIPTION
## Summary

The `?` help overlay used to explain keys and a handful of concepts but had
no in-TUI reference for the tree pane's own markers/badges — reviewers had
to leave the TUI to figure out what `~`, `x`, `!`, `chg:`, `api:`, `fan-in:`,
`warn:`, `split:`, `lines:`, `(cycle)`, `(dimmed name)`, `[test]`, `N tests`,
`(skipped: ...)` mean. This PR adds a Markers section to the overlay that
renders each swatch with its **real** ratatui style (reused from `row_view`,
not duplicated) so the legend can never drift from what the tree pane
actually draws.

## Design

- New `MarkerLegendEntry` in `crate::help` carries just the swatch text and
  the explanation; `crate::ui::overlay::marker_swatch_spans` looks the style
  up from `crate::row_view`'s own style producers.
- Existing style helpers (`cyan_badge_style`, `warning_badge_style`,
  `split_badge_style`, `band_style`, `symbol_marker_span`,
  `symbol_name_style`, `risk_marker_style`) were promoted to `pub(crate)`
  so the overlay reuses them — no badge-descriptor registry, no parallel
  style table.
- Ordering follows the added → changed → removed → aggregate reading order
  the mermaid legend already uses (ADR 0039 / 0040), plus row-anatomy
  entries (`v / >` expand marker and the symbol-kind prefix) grouped up top.
- Glossary was slimmed to genuinely conceptual entries (order modes, blast
  radius, cycle, jumplist); marker-level entries (`chg: / api: / fan-in:`,
  `!`, `N tests`) that the Markers section now documents were removed to
  avoid drifted duplicated wording.

## Review findings addressed

- **Blocker**: `(cycle)` swatch previously fell through to plain text — fixed
  with an explicit arm styling it bold yellow to match `entry_row_line`'s
  own render, plus a pinning test.
- Added the previously-missing swatch-style tests for `warn:`, `split:`, `~`.
- Removed the three Glossary entries the Markers section now covers.
- Added a kind-abbrev entry (`fn struct enum trait class iface type`) and a
  `(skipped: ...)` entry so the legend covers every marker a tree row can
  emit.

## Test plan

- [x] `make test` — 641 passed, 0 failed
- [x] `make lint` — clean (fmt + clippy -D warnings)
- [x] Dynamic verification: `rinkaku --tui --base HEAD~3` in tmux, `?` to
      open the overlay, scroll to Markers section — confirmed via ANSI
      escape capture that `(cycle)` renders bold yellow, `warn:N` yellow
      number, `split:N` red number, `~` yellow, `+` green, `x` red;
      confirmed Glossary no longer shows the duplicated entries.

https://claude.ai/code/session_01HuToEMUD2tRARq9BDU2Jdv