### PR TITLE
fix(tui): place a mixed file's TestGroup at its source-order position

### DIFF
--- a/docs/adr/0043-tui-risk-oriented-visual-encoding.md
+++ b/docs/adr/0043-tui-risk-oriented-visual-encoding.md
@@ -1,6 +1,10 @@
 # 0043. Risk-oriented visual encoding for the TUI entry tree
 
-- Status: accepted
+- Status: accepted; decision 1's "appended after production symbols"
+  placement superseded (partially) by
+  [ADR 0045](0045-test-group-source-order-placement.md) — the fold
+  itself, its collapsed-by-default state, and the `N tests` label are
+  unchanged
 - Date: 2026-07-14
 - Related: [ADR 0035](0035-tests-sorted-last-in-entry-tree.md) (whole-test-file
   section, per-symbol `test` badge this ADR removes),

--- a/docs/adr/0045-test-group-source-order-placement.md
+++ b/docs/adr/0045-test-group-source-order-placement.md
@@ -1,0 +1,138 @@
+# 0045. Place a mixed file's `TestGroup` child at its source position, not always last
+
+- Status: accepted
+- Date: 2026-07-14
+- Amends: [ADR 0043](0043-tui-risk-oriented-visual-encoding.md) decision 1
+  (the "appended after production symbols" placement only — the fold
+  itself, its collapsed-by-default state, the `N tests` label, and the
+  removed per-symbol `test` badge are all unchanged)
+- Related: [ADR 0027](0027-diff-pane-follows-symbol-selection.md)
+  (symbol-selection auto-scroll, which assumes the diff pane's section
+  order and the entry tree's row order agree), [ADR 0030](0030-diff-scroll-syncs-tree-selection.md)
+  (diff-pane-to-tree scroll sync, the reverse direction of the same
+  assumption)
+
+## Context
+
+ADR 0043 decision 1 folds a mixed file's test symbols into one
+`NodeKind::TestGroup` child, appended **after every production symbol**
+in that file's `children`, regardless of where the test symbols actually
+sit in the source file. The diff pane (`crate::diff_shape`), by
+contrast, always renders a file's hunks in source order (unchanged by
+this ADR — see the Decision section below) and ADR 0027 auto-scrolls the
+diff pane to a selected row's section start.
+
+For a file that interleaves production and test code — a common Rust
+shape is one or more `#[cfg(test)] mod tests` blocks positioned after
+some functions but before others, or a file with test helpers threaded
+between production functions — the tree's fixed "TestGroup always last"
+placement can put the group node *above* production symbols that
+actually appear later in the file. Moving the cursor down through the
+tree's rows (production symbol, production symbol, ..., `TestGroup`,
+next production symbol) does not correspond to moving down through the
+file (since the `TestGroup` row, wherever it sits in the file, is always
+last in the tree). The diff pane's auto-scroll offset then moves
+non-monotonically as the cursor descends the tree, undoing the
+"moving the cursor visibly scrolls the pane" property ADR 0027
+established.
+
+`TestGroup` starts collapsed by default (`Nav::new_collapsing_test_groups`),
+so this is not visible on every keystroke — collapsed, the group
+contributes exactly one row, and jumping into/out of a collapsed group
+is still just one non-monotonic step, not a sequence of them. It
+matters at exactly two points: navigating the cursor onto the (still
+collapsed) `TestGroup` row itself, and — more visibly — after expanding
+it, where every contained test-symbol row now also sits at the tree's
+fixed last-child position instead of near the production siblings it
+sits between in the file.
+
+## Decision
+
+**Change `TestGroup`'s insertion position from fixed-last to
+source-order.** `build_file_node` (`rinkaku-tui/src/tree/mod.rs`)
+computes the `TestGroup` node's position among a file's `children` from
+the earliest test symbol's `ExtractedSymbol::range.start` (the same
+new-side line the diff pane's hunks are keyed by), compared against each
+production symbol's own `range.start`: the group is inserted immediately
+before the first production symbol whose `range.start` is greater than
+the minimum test-symbol `range.start`, or appended last when every
+production symbol's range starts earlier (the common case — a trailing
+`#[cfg(test)] mod tests` block, which is why the previous fixed-last
+placement looked correct for most of this repository's own files).
+
+The group itself is unaffected: still exactly one node per mixed file
+(a file with test symbols scattered across multiple non-contiguous
+blocks still folds into a single group, positioned at its *earliest*
+test symbol's line — not one group per contiguous block), still starts
+collapsed, still renders the `N tests` label, still carries none of the
+removed per-symbol `test` badge. Only *where* that one node lands among
+its siblings changes.
+
+`ExtractedSymbol::range` is read inside `build_file_node`/`insert_file`
+only for this ordering decision — it is not threaded onto `SymbolRef`
+(the tree's public per-symbol view-model), since no other consumer of
+`SymbolRef` needs a line number and adding one would widen that type's
+public shape for a single internal call site.
+
+## Alternatives
+
+- **Do nothing (keep fixed-last placement)**: rejected — this is the
+  status quo the non-monotonic auto-scroll problem described above
+  comes from.
+- **Revert ADR 0043 decision 1 entirely (un-fold `TestGroup`, restore
+  ADR 0035's inline per-symbol `test` badge)**: considered first, since
+  it would also fix the ordering problem (nothing to place out of order
+  if there is no separate group node). Rejected: ADR 0043 decision 1's
+  own motivation (a file with a dozen `#[test]` functions floods the
+  tree with individually-badged rows) is a real, independent problem
+  from the ordering complaint this ADR addresses, and reverting it would
+  reintroduce that flooding to fix a narrower issue. The two properties
+  — "test rows don't flood the tree" and "row order tracks source
+  order" — are not in conflict once the group's *position*, not its
+  *existence*, is what moves.
+- **Split into multiple `TestGroup` nodes, one per contiguous block of
+  test symbols**: considered, since it would make every group's position
+  exactly track its block's location with no single-earliest-symbol
+  approximation needed. Rejected: multiplies the row-flooding problem
+  ADR 0043 decision 1 was written to solve back up by however many
+  disjoint test blocks a file has, and a reviewer gains little from
+  seeing "3 tests" / "2 tests" / "4 tests" at three different scroll
+  positions over seeing one "9 tests" at the position of the first
+  block — the position of the *first* test symbol is what the diff
+  pane's auto-scroll needs to agree with for the cursor step that
+  selects the group row, and every row after that within an expanded
+  group is a manual scroll the reviewer controls directly.
+- **Key the group's position on the diff pane's shaped section offsets
+  (`crate::diff_shape::hunk_start_lines`) instead of
+  `ExtractedSymbol::range.start`**: rejected — this task's boundary
+  keeps `diff_shape.rs`/`ui/` untouched (a parallel change is already in
+  flight against that surface), and `range.start` is already the same
+  new-side line basis `diff_shape.rs` itself derives its section offsets
+  from, so reading it directly in `tree/mod.rs` reaches the same
+  ordering without a cross-module dependency on the diff pane's shaping
+  code.
+
+## Consequences
+
+- `build_file_node` needs each symbol's `range.start` at partition time,
+  read directly from `ExtractedSymbol` before it is converted into a
+  `SymbolRef` (which does not carry a line number) — an internal
+  computation, not a new field on any public tree type.
+- A file where every test symbol trails every production symbol (the
+  common case) renders identically to before this ADR: the group still
+  lands last, since "insert before the first production symbol with a
+  later line" degrades to "append" when no such symbol exists.
+- A file with production symbols both before *and* after its earliest
+  test symbol now shows the `TestGroup` row interleaved among the
+  production rows at the position its first test symbol occupies in the
+  file, instead of always last — matching the diff pane's source-order
+  section list and keeping the auto-scroll offset (ADR 0027) monotonic
+  as the cursor descends the tree.
+- No change to `NodeKind::TestGroup`'s shape, `Nav::new_collapsing_test_groups`'s
+  collapsed-by-default behavior, `order/sort.rs`'s `SiblingTier::File`
+  classification of a `TestGroup` node, or any rendering
+  (`row_view.rs`/`ui/entry.rs`) — every consumer keyed on `NodeKind`
+  alone still matches the same arm; only the position of the node within
+  its parent's `children` `Vec` differs.
+- No output-format (Markdown/JSON) change: this ADR is scoped entirely
+  to `rinkaku-tui`'s tree-building view-model.

--- a/rinkaku-tui/src/tree/mod.rs
+++ b/rinkaku-tui/src/tree/mod.rs
@@ -365,8 +365,9 @@ struct FileBuilder {
     /// Each symbol alongside its new-side `ExtractedSymbol::range.start`,
     /// kept only long enough for `build_file_node` to place a `TestGroup`
     /// child at its source position (ADR 0045) — `SymbolRef` itself carries
-    /// no line number.
-    symbols: Vec<(SymbolRef, usize)>,
+    /// no line number. `None` for a removed symbol (`insert_removed`), which
+    /// has no range to report and must not participate in that placement.
+    symbols: Vec<(SymbolRef, Option<usize>)>,
     /// Set by `insert_skipped` — see `TreeNode::skip_reason`'s doc comment.
     skip_reason: Option<SkipReason>,
     /// Set by `insert_test_file` — see `TreeNode::test_symbol_count`'s doc
@@ -422,7 +423,7 @@ impl<'a> TreeBuilder<'a> {
                     removed: false,
                     is_test: symbol.is_test,
                 },
-                symbol.range.start,
+                Some(symbol.range.start),
             ));
         }
     }
@@ -441,10 +442,7 @@ impl<'a> TreeBuilder<'a> {
                 // `SymbolRef::is_test`'s doc comment.
                 is_test: false,
             },
-            // No range to report; harmless since a removed symbol is never
-            // `is_test` (`SymbolRef::is_test`'s doc comment), so it never
-            // enters the comparison this line feeds (ADR 0045).
-            usize::MAX,
+            None,
         ));
     }
 
@@ -712,16 +710,23 @@ fn build_file_node(
 /// `#[cfg(test)] mod tests` block" case. `test_symbols` empty returns 0
 /// (unused by the caller in that case, since `build_test_group_node` returns
 /// `None` for an empty list and no insertion happens at all).
+///
+/// A `None` line (a removed symbol, which is never `is_test` so it can only
+/// appear in `production_symbols`) is excluded from the position search
+/// entirely rather than treated as "after every test symbol" — otherwise a
+/// removed symbol trailing a test block would itself be mistaken for the
+/// first later-positioned production symbol and get the group inserted
+/// ahead of it.
 fn test_group_insert_index(
-    test_symbols: &[(SymbolRef, usize)],
-    production_symbols: &[(SymbolRef, usize)],
+    test_symbols: &[(SymbolRef, Option<usize>)],
+    production_symbols: &[(SymbolRef, Option<usize>)],
 ) -> usize {
-    let Some(earliest_test_line) = test_symbols.iter().map(|(_, line)| *line).min() else {
+    let Some(earliest_test_line) = test_symbols.iter().filter_map(|(_, line)| *line).min() else {
         return 0;
     };
     production_symbols
         .iter()
-        .position(|(_, line)| *line > earliest_test_line)
+        .position(|(_, line)| matches!(line, Some(line) if *line > earliest_test_line))
         .unwrap_or(production_symbols.len())
 }
 

--- a/rinkaku-tui/src/tree/mod.rs
+++ b/rinkaku-tui/src/tree/mod.rs
@@ -362,7 +362,11 @@ struct DirBuilder {
 
 #[derive(Default)]
 struct FileBuilder {
-    symbols: Vec<SymbolRef>,
+    /// Each symbol alongside its new-side `ExtractedSymbol::range.start`,
+    /// kept only long enough for `build_file_node` to place a `TestGroup`
+    /// child at its source position (ADR 0045) — `SymbolRef` itself carries
+    /// no line number.
+    symbols: Vec<(SymbolRef, usize)>,
     /// Set by `insert_skipped` — see `TreeNode::skip_reason`'s doc comment.
     skip_reason: Option<SkipReason>,
     /// Set by `insert_test_file` — see `TreeNode::test_symbol_count`'s doc
@@ -409,30 +413,39 @@ impl<'a> TreeBuilder<'a> {
              report.files/report.skipped must not overlap on the same path"
         );
         for symbol in symbols {
-            file_builder.symbols.push(SymbolRef {
-                id: symbol.id.clone(),
-                name: symbol.name.clone(),
-                kind: symbol.kind,
-                classification: symbol.classification,
-                removed: false,
-                is_test: symbol.is_test,
-            });
+            file_builder.symbols.push((
+                SymbolRef {
+                    id: symbol.id.clone(),
+                    name: symbol.name.clone(),
+                    kind: symbol.kind,
+                    classification: symbol.classification,
+                    removed: false,
+                    is_test: symbol.is_test,
+                },
+                symbol.range.start,
+            ));
         }
     }
 
     fn insert_removed(&mut self, path: &str, removed: &rinkaku_core::extract::RemovedSymbol) {
         let segments: Vec<&str> = path.split('/').collect();
         let file_builder = self.root.file_at(&segments);
-        file_builder.symbols.push(SymbolRef {
-            id: format!("{path}::{}", removed.name),
-            name: removed.name.clone(),
-            kind: removed.kind,
-            classification: None,
-            removed: true,
-            // `RemovedSymbol` carries no `is_test` flag of its own — see
-            // `SymbolRef::is_test`'s doc comment.
-            is_test: false,
-        });
+        file_builder.symbols.push((
+            SymbolRef {
+                id: format!("{path}::{}", removed.name),
+                name: removed.name.clone(),
+                kind: removed.kind,
+                classification: None,
+                removed: true,
+                // `RemovedSymbol` carries no `is_test` flag of its own — see
+                // `SymbolRef::is_test`'s doc comment.
+                is_test: false,
+            },
+            // No range to report; harmless since a removed symbol is never
+            // `is_test` (`SymbolRef::is_test`'s doc comment), so it never
+            // enters the comparison this line feeds (ADR 0045).
+            usize::MAX,
+        ));
     }
 
     /// Inserts a whole- or mixed-test-file summary (`report.tests`, see
@@ -652,14 +665,17 @@ fn build_file_node(
     // `Section::Tests`, so its symbols stay flat, ungrouped children here
     // (`TreeBuilder::group_test_symbols`'s doc comment).
     let (test_symbols, production_symbols): (Vec<_>, Vec<_>) = if group_test_symbols {
-        file.symbols.into_iter().partition(|s| s.is_test)
+        file.symbols.into_iter().partition(|(s, _)| s.is_test)
     } else {
         (Vec::new(), file.symbols)
     };
+    // ADR 0045: the group's position among its production siblings is
+    // decided before either list loses its line numbers below.
+    let test_group_insert_at = test_group_insert_index(&test_symbols, &production_symbols);
 
     let mut children: Vec<TreeNode> = production_symbols
         .into_iter()
-        .map(|symbol_ref| {
+        .map(|(symbol_ref, _)| {
             let symbol_badges = symbol_badges(&symbol_ref, fan_in_by_id);
             badges.merge(symbol_badges);
             TreeNode {
@@ -673,9 +689,10 @@ fn build_file_node(
         })
         .collect();
 
+    let test_symbols: Vec<SymbolRef> = test_symbols.into_iter().map(|(s, _)| s).collect();
     if let Some(test_group) = build_test_group_node(&path, test_symbols, fan_in_by_id) {
         badges.merge(test_group.badges);
-        children.push(test_group);
+        children.insert(test_group_insert_at, test_group);
     }
 
     TreeNode {
@@ -686,6 +703,26 @@ fn build_file_node(
         skip_reason: file.skip_reason,
         test_symbol_count: file.test_symbol_count,
     }
+}
+
+/// Where a mixed file's `TestGroup` child belongs among `production_symbols`
+/// (ADR 0045): immediately before the first production symbol whose line
+/// starts after the earliest test symbol's line, or after every production
+/// symbol (`production_symbols.len()`) when none does — the common "trailing
+/// `#[cfg(test)] mod tests` block" case. `test_symbols` empty returns 0
+/// (unused by the caller in that case, since `build_test_group_node` returns
+/// `None` for an empty list and no insertion happens at all).
+fn test_group_insert_index(
+    test_symbols: &[(SymbolRef, usize)],
+    production_symbols: &[(SymbolRef, usize)],
+) -> usize {
+    let Some(earliest_test_line) = test_symbols.iter().map(|(_, line)| *line).min() else {
+        return 0;
+    };
+    production_symbols
+        .iter()
+        .position(|(_, line)| *line > earliest_test_line)
+        .unwrap_or(production_symbols.len())
 }
 
 /// A single symbol's own (non-aggregated) badge contribution.

--- a/rinkaku-tui/src/tree/tree_tests/tests_section.rs
+++ b/rinkaku-tui/src/tree/tree_tests/tests_section.rs
@@ -390,6 +390,151 @@ fn should_append_test_group_last_when_every_test_symbol_trails_every_production_
 }
 
 #[test]
+fn should_not_let_a_removed_symbol_be_mistaken_for_a_later_production_symbol() {
+    // ADR 0045 regression: a removed symbol carries no line of its own
+    // (`RemovedSymbol` has no `range`), so it must never be treated as
+    // "positioned after the test block" — TestGroup still appends last,
+    // the removed symbol keeps its own insertion-order position ahead of it.
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/mixed.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    range: LineRange { start: 1, end: 5 },
+                    ..symbol("src/mixed.rs::real_fn", "real_fn", SymbolKind::Function)
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 10, end: 15 },
+                    is_test: true,
+                    ..symbol("src/mixed.rs::test_it", "test_it", SymbolKind::Function)
+                },
+            ],
+        }],
+        removed: vec![RemovedSymbol {
+            name: "removed_fn".to_string(),
+            kind: SymbolKind::Function,
+            path: "src/mixed.rs".to_string(),
+            signature: "fn removed_fn()".to_string(),
+        }],
+        ..empty_report()
+    };
+
+    let badges = Badges {
+        changed_symbols: 2,
+        contract_changes: 1,
+        fan_in: 0,
+        ..Badges::default()
+    };
+    let expected = Tree {
+        roots: vec![dir_wrapping(
+            "src",
+            badges,
+            vec![TreeNode {
+                kind: NodeKind::File,
+                path: "src/mixed.rs".to_string(),
+                badges,
+                children: vec![
+                    symbol_leaf("src/mixed.rs", "real_fn"),
+                    TreeNode {
+                        kind: NodeKind::Symbol(SymbolRef {
+                            id: "src/mixed.rs::removed_fn".to_string(),
+                            name: "removed_fn".to_string(),
+                            kind: SymbolKind::Function,
+                            classification: None,
+                            removed: true,
+                            is_test: false,
+                        }),
+                        path: "src/mixed.rs".to_string(),
+                        badges: Badges {
+                            changed_symbols: 0,
+                            contract_changes: 1,
+                            fan_in: 0,
+                            ..Badges::default()
+                        },
+                        children: vec![],
+                        skip_reason: None,
+                        test_symbol_count: None,
+                    },
+                    TreeNode {
+                        kind: NodeKind::TestGroup { count: 1 },
+                        path: "src/mixed.rs::tests".to_string(),
+                        badges: one_symbol_badges(),
+                        children: vec![TreeNode {
+                            kind: NodeKind::Symbol(SymbolRef {
+                                is_test: true,
+                                ..symbol_ref("src/mixed.rs::test_it", "test_it")
+                            }),
+                            path: "src/mixed.rs".to_string(),
+                            badges: one_symbol_badges(),
+                            children: vec![],
+                            skip_reason: None,
+                            test_symbol_count: None,
+                        }],
+                        skip_reason: None,
+                        test_symbol_count: None,
+                    },
+                ],
+                skip_reason: None,
+                test_symbol_count: None,
+            }],
+        )],
+    };
+    let actual = build_tree(&report);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_break_ties_toward_production_when_a_test_symbol_shares_its_start_line() {
+    // Strict `>` comparison: a production symbol sharing the test block's
+    // exact start line is not treated as "after" it, so it stays before
+    // TestGroup in the fixed insertion-order tie case.
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/mixed.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    range: LineRange { start: 10, end: 15 },
+                    ..symbol(
+                        "src/mixed.rs::same_line_fn",
+                        "same_line_fn",
+                        SymbolKind::Function,
+                    )
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 10, end: 15 },
+                    is_test: true,
+                    ..symbol("src/mixed.rs::test_it", "test_it", SymbolKind::Function)
+                },
+            ],
+        }],
+        ..empty_report()
+    };
+
+    let tree = build_tree(&report);
+    let src = &tree.roots[0];
+    let file = &src.children[0];
+    let child_kinds: Vec<&str> = file
+        .children
+        .iter()
+        .map(|child| match &child.kind {
+            NodeKind::Symbol(symbol_ref) => symbol_ref.name.as_str(),
+            NodeKind::TestGroup { .. } => "TestGroup",
+            _ => "other",
+        })
+        .collect();
+
+    // NOTE: partial assert (child kind sequence only) — the full node
+    // shape for a single production symbol plus a one-member TestGroup is
+    // already pinned by
+    // `should_append_test_group_last_when_every_test_symbol_trails_every_production_symbol`;
+    // this test's only concern is the tie-break order itself.
+    assert_eq!(vec!["same_line_fn", "TestGroup"], child_kinds);
+}
+
+#[test]
 fn should_group_scattered_test_symbols_at_the_earliest_ones_line() {
     // Multiple, non-contiguous test symbols still fold into one
     // TestGroup (ADR 0045 rejected per-block splitting) positioned at

--- a/rinkaku-tui/src/tree/tree_tests/tests_section.rs
+++ b/rinkaku-tui/src/tree/tree_tests/tests_section.rs
@@ -245,6 +245,206 @@ fn should_keep_a_mixed_file_in_the_production_tree_and_omit_the_tests_section() 
 }
 
 #[test]
+fn should_place_test_group_at_earliest_test_symbol_line_when_production_symbols_surround_it() {
+    // ADR 0045: production symbols both before and after the test
+    // block must not push TestGroup to the fixed last position —
+    // it inserts immediately before the first production symbol whose
+    // line comes after the earliest test symbol's line.
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/mixed.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    range: LineRange { start: 1, end: 5 },
+                    ..symbol("src/mixed.rs::before_fn", "before_fn", SymbolKind::Function)
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 10, end: 15 },
+                    is_test: true,
+                    ..symbol("src/mixed.rs::test_it", "test_it", SymbolKind::Function)
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 20, end: 25 },
+                    ..symbol("src/mixed.rs::after_fn", "after_fn", SymbolKind::Function)
+                },
+            ],
+        }],
+        ..empty_report()
+    };
+
+    let three_symbol_badges = Badges {
+        changed_symbols: 3,
+        contract_changes: 0,
+        fan_in: 0,
+        ..Badges::default()
+    };
+    let expected = Tree {
+        roots: vec![dir_wrapping(
+            "src",
+            three_symbol_badges,
+            vec![TreeNode {
+                kind: NodeKind::File,
+                path: "src/mixed.rs".to_string(),
+                badges: three_symbol_badges,
+                children: vec![
+                    symbol_leaf("src/mixed.rs", "before_fn"),
+                    TreeNode {
+                        kind: NodeKind::TestGroup { count: 1 },
+                        path: "src/mixed.rs::tests".to_string(),
+                        badges: one_symbol_badges(),
+                        children: vec![TreeNode {
+                            kind: NodeKind::Symbol(SymbolRef {
+                                is_test: true,
+                                ..symbol_ref("src/mixed.rs::test_it", "test_it")
+                            }),
+                            path: "src/mixed.rs".to_string(),
+                            badges: one_symbol_badges(),
+                            children: vec![],
+                            skip_reason: None,
+                            test_symbol_count: None,
+                        }],
+                        skip_reason: None,
+                        test_symbol_count: None,
+                    },
+                    symbol_leaf("src/mixed.rs", "after_fn"),
+                ],
+                skip_reason: None,
+                test_symbol_count: None,
+            }],
+        )],
+    };
+    let actual = build_tree(&report);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_append_test_group_last_when_every_test_symbol_trails_every_production_symbol() {
+    // The common case (a trailing `#[cfg(test)] mod tests` block): with
+    // no production symbol positioned after the earliest test symbol,
+    // placement degrades to the same "append last" behavior as before
+    // ADR 0045.
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/mixed.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    range: LineRange { start: 1, end: 5 },
+                    ..symbol("src/mixed.rs::real_fn", "real_fn", SymbolKind::Function)
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 10, end: 15 },
+                    is_test: true,
+                    ..symbol("src/mixed.rs::test_it", "test_it", SymbolKind::Function)
+                },
+            ],
+        }],
+        ..empty_report()
+    };
+
+    let two_symbol_badges = Badges {
+        changed_symbols: 2,
+        contract_changes: 0,
+        fan_in: 0,
+        ..Badges::default()
+    };
+    let expected = Tree {
+        roots: vec![dir_wrapping(
+            "src",
+            two_symbol_badges,
+            vec![TreeNode {
+                kind: NodeKind::File,
+                path: "src/mixed.rs".to_string(),
+                badges: two_symbol_badges,
+                children: vec![
+                    symbol_leaf("src/mixed.rs", "real_fn"),
+                    TreeNode {
+                        kind: NodeKind::TestGroup { count: 1 },
+                        path: "src/mixed.rs::tests".to_string(),
+                        badges: one_symbol_badges(),
+                        children: vec![TreeNode {
+                            kind: NodeKind::Symbol(SymbolRef {
+                                is_test: true,
+                                ..symbol_ref("src/mixed.rs::test_it", "test_it")
+                            }),
+                            path: "src/mixed.rs".to_string(),
+                            badges: one_symbol_badges(),
+                            children: vec![],
+                            skip_reason: None,
+                            test_symbol_count: None,
+                        }],
+                        skip_reason: None,
+                        test_symbol_count: None,
+                    },
+                ],
+                skip_reason: None,
+                test_symbol_count: None,
+            }],
+        )],
+    };
+    let actual = build_tree(&report);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_group_scattered_test_symbols_at_the_earliest_ones_line() {
+    // Multiple, non-contiguous test symbols still fold into one
+    // TestGroup (ADR 0045 rejected per-block splitting) positioned at
+    // the earliest test symbol's line, not the last one's.
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/mixed.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    range: LineRange { start: 1, end: 5 },
+                    ..symbol("src/mixed.rs::before_fn", "before_fn", SymbolKind::Function)
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 10, end: 12 },
+                    is_test: true,
+                    ..symbol("src/mixed.rs::test_a", "test_a", SymbolKind::Function)
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 20, end: 25 },
+                    ..symbol("src/mixed.rs::middle_fn", "middle_fn", SymbolKind::Function)
+                },
+                ExtractedSymbol {
+                    range: LineRange { start: 30, end: 32 },
+                    is_test: true,
+                    ..symbol("src/mixed.rs::test_b", "test_b", SymbolKind::Function)
+                },
+            ],
+        }],
+        ..empty_report()
+    };
+
+    let tree = build_tree(&report);
+    let src = &tree.roots[0];
+    let file = &src.children[0];
+    let child_kinds: Vec<&str> = file
+        .children
+        .iter()
+        .map(|child| match &child.kind {
+            NodeKind::Symbol(symbol_ref) => symbol_ref.name.as_str(),
+            NodeKind::TestGroup { .. } => "TestGroup",
+            _ => "other",
+        })
+        .collect();
+
+    // NOTE: partial assert (child kind/name sequence only) — this test's
+    // sole concern is ordering among four children whose full badge/path
+    // shape is already pinned by the other tests in this module; a full
+    // `Tree` comparison here would restate that shape without
+    // strengthening the ordering assertion.
+    assert_eq!(vec!["before_fn", "TestGroup", "middle_fn"], child_kinds);
+    assert_eq!(NodeKind::TestGroup { count: 2 }, file.children[1].kind);
+}
+
+#[test]
 fn should_not_append_a_tests_section_when_there_are_no_test_files_at_all() {
     let report = Report {
         origin: rinkaku_core::render::ReportOrigin::Diff,


### PR DESCRIPTION
## Summary

- ADR 0043 folds a mixed file's test symbols into one `TestGroup` child, but always appended it *after* every production symbol regardless of where the test symbols actually sit in the file. For a file with production code both before and after its test block(s), that diverged from the diff pane's source-order section list, so the auto-scroll offset (ADR 0027) moved non-monotonically as the cursor descended the tree.
- `build_file_node` now positions `TestGroup` at its earliest test symbol's source line, interleaved with production symbols instead of fixed-last. The fold itself, collapsed-by-default state, and `N tests` label are all unchanged — only the node's position among its siblings moves.
- ADR 0045 records this as a partial supersede of ADR 0043 decision 1 (placement only); ADR 0043's header now links to it.
- A static review pass on the first draft of this change caught a real bug: the position search used a `usize::MAX` sentinel for a removed symbol's missing line, which always compared greater than the test block's line and let a removed symbol trailing a test block be mistaken for a later production symbol (`TestGroup` landed ahead of it instead of after). Fixed by switching to `Option<usize>` and excluding `None` from the search entirely, with a regression test pinning the correct order.

## Motivation

Diff pane always renders a file's hunks in source order (ADR 0027), and a symbol-row selection auto-scrolls to that symbol's section. With `TestGroup` fixed-last, moving the tree cursor down through a file's rows didn't correspond to moving down through the file whenever production code followed the test block — the auto-scroll offset would jump backward. This PR keeps tree-row order and diff-pane section order aligned.

## Related ADRs

- [`docs/adr/0045-test-group-source-order-placement.md`](docs/adr/0045-test-group-source-order-placement.md) — new, amends ADR 0043 decision 1's placement rule only.
- [`docs/adr/0043-tui-risk-oriented-visual-encoding.md`](docs/adr/0043-tui-risk-oriented-visual-encoding.md) — status line updated to note the partial supersede.

## QA

**Unit tests** (`make test`): 663 passing, including:
- `should_place_test_group_at_earliest_test_symbol_line_when_production_symbols_surround_it`
- `should_append_test_group_last_when_every_test_symbol_trails_every_production_symbol` (regression: common trailing-block case unchanged)
- `should_group_scattered_test_symbols_at_the_earliest_ones_line` (multiple non-contiguous test blocks still fold into one group)
- `should_not_let_a_removed_symbol_be_mistaken_for_a_later_production_symbol` (review-caught regression, confirmed Red on the pre-fix `usize::MAX` sentinel before the `Option<usize>` fix turned it Green)
- `should_break_ties_toward_production_when_a_test_symbol_shares_its_start_line` (pins the existing strict-`>` tie-break: production wins on a shared start line)

**Dynamic verification** (tmux, real binary): 10/10 items pass — mixed/trailing/scattered/whole-test fixtures exercised against a real build, monotonic auto-scroll confirmed while navigating the tree, output compared against `main`, and failure-mode checks (empty diff, non-TTY stdin/stdout) showed no regression.

**Lint** (`make lint`): clean — `cargo fmt --all --check` + `cargo clippy --all-targets --all-features -- -D warnings`, zero warnings.

## Scope note

Deliberately does not touch `rinkaku-tui/src/diff_shape.rs` or `rinkaku-tui/src/ui/` — a parallel branch (`feat/tui-split-view-diff`, using ADR 0044) is in flight against that surface. This PR is scoped entirely to `rinkaku-tui/src/tree/`.