### PR TITLE
feat(tui): add split (side-by-side) view for the diff pane

### DIFF
--- a/docs/adr/0044-tui-split-view-diff-pane.md
+++ b/docs/adr/0044-tui-split-view-diff-pane.md
@@ -101,21 +101,30 @@ sync when the view mode is toggled mid-session.
 **5. Rendering.** `crate::ui::diff_pane::draw_diff_pane` branches on
 `app.diff_view_mode()`: unified keeps calling `diff_pane_lines` exactly
 as today; split calls a new `diff_pane_split_rows`, which produces the
-same section/header/hunk-header scaffolding as `diff_pane_lines` (one
-`SplitRow`-equivalent per scaffold line, `left`/`right` holding the same
-text on both sides for a title/contract-header/hunk-header line, so
-scaffold lines don't need their own special case) and renders it inside
-a horizontal 50/50 `Layout::horizontal` split of the pane's body area
-(inside `render_scrollable_pane`'s existing body — see Decision 6 on
-why `render_scrollable_pane` itself needs one small extension, not a
-parallel implementation). Old-side lines keep the `-`/red styling,
-new-side lines keep `+`/green, a filler cell renders as a blank styled
-line — no new color semantics, reusing `diff_line`/`marker_span`/
+same section/header/hunk-header scaffolding as `diff_pane_lines` and
+renders it inside a horizontal 50/50 `Layout::horizontal` split of the
+pane's body area (inside `render_scrollable_pane`'s existing body — see
+Decision 6 on why `render_scrollable_pane` itself needs one small
+extension, not a parallel implementation). A title/hunk-header scaffold
+line renders identically on both sides (`left`/`right` share it,
+needing no special case), but the contract header's 2-line old/new
+signature pair is the one scaffold element split view treats
+differently from unified: both signatures render on the *same* row
+(`left` = old, `right` = new) rather than unified's two separate
+`-`/`+` lines, with a blank filler row below to keep the section's
+2-line contract-header budget intact for the shared line-counting
+Decision 4 relies on — putting the two signatures on separate rows
+(mirroring unified's own line order) would reintroduce the exact
+"scan past an interleaved line to compare" problem this whole ADR
+exists to fix, this time inside the one scaffold element a reviewer
+most wants aligned. Old-side lines keep the `-`/red styling, new-side
+lines keep `+`/green, a filler cell renders as a blank styled line —
+no new color semantics, reusing `diff_line`/`marker_span`/
 `plain_diff_line`'s existing per-`DiffLineKind` styling and ADR 0018's
 highlighting lookup (by `source_index`, unchanged) on whichever side has
 real content.
 
-**6. `render_scrollable_pane` gains a `Column` enum parameter
+**6. `render_scrollable_pane` gains a `Body` enum parameter
 (`Single` | `Split`) rather than a second function.** `Single` is
 today's exact behavior (one `Paragraph`, unchanged). `Split` lays the
 already-wrapped body out as two side-by-side `Paragraph`s sharing one
@@ -150,7 +159,7 @@ direct payoff of decisions 3–4: `App::right_pane_scroll`,
 `symbol_id_for_scroll_line`, and `highlight::lookup_hunk_highlight_by_index`
 are all called exactly as they are today regardless of
 `diff_view_mode`; only `diff_pane_lines` vs. `diff_pane_split_rows` (and
-`render_scrollable_pane`'s new `Column` parameter) differ between the
+`render_scrollable_pane`'s new `Body` parameter) differ between the
 two modes.
 
 ## Alternatives
@@ -212,10 +221,10 @@ two modes.
 - `crate::ui::diff_pane` gains a second line-building function
   (`diff_pane_split_rows`) alongside `diff_pane_lines`, and
   `crate::ui::scroll::render_scrollable_pane` gains one new parameter
-  (`Column`) — every existing call site (Detail pane, Blast-radius pane,
-  help overlay, jump popup) passes `Column::Single`, matching today's
+  (`Body`) — every existing call site (Detail pane, Blast-radius pane,
+  help overlay, jump popup) passes `Body::Single`, matching today's
   behavior exactly; only the Diff pane's split-mode call site uses
-  `Column::Split`.
+  `Body::Split`.
 - Split mode's rendered row count for a replaced run can include blank
   filler rows the unified view never showed (decision 4) — a visible,
   deliberate trade for keeping every prior ADR's scroll-sync code

--- a/docs/adr/0044-tui-split-view-diff-pane.md
+++ b/docs/adr/0044-tui-split-view-diff-pane.md
@@ -1,0 +1,228 @@
+# 0044. Split (side-by-side) view for the diff pane
+
+- Status: accepted
+- Date: 2026-07-14
+
+## Context
+
+The diff pane (ADR 0020) has only ever rendered unified hunks: `-`/`+`
+lines interleaved in file order, one column. Dogfooding on larger
+signature-shape changes (a parameter reordered, a struct field renamed
+across several adjacent lines) found unified rendering hard to read for
+exactly that shape of edit — the old and new versions of a changed
+block are not visually aligned, so spotting *which* token changed
+requires the reader to hold both versions in their head while scanning
+down a single interleaved column. A side-by-side (old-left, new-right)
+view is the standard mitigation every major diff UI (GitHub, GitLab,
+most editors) offers as an alternative, not a replacement, to unified —
+some edits (a single added/removed line, a whole-file rewrite) read
+better unified, others read better split, and the reviewer is in the
+best position to judge per hunk.
+
+Two invariants from prior ADRs constrain the design:
+
+- **ADR 0027/ADR 0030's scroll-sync is line-index-based.**
+  `crate::diff_shape::hunk_start_lines`/`section_start_line_for_symbol`/
+  `symbol_id_for_scroll_line` all operate on one shared "logical line"
+  coordinate space that `crate::ui::diff_pane::diff_pane_lines` renders
+  1:1 and `crate::ui::scroll::render_scrollable_pane` scrolls through.
+  Any split-view design that introduces a *second*, differently-sized
+  coordinate space (e.g. one row per aligned pair, but a pair can absorb
+  a variable number of unified lines when a run is re-flowed) would need
+  either a second copy of all three lookup functions or a translation
+  layer between the two spaces — real complexity this ADR wants to
+  avoid if a simpler shape is available.
+- **`crate::diff_shape` must stay free of `ratatui` types** (its own
+  module doc comment, ADR 0020 decision 5) — pairing logic belongs
+  there as plain data, rendering stays in `crate::ui::diff_pane`.
+
+## Decision
+
+**1. Toggle key: `v` / `V`**, both mapped to a single
+`InputKey::ToggleSplitView`, global regardless of focus (mirroring
+`d`/`D`'s ToggleDiff and `r`/`R`'s ToggleBlastRadius — a per-`App` mode,
+not a per-row one). Chosen because neither `v` nor `V` was already bound
+(confirmed by reading every `KeyCode::Char` arm in
+`rinkaku-tui/src/lib.rs`'s `translate_key`) and it is the closest
+single-letter mnemonic to the feature's own name ("split view") without
+colliding with `s`/`S` (already `InputKey::Source`).
+
+**2. `App` gains a `diff_view_mode: DiffViewMode` field** (`Unified` |
+`Split`, `Default` = `Unified` — unified is what every prior ADR's
+screenshots/dogfooding already assumes, so it stays the opening state).
+`InputKey::ToggleSplitView` flips it; like `RightPane`, it is a mode
+independent of the current row selection, so moving the cursor after
+toggling keeps showing split (or unified) for the newly selected
+row/file.
+
+**3. Pairing is a new pure function in `crate::diff_shape`,
+`pair_hunk_lines`, producing one `SplitRow` per *unified logical line*
+— not one row per aligned old/new pair.** This is the direct consequence
+of the first constraint in Context: reusing `hunk_start_lines`/
+`section_start_line_for_symbol`/`symbol_id_for_scroll_line` unchanged
+requires the split view's row count and row order to be identical to
+the unified view's. Concretely:
+
+- A `Context` line produces one `SplitRow { left: Some(line), right:
+  Some(line) }` — the same text on both sides.
+- A maximal run of consecutive `Removed` lines immediately followed by a
+  maximal run of consecutive `Added` lines (the standard unified-diff
+  "replace" shape) is paired positionally: row `i` of the run gets
+  `left: removed_run.get(i)`, `right: added_run.get(i)` — `None` on
+  whichever side ran out first when the two runs have different
+  lengths (a pure insertion or deletion within the run). This produces
+  exactly `max(removed_run.len(), added_run.len())` rows for the run,
+  which can be *fewer* rows than the unified view's `removed_run.len()
+  + added_run.len()` — see Decision 4 for how the shared line-index
+  space absorbs that.
+- A `Removed` run with no following `Added` run (pure deletion) or an
+  `Added` run with no preceding `Removed` run (pure insertion) pairs
+  every line against `None` on the other side, one row per line — no
+  length mismatch to resolve.
+
+**4. The shared line-index space is preserved by making `SplitRow`
+itself the thing both views render per logical line — including a
+`None`/`None` filler row for a unified line `walk_sections`
+already counted but a merged split pair consumed.** Concretely,
+`pair_hunk_lines` returns exactly `hunk.lines.len()` `SplitRow`s, one
+per original `DiffLine`, not `max(removed, added)`: when a paired-off
+`Removed`/`Added` pair merges onto one *rendered* split row, the
+*second* line's `SplitRow` in source order carries `left: None, right:
+None` (a blank filler row) rather than being dropped, so the total row
+count — and therefore every offset `walk_sections` already computes —
+stays identical to the unified count. This is a deliberate trade
+(Alternatives below): it costs a few blank filler rows inside a
+replaced run in split mode, in exchange for zero changes to
+`hunk_start_lines`, `section_start_line_for_symbol`,
+`symbol_id_for_scroll_line`, or `walk_sections` itself, and zero risk of
+desyncing ADR 0027's tree→diff auto-scroll or ADR 0030's diff→tree
+sync when the view mode is toggled mid-session.
+
+**5. Rendering.** `crate::ui::diff_pane::draw_diff_pane` branches on
+`app.diff_view_mode()`: unified keeps calling `diff_pane_lines` exactly
+as today; split calls a new `diff_pane_split_rows`, which produces the
+same section/header/hunk-header scaffolding as `diff_pane_lines` (one
+`SplitRow`-equivalent per scaffold line, `left`/`right` holding the same
+text on both sides for a title/contract-header/hunk-header line, so
+scaffold lines don't need their own special case) and renders it inside
+a horizontal 50/50 `Layout::horizontal` split of the pane's body area
+(inside `render_scrollable_pane`'s existing body — see Decision 6 on
+why `render_scrollable_pane` itself needs one small extension, not a
+parallel implementation). Old-side lines keep the `-`/red styling,
+new-side lines keep `+`/green, a filler cell renders as a blank styled
+line — no new color semantics, reusing `diff_line`/`marker_span`/
+`plain_diff_line`'s existing per-`DiffLineKind` styling and ADR 0018's
+highlighting lookup (by `source_index`, unchanged) on whichever side has
+real content.
+
+**6. `render_scrollable_pane` gains a `Column` enum parameter
+(`Single` | `Split`) rather than a second function.** `Single` is
+today's exact behavior (one `Paragraph`, unchanged). `Split` lays the
+already-wrapped body out as two side-by-side `Paragraph`s sharing one
+`(scroll as u16, 0)` offset — wrapping happens independently per side
+(each side's own text can wrap to a different number of visual rows at
+a narrow width), so `Split` wraps the *logical* rows first with each
+side's own half-width, then re-pads the shorter side's wrapped output
+so both columns still agree on a total visual-row count before
+scrolling — mirroring how the existing `wrap_lines` call already has to
+run before `clamp_scroll`/`scroll_indicator` for the unified case (this
+module's own doc comment). This keeps the clamp/indicator math — and
+the `header_lines` split above the scrollable body — shared code, not
+duplicated.
+
+**7. Narrow-terminal fallback: below `MIN_SPLIT_VIEW_WIDTH` (100
+columns for the diff pane's own area, chosen so each side gets roughly
+an 80-column-equivalent budget after the border and a 1-column gutter),
+`draw_diff_pane` renders unified regardless of `diff_view_mode`, with a
+one-line dim note appended to the pane header
+(`"(split view needs a wider pane)"`)** — rather than rendering an
+unreadably narrow split. The toggle key itself still flips
+`diff_view_mode` (so widening the terminal or the pane immediately
+shows split without needing to press `v` again), matching how other
+panes in this crate degrade gracefully rather than refusing input
+outright.
+
+**8. Scroll-sync (ADR 0027/0030), hunk-jump (`]`/`[`), and highlighting
+(ADR 0018) all continue to operate on the shared logical-line coordinate
+space unchanged — no new code path for any of them.** This is the
+direct payoff of decisions 3–4: `App::right_pane_scroll`,
+`hunk_start_lines`, `section_start_line_for_symbol`,
+`symbol_id_for_scroll_line`, and `highlight::lookup_hunk_highlight_by_index`
+are all called exactly as they are today regardless of
+`diff_view_mode`; only `diff_pane_lines` vs. `diff_pane_split_rows` (and
+`render_scrollable_pane`'s new `Column` parameter) differ between the
+two modes.
+
+## Alternatives
+
+- **One row per aligned pair (`max(removed, added)` rows per run,
+  fewer total rows than unified) instead of decision 4's filler-row
+  padding.** Rejected: this is the "second coordinate space" problem
+  Context calls out — `hunk_start_lines`/`section_start_line_for_symbol`/
+  `symbol_id_for_scroll_line` would need a second implementation (or a
+  translation table) for split mode, and toggling `v` mid-scroll would
+  need to convert the current `right_pane_scroll` between the two
+  spaces to avoid the reviewer's position jumping. A few blank filler
+  rows inside a replaced run is a small, visible, well-understood cost;
+  a second scroll-coordinate space is an ongoing maintenance and
+  correctness burden across three ADRs' worth of existing sync logic.
+- **A real Myers-diff-style token/line alignment (LCS-based), instead
+  of decision 3's positional pairing within same-kind runs.** Rejected
+  as over-engineering for this pane: unified diff hunks already come
+  from git's own line-level diff, so within one hunk there is no
+  "which old line corresponds to which new line" ambiguity left to
+  resolve beyond grouping consecutive removed/added runs — a second diff
+  algorithm on top of git's own output would re-litigate a decision git
+  already made, for a pane whose job is presenting git's hunks, not
+  re-diffing them.
+- **Compute two independent row counts (unified vs. split) and give
+  `App` a per-mode scroll offset.** Rejected: doubles the state
+  `App::right_pane_scroll`'s own doc comment already carefully
+  documents (unclamped request, clamped at draw time, folded back after
+  every frame — ADR 0020's per-frame-recompute lesson), and a reviewer
+  toggling `v` mid-read would need a defined rule for what the *other*
+  mode's offset should be when they toggle back, a design surface this
+  ADR's single shared coordinate space avoids needing at all.
+- **Render split as two entirely separate bordered panes (old pane,
+  new pane) instead of one pane with an internal 50/50 split.**
+  Rejected: doubles the border/title/header chrome for content that is
+  one logical diff, and `render_scrollable_pane`'s single-scroll-offset
+  contract (decision 6) would need to be duplicated across two
+  `Frame::render_widget` calls with hand-synchronized scroll state —
+  more surface for the same result the internal split achieves with one
+  `Layout::horizontal` call.
+- **No narrow-terminal fallback; let split render at any width, however
+  cramped.** Rejected: a diff pane narrower than ~50 columns per side
+  wraps every real code line multiple times, defeating the whole
+  point of side-by-side alignment (rows no longer visually line up once
+  either side wraps to a different visual-row count than the other) —
+  decision 7's threshold keeps the feature only available when it can
+  actually deliver the readability win it exists for.
+
+## Consequences
+
+- A reviewer can toggle between unified and split rendering per
+  session with `v`/`V`, independent of which row is selected — the same
+  ergonomics `d`/`D` (Detail/Diff) and `r`/`R` (BlastRadius) already
+  established for other per-`App` display modes.
+- `crate::diff_shape` gains one new pure function (`pair_hunk_lines`)
+  and one new type (`SplitRow`), unit-tested the same way
+  `hunk_start_lines`/`section_start_line_for_symbol` already are — no
+  new `ratatui` dependency in that module.
+- `crate::ui::diff_pane` gains a second line-building function
+  (`diff_pane_split_rows`) alongside `diff_pane_lines`, and
+  `crate::ui::scroll::render_scrollable_pane` gains one new parameter
+  (`Column`) — every existing call site (Detail pane, Blast-radius pane,
+  help overlay, jump popup) passes `Column::Single`, matching today's
+  behavior exactly; only the Diff pane's split-mode call site uses
+  `Column::Split`.
+- Split mode's rendered row count for a replaced run can include blank
+  filler rows the unified view never showed (decision 4) — a visible,
+  deliberate trade for keeping every prior ADR's scroll-sync code
+  unchanged, not a bug.
+- Terminals narrower than `MIN_SPLIT_VIEW_WIDTH` never actually render
+  split, regardless of the toggle state — this is a graceful
+  degradation, not a silent failure (the pane header notes why).
+- No backward-compatibility concern: the TUI has never shipped a
+  release (ADR 0015/0016, restated by every TUI-scoped ADR since), so
+  this is a pure addition, not a migration.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -55,6 +55,11 @@ only becomes load-bearing when the output would otherwise not be TUI
 - **Diff pane (right, default)** — the raw unified-diff hunks touching
   the selected row, syntax-highlighted for the four built-in languages
   ([ADR 0018](adr/0018-syntax-highlight-diff-pane-via-tree-sitter.md)).
+  Press `v`/`V` to switch to a split (side-by-side old/new) view for the
+  same hunks — useful for edits where seeing the old and new lines
+  aligned next to each other is easier to scan than interleaved `-`/`+`
+  lines. Split view needs a reasonably wide pane; on a narrow terminal
+  it falls back to unified and the pane header notes why.
 - **Detail pane (right)** — what the cursor is on: classification,
   signature (with an old/new diff on contract change), used-by, callees;
   or, for a directory, its badge breakdown and cycle members.
@@ -95,6 +100,7 @@ Press `?` in the TUI for the always-up-to-date table.
 | `o` / `O` | Toggle topological / alphabetical ordering |
 | `d` / `D` | Toggle right pane between diff and detail |
 | `r` / `R` | Toggle right pane to blast radius |
+| `v` / `V` | Toggle the Diff pane between unified and split (side-by-side) rendering |
 | `s` / `S` | Open the source view for the symbol under the cursor |
 | `gd` / `gr` | Jump to a callee / caller ([ADR 0022](adr/0022-jump-navigation-and-jumplist.md)) |
 | `ctrl-o` / `ctrl-i` | Jump back / forward through the jumplist |

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -4,7 +4,7 @@
 //! against `Screen`/`Focus` state. Struct/enum definitions and state
 //! accessors stay in `app/mod.rs`; only the dispatch logic lives here.
 
-use super::{App, Focus, InputKey, JumplistEntry, PendingPrefix, RightPane, Screen};
+use super::{App, DiffViewMode, Focus, InputKey, JumplistEntry, PendingPrefix, RightPane, Screen};
 use crate::nav::Action;
 use crate::order::OrderMode;
 use crate::tree::NodeKind;
@@ -406,6 +406,12 @@ impl App {
                     // the previous pane" rule that would only apply to
                     // some keys and not others.
                     RightPane::Detail | RightPane::BlastRadius => RightPane::Diff,
+                };
+            }
+            (Screen::Entry, _, InputKey::ToggleSplitView) => {
+                self.diff_view_mode = match self.diff_view_mode {
+                    DiffViewMode::Unified => DiffViewMode::Split,
+                    DiffViewMode::Split => DiffViewMode::Unified,
                 };
             }
             (Screen::Entry, _, InputKey::ToggleBlastRadius) => {

--- a/rinkaku-tui/src/app/input_key.rs
+++ b/rinkaku-tui/src/app/input_key.rs
@@ -193,4 +193,11 @@ pub enum InputKey {
     /// Reuses [`Self::Back`]'s physical key for the same reason
     /// `PopupConfirm` reuses `Open`'s.
     PopupCancel,
+    /// `v`/`V` (ADR 0044): toggles the Diff pane between unified and split
+    /// (side-by-side) rendering. A per-`App` mode, not a per-row one —
+    /// mirrors [`Self::ToggleDiff`]/[`Self::ToggleBlastRadius`]'s own
+    /// "global regardless of `Focus`" precedent, since this is a display
+    /// mode for whichever content the Diff pane already shows, not an
+    /// action on the row under the cursor.
+    ToggleSplitView,
 }

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -112,6 +112,23 @@ pub enum RightPane {
     BlastRadius,
 }
 
+/// Whether the Diff pane renders unified (interleaved `-`/`+` lines) or
+/// split (side-by-side old/new columns) content (ADR 0044). A per-`App`
+/// mode, independent of the current row selection — toggling `v`/`V`
+/// ([`InputKey::ToggleSplitView`]) keeps showing split (or unified) as the
+/// cursor moves to a different row, the same way [`RightPane`] already
+/// persists across cursor moves.
+///
+/// Defaults to `Unified`: every prior ADR describing the Diff pane assumes
+/// unified rendering, so it stays the opening state rather than surprising
+/// a reviewer who has not yet discovered the toggle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DiffViewMode {
+    #[default]
+    Unified,
+    Split,
+}
+
 /// The right-hand pane's content for the row currently under the cursor
 /// (TUI iteration 2), unifying what used to be [`App::selected_detail`]'s
 /// symbol-only contract: a directory or file row now has its own detail
@@ -256,6 +273,9 @@ pub struct App {
     /// "go to Diff" gesture (see that branch's own comment) and does not
     /// read this field at all.
     blast_radius_return_pane: RightPane,
+    /// Whether the Diff pane renders unified or split content (ADR 0044) —
+    /// see [`DiffViewMode`]'s own doc comment.
+    diff_view_mode: DiffViewMode,
     /// The user's requested scroll offset (in lines) into the right-hand
     /// pane's content, as an unclamped "how far down would the user like to
     /// be" value rather than an authoritative display position: `App` has
@@ -343,6 +363,7 @@ impl App {
             screen: Screen::Entry,
             right_pane: RightPane::default(),
             blast_radius_return_pane: RightPane::default(),
+            diff_view_mode: DiffViewMode::default(),
             right_pane_scroll: 0,
             focus: Focus::default(),
             help_open: false,
@@ -419,6 +440,11 @@ impl App {
 
     pub fn right_pane(&self) -> RightPane {
         self.right_pane
+    }
+
+    /// Whether the Diff pane renders unified or split content (ADR 0044).
+    pub fn diff_view_mode(&self) -> DiffViewMode {
+        self.diff_view_mode
     }
 
     /// Which pane currently receives motion keys (ADR 0020) — see [`Focus`]'s

--- a/rinkaku-tui/src/app/tests/right_pane.rs
+++ b/rinkaku-tui/src/app/tests/right_pane.rs
@@ -1,5 +1,7 @@
 use super::{empty_report, report_with_one_symbol, report_with_two_directories_and_graph, symbol};
-use crate::app::{App, BlastRadiusSelection, DiffFocus, DiffTarget, InputKey, RightPane, Screen};
+use crate::app::{
+    App, BlastRadiusSelection, DiffFocus, DiffTarget, DiffViewMode, InputKey, RightPane, Screen,
+};
 use pretty_assertions::assert_eq;
 use rinkaku_core::diff::LineRange;
 use rinkaku_core::extract::ExtractedSymbol;
@@ -104,6 +106,60 @@ fn should_return_to_detail_when_blast_radius_is_toggled_off_after_entering_from_
     let app = app.handle_key(InputKey::ToggleBlastRadius);
 
     assert_eq!(RightPane::Detail, app.right_pane());
+}
+
+#[test]
+fn should_default_diff_view_mode_to_unified() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
+}
+
+#[test]
+fn should_toggle_diff_view_mode_between_unified_and_split() {
+    let report = empty_report();
+    let app = App::new(&report);
+    assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
+
+    let app = app.handle_key(InputKey::ToggleSplitView);
+    assert_eq!(DiffViewMode::Split, app.diff_view_mode());
+
+    let app = app.handle_key(InputKey::ToggleSplitView);
+    assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
+}
+
+#[test]
+fn should_preserve_diff_view_mode_when_cursor_moves_to_a_different_row() {
+    // A per-`App` mode, not a per-row one (ADR 0044 decision 2) — mirrors
+    // `RightPane`'s own persistence across cursor moves.
+    let report = report_with_two_directories_and_graph();
+    let app = App::new(&report).handle_key(InputKey::ToggleSplitView);
+    assert_eq!(DiffViewMode::Split, app.diff_view_mode());
+
+    let app = app.handle_key(InputKey::Down);
+
+    assert_eq!(DiffViewMode::Split, app.diff_view_mode());
+}
+
+#[test]
+fn should_ignore_toggle_split_view_while_source_screen_is_open() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Source);
+    assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
+
+    let app = app.handle_key(InputKey::ToggleSplitView);
+
+    assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
+    assert_eq!(
+        Screen::Source {
+            symbol_id: "lib.rs::foo".to_string(),
+            scroll_top: 0,
+        },
+        *app.screen()
+    );
 }
 
 #[test]

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -26,7 +26,7 @@
 //! `ui::draw` must not call `App::selected_blast_radius_view` either.
 
 use crate::app::DiffTarget;
-use crate::diff_view::{FileHunks, Hunk, file_hunks};
+use crate::diff_view::{DiffLine, DiffLineKind, FileHunks, Hunk, file_hunks};
 use rinkaku_core::extract::Classification;
 use rinkaku_core::render::Report;
 
@@ -381,6 +381,118 @@ pub fn changed_line_ranges(sections: &[&DiffSection]) -> Vec<(usize, usize)> {
     ranges.sort_unstable();
     ranges.dedup();
     ranges
+}
+
+/// One rendered row of a split (side-by-side) diff view (ADR 0044): the
+/// old-side and new-side [`DiffLine`] shown on that row, either of which
+/// can be `None` — a filler cell with nothing on that side. `left_index`/
+/// `right_index` is that side's line's position in the hunk's original
+/// `lines` slice (`None` alongside a `None` line) — `crate::ui::diff_pane`
+/// needs this to look up [`crate::highlight::lookup_hunk_highlight_by_index`]'s
+/// per-line highlight table, which is indexed by that original interleaved
+/// position, not by `SplitRow` position (the two diverge as soon as any run
+/// merges two source lines onto one row).
+///
+/// [`pair_hunk_lines`] always returns one `SplitRow` per input
+/// [`DiffLine`], never fewer, so a hunk's split-mode row count matches its
+/// unified-mode row count exactly (ADR 0044 decision 4) — this is what lets
+/// [`walk_sections`]/[`hunk_start_lines`]/[`section_start_line_for_symbol`]/
+/// [`symbol_id_for_scroll_line`] stay unchanged regardless of
+/// [`crate::app::DiffViewMode`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SplitRow {
+    pub left: Option<DiffLine>,
+    pub left_index: Option<usize>,
+    pub right: Option<DiffLine>,
+    pub right_index: Option<usize>,
+}
+
+/// Pairs a hunk's interleaved `lines` into old-side/new-side [`SplitRow`]s
+/// for the split diff view (ADR 0044 decision 3). A `Context` line mirrors
+/// onto both sides. A maximal run of consecutive `Removed` lines
+/// immediately followed by a maximal run of consecutive `Added` lines pairs
+/// positionally (row `i` of the run gets the run's `i`-th removed/added
+/// line); when the two runs differ in length, the longer run's excess lines
+/// pair against `None` on the shorter side, one row per excess line. A
+/// `Removed` run with no following `Added` run (or vice versa) pairs every
+/// line against `None` on the other side.
+///
+/// Always returns exactly `lines.len()` rows (ADR 0044 decision 4): when a
+/// positional pairing merges two source lines onto one rendered row, a
+/// trailing `SplitRow { left: None, right: None }` filler row is appended
+/// for each merge, so the total row count never drops below the unified
+/// view's own line count — see [`SplitRow`]'s own doc comment for why this
+/// invariant matters.
+pub fn pair_hunk_lines(lines: &[DiffLine]) -> Vec<SplitRow> {
+    let mut rows = Vec::with_capacity(lines.len());
+    let mut i = 0;
+    while i < lines.len() {
+        match lines[i].kind {
+            DiffLineKind::Context => {
+                rows.push(SplitRow {
+                    left: Some(lines[i].clone()),
+                    left_index: Some(i),
+                    right: Some(lines[i].clone()),
+                    right_index: Some(i),
+                });
+                i += 1;
+            }
+            DiffLineKind::Removed => {
+                let removed_start = i;
+                let mut removed_end = i;
+                while removed_end < lines.len() && lines[removed_end].kind == DiffLineKind::Removed
+                {
+                    removed_end += 1;
+                }
+                let added_start = removed_end;
+                let mut added_end = removed_start.max(added_start);
+                while added_end < lines.len() && lines[added_end].kind == DiffLineKind::Added {
+                    added_end += 1;
+                }
+
+                let removed_run = &lines[removed_start..removed_end];
+                let added_run = &lines[added_start..added_end];
+                let paired = removed_run.len().max(added_run.len());
+                for offset in 0..paired {
+                    rows.push(SplitRow {
+                        left: removed_run.get(offset).cloned(),
+                        left_index: (offset < removed_run.len()).then_some(removed_start + offset),
+                        right: added_run.get(offset).cloned(),
+                        right_index: (offset < added_run.len()).then_some(added_start + offset),
+                    });
+                }
+                // Decision 4's filler rows: the run consumed
+                // `removed_run.len() + added_run.len()` source lines but
+                // only emitted `paired` rows so far — pad back up to the
+                // source count with blank filler rows.
+                let consumed = removed_run.len() + added_run.len();
+                for _ in paired..consumed {
+                    rows.push(SplitRow {
+                        left: None,
+                        left_index: None,
+                        right: None,
+                        right_index: None,
+                    });
+                }
+
+                i = added_end;
+            }
+            DiffLineKind::Added => {
+                // An `Added` run with no preceding `Removed` run (a pure
+                // insertion) — the `Removed` arm above already consumes any
+                // `Added` run that immediately follows a `Removed` run, so
+                // reaching this arm means there was none.
+                rows.push(SplitRow {
+                    left: None,
+                    left_index: None,
+                    right: Some(lines[i].clone()),
+                    right_index: Some(i),
+                });
+                i += 1;
+            }
+        }
+    }
+    rows
 }
 
 #[cfg(test)]

--- a/rinkaku-tui/src/diff_shape_tests/mod.rs
+++ b/rinkaku-tui/src/diff_shape_tests/mod.rs
@@ -24,6 +24,7 @@ use rinkaku_core::render::{FileReport, ReportOrigin};
 mod build_diff_pane_content;
 mod changed_line_ranges;
 mod hunk_start_lines;
+mod pair_hunk_lines;
 mod section_start_line;
 mod symbol_id_for_scroll_line;
 

--- a/rinkaku-tui/src/diff_shape_tests/pair_hunk_lines.rs
+++ b/rinkaku-tui/src/diff_shape_tests/pair_hunk_lines.rs
@@ -1,0 +1,213 @@
+use super::*;
+use crate::diff_view::{DiffLine, DiffLineKind};
+use pretty_assertions::assert_eq;
+
+fn line(kind: DiffLineKind, content: &str) -> DiffLine {
+    DiffLine {
+        kind,
+        content: content.to_string(),
+    }
+}
+
+fn context(content: &str) -> DiffLine {
+    line(DiffLineKind::Context, content)
+}
+
+fn added(content: &str) -> DiffLine {
+    line(DiffLineKind::Added, content)
+}
+
+fn removed(content: &str) -> DiffLine {
+    line(DiffLineKind::Removed, content)
+}
+
+fn row(left: Option<(DiffLine, usize)>, right: Option<(DiffLine, usize)>) -> SplitRow {
+    SplitRow {
+        left: left.as_ref().map(|(line, _)| line.clone()),
+        left_index: left.map(|(_, index)| index),
+        right: right.as_ref().map(|(line, _)| line.clone()),
+        right_index: right.map(|(_, index)| index),
+    }
+}
+
+#[test]
+fn should_return_empty_rows_when_hunk_has_no_lines() {
+    let actual = pair_hunk_lines(&[]);
+
+    assert_eq!(Vec::<SplitRow>::new(), actual);
+}
+
+#[test]
+fn should_mirror_context_line_onto_both_sides() {
+    let lines = vec![context("fn a() {}")];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![row(
+            Some((context("fn a() {}"), 0)),
+            Some((context("fn a() {}"), 0)),
+        )],
+        actual
+    );
+}
+
+#[test]
+fn should_pair_equal_length_removed_and_added_runs_positionally() {
+    // ADR 0044 decision 4's total-row invariant: 1 removed + 1 added is 2
+    // source lines, so the paired row is followed by one filler row even
+    // though every removed/added line found a match — row count must
+    // always equal `lines.len()`.
+    let lines = vec![removed("fn old() {}"), added("fn new() {}")];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![
+            row(
+                Some((removed("fn old() {}"), 0)),
+                Some((added("fn new() {}"), 1)),
+            ),
+            row(None, None),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_pad_right_side_with_filler_row_when_removed_run_is_longer_than_added_run() {
+    // Removed run (2 lines) longer than added run (1 line): the run
+    // pairs positionally up to the shorter side's length, then the
+    // excess removed line pairs against `None` on the right. Total rows
+    // stays at `hunk.lines.len()` (3) — one filler `None`/`None` row
+    // absorbs the count the merged pair "saved" (ADR 0044 decision 4).
+    let lines = vec![removed("line 1"), removed("line 2"), added("line 1'")];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![
+            row(Some((removed("line 1"), 0)), Some((added("line 1'"), 2)),),
+            row(Some((removed("line 2"), 1)), None),
+            row(None, None),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_pad_left_side_with_filler_row_when_added_run_is_longer_than_removed_run() {
+    let lines = vec![removed("line 1"), added("line 1'"), added("line 2'")];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![
+            row(Some((removed("line 1"), 0)), Some((added("line 1'"), 1)),),
+            row(None, Some((added("line 2'"), 2))),
+            row(None, None),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_pair_pure_deletion_run_against_none_on_the_right() {
+    let lines = vec![removed("line 1"), removed("line 2")];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![
+            row(Some((removed("line 1"), 0)), None),
+            row(Some((removed("line 2"), 1)), None),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_pair_pure_insertion_run_against_none_on_the_left() {
+    let lines = vec![added("line 1"), added("line 2")];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![
+            row(None, Some((added("line 1"), 0))),
+            row(None, Some((added("line 2"), 1))),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_pair_context_removed_added_context_sequence_in_source_order() {
+    // The removed/added run is a 1/1 pair, so it gets a filler row after it
+    // (ADR 0044 decision 4's total-row invariant — see
+    // `should_pair_equal_length_removed_and_added_runs_positionally`).
+    let lines = vec![
+        context("fn a() {}"),
+        removed("fn old() {}"),
+        added("fn new() {}"),
+        context("fn c() {}"),
+    ];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![
+            row(
+                Some((context("fn a() {}"), 0)),
+                Some((context("fn a() {}"), 0)),
+            ),
+            row(
+                Some((removed("fn old() {}"), 1)),
+                Some((added("fn new() {}"), 2)),
+            ),
+            row(None, None),
+            row(
+                Some((context("fn c() {}"), 3)),
+                Some((context("fn c() {}"), 3)),
+            ),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_treat_two_separate_replace_runs_independently() {
+    let lines = vec![
+        removed("old 1"),
+        added("new 1"),
+        context("keep"),
+        removed("old 2"),
+        added("new 2"),
+    ];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![
+            row(Some((removed("old 1"), 0)), Some((added("new 1"), 1)),),
+            row(None, None),
+            row(Some((context("keep"), 2)), Some((context("keep"), 2)),),
+            row(Some((removed("old 2"), 3)), Some((added("new 2"), 4)),),
+            row(None, None),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_return_hunk_lines_len_rows_regardless_of_run_shape() {
+    // ADR 0044 decision 4's own invariant: row count always equals
+    // `lines.len()`, so `walk_sections`'s line-counting (and therefore
+    // every scroll-sync offset it feeds) never has to branch on
+    // `diff_view_mode`.
+    let lines = vec![removed("a"), removed("b"), removed("c"), added("a'")];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(lines.len(), actual.len());
+}

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -135,6 +135,10 @@ const GLOBAL_BINDINGS: &[KeyBinding] = &[
         description: "Toggle the right pane to the blast radius of the selected row",
     },
     KeyBinding {
+        keys: "v / V",
+        description: "Toggle the Diff pane between unified and split (side-by-side) rendering",
+    },
+    KeyBinding {
         keys: "o / O",
         description: "Toggle topological/alphabetical ordering",
     },

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -974,6 +974,7 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         }
         KeyCode::Char('d') | KeyCode::Char('D') => Some(InputKey::ToggleDiff),
         KeyCode::Char('r') | KeyCode::Char('R') => Some(InputKey::ToggleBlastRadius),
+        KeyCode::Char('v') | KeyCode::Char('V') => Some(InputKey::ToggleSplitView),
         // `G` (`Shift-g`, ADR 0026): scroll to the bottom. Distinct from
         // single-key lowercase `g` (`PendingGoto` below), which is the
         // leading key of the `gd`/`gr`/`gg` two-key sequences resolved

--- a/rinkaku-tui/src/lib_tests/translate_key.rs
+++ b/rinkaku-tui/src/lib_tests/translate_key.rs
@@ -122,6 +122,26 @@ fn should_translate_uppercase_r_to_toggle_blast_radius() {
 }
 
 #[test]
+fn should_translate_lowercase_v_to_toggle_split_view() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('v'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ToggleSplitView), actual);
+}
+
+#[test]
+fn should_translate_uppercase_v_to_toggle_split_view() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('V'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ToggleSplitView), actual);
+}
+
+#[test]
 fn should_translate_right_bracket_to_next_hunk() {
     let report = empty_report();
     let app = App::new(&report);

--- a/rinkaku-tui/src/ui/blast_radius.rs
+++ b/rinkaku-tui/src/ui/blast_radius.rs
@@ -3,7 +3,7 @@
 //! row under the cursor. Layout only — the actual re-rooted view is
 //! computed once per handled key by `crate::run_app` and handed in.
 
-use super::scroll::render_scrollable_pane;
+use super::scroll::{Body, render_scrollable_pane};
 use super::style::pane_border_style;
 use crate::app::{App, BlastRadiusSelection, Focus};
 use ratatui::Frame;
@@ -73,7 +73,7 @@ pub(crate) fn draw_blast_radius_pane(
                 frame,
                 &title,
                 &[],
-                &lines,
+                Body::Single(&lines),
                 app.right_pane_scroll(),
                 area,
                 focused,

--- a/rinkaku-tui/src/ui/detail_pane.rs
+++ b/rinkaku-tui/src/ui/detail_pane.rs
@@ -3,7 +3,7 @@
 //! summary for a file row. Layout only — the underlying view models
 //! (`DetailView`, `DirDetail`, `FileDetail`) come from `crate::detail`.
 
-use super::scroll::render_scrollable_pane;
+use super::scroll::{Body, render_scrollable_pane};
 use super::style::pane_border_style;
 use crate::app::{App, Focus, SelectedDetail};
 use crate::detail::{DetailView, DirDetail, FileDetail, SignatureView};
@@ -46,7 +46,7 @@ pub(crate) fn draw_detail_pane(
         frame,
         " Detail ",
         &[],
-        &lines,
+        Body::Single(&lines),
         app.right_pane_scroll(),
         area,
         focused,

--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -4,10 +4,10 @@
 //! grouped into per-symbol sections for a file row.
 
 use super::scroll::{
-    render_scrollable_pane, truncate_line_to_width, truncate_to_width_keeping_tail,
+    Body, render_scrollable_pane, truncate_line_to_width, truncate_to_width_keeping_tail,
 };
 use super::style::{pane_border_style, styled_content_spans};
-use crate::app::{App, DiffTarget, Focus};
+use crate::app::{App, DiffTarget, DiffViewMode, Focus};
 use crate::diff_shape::DiffSection;
 use crate::diff_view::{DiffLine, DiffLineKind};
 use crate::highlight::{self, HighlightedFile, TokenSpan};
@@ -19,6 +19,14 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph};
 use rinkaku_core::render::Report;
+
+/// The Diff pane's own area width below which split (side-by-side)
+/// rendering falls back to unified regardless of [`DiffViewMode`] (ADR 0044
+/// decision 7): 100 columns leaves roughly 49 usable columns per side after
+/// the border and the 1-column gutter — narrower than that, a real code
+/// line wraps onto several visual rows on each side and the two columns no
+/// longer stay visually aligned, defeating split view's own purpose.
+pub(crate) const MIN_SPLIT_VIEW_WIDTH: u16 = 100;
 
 /// Background tint for an `Added`/`Removed` line (ADR 0018 decision: diff
 /// signal moves to the background so a token's own color can carry the
@@ -180,12 +188,33 @@ pub(crate) fn draw_diff_pane(
     };
 
     let highlighted_file = highlight::highlighted_file(diff_highlights, path);
+
+    // ADR 0044 decision 7: split view falls back to unified below
+    // `MIN_SPLIT_VIEW_WIDTH`, regardless of `diff_view_mode` — a pane this
+    // narrow cannot show two aligned columns without each one wrapping to a
+    // different visual-row count, defeating the alignment split view exists
+    // for. The toggle itself is untouched (`app.diff_view_mode()` keeps its
+    // real value), so widening the terminal immediately shows split without
+    // needing `v` pressed again.
+    let split_requested = app.diff_view_mode() == DiffViewMode::Split;
+    let split_fits = area.width >= MIN_SPLIT_VIEW_WIDTH;
+    let render_split = split_requested && split_fits;
+
     // ADR 0027: `DiffPaneContent` no longer has a symbol-clip variant, so
-    // the diff pane always renders with section headers on. `diff_pane_lines`'s
-    // `show_section_headers` parameter is now always `true` at this call
-    // site, kept as a parameter to leave that layout knob visible in one
-    // place rather than hard-coding it inside `diff_pane_lines`.
-    let lines = diff_pane_lines(&sections, true, highlighted_file);
+    // the diff pane always renders with section headers on. `diff_pane_lines`'s/
+    // `diff_pane_split_rows`'s `show_section_headers` parameter is now always
+    // `true` at this call site, kept as a parameter to leave that layout knob
+    // visible in one place rather than hard-coding it inside either function.
+    let unified_lines = if render_split {
+        Vec::new()
+    } else {
+        diff_pane_lines(&sections, true, highlighted_file)
+    };
+    let split_rows = if render_split {
+        diff_pane_split_rows(&sections, true, highlighted_file)
+    } else {
+        (Vec::new(), Vec::new())
+    };
 
     // A symbol row's ranges scope to that symbol's own section only; a
     // file row (no `selected_diff_focus`) scopes to every section — mirrors
@@ -218,19 +247,34 @@ pub(crate) fn draw_diff_pane(
         (None, header_name.unwrap_or(path))
     };
     let selected_badges = selected_row_badges(app);
-    let header_lines = diff_pane_header_lines(
+    let mut header_lines = diff_pane_header_lines(
         selection_name,
         header_path,
         &selected_badges,
         &ranges,
         header_width,
     );
+    // ADR 0044 decision 7: the toggle stays flipped even when the pane is
+    // too narrow to honor it — this note is the only visible sign why `v`
+    // didn't change anything, rather than a silent no-op.
+    if split_requested && !split_fits {
+        header_lines.push(Line::styled(
+            "(split view needs a wider pane)",
+            Style::default().add_modifier(Modifier::DIM),
+        ));
+    }
+
+    let body = if render_split {
+        Body::Split(&split_rows.0, &split_rows.1)
+    } else {
+        Body::Single(&unified_lines)
+    };
 
     Some(render_scrollable_pane(
         frame,
         DIFF_PANE_TITLE,
         &header_lines,
-        &lines,
+        body,
         app.right_pane_scroll(),
         area,
         focused,
@@ -334,6 +378,108 @@ pub(crate) fn diff_pane_lines(
         }
     }
     lines
+}
+
+/// Split-view (ADR 0044) counterpart of [`diff_pane_lines`]: the same
+/// section/contract-header/hunk-header scaffold (a scaffold line renders
+/// identically on both sides, so `left`/`right` share it), but each hunk's
+/// body is paired via [`crate::diff_shape::pair_hunk_lines`] into old-side/
+/// new-side columns instead of one interleaved column. Returns `(left,
+/// right)`, each the same length — [`crate::diff_shape::SplitRow`]'s own
+/// invariant (one row per source [`DiffLine`]) means every hunk contributes
+/// the same row count here as it does to [`diff_pane_lines`], so this
+/// function's total line count always matches `diff_pane_lines`'s for the
+/// same `sections`/`show_section_headers` — required for `walk_sections`'
+/// shared line-counting (ADR 0044 decision 4) to stay correct regardless of
+/// which of the two this pane actually renders.
+pub(crate) fn diff_pane_split_rows(
+    sections: &[&DiffSection],
+    show_section_headers: bool,
+    highlighted_file: Option<&HighlightedFile>,
+) -> (Vec<Line<'static>>, Vec<Line<'static>>) {
+    let mut left = Vec::new();
+    let mut right = Vec::new();
+    for (section_index, section) in sections.iter().enumerate() {
+        if section_index > 0 {
+            left.push(Line::raw(""));
+            right.push(Line::raw(""));
+        }
+        if show_section_headers {
+            let title = Line::styled(
+                section.title.clone(),
+                Style::default().add_modifier(Modifier::BOLD),
+            );
+            left.push(title.clone());
+            right.push(title);
+        }
+        if let Some(contract) = &section.contract_header {
+            left.push(Line::styled(
+                format!("- {}", contract.previous_signature),
+                Style::default().fg(Color::Red),
+            ));
+            right.push(Line::raw(""));
+            left.push(Line::raw(""));
+            right.push(Line::styled(
+                format!("+ {}", contract.signature),
+                Style::default().fg(Color::Green),
+            ));
+        }
+
+        for (hunk_index, attributed) in section.hunks.iter().enumerate() {
+            if hunk_index > 0 || show_section_headers || section.contract_header.is_some() {
+                left.push(Line::raw(""));
+                right.push(Line::raw(""));
+            }
+            let header = Line::styled(
+                attributed.hunk.header.clone(),
+                Style::default().fg(Color::DarkGray),
+            );
+            left.push(header.clone());
+            right.push(header);
+
+            let hunk_highlight = highlight::lookup_hunk_highlight_by_index(
+                highlighted_file,
+                attributed.source_index,
+            );
+            let split_rows = crate::diff_shape::pair_hunk_lines(&attributed.hunk.lines);
+
+            for split_row in &split_rows {
+                left.push(split_side_line(
+                    split_row.left.as_ref(),
+                    split_row.left_index,
+                    hunk_highlight,
+                ));
+                right.push(split_side_line(
+                    split_row.right.as_ref(),
+                    split_row.right_index,
+                    hunk_highlight,
+                ));
+            }
+        }
+    }
+    (left, right)
+}
+
+/// One [`SplitRow`](crate::diff_shape::SplitRow) side's rendered [`Line`] —
+/// a blank filler line for a `None` cell, or `diff_line`'s usual rendering
+/// looked up by `index` (that side's position in the hunk's *original*
+/// interleaved `lines`, [`crate::diff_shape::SplitRow::left_index`]/
+/// `right_index`'s own doc comment on why this must be the original index,
+/// not the split row's own position).
+fn split_side_line(
+    line: Option<&DiffLine>,
+    index: Option<usize>,
+    hunk_highlight: Option<&[Option<Vec<TokenSpan>>]>,
+) -> Line<'static> {
+    match (line, index) {
+        (Some(line), Some(index)) => {
+            let token_spans = hunk_highlight
+                .and_then(|lines| lines.get(index).cloned())
+                .flatten();
+            diff_line(line, token_spans)
+        }
+        _ => Line::raw(""),
+    }
 }
 
 /// Builds one display line for a hunk body line, coloring its code tokens

--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -381,17 +381,22 @@ pub(crate) fn diff_pane_lines(
 }
 
 /// Split-view (ADR 0044) counterpart of [`diff_pane_lines`]: the same
-/// section/contract-header/hunk-header scaffold (a scaffold line renders
-/// identically on both sides, so `left`/`right` share it), but each hunk's
-/// body is paired via [`crate::diff_shape::pair_hunk_lines`] into old-side/
-/// new-side columns instead of one interleaved column. Returns `(left,
-/// right)`, each the same length — [`crate::diff_shape::SplitRow`]'s own
-/// invariant (one row per source [`DiffLine`]) means every hunk contributes
-/// the same row count here as it does to [`diff_pane_lines`], so this
-/// function's total line count always matches `diff_pane_lines`'s for the
-/// same `sections`/`show_section_headers` — required for `walk_sections`'
-/// shared line-counting (ADR 0044 decision 4) to stay correct regardless of
-/// which of the two this pane actually renders.
+/// section/contract-header/hunk-header scaffold, but each hunk's body is
+/// paired via [`crate::diff_shape::pair_hunk_lines`] into old-side/new-side
+/// columns instead of one interleaved column. A title/hunk-header line
+/// renders identically on both sides (`left`/`right` share it); the
+/// contract header's old/new signatures render side by side on one row
+/// instead — the whole point of a split view is comparing them without
+/// scanning past an interleaved line in between. Returns `(left, right)`,
+/// each the same length — [`crate::diff_shape::SplitRow`]'s own invariant
+/// (one row per source [`DiffLine`]) means every hunk contributes the same
+/// row count here as it does to [`diff_pane_lines`], and the contract
+/// header's own filler row below the paired signatures keeps its 2-line
+/// scaffold budget intact — so this function's total line count always
+/// matches `diff_pane_lines`'s for the same `sections`/`show_section_headers`,
+/// required for `walk_sections`' shared line-counting (ADR 0044 decision 4)
+/// to stay correct regardless of which of the two this pane actually
+/// renders.
 pub(crate) fn diff_pane_split_rows(
     sections: &[&DiffSection],
     show_section_headers: bool,
@@ -417,12 +422,12 @@ pub(crate) fn diff_pane_split_rows(
                 format!("- {}", contract.previous_signature),
                 Style::default().fg(Color::Red),
             ));
-            right.push(Line::raw(""));
-            left.push(Line::raw(""));
             right.push(Line::styled(
                 format!("+ {}", contract.signature),
                 Style::default().fg(Color::Green),
             ));
+            left.push(Line::raw(""));
+            right.push(Line::raw(""));
         }
 
         for (hunk_index, attributed) in section.hunks.iter().enumerate() {

--- a/rinkaku-tui/src/ui/diff_pane_tests/mod.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/mod.rs
@@ -6,6 +6,9 @@
 //! - `row_kinds` — the "which content shows for which row" coverage:
 //!   symbol row, skipped file (binary and textual), file selection with
 //!   per-symbol section headers, and the contract-header disclosure order
+//! - `split_view` — ADR 0044's side-by-side rendering: paired old/new
+//!   lines, the narrow-pane fallback to unified, and unified staying the
+//!   default when the toggle was never pressed
 //! - `styling` — token/diff background tint, hunk-header color, and the
 //!   unrecognized-extension style fallback
 
@@ -21,6 +24,7 @@ use rinkaku_core::render::FileReport;
 
 mod header_lines;
 mod row_kinds;
+mod split_view;
 mod styling;
 
 pub(super) fn symbol(id: &str, name: &str) -> ExtractedSymbol {

--- a/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::app::InputKey;
+use crate::diff_shape::{ContractHeader, DiffSection};
+use pretty_assertions::assert_eq;
 
 #[test]
 fn should_draw_old_and_new_lines_side_by_side_when_split_view_is_toggled_on() {
@@ -91,6 +93,124 @@ index e69de29..4b825dc 100644
     assert!(text.contains("-fn old_foo() {}"));
     assert!(text.contains("+fn foo() {}"));
     assert!(text.contains("split view needs a wider pane"));
+}
+
+#[test]
+fn should_pair_old_and_new_signature_on_one_row_when_section_has_a_contract_header() {
+    // Regression coverage for the diagonal-placement bug a static review
+    // caught: the contract header's old/new signatures must land on the
+    // *same* row (left = old, right = new), not on two separate rows with
+    // one side blank each — the whole point of a split view is comparing
+    // them without scanning past an interleaved row in between.
+    let section = DiffSection {
+        title: "fn foo(a: i32, b: i32)".to_string(),
+        symbol_id: Some("lib.rs::foo".to_string()),
+        contract_header: Some(ContractHeader {
+            previous_signature: "fn foo(a: i32)".to_string(),
+            signature: "fn foo(a: i32, b: i32)".to_string(),
+        }),
+        hunks: vec![],
+    };
+
+    let (left, right) = diff_pane_split_rows(&[&section], true, None);
+
+    assert_eq!(
+        vec![
+            Line::styled(
+                "fn foo(a: i32, b: i32)".to_string(),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Line::styled(
+                "- fn foo(a: i32)".to_string(),
+                Style::default().fg(Color::Red),
+            ),
+            Line::raw(""),
+        ],
+        left
+    );
+    assert_eq!(
+        vec![
+            Line::styled(
+                "fn foo(a: i32, b: i32)".to_string(),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Line::styled(
+                "+ fn foo(a: i32, b: i32)".to_string(),
+                Style::default().fg(Color::Green),
+            ),
+            Line::raw(""),
+        ],
+        right
+    );
+    // ADR 0044 decision 4's shared line-counting invariant: both sides
+    // stay the same length regardless of the contract-header pairing.
+    assert_eq!(left.len(), right.len());
+}
+
+#[test]
+fn should_draw_old_and_new_signature_side_by_side_when_symbol_signature_changed() {
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![ExtractedSymbol {
+                classification: Some(Classification::SignatureChanged),
+                previous_signature: Some("fn foo(a: i32)".to_string()),
+                signature: "fn foo(a: i32, b: i32)".to_string(),
+                ..symbol("lib.rs::foo", "foo")
+            }],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+    // Row 0 is the "lib.rs" file row, row 1 is the "foo" symbol.
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::ToggleSplitView);
+    let diff_text = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,1 +1,1 @@
+-fn foo(a: i32) {}
++fn foo(a: i32, b: i32) {}
+";
+    let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+    let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+    let diff_content = diff_content_for(&report, &diff_files, &app);
+    let mut terminal = Terminal::new(TestBackend::new(200, 20)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &diff_content,
+                &diff_highlights,
+                &BlastRadiusSelection::NotApplicable,
+                None,
+            );
+        })
+        .expect("draw");
+
+    let text = buffer_text(&terminal);
+    let contract_row = text
+        .lines()
+        .find(|line| line.contains("- fn foo(a: i32)") && line.contains("+ fn foo(a: i32, b: i32)"))
+        .unwrap_or_else(|| panic!("expected the old/new signature on one row, got:\n{text}"));
+    assert!(contract_row.contains("- fn foo(a: i32)"));
+    assert!(contract_row.contains("+ fn foo(a: i32, b: i32)"));
 }
 
 #[test]

--- a/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
@@ -1,0 +1,139 @@
+use super::*;
+use crate::app::InputKey;
+
+#[test]
+fn should_draw_old_and_new_lines_side_by_side_when_split_view_is_toggled_on() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::ToggleSplitView);
+    let diff_text = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,1 +1,1 @@
+-fn old_foo() {}
++fn foo() {}
+";
+    let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+    let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+    let diff_content = diff_content_for(&report, &diff_files, &app);
+    // Wide enough that the diff pane's own 60%-of-width share
+    // (`ENTRY_RIGHT_WIDTH_PERCENT`) still clears `MIN_SPLIT_VIEW_WIDTH`.
+    let mut terminal = Terminal::new(TestBackend::new(200, 20)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &diff_content,
+                &diff_highlights,
+                &BlastRadiusSelection::NotApplicable,
+                None,
+            );
+        })
+        .expect("draw");
+
+    let text = buffer_text(&terminal);
+    // Both sides render on the same row since one removed line pairs
+    // positionally against one added line (`pair_hunk_lines`), and the
+    // pane is wide enough to stay in split mode.
+    let paired_row = text
+        .lines()
+        .find(|line| line.contains("old_foo") && line.contains("fn foo()"))
+        .unwrap_or_else(|| panic!("expected a row with both sides, got:\n{text}"));
+    assert!(paired_row.contains("-fn old_foo() {}"));
+    assert!(paired_row.contains("+fn foo() {}"));
+}
+
+#[test]
+fn should_fall_back_to_unified_when_pane_is_narrower_than_the_split_view_minimum() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::ToggleSplitView);
+    let diff_text = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,1 +1,1 @@
+-fn old_foo() {}
++fn foo() {}
+";
+    let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+    let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+    let diff_content = diff_content_for(&report, &diff_files, &app);
+    // Narrower than `MIN_SPLIT_VIEW_WIDTH` (100): the pane must render
+    // unified (ADR 0044 decision 7) even though `diff_view_mode` is
+    // `Split`, with a note explaining why the toggle had no visible
+    // effect.
+    let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &diff_content,
+                &diff_highlights,
+                &BlastRadiusSelection::NotApplicable,
+                None,
+            );
+        })
+        .expect("draw");
+
+    let text = buffer_text(&terminal);
+    assert!(text.contains("-fn old_foo() {}"));
+    assert!(text.contains("+fn foo() {}"));
+    assert!(text.contains("split view needs a wider pane"));
+}
+
+#[test]
+fn should_render_unified_when_split_view_is_not_toggled_on() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report).handle_key(InputKey::Down);
+    let diff_text = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,1 +1,1 @@
+-fn old_foo() {}
++fn foo() {}
+";
+    let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+    let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+    let diff_content = diff_content_for(&report, &diff_files, &app);
+    // Wide enough that the diff pane's own 60%-of-width share
+    // (`ENTRY_RIGHT_WIDTH_PERCENT`) still clears `MIN_SPLIT_VIEW_WIDTH`.
+    let mut terminal = Terminal::new(TestBackend::new(200, 20)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &diff_content,
+                &diff_highlights,
+                &BlastRadiusSelection::NotApplicable,
+                None,
+            );
+        })
+        .expect("draw");
+
+    let text = buffer_text(&terminal);
+    assert!(!text.contains("split view needs a wider pane"));
+    // Unified mode interleaves the two lines rather than pairing them
+    // onto one row — the removed line's own row contains no added text.
+    let removed_row = text
+        .lines()
+        .find(|line| line.contains("-fn old_foo() {}"))
+        .unwrap_or_else(|| panic!("expected a row with the removed line, got:\n{text}"));
+    assert!(!removed_row.contains("+fn foo() {}"));
+}

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -2,7 +2,9 @@
 //! composited on top of whatever screen was already rendered underneath,
 //! after the pane split has drawn everything else.
 
-use super::scroll::{render_scrollable_pane, truncate_to_width, windowed_rows_with_indicators};
+use super::scroll::{
+    Body, render_scrollable_pane, truncate_to_width, windowed_rows_with_indicators,
+};
 use crate::row_view::{
     band_style, cyan_badge_style, risk_marker_style, split_badge_style, symbol_marker_span,
     symbol_name_style, test_badge_style, warning_badge_style,
@@ -197,7 +199,7 @@ pub(crate) fn draw_help_overlay(
         frame,
         " Help (? to close) ",
         &[],
-        &lines,
+        Body::Single(&lines),
         requested_scroll,
         overlay_area,
         true,

--- a/rinkaku-tui/src/ui/scroll.rs
+++ b/rinkaku-tui/src/ui/scroll.rs
@@ -74,11 +74,15 @@ use unicode_width::UnicodeWidthChar;
 /// content itself was considered and rejected for exactly this reason. Pass
 /// `&[]` for a pane with no pinned header (every caller except the Diff
 /// pane's identification/stats header).
+///
+/// `body` selects single-column (`Body::Single`, every caller except the
+/// Diff pane's split mode) or side-by-side (`Body::Split`, ADR 0044)
+/// rendering of the scrollable content — see [`Body`]'s own doc comment.
 pub(crate) fn render_scrollable_pane(
     frame: &mut Frame,
     title: &str,
     header_lines: &[Line<'static>],
-    lines: &[Line<'static>],
+    body: Body<'_>,
     requested_scroll: usize,
     area: Rect,
     focused: bool,
@@ -91,16 +95,55 @@ pub(crate) fn render_scrollable_pane(
     let [header_area, body_area] =
         Layout::vertical([Constraint::Length(header_rows), Constraint::Min(0)]).areas(inner_area);
 
-    let viewport_width = body_area.width as usize;
     let viewport_height = body_area.height as usize;
-    let wrapped = wrap_lines(lines, viewport_width);
-    let scroll = clamp_scroll(wrapped.len(), viewport_height, requested_scroll);
+    let (content_len, scroll) = match body {
+        Body::Single(lines) => {
+            let viewport_width = body_area.width as usize;
+            let wrapped = wrap_lines(lines, viewport_width);
+            let scroll = clamp_scroll(wrapped.len(), viewport_height, requested_scroll);
+            let paragraph = Paragraph::new(wrapped.clone()).scroll((scroll as u16, 0));
+            frame.render_widget(paragraph, body_area);
+            (wrapped.len(), scroll)
+        }
+        Body::Split(left, right) => {
+            // A 1-column gutter between the two sides, mirroring a border's
+            // own single-column width, so the two columns read as visually
+            // distinct panes rather than running edge to edge.
+            let [left_area, gutter_area, right_area] = Layout::horizontal([
+                Constraint::Percentage(50),
+                Constraint::Length(1),
+                Constraint::Min(0),
+            ])
+            .areas(body_area);
+            let (left_rows, right_rows) = pair_wrap(
+                left,
+                right,
+                left_area.width as usize,
+                right_area.width as usize,
+            );
+            let scroll = clamp_scroll(left_rows.len(), viewport_height, requested_scroll);
+
+            frame.render_widget(
+                Paragraph::new(left_rows.clone()).scroll((scroll as u16, 0)),
+                left_area,
+            );
+            frame.render_widget(
+                Paragraph::new(vec![Line::raw("│"); left_rows.len()]).scroll((scroll as u16, 0)),
+                gutter_area,
+            );
+            frame.render_widget(
+                Paragraph::new(right_rows.clone()).scroll((scroll as u16, 0)),
+                right_area,
+            );
+            (left_rows.len(), scroll)
+        }
+    };
 
     // Callers pass a title already padded with a leading/trailing space
     // (e.g. `" Detail "`, matching every other `Block` title in this
     // module) — trim the trailing one before appending the indicator so
     // the two don't produce a double space (`"Detail  (1-17/43)"`).
-    let title = match scroll_indicator(wrapped.len(), viewport_height, scroll) {
+    let title = match scroll_indicator(content_len, viewport_height, scroll) {
         Some(indicator) => format!("{}{indicator} ", title.trim_end()),
         None => title.to_string(),
     };
@@ -113,9 +156,52 @@ pub(crate) fn render_scrollable_pane(
         let header = Paragraph::new(header_lines[..header_rows as usize].to_vec());
         frame.render_widget(header, header_area);
     }
-    let paragraph = Paragraph::new(wrapped).scroll((scroll as u16, 0));
-    frame.render_widget(paragraph, body_area);
     scroll
+}
+
+/// [`render_scrollable_pane`]'s scrollable content, either a single column
+/// (every pane except the Diff pane's split mode) or two side-by-side
+/// columns (ADR 0044) sharing one scroll offset.
+pub(crate) enum Body<'a> {
+    Single(&'a [Line<'static>]),
+    Split(&'a [Line<'static>], &'a [Line<'static>]),
+}
+
+/// Wraps `left`/`right` independently to their own column widths, then pads
+/// the shorter wrapped side back up to the longer side's row count with
+/// blank filler lines — so both columns scroll in lockstep off one shared
+/// offset (ADR 0044 decision 6). `left`/`right` already agree on *logical*
+/// row count by construction ([`crate::diff_shape::SplitRow`]'s own
+/// invariant, `diff_pane_split_rows`'s doc comment), but a long single
+/// logical line can still wrap to a different number of *visual* rows than
+/// its counterpart on the other side at a narrow column width — this
+/// function pads per logical row so the two columns never drift out of
+/// alignment after wrapping.
+pub(crate) fn pair_wrap(
+    left: &[Line<'static>],
+    right: &[Line<'static>],
+    left_width: usize,
+    right_width: usize,
+) -> (Vec<Line<'static>>, Vec<Line<'static>>) {
+    let mut left_out = Vec::new();
+    let mut right_out = Vec::new();
+    let row_count = left.len().max(right.len());
+    for index in 0..row_count {
+        let left_wrapped = left
+            .get(index)
+            .map(|line| wrap_one_line(line, left_width))
+            .unwrap_or_else(|| vec![Line::raw("")]);
+        let right_wrapped = right
+            .get(index)
+            .map(|line| wrap_one_line(line, right_width))
+            .unwrap_or_else(|| vec![Line::raw("")]);
+        let rows = left_wrapped.len().max(right_wrapped.len());
+        for row in 0..rows {
+            left_out.push(left_wrapped.get(row).cloned().unwrap_or(Line::raw("")));
+            right_out.push(right_wrapped.get(row).cloned().unwrap_or(Line::raw("")));
+        }
+    }
+    (left_out, right_out)
 }
 
 /// Wraps each of `lines` to `width` display columns, splitting a logical

--- a/rinkaku-tui/src/ui/scroll_tests/mod.rs
+++ b/rinkaku-tui/src/ui/scroll_tests/mod.rs
@@ -7,10 +7,13 @@
 //! - `wrap_lines` — `wrap_lines`/`wrap_one_line`
 //! - `truncation` — `truncate_to_width`/`truncate_to_width_keeping_tail`/
 //!   `truncate_line_to_width`
+//! - `pair_wrap` — ADR 0044's per-side wrap-then-pad helper for the Diff
+//!   pane's split view
 
 use super::*;
 
 mod clamp_and_indicator;
+mod pair_wrap;
 mod truncation;
 mod windowing;
 mod wrap_lines;

--- a/rinkaku-tui/src/ui/scroll_tests/pair_wrap.rs
+++ b/rinkaku-tui/src/ui/scroll_tests/pair_wrap.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+#[test]
+fn should_return_empty_columns_when_both_sides_are_empty() {
+    let actual = pair_wrap(&[], &[], 10, 10);
+
+    assert_eq!((Vec::new(), Vec::new()), actual);
+}
+
+#[test]
+fn should_keep_one_row_per_side_when_neither_line_wraps() {
+    let left = vec![Line::raw("old")];
+    let right = vec![Line::raw("new")];
+
+    let actual = pair_wrap(&left, &right, 10, 10);
+
+    assert_eq!((vec![Line::raw("old")], vec![Line::raw("new")]), actual);
+}
+
+#[test]
+fn should_pad_shorter_wrapped_side_when_left_line_wraps_and_right_does_not() {
+    // "abcdefgh" wraps to 2 rows at width 4 ("abcd"/"efgh"); the right
+    // side's one logical row must grow a blank filler row so both
+    // columns stay the same length for the shared scroll offset (ADR
+    // 0044 decision 6).
+    let left = vec![Line::raw("abcdefgh")];
+    let right = vec![Line::raw("new")];
+
+    let actual = pair_wrap(&left, &right, 4, 10);
+
+    assert_eq!(
+        (
+            vec![Line::raw("abcd"), Line::raw("efgh")],
+            vec![Line::raw("new"), Line::raw("")],
+        ),
+        actual
+    );
+}
+
+#[test]
+fn should_pad_missing_side_when_one_column_has_fewer_logical_rows() {
+    // The left column has two logical rows, the right only one — the
+    // second logical row pairs a real left line against an absent right
+    // line, which must still produce a filler row on the right.
+    let left = vec![Line::raw("old 1"), Line::raw("old 2")];
+    let right = vec![Line::raw("new 1")];
+
+    let actual = pair_wrap(&left, &right, 10, 10);
+
+    assert_eq!(
+        (
+            vec![Line::raw("old 1"), Line::raw("old 2")],
+            vec![Line::raw("new 1"), Line::raw("")],
+        ),
+        actual
+    );
+}


### PR DESCRIPTION
## Summary

Adds a split (side-by-side) view to the TUI diff pane, toggled with `v` / `V`. The unified view remains the default; the toggle persists across row moves and pane switches. Design is recorded in ADR 0044.

- `pair_hunk_lines` (pure function) pairs each hunk's interleaved lines into `SplitRow`s, always returning exactly as many rows as the unified view — so the ADR 0027 (tree → diff auto-scroll) and ADR 0030 (diff scroll → tree selection) machinery works unchanged.
- `render_scrollable_pane` gains a `Body::Single`/`Body::Split` parameter; `Body::Split` wraps both columns per logical row so they share one scroll offset. All existing callers (detail, blast radius, help) pass `Body::Single` unchanged.
- Below 100 columns the pane falls back to unified with a `(split view needs a wider pane)` note; the toggle state is kept and split resumes automatically when the pane widens.
- Contract headers render `- previous` / `+ new` side by side on one row (a review of this branch caught an initial diagonal layout; fixed in `b388d74` with regression tests).

## QA

- `make test` (683 tests) and `make lint` pass.
- Dynamic verification in tmux against real diffs: `v`/`V` toggling, old/new alignment for replace/add-only/delete-only/rename/large hunks, CJK and long-line wrapping, width-threshold fallback and auto-resume, ADR 0027/0030 scroll sync in split mode (including `Ctrl-d`/`Ctrl-u` across section boundaries), and no regression in detail/blast-radius/help panes.
- Failure modes: non-TTY stdin/stdout, empty diff, missing files, conflicting flags — no panics, terminal restored correctly.
- Reviewed via a map-assisted static pass (map generated with a trusted `main` build) plus an independent dynamic pass; the one blocker found (contract-header layout) is fixed in this branch.