### PR TITLE
docs(experiments): record experiment 0001 rounds 33 and 34

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/033.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/033.md
@@ -1,0 +1,68 @@
+# Round 33
+
+- Subject: PR #154 — split (side-by-side) view for the Diff pane (ADR
+  0044), letting the previous- and new-side hunk lines render in two
+  columns instead of the existing unified layout.
+- Protocol: same cost-reduced configuration as rounds 27-32 — one
+  static reviewer combining the map-assisted pass and the independent
+  pass, one separate dynamic-verification agent.
+- **Map delivery**: variant (b) — the static reviewer built rinkaku
+  from a trusted clean `main` checkout (`f4e1b35`) itself and ran that
+  binary's `rinkaku --base main` inside the branch worktree before
+  reading any code.
+- **What the map surfaced**: `DiffViewMode` (5 uses), `Body` (5 uses),
+  `App` (signature change, 4 uses), and `render_scrollable_pane`
+  (signature change, 4 uses) came up as the highest fan-in changed
+  symbols; the single densest concentration of changed symbols was
+  `pair_hunk_lines.rs` (15 symbols in one file). The reviewer used this
+  to prioritize `pair_hunk_lines`/`pair_wrap` for the deepest read and
+  traced `render_scrollable_pane`'s four call sites for regressions in
+  the existing scroll/sync machinery.
+- **Static finding (BLOCKER)**: in `diff_pane.rs`,
+  `diff_pane_split_rows` mis-paired contract-header rows — a removed
+  `previous_signature` line rendered on the left with an empty right
+  cell, and the following added `new` signature line rendered on the
+  right with an empty left cell, producing a diagonal staircase instead
+  of a left/right comparison for the one row type (contract headers)
+  where side-by-side comparison matters most. **This was not on the
+  map's fan-in list** — `pair_hunk_lines`/`pair_wrap` were flagged as
+  the densest file, but the actual defect was a distinct pairing
+  function reached only by reading that file in full, not by following
+  a ranked symbol. The map allocated attention to the right file; the
+  finding itself came from independent close reading once there, not
+  from the ranking.
+- **Static findings (should-fix, nit)**: the contract-header pairing
+  path had no test coverage — every fixture in the split-view test
+  module hard-codes `previous_signature: None`, so the diagonal-pairing
+  defect had no failing test to catch it (should-fix, addressed
+  alongside the blocker fix); ADR 0044 names an enum variant that
+  doesn't match the shipped identifier (nit, doc-only).
+- **Dynamic pass**: 13 checks, all pass — split/unified toggle,
+  left/right row alignment on ordinary hunks, ADR 0027 forward sync and
+  ADR 0030 reverse sync both intact in split mode, CJK width handling
+  and line wrapping, narrow-terminal (width 100) fallback to unified
+  and automatic recovery back to split above the threshold, and four
+  hostile-input invocations (non-TTY stdin/stdout, empty diff,
+  conflicting flags, missing file) with no panic. The dynamic pass did
+  not catch the contract-header pairing defect — none of the fixtures
+  it drove included a hunk with a signature change, so the diagonal
+  layout never rendered during the dynamic sweep.
+- Severity summary: 1 blocker, 1 should-fix, 1 nit — all fixed in the
+  same PR (`b388d74`: one-line-pair-plus-filler pairing for contract
+  headers, two new regression tests covering the previously-untested
+  path). `make test`: 683 passed. `make lint`: clean.
+- Takeaway: this round is a clean counter-example to round 34's map-
+  leads-to-defect shape recorded in the same batch. The map correctly
+  routed attention to the file with the defect (`pair_hunk_lines.rs`
+  was both the densest-changed-symbols file and where the bug lived),
+  but the specific defect — a pairing function producing a diagonal
+  instead of a side-by-side layout — was not itself represented by any
+  fan-in count or contract marker, and surfaced only because the
+  reviewer read the whole file rather than stopping at the symbols the
+  map ranked highest. Dynamic verification's miss reinforces the same
+  point from the other direction: none of its 13 checks happened to
+  exercise a hunk with a signature change, so a defect confined to one
+  specific row kind escaped a sweep that covered toggling, alignment,
+  sync, width handling, and hostile inputs but not that particular
+  content shape. Attention allocation and content-shape coverage are
+  both necessary and neither is sufficient on its own.

--- a/docs/experiments/0001-map-assisted-llm-review/rounds/034.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/034.md
@@ -1,0 +1,63 @@
+# Round 34
+
+- Subject: PR #155 — place a mixed file's `TestGroup` at its source-
+  order position in the entry tree, instead of always trailing after
+  every non-test symbol (ADR 0045).
+- Protocol: same cost-reduced configuration as rounds 27-33 — one
+  static reviewer combining the map-assisted pass and the independent
+  pass, one separate dynamic-verification agent.
+- **Map delivery**: variant (b) — the static reviewer built rinkaku
+  from a trusted clean `main` checkout (`f4e1b35`) itself and ran that
+  binary's `rinkaku --base main` inside the branch worktree before
+  reading any code.
+- **What the map surfaced**: 5 of the PR's 8 changed symbols
+  concentrated in `tree/mod.rs`; `build_file_node` and the new function
+  `test_group_insert_index` were the highest fan-in changed symbols;
+  `FileBuilder`'s signature change (`Vec<SymbolRef>` →
+  `Vec<(SymbolRef, usize)>`) was called out as a contract marker. The
+  reviewer followed this chain directly to the `usize::MAX` sentinel
+  used inside `insert_removed`'s position search.
+- **Static finding (should-fix)**: the `usize::MAX` sentinel used to
+  mark a removed symbol's absent source position can match the
+  position-search comparison used by `test_group_insert_index` in
+  files that mix a trailing test block with at least one removed
+  symbol, causing the `TestGroup` to be inserted before the removed
+  symbol instead of after all remaining source-order symbols. **The
+  map's contract marker on `FileBuilder`'s signature change pointed
+  directly at the defect** — the reviewer went from the changed-tuple
+  signature to the sentinel-based position search to the fault in one
+  traced path, the inverse of round 33's outcome where the map
+  correctly ranked the right file but not the right function. A
+  same-finding nit: a comment beside the sentinel describing it as
+  harmless was inaccurate given this defect and needed updating
+  alongside the fix.
+- **Dynamic pass**: 10 checks, all pass on the fixed build — self-
+  constructed `mixed`/`trailing`/`scattered`/`whole-test` fixtures
+  compared against a `main` build to confirm ordering, manual scroll
+  sweep confirming monotonic tree order (the non-monotonic-scroll
+  symptom that motivated ADR 0045 was reproduced against unpatched
+  `main` first, then confirmed fixed on the branch), and four hostile-
+  input invocations with no panic.
+- Severity summary: 1 should-fix, 1 nit — both fixed in the same PR
+  (`cde5bed`: sentinel replaced by `Option<usize>`, eliminating the
+  ambiguous-value class entirely rather than special-casing the
+  comparison; the inaccurate "harmless" comment was deleted as part of
+  the same change since the type now makes the invariant explicit).
+  Two new tests added, confirmed red against the pre-fix code and green
+  after. `make test`: 663 passed. `make lint`: clean.
+- Takeaway: paired with round 33 in the same batch, this round is the
+  positive case of the same dynamic — a `FileBuilder` signature change
+  flagged as a contract marker took the reviewer directly from map to
+  root cause, where round 33's densest-file ranking got the reviewer
+  to the right file but not the right function. Read together, the two
+  rounds reinforce that the map's routing power varies with how
+  directly a defect's cause is reflected in the signature-level surface
+  it reports on: a changed tuple shape *is* the mechanism here, while a
+  mis-paired rendering row in round 33 was not something any fan-in
+  count or contract marker could name. The fix itself also generalizes
+  round 31's lesson about ambiguous sentinel values: replacing
+  `usize::MAX` with `Option<usize>` didn't just patch the one
+  comparison, it made the "no source position" case unrepresentable as
+  a number that could accidentally compare equal to a real position —
+  the same category of fix as making a drift-prone default match arm
+  exhaustive instead of patching each fallthrough as it's found.


### PR DESCRIPTION
## Summary
- Records experiment 0001 round 33 (PR #154, split-view diff pane) and round 34 (PR #155, TestGroup source-order placement) under `docs/experiments/0001-map-assisted-llm-review/rounds/`.
- Per this doc's own convention, only adds round files this PR; folding into the README index/Conclusions is left to a separate follow-up.

## Test plan
- [x] `make test`
- [x] `make lint`