### PR TITLE
docs(experiments): record experiment 0001 round 32 (PR #150)

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/032.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/032.md
@@ -1,0 +1,113 @@
+# Round 32
+
+- Subject: PR #150 — pin a multi-line, non-scrolling identification
+  header above the Diff pane so a long path or symbol name is never
+  truncated away by the single-line title. Header lines: 1 = `<symbol>
+  · <path>` (bold, head-truncated to keep the informative tail), 2 =
+  the tree row's own badge set rendered through the shared
+  `push_badge_spans` (`rinkaku-tui/src/row_view.rs`, promoted to
+  `pub(crate)` this PR so both the tree renderer and the header renderer
+  share one span builder), 3 = `range: 23-73, ...` (dim, sorted +
+  deduped new-side line spans, head-truncated with the `range: ` prefix
+  pinned). Rendered outside the scroll body via `Layout::vertical` in
+  `render_scrollable_pane`, which is why ADR 0027 forward sync / ADR
+  0030 reverse sync stayed intact automatically — the header sits
+  *above* the coordinates those syncs compute against, so they never
+  see it. Reverts PR #144's `Diff: <name>` title change (the name now
+  lives in the header, and the title returns to the plain `" Diff "`
+  every other pane uses). Test-module split shipped in a separate
+  commit within the same PR because the header pushed `diff_pane.rs`
+  (1120 lines) and `scroll.rs` (1032 lines) past rinkaku's own
+  file-size warn threshold — extracted using ADR 0028's `#[cfg(test)]
+  #[path = "..."] mod tests;` pattern (canonical precedents: PR #93,
+  PR #95, PR #82), landing `diff_pane.rs` at 343 lines and `scroll.rs`
+  at 502.
+- Protocol note: two rounds inside the same PR. Round 1 shipped
+  `chg: <ranges> (+A/-R)` as line 3. Both a user screenshot and the
+  static reviewer (independently, with a synthetic diff whose hunks
+  cloned across owning symbols) flagged that the ranges duplicated and
+  the +/- counts inflated N-fold for file rows — the ADR 0029 hunk-
+  clone amplification that the map itself has no way to display, since
+  the defect lives entirely in numeric output and not in the signature
+  surface. Round 2 redesigned line 2 (`push_badge_spans` reuse instead
+  of a bespoke stats formatter) and line 3 (sort + dedup ranges,
+  `(+A/-R)` dropped), and both static and dynamic passes approved with
+  only nits.
+- **Map delivery**: variant (b) again — the static reviewer built
+  rinkaku from a trusted clean `main` checkout itself and ran that
+  binary's `rinkaku --base main` inside the branch worktree before
+  reading any code. Same shape as rounds 27-30.
+- **User-observed defect front-ran static review**: the ADR 0029
+  hunk-clone amplification in the round-1 `(+A/-R)` output was
+  reported by the user from a screenshot before the static reviewer's
+  synthetic-diff reproduction landed. Both observations converged on
+  the same underlying defect (line 3's numeric stats double-counted
+  cloned hunks) from different starting points — the user from a real
+  branch's actual diff, the reviewer from a constructed test case
+  designed to trigger the clone path. A useful reminder that
+  dogfooding-by-user is a real review signal even alongside two formal
+  review passes, and specifically catches defects that live in the
+  numeric output of a rendering rather than in the code paths a static
+  reviewer traces or the interactions a dynamic reviewer sweeps.
+- **Round-2 static findings (all nits, all folded into the redesign
+  commit)**: `selected_diff_title_name` → `selected_diff_header_name`
+  rename to match the new header framing (post-PR #144 residue); the
+  file-row branch inside `App::selected_diff_header_name` turned out
+  to be dead once both row kinds flowed through the same accessor
+  (removed); a stale `Diff: bar` reference inside a comment
+  contradicted the redesign (updated).
+- **Round-2 dynamic findings (all nits, all accepted as-is with a
+  known-non-goals note in the PR body)**: line 2's spans truncate their
+  trailing edge (per-span cap in `push_badge_spans`) while lines 1
+  and 3 truncate their leading edge; the tree row itself omits symbol
+  badges while the header now exposes them for symbol rows; the `!`
+  risk marker on the tree row is not repeated in header line 1. All
+  three were called out and judged intentional / documented /
+  derivable, not shipped changes.
+- **Post-review nits (this ship-through pass, folded into a single
+  fix commit)**: `entry.rs` doc comment still said "2-line header"
+  after the redesign made it up to 3 lines (updated). Line 3 also had
+  a defensive gap at pathological widths: `truncate_to_width_keeping
+  _tail` returned empty when `width < "range: ".chars().count()`, but
+  the header still pushed `Span::raw("range: ")` — ratatui clips
+  silently, so the overflow read as `range: ` being the whole
+  message. Fixed by dropping the whole line when width cannot fit
+  the prefix, plus a unit test.
+- Severity summary across both rounds: 1 blocker (round 1's ADR 0029
+  inflation, fixed by the round-2 redesign), 0 should-fix, 5 nits (3
+  static in round 2, 2 doc/edge-case in the ship-through pass; all
+  folded into the same PR). `make test`: 176 + 399 + 658 passed. `make
+  lint`: clean.
+- Cost (not harness-timed; rough token totals): implementation ~283k
+  (round 1) + ~403k (round 2 redesign); reviewers ~130k (round 1
+  static) + ~149k (round 2 static) + ~131k (round 2 dynamic).
+- Takeaway 1 — user dogfooding front-runs static review on numeric-
+  output defects. The map has nothing to say about a stat that reads
+  `+45/-30` when the ground truth is `+9/-6`; the code path *is* the
+  code path, and it takes real input plus a screenshot (or a targeted
+  synthetic test) to expose the inflation. When both a user and a
+  formal reviewer independently land on the same numeric-output
+  defect from opposite ends, that convergence is not redundancy — it
+  is evidence that the class was structurally invisible to the
+  reading passes and needed empirical exposure.
+- Takeaway 2 — reusing an existing rendering path as the source of
+  truth for a new surface is a stronger drift guard than any test
+  could be. Line 2 lifts `push_badge_spans` verbatim, so the tree row
+  and the header render the same spans by construction; there is no
+  parallel formatting logic to keep in sync, and every future badge
+  change reaches both surfaces for free. A `should_render_line_2
+  _span_for_span_from_the_same_badges_the_tree_row_would_render` test
+  pins the invariant, but the invariant only exists because the
+  builder is shared — the test cannot make two independent
+  implementations agree, it can only detect when they stop agreeing.
+- Takeaway 3 — when a rendering has a natural coordinate system (the
+  scrollable body), pin extras (headers, banners) *outside* it. This
+  PR's header required zero code changes to `walk_sections`, ADR
+  0027's forward sync, or ADR 0030's reverse sync — those all
+  operate on the body coordinates the header sits above and does not
+  participate in. A tempting alternative was to prepend the header
+  lines to the body's own `Vec<Line>` and let the existing scroll
+  handle it, but then the sync math would have needed a "reserved
+  rows" offset threaded through every consumer, and any future
+  reviewer would have had to remember it. The vertical-split
+  approach isolates the change by construction.


### PR DESCRIPTION
## Summary

Records round 32 of experiment 0001 — the multi-line Diff pane header
PR (#150). Two rounds inside a single PR: round 1 shipped a `chg:
<ranges> (+A/-R)` line 3 that a user screenshot flagged as inflated
(ADR 0029 hunk-clone amplification), corroborated independently by
the static reviewer with a synthetic test. Round 2 redesigned line 2
around `push_badge_spans` reuse (single source of truth with the tree
row) and line 3 around sort + dedup ranges; both static and dynamic
passes approved with nits only.

## Test plan

- [x] `make lint` — n/a for docs, but round file conforms to existing
      round-file style.
- [x] Confirmed round number 032 by checking `docs/experiments/
      0001-map-assisted-llm-review/rounds/` (last on origin/main was
      030) and `gh pr list --search "experiment 0001 round"` (031 is
      in-flight as PR #149).

https://claude.ai/code/session_01HuToEMUD2tRARq9BDU2Jdv