### PR TITLE
feat(tui): polish the diff pane (background tint fallback, v hint, split default)

### DIFF
--- a/docs/adr/0018-syntax-highlight-diff-pane-via-tree-sitter.md
+++ b/docs/adr/0018-syntax-highlight-diff-pane-via-tree-sitter.md
@@ -96,3 +96,18 @@ edited on disk after opening the source screen no longer picks up the
 edit until the screen is re-opened (`s` again), trading that rare case
 for the "no per-frame reparse" invariant this crate holds everywhere
 else.
+
+## Amendment: fallback style now carries the background tint too
+
+Dogfooding found the plain-style fallback (`plain_diff_line`, used when a
+hunk has no highlight data at all) inconsistent with the highlighted
+path: a highlighted line's `+`/`-` marker and tokens sit on the
+`ADDED_BG`/`REMOVED_BG` tint from this ADR's main decision, but the
+fallback rendered green/red foreground on no background, so an
+unrecognized-extension file's hunks read visually different from a
+highlighted one for the same diff signal. `plain_diff_line` now applies
+the same `ADDED_BG`/`REMOVED_BG` tint as the highlighted path (context
+lines stay unstyled either way); the contract header (the bold red `-`/
+green `+` old/new signature pair before a section's hunks) is unchanged,
+since it is not an actual diff line and keeps signaling via foreground
+color alone.

--- a/docs/adr/0044-tui-split-view-diff-pane.md
+++ b/docs/adr/0044-tui-split-view-diff-pane.md
@@ -235,3 +235,18 @@ two modes.
 - No backward-compatibility concern: the TUI has never shipped a
   release (ADR 0015/0016, restated by every TUI-scoped ADR since), so
   this is a pure addition, not a migration.
+
+## Amendment: default flipped to `Split`
+
+Decision 2 originally defaulted `DiffViewMode` to `Unified`, reasoning
+that every prior ADR's screenshots assumed unified rendering. Further
+dogfooding after the toggle shipped found the opposite: split is the
+more useful *opening* state for the pane's typical case (a signature or
+small block edit, exactly what the split view exists to make legible),
+and reviewers were pressing `v` immediately on most sessions anyway.
+`DiffViewMode::default()` now returns `Split`. Decision 7's narrow-
+terminal fallback (`MIN_SPLIT_VIEW_WIDTH`) already renders unified
+whenever the pane is too narrow for split, independent of
+`diff_view_mode` — so this default change carries no new risk for
+narrow terminals, only for wide ones where split was already available
+a keypress away.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -55,11 +55,12 @@ only becomes load-bearing when the output would otherwise not be TUI
 - **Diff pane (right, default)** — the raw unified-diff hunks touching
   the selected row, syntax-highlighted for the four built-in languages
   ([ADR 0018](adr/0018-syntax-highlight-diff-pane-via-tree-sitter.md)).
-  Press `v`/`V` to switch to a split (side-by-side old/new) view for the
-  same hunks — useful for edits where seeing the old and new lines
-  aligned next to each other is easier to scan than interleaved `-`/`+`
-  lines. Split view needs a reasonably wide pane; on a narrow terminal
-  it falls back to unified and the pane header notes why.
+  Opens in a split (side-by-side old/new) view by default — useful for
+  edits where seeing the old and new lines aligned next to each other is
+  easier to scan than interleaved `-`/`+` lines. Press `v`/`V` to switch
+  to unified rendering for the same hunks. Split view needs a reasonably
+  wide pane; on a narrow terminal it falls back to unified regardless of
+  the toggle, and the pane header notes why.
 - **Detail pane (right)** — what the cursor is on: classification,
   signature (with an old/new diff on contract change), used-by, callees;
   or, for a directory, its badge breakdown and cycle members.

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -119,13 +119,15 @@ pub enum RightPane {
 /// cursor moves to a different row, the same way [`RightPane`] already
 /// persists across cursor moves.
 ///
-/// Defaults to `Unified`: every prior ADR describing the Diff pane assumes
-/// unified rendering, so it stays the opening state rather than surprising
-/// a reviewer who has not yet discovered the toggle.
+/// Defaults to `Split` (ADR 0044 amendment): dogfooding found split the
+/// more useful opening state for the pane's usual case (a signature or
+/// small block edit), and `MIN_SPLIT_VIEW_WIDTH`'s narrow-terminal
+/// fallback already keeps a cramped pane on unified regardless of this
+/// default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DiffViewMode {
-    #[default]
     Unified,
+    #[default]
     Split,
 }
 

--- a/rinkaku-tui/src/app/tests/right_pane.rs
+++ b/rinkaku-tui/src/app/tests/right_pane.rs
@@ -109,24 +109,26 @@ fn should_return_to_detail_when_blast_radius_is_toggled_off_after_entering_from_
 }
 
 #[test]
-fn should_default_diff_view_mode_to_unified() {
+fn should_default_diff_view_mode_to_split() {
+    // ADR 0044 amendment: dogfooding found split the more useful opening
+    // state for the pane's typical case (a signature or small block edit).
     let report = empty_report();
     let app = App::new(&report);
 
-    assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
+    assert_eq!(DiffViewMode::Split, app.diff_view_mode());
 }
 
 #[test]
-fn should_toggle_diff_view_mode_between_unified_and_split() {
+fn should_toggle_diff_view_mode_between_split_and_unified() {
     let report = empty_report();
     let app = App::new(&report);
-    assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
-
-    let app = app.handle_key(InputKey::ToggleSplitView);
     assert_eq!(DiffViewMode::Split, app.diff_view_mode());
 
     let app = app.handle_key(InputKey::ToggleSplitView);
     assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
+
+    let app = app.handle_key(InputKey::ToggleSplitView);
+    assert_eq!(DiffViewMode::Split, app.diff_view_mode());
 }
 
 #[test]
@@ -135,11 +137,11 @@ fn should_preserve_diff_view_mode_when_cursor_moves_to_a_different_row() {
     // `RightPane`'s own persistence across cursor moves.
     let report = report_with_two_directories_and_graph();
     let app = App::new(&report).handle_key(InputKey::ToggleSplitView);
-    assert_eq!(DiffViewMode::Split, app.diff_view_mode());
+    assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
 
     let app = app.handle_key(InputKey::Down);
 
-    assert_eq!(DiffViewMode::Split, app.diff_view_mode());
+    assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
 }
 
 #[test]
@@ -148,11 +150,11 @@ fn should_ignore_toggle_split_view_while_source_screen_is_open() {
     let app = App::new(&report)
         .handle_key(InputKey::Down)
         .handle_key(InputKey::Source);
-    assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
+    assert_eq!(DiffViewMode::Split, app.diff_view_mode());
 
     let app = app.handle_key(InputKey::ToggleSplitView);
 
-    assert_eq!(DiffViewMode::Unified, app.diff_view_mode());
+    assert_eq!(DiffViewMode::Split, app.diff_view_mode());
     assert_eq!(
         Screen::Source {
             symbol_id: "lib.rs::foo".to_string(),

--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -316,11 +316,11 @@ fn selected_row_badges(app: &App) -> Badges {
 /// Within each section, hunk headers stay dim, `+`/`-` marker glyphs keep
 /// their existing bold green/red foreground, and each line's own code
 /// tokens are colored by [`highlight::lookup_hunk_highlight_by_index`] when
-/// available (ADR 0018/0020) — falling back to the plain green/red/
-/// unstyled line style this pane always had when a hunk has no highlight
-/// (unknown extension, parse/query failure, or `highlighted_file` itself
-/// being `None`) so highlighting can never make a diff harder to read than
-/// before.
+/// available (ADR 0018/0020) — falling back to [`plain_diff_line`] (green/
+/// red foreground plus the same `ADDED_BG`/`REMOVED_BG` tint, unstyled for
+/// context) when a hunk has no highlight (unknown extension, parse/query
+/// failure, or `highlighted_file` itself being `None`) so highlighting can
+/// never make a diff harder to read than before.
 pub(crate) fn diff_pane_lines(
     sections: &[&DiffSection],
     show_section_headers: bool,
@@ -489,10 +489,12 @@ fn split_side_line(
 
 /// Builds one display line for a hunk body line, coloring its code tokens
 /// per `token_spans` (`None` when highlighting is unavailable for this
-/// line — falls back to the pane's original plain style). The `+`/`-`
-/// marker glyph itself is always pushed as its own bold-colored span, kept
-/// outside of `line.content`'s token coloring so it is never masked by a
-/// token span that happens to start at byte 0.
+/// line — falls back to [`plain_diff_line`], which now also carries the
+/// `ADDED_BG`/`REMOVED_BG` tint so a highlighted and an unhighlighted hunk
+/// read as the same "this line changed" signal). The `+`/`-` marker glyph
+/// itself is always pushed as its own bold-colored span, kept outside of
+/// `line.content`'s token coloring so it is never masked by a token span
+/// that happens to start at byte 0.
 pub(crate) fn diff_line(line: &DiffLine, token_spans: Option<Vec<TokenSpan>>) -> Line<'static> {
     match &token_spans {
         Some(spans) => {
@@ -509,17 +511,20 @@ pub(crate) fn diff_line(line: &DiffLine, token_spans: Option<Vec<TokenSpan>>) ->
     }
 }
 
-/// The pane's original (pre-ADR-0018) plain green/red/unstyled line style —
-/// the fallback for a line highlighting could not cover.
+/// The fallback line style for a line highlighting could not cover
+/// (unknown extension, parse/query failure, or no highlighted file at
+/// all): the same `+`/`-`/green/red foreground as the highlighted path,
+/// plus the same `ADDED_BG`/`REMOVED_BG` tint — a context line stays
+/// unstyled since it carries no diff signal either way.
 pub(crate) fn plain_diff_line(line: &DiffLine) -> Line<'static> {
     match line.kind {
         DiffLineKind::Added => Line::styled(
             format!("+{}", line.content),
-            Style::default().fg(Color::Green),
+            Style::default().fg(Color::Green).bg(ADDED_BG),
         ),
         DiffLineKind::Removed => Line::styled(
             format!("-{}", line.content),
-            Style::default().fg(Color::Red),
+            Style::default().fg(Color::Red).bg(REMOVED_BG),
         ),
         DiffLineKind::Context => Line::raw(format!(" {}", line.content)),
     }

--- a/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
@@ -4,11 +4,11 @@ use crate::diff_shape::{ContractHeader, DiffSection};
 use pretty_assertions::assert_eq;
 
 #[test]
-fn should_draw_old_and_new_lines_side_by_side_when_split_view_is_toggled_on() {
+fn should_draw_old_and_new_lines_side_by_side_by_default() {
+    // ADR 0044 amendment: split is now the default `DiffViewMode`, so no
+    // `ToggleSplitView` press is needed to reach it here.
     let report = report_with_one_symbol();
-    let app = App::new(&report)
-        .handle_key(InputKey::Down)
-        .handle_key(InputKey::ToggleSplitView);
+    let app = App::new(&report).handle_key(InputKey::Down);
     let diff_text = "\
 diff --git a/lib.rs b/lib.rs
 index e69de29..4b825dc 100644
@@ -53,10 +53,11 @@ index e69de29..4b825dc 100644
 
 #[test]
 fn should_fall_back_to_unified_when_pane_is_narrower_than_the_split_view_minimum() {
+    // ADR 0044 amendment: split is now the default `DiffViewMode`, so no
+    // `ToggleSplitView` press is needed to have `diff_view_mode` be `Split`
+    // here.
     let report = report_with_one_symbol();
-    let app = App::new(&report)
-        .handle_key(InputKey::Down)
-        .handle_key(InputKey::ToggleSplitView);
+    let app = App::new(&report).handle_key(InputKey::Down);
     let diff_text = "\
 diff --git a/lib.rs b/lib.rs
 index e69de29..4b825dc 100644
@@ -172,10 +173,10 @@ fn should_draw_old_and_new_signature_side_by_side_when_symbol_signature_changed(
         file_size_bands: vec![],
         removed: vec![],
     };
-    // Row 0 is the "lib.rs" file row, row 1 is the "foo" symbol.
-    let app = App::new(&report)
-        .handle_key(InputKey::Down)
-        .handle_key(InputKey::ToggleSplitView);
+    // Row 0 is the "lib.rs" file row, row 1 is the "foo" symbol. ADR 0044
+    // amendment: split is now the default `DiffViewMode`, so no
+    // `ToggleSplitView` press is needed to reach it here.
+    let app = App::new(&report).handle_key(InputKey::Down);
     let diff_text = "\
 diff --git a/lib.rs b/lib.rs
 index e69de29..4b825dc 100644
@@ -214,9 +215,14 @@ index e69de29..4b825dc 100644
 }
 
 #[test]
-fn should_render_unified_when_split_view_is_not_toggled_on() {
+fn should_render_unified_when_split_view_is_toggled_off() {
+    // ADR 0044 amendment: split is now the default `DiffViewMode`, so
+    // reaching unified rendering here needs an explicit `ToggleSplitView`
+    // press (the opposite of this test's pre-amendment setup).
     let report = report_with_one_symbol();
-    let app = App::new(&report).handle_key(InputKey::Down);
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::ToggleSplitView);
     let diff_text = "\
 diff --git a/lib.rs b/lib.rs
 index e69de29..4b825dc 100644

--- a/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
@@ -233,12 +233,58 @@ index e69de29..4b825dc 100644
     let text = buffer_text(&terminal);
     assert!(text.contains("+b: 2"));
 
-    // Falls back to the pane's original plain green foreground with no
-    // background tint at all (`Some(Color::Reset)` is ratatui's
-    // "unset" — see the context-line test above for why this isn't
-    // `None`) — highlighting failing (or, here, never applying) must
-    // never break the pre-existing diff styling.
+    // Falls back to the pane's plain green foreground, now with the same
+    // `ADDED_BG` tint a highlighted line carries — highlighting failing
+    // (or, here, never applying) must not lose the diff background signal.
     let added_style = find_cell_style(&terminal, "+b: 2", "b");
-    assert_eq!(Some(Color::Reset), added_style.bg);
+    assert_eq!(Some(ADDED_BG), added_style.bg);
     assert_eq!(Some(Color::Green), added_style.fg);
+}
+
+#[test]
+fn should_apply_added_background_tint_to_plain_diff_line_when_no_token_spans() {
+    let line = crate::diff_view::DiffLine {
+        kind: crate::diff_view::DiffLineKind::Added,
+        content: "fn foo() {}".to_string(),
+    };
+
+    let actual = plain_diff_line(&line);
+
+    assert_eq!(
+        Line::styled(
+            "+fn foo() {}".to_string(),
+            Style::default().fg(Color::Green).bg(ADDED_BG),
+        ),
+        actual
+    );
+}
+
+#[test]
+fn should_apply_removed_background_tint_to_plain_diff_line_when_no_token_spans() {
+    let line = crate::diff_view::DiffLine {
+        kind: crate::diff_view::DiffLineKind::Removed,
+        content: "fn foo() {}".to_string(),
+    };
+
+    let actual = plain_diff_line(&line);
+
+    assert_eq!(
+        Line::styled(
+            "-fn foo() {}".to_string(),
+            Style::default().fg(Color::Red).bg(REMOVED_BG),
+        ),
+        actual
+    );
+}
+
+#[test]
+fn should_keep_context_line_unstyled_in_plain_diff_line_when_no_token_spans() {
+    let line = crate::diff_view::DiffLine {
+        kind: crate::diff_view::DiffLineKind::Context,
+        content: "fn foo() {}".to_string(),
+    };
+
+    let actual = plain_diff_line(&line);
+
+    assert_eq!(Line::raw(" fn foo() {}".to_string()), actual);
 }

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -37,7 +37,10 @@ pub(crate) fn draw_status_line(frame: &mut Frame, app: &App, report: &Report, ar
 /// `]`/`[` jump for that pane/focus combination (it needs the Diff pane's
 /// shaped hunk-offset table, which Detail/BlastRadius have no equivalent
 /// of), so advertising the key while Detail/BlastRadius is showing would
-/// describe a binding that does nothing there.
+/// describe a binding that does nothing there. `v: split`
+/// ([`crate::app::InputKey::ToggleSplitView`], ADR 0044) is scoped the
+/// same way: the toggle is global, but it only has a visible effect while
+/// the Diff pane is on screen.
 ///
 /// Extracted as its own pure function (no `ratatui` types) so the text
 /// itself — not just that *something* renders — is unit-testable, mirroring
@@ -68,7 +71,7 @@ pub(crate) fn status_line_text(app: &App, report: &Report) -> String {
                     "j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
                 }
                 crate::app::Focus::Right if app.right_pane() == crate::app::RightPane::Diff => {
-                    "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  ]/[: next/prev hunk  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
+                    "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  ]/[: next/prev hunk  v: split  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
                 }
                 crate::app::Focus::Right => {
                     "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
@@ -268,7 +271,7 @@ mod tests {
         let actual = status_line_text(&app, &report);
 
         assert_eq!(
-            "order: topological  |  j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  ]/[: next/prev hunk  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
+            "order: topological  |  j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  ]/[: next/prev hunk  v: split  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
                 .to_string(),
             actual
         );


### PR DESCRIPTION
## Summary

Three small diff-pane improvements found while dogfooding the split view:

1. **Background tint for unhighlighted hunk lines** — added/removed lines in files without tree-sitter highlight support (markdown, shell, ...) now get the same `ADDED_BG`/`REMOVED_BG` background tint as highlighted languages, so every hunk reads consistently. Context lines stay unstyled. The contract header (old/new signature summary) deliberately stays foreground-only to distinguish it from real hunk lines. ADR 0018 amended.
2. **`v: split` in the footer hint** — the diff-pane-focused status line now advertises the split toggle, scoped like the existing `]/[` hint.
3. **Split view is the default** — `DiffViewMode` now defaults to `Split`; narrow panes (< 100 columns) still fall back to unified with a note, per the existing width fallback. ADR 0044 amended, `docs/tui.md` updated.

## QA

- `make test` (691 tests) and `make lint` pass.
- Dynamic verification in tmux: background tint on md/sh hunks with unstyled context lines, unchanged rust rendering, contract header foreground-only in both unified and split, no filler-row bleed, split-by-default on wide terminals with narrow-terminal fallback and auto-resume, `v: split` shown only with diff-pane focus, help/detail/blast-radius/source regressions checked.
- Failure modes: non-TTY, empty diff, deleted-file diff — no panics.
- Reviewed via a map-assisted static pass (map from a trusted `main` build) plus an independent dynamic pass; no findings.