### PR TITLE
feat(tui): overlay the diff onto the source view

### DIFF
--- a/docs/adr/0046-source-view-diff-overlay.md
+++ b/docs/adr/0046-source-view-diff-overlay.md
@@ -175,3 +175,21 @@ position ADR 0026 already centers on the symbol.
 - A file edited on disk since the diff was produced silently loses its
   overlay (decision 5) rather than showing a misleading one — visible
   in the pane header, not a silent gap.
+- **`--pr` mode loses the overlay for every file the PR actually
+  changes.** `--pr` resolves a workdir (current directory, an
+  existing `ghq` clone, or a cache clone) and fetches the PR's head
+  ref (`refs/pull/N/head`) into it, but never checks that ref out
+  (`main.rs`'s own module doc comment on the `--pr` read strategy) —
+  the working tree `crate::source::load_symbol_source` reads stays
+  whatever was checked out before rinkaku ran, not the PR's new side.
+  For a file the PR modifies, that means every `Context` line's
+  drift check (decision 5) fails, and the overlay silently disables
+  itself with the pane-title note. This fails safe (the overlay never
+  tints content that doesn't match the diff), but it means the
+  feature is least available exactly where a PR review needs it most.
+  Fixing this requires reading the source view's content from the
+  diff's new-side snapshot (`git show <head SHA>:<path>`) at the IO
+  boundary for `--pr` mode specifically, rather than the working tree
+  — `--base` mode is unaffected, since there the working tree already
+  *is* the new side by construction. Left as a follow-up rather than
+  folded into this ADR's decision.

--- a/docs/adr/0046-source-view-diff-overlay.md
+++ b/docs/adr/0046-source-view-diff-overlay.md
@@ -1,0 +1,177 @@
+# 0046. Overlay the diff onto the source view instead of a full-file diff pane mode
+
+- Status: accepted
+- Date: 2026-07-14
+
+## Context
+
+The diff pane (ADR 0020) only ever shows the hunks touching the
+selected row — for a symbol row, just that symbol's own lines; for a
+file row, every hunk grouped by section. A reviewer who wants to see a
+changed symbol in the context of its *whole file*, with the change
+still marked, has no path to that today: the diff pane deliberately
+never shows unchanged surrounding code, and the source view (`s`, ADR
+0015) shows the whole file but has no notion of what changed in it —
+every line renders identically regardless of whether the diff touched
+it.
+
+Two ways to close this gap were on the table:
+
+1. Add a "full file" mode to the diff pane itself.
+2. Overlay the diff's added/removed lines onto the existing source
+   view.
+
+The diff pane's line-index coordinate space is load-bearing: ADR
+0027/0030's scroll sync (tree selection <-> diff pane scroll position)
+and ADR 0044's split-view pairing both operate on "logical line
+number within the rendered hunks," a coordinate space that only
+includes lines the diff actually touched (plus a few lines of
+surrounding context git includes in the hunk). Stretching that same
+pane to show *every* line of the file — most of which are outside any
+hunk — would require either a second, parallel coordinate space (the
+exact problem ADR 0044's Context section already flagged and designed
+around when it chose hunk-relative pairing over full alignment) or
+teaching every consumer of today's hunk-relative space
+(`hunk_start_lines`, `section_start_line_for_symbol`,
+`symbol_id_for_scroll_line`) to also understand full-file line numbers.
+Neither is a small change, and both risk desyncing scroll-sync logic
+three prior ADRs went to specific lengths to keep simple.
+
+The source view, by contrast, already renders every line of the file
+(`crate::source::SourceView.lines`) and already composites one
+line-level visual signal on top of syntax highlighting (ADR 0018's
+amendment: the drilled-into symbol's own range gets a background
+tint, composed with token foreground colors via
+`ui::style::styled_content_spans`). Adding a second line-level
+background tint — added/removed, this time keyed by the diff rather
+than the symbol's own range — is the same composition technique
+applied a second time, not a new mechanism.
+
+## Decision
+
+**1. The source view (`s`), not the diff pane, is the home for
+full-file diff context.** When the drilled-into symbol's file has an
+entry in the diff, the source view composites the diff onto its
+existing full-file rendering: an **added** line gets `ADDED_BG`
+(`crate::ui::diff_pane::ADDED_BG`) with a `+` gutter marker; a
+**removed** line is inserted immediately before the new-side position
+it used to occupy, gets `REMOVED_BG`, and a `-` gutter marker. Lines
+the diff didn't touch keep the source view's existing plain gutter
+(the line number) and no background tint, same as today.
+
+**2. Always on, no toggle.** Every symbol's file either has diff
+hunks or it doesn't; when it does, the overlay is exactly the
+information a reviewer opening the source view from a changed symbol
+wants to see, and there is no rendering this ADR is aware of that the
+overlay would make *worse* for a hunk-having file (unlike ADR 0044's
+split view, which trades width for alignment and genuinely isn't
+always the better choice). A toggle would add a key binding and a
+mode dimension for a feature with no real "I'd rather not see this"
+case. If a real one surfaces later, a toggle can be added as an
+amendment.
+
+**3. Line-number mapping is a new pure function, `source_diff::hunk_overlay_lines`,
+in a new module `rinkaku_tui::source_diff`.** Given one `Hunk` (already
+parsed by `crate::diff_view`), it walks `hunk.lines` and computes each
+line's position in the overlay: an `Added`/`Context` line's new-side
+line number advances a running counter seeded from `hunk.new_range`'s
+start (mirroring how `crate::diff_view::Hunk::new_range` itself is
+derived — module doc comment there); a `Removed` line carries the
+*next* new-side line number, meaning "insert immediately before this
+line" — the same "deletion is a position, not a line" convention
+`crate::diff_view::hunk_intersects` already established for a
+pure-deletion hunk's `new_range`, reused here rather than inventing a
+second one. `Context` lines are dropped from the overlay's output —
+the source view's own lines already render them; the overlay only
+needs to add information for `Added`/`Removed`.
+
+**4. Composition into display rows is a second pure function,
+`source_diff::overlay_source_lines`.** Given `SourceView.lines` and
+the flattened overlay entries for every intersecting hunk in the
+file, it produces one `Vec<OverlayRow>` — one entry per source line
+(kind `Unchanged`, carrying that line's own 1-based number) plus one
+extra entry immediately before an `Added` line's number for each
+`Removed` overlay entry at that position (kind `Removed`, carrying no
+source line number — nothing in `SourceView.lines` to point at,
+consistent with `crate::diff_view::Hunk::new_range`'s own convention
+that a deletion has a position but not a line of its own). An `Added`
+line's entry is the existing `Unchanged` row at that line number,
+re-tagged `Added`; the function does not duplicate it.
+
+**5. Working-tree drift degrades to no overlay for that file, not a
+best-effort mismatch.** `crate::source::load_symbol_source`'s own doc
+comment already documents that the source view reads the live working
+tree while `report`/`diff_text` may have been built from a historical
+commit or stdin — the file's current content and the diff's hunks can
+disagree about what a given new-side line number actually contains.
+`overlay_source_lines` detects this the only way available without a
+second file read: each hunk's `Context` lines carry the exact text
+`crate::diff_view` parsed from the diff itself, so before compositing,
+every context line's text is compared against `SourceView.lines` at
+its computed line number. On the first mismatch, the whole file's
+overlay is dropped (not just the one disagreeing hunk) and the source
+view renders exactly as it does today, unmodified, with a one-line
+note appended to the pane header: `"(diff overlay unavailable — file
+on disk doesn't match the diff)"`. Silently overlaying a
+partially-wrong mapping would show colored lines in the wrong place,
+which is worse than showing no overlay at all; a per-hunk partial
+overlay would leave the reviewer unsure which hunks in the same file
+to trust.
+
+**6. Rendering reuses the existing token-foreground / background-tint
+composition.** `ui::source_screen::source_lines` already composes
+`styled_content_spans`'s token foreground with the symbol's own
+`SOURCE_HIGHLIGHT_BG` background tint; the diff overlay's
+`ADDED_BG`/`REMOVED_BG` slot into the same `bg: Option<Color>`
+parameter. When both signals would apply to the same line (a changed
+line that also falls inside the drilled-into symbol's own range), the
+diff's added/removed tint wins — it is the more specific, higher-value
+signal for a reviewer who followed a changed symbol into its file
+specifically to see what changed, and the symbol-range tint's whole
+job (orienting the reader to "you are here") is already accomplished
+by the gutter's line-number highlighting plus the initial scroll
+position ADR 0026 already centers on the symbol.
+
+## Alternatives
+
+- **Full-file mode inside the diff pane.** Rejected per Context: reuses
+  a coordinate space three prior ADRs (0027, 0030, 0044) built specific
+  scroll-sync and pairing logic around, none of which anticipated
+  "every line of the file, not just hunk lines." Doubling that space
+  risks the exact class of bug ADR 0044's Alternatives section already
+  called out and designed around once.
+- **A toggle key for the overlay.** Rejected per decision 2: no
+  identified case where a reviewer benefits from suppressing it once
+  it's available, unlike split view's genuine per-hunk trade-off.
+- **Best-effort overlay on working-tree drift, applied hunk-by-hunk.**
+  Rejected per decision 5: a half-correct overlay (some hunks placed
+  right, others silently wrong) is harder to trust than a clearly
+  absent one with an explicit note.
+- **Re-locate hunks against the live file via a text diff (e.g. a
+  Myers diff between the hunk's recorded old-side text and the current
+  file) instead of dropping the overlay on any mismatch.** Rejected as
+  a second diffing algorithm layered on top of git's own hunks, the
+  same "re-litigating a decision git already made" objection ADR
+  0044's Alternatives raised against LCS-based split-view alignment —
+  and the source view's own doc comment already accepts working-tree
+  drift as a known, documented limitation for the symbol-range
+  highlight; the overlay inherits the same limitation rather than
+  solving a problem the base feature doesn't solve either.
+
+## Consequences
+
+- A reviewer pressing `s` on a changed symbol sees the change directly
+  in the file, colored the same way the diff pane colors it, without
+  losing the full-file context the diff pane deliberately never shows.
+- `rinkaku-tui` gains one new module (`source_diff`), keeping
+  `crate::diff_view`, `crate::source`, and `crate::ui::source_screen`
+  each under the file-size discipline's watch threshold rather than
+  growing an already-large file further.
+- The overlay depends on `crate::diff_view::parse_diff_hunks`'s output,
+  already computed once per session by `crate::run_app` — no new IO,
+  no new tree-sitter parse, only a pure composition pass alongside the
+  existing `load_highlighted_symbol_source` call the `s` key already
+  triggers.
+- A file edited on disk since the diff was produced silently loses its
+  overlay (decision 5) rather than showing a misleading one — visible
+  in the pane header, not a silent gap.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -138,7 +138,9 @@ the changed lines alone. The overlay is always on; there's no key to
 toggle it off. If the file on disk no longer matches the diff (edited
 since it was produced, or diffed against a different revision), the
 pane falls back to its plain, unhighlighted rendering and says so in
-its title.
+its title. In particular, `--pr` shows your local checkout here, not
+a snapshot of the PR's branch, so files the PR changes typically fall
+back to plain rendering too.
 
 ## Combining with `--entry`
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -129,6 +129,17 @@ line range. Reads the working tree (not the historical commit
 `--base`/`--pr` compared against), so the highlighted range can drift
 if you edit the file after opening the TUI. `esc`/`q` returns.
 
+When the open file has diff hunks, they're overlaid directly onto the
+full file: added lines get a green background and a `+` gutter,
+removed lines appear as extra red-background rows with a `-` gutter
+inserted at the position they used to occupy — the diff pane's
+signal, but in the context of the whole file rather than clipped to
+the changed lines alone. The overlay is always on; there's no key to
+toggle it off. If the file on disk no longer matches the diff (edited
+since it was produced, or diffed against a different revision), the
+pane falls back to its plain, unhighlighted rendering and says so in
+its title.
+
 ## Combining with `--entry`
 
 `--entry <path>` combined with the TUI opens with the cursor already on

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -183,6 +183,7 @@ pub(crate) fn run_app(
                 &diff_highlights,
                 &blast_radius_selection,
                 source_content.as_ref(),
+                &diff_hunks,
             );
         })?;
         app = clamp_right_pane_scroll_after_draw(app, outcome.clamped_right_pane_scroll);

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -40,6 +40,7 @@ pub mod order;
 pub mod row_view;
 mod session;
 pub mod source;
+pub mod source_diff;
 pub mod splash;
 pub mod tree;
 pub mod ui;

--- a/rinkaku-tui/src/source_diff.rs
+++ b/rinkaku-tui/src/source_diff.rs
@@ -6,6 +6,10 @@
 
 use crate::diff_view::{DiffLineKind, FileHunks, Hunk};
 
+#[cfg(test)]
+#[path = "source_diff/tests.rs"]
+mod tests;
+
 /// One diff-only line an overlay adds beyond what [`crate::source::SourceView`]
 /// already renders, either a new-side line already present in the source
 /// (`Added`) or a line that no longer exists there (`Removed`).
@@ -165,6 +169,69 @@ pub fn overlay_source_lines(
     Some(rows)
 }
 
+/// Slices `rows` (an [`overlay_source_lines`] result) down to the rows
+/// belonging to the 1-based inclusive source line range
+/// `[start_line, end_line]` — the source view's already-clamped scroll
+/// window (`crate::ui::source_screen::clamped_window`, which operates on
+/// raw source line indices, unaffected by how many extra `Removed` rows an
+/// overlay inserts).
+///
+/// A `Removed` row has no `line_number` of its own (`OverlayRow`'s own doc
+/// comment); its *anchor* is the `Unchanged`/`Added` row immediately
+/// following it in `rows`' own order (or, for a run of `Removed` rows at
+/// the very end of `rows` — a deletion at end of file, `overlay_source_lines`'s
+/// own trailing-position handling — the source's last line, since that run
+/// renders only once the reviewer has scrolled to see the file's end). A
+/// `Removed` row is included exactly when its anchor line number falls in
+/// `[start_line, end_line]`.
+pub fn rows_in_source_range(
+    rows: &[OverlayRow],
+    start_line: usize,
+    end_line: usize,
+) -> &[OverlayRow] {
+    let anchors = row_anchor_line_numbers(rows);
+
+    let first = anchors.iter().position(|anchor| *anchor >= start_line);
+    let Some(first) = first else {
+        return &[];
+    };
+    let last = anchors[first..]
+        .iter()
+        .position(|anchor| *anchor > end_line)
+        .map(|offset| first + offset)
+        .unwrap_or(rows.len());
+
+    &rows[first..last]
+}
+
+/// One entry per `rows`, the 1-based source line number that row is
+/// anchored to for range-membership purposes ([`rows_in_source_range`]'s
+/// own doc comment on what "anchor" means for a `Removed` row).
+fn row_anchor_line_numbers(rows: &[OverlayRow]) -> Vec<usize> {
+    let last_line_number =
+        rows.iter()
+            .filter_map(|row| match row {
+                OverlayRow::Unchanged { line_number, .. }
+                | OverlayRow::Added { line_number, .. } => Some(*line_number),
+                OverlayRow::Removed { .. } => None,
+            })
+            .next_back()
+            .unwrap_or(0);
+
+    let mut anchors = vec![0; rows.len()];
+    for (index, row) in rows.iter().enumerate().rev() {
+        anchors[index] = match row {
+            OverlayRow::Unchanged { line_number, .. } | OverlayRow::Added { line_number, .. } => {
+                *line_number
+            }
+            OverlayRow::Removed { .. } => {
+                anchors.get(index + 1).copied().unwrap_or(last_line_number)
+            }
+        };
+    }
+    anchors
+}
+
 /// Whether every `Context` line in `hunk` matches `source_lines` at the
 /// position [`hunk_overlay_lines`]'s own walk would place it — the drift
 /// check backing [`overlay_source_lines`]'s `None` return (ADR 0046
@@ -194,333 +261,4 @@ fn hunk_matches_source(hunk: &Hunk, source_lines: &[String]) -> bool {
         }
     }
     true
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::diff_view::DiffLine;
-    use pretty_assertions::assert_eq;
-
-    fn diff_line(kind: DiffLineKind, content: &str) -> DiffLine {
-        DiffLine {
-            kind,
-            content: content.to_string(),
-        }
-    }
-
-    // --- hunk_overlay_lines ---
-
-    #[test]
-    fn should_return_empty_when_hunk_has_no_new_range() {
-        let hunk = Hunk {
-            header: "@@ garbage @@".to_string(),
-            new_range: None,
-            lines: vec![diff_line(DiffLineKind::Context, "fn a() {}")],
-        };
-
-        let actual = hunk_overlay_lines(&hunk);
-
-        assert_eq!(Vec::<HunkOverlayLine>::new(), actual);
-    }
-
-    #[test]
-    fn should_position_added_lines_by_new_side_line_number_for_a_pure_addition() {
-        let hunk = Hunk {
-            header: "@@ -1,1 +1,3 @@".to_string(),
-            new_range: Some((1, 3)),
-            lines: vec![
-                diff_line(DiffLineKind::Context, "fn a() {}"),
-                diff_line(DiffLineKind::Added, "fn b() {}"),
-                diff_line(DiffLineKind::Added, "fn c() {}"),
-            ],
-        };
-
-        let expected = vec![
-            HunkOverlayLine {
-                position: 2,
-                kind: OverlayLineKind::Added,
-                content: "fn b() {}".to_string(),
-            },
-            HunkOverlayLine {
-                position: 3,
-                kind: OverlayLineKind::Added,
-                content: "fn c() {}".to_string(),
-            },
-        ];
-        let actual = hunk_overlay_lines(&hunk);
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_position_removed_lines_before_the_new_side_line_they_used_to_precede() {
-        let hunk = Hunk {
-            header: "@@ -1,3 +1,2 @@".to_string(),
-            new_range: Some((1, 2)),
-            lines: vec![
-                diff_line(DiffLineKind::Context, "fn a() {}"),
-                diff_line(DiffLineKind::Removed, "fn old() {}"),
-                diff_line(DiffLineKind::Context, "fn c() {}"),
-            ],
-        };
-
-        let expected = vec![HunkOverlayLine {
-            position: 2,
-            kind: OverlayLineKind::Removed,
-            content: "fn old() {}".to_string(),
-        }];
-        let actual = hunk_overlay_lines(&hunk);
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_position_removed_line_at_file_end_when_hunk_is_a_trailing_pure_deletion() {
-        let hunk = Hunk {
-            header: "@@ -3,1 +2,0 @@".to_string(),
-            new_range: Some((3, 2)),
-            lines: vec![diff_line(DiffLineKind::Removed, "fn tail() {}")],
-        };
-
-        let expected = vec![HunkOverlayLine {
-            position: 3,
-            kind: OverlayLineKind::Removed,
-            content: "fn tail() {}".to_string(),
-        }];
-        let actual = hunk_overlay_lines(&hunk);
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_position_mixed_added_and_removed_lines_in_one_replace_hunk() {
-        let hunk = Hunk {
-            header: "@@ -1,3 +1,3 @@".to_string(),
-            new_range: Some((1, 3)),
-            lines: vec![
-                diff_line(DiffLineKind::Context, "fn a() {}"),
-                diff_line(DiffLineKind::Removed, "fn old() {}"),
-                diff_line(DiffLineKind::Added, "fn new() {}"),
-                diff_line(DiffLineKind::Context, "fn c() {}"),
-            ],
-        };
-
-        let expected = vec![
-            HunkOverlayLine {
-                position: 2,
-                kind: OverlayLineKind::Removed,
-                content: "fn old() {}".to_string(),
-            },
-            HunkOverlayLine {
-                position: 2,
-                kind: OverlayLineKind::Added,
-                content: "fn new() {}".to_string(),
-            },
-        ];
-        let actual = hunk_overlay_lines(&hunk);
-
-        assert_eq!(expected, actual);
-    }
-
-    // --- overlay_source_lines ---
-
-    fn file_hunks(hunks: Vec<Hunk>) -> FileHunks {
-        FileHunks {
-            path: "src/lib.rs".to_string(),
-            hunks,
-        }
-    }
-
-    #[test]
-    fn should_return_empty_rows_when_file_has_no_hunks() {
-        let source_lines = vec!["fn a() {}".to_string()];
-        let hunks = file_hunks(vec![]);
-
-        let expected = vec![OverlayRow::Unchanged {
-            line_number: 1,
-            content: "fn a() {}".to_string(),
-        }];
-        let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_tag_a_pure_addition_as_added_rows_at_their_source_positions() {
-        let source_lines = vec![
-            "fn a() {}".to_string(),
-            "fn b() {}".to_string(),
-            "fn c() {}".to_string(),
-        ];
-        let hunks = file_hunks(vec![Hunk {
-            header: "@@ -1,2 +1,3 @@".to_string(),
-            new_range: Some((1, 3)),
-            lines: vec![
-                diff_line(DiffLineKind::Context, "fn a() {}"),
-                diff_line(DiffLineKind::Added, "fn b() {}"),
-                diff_line(DiffLineKind::Context, "fn c() {}"),
-            ],
-        }]);
-
-        let expected = vec![
-            OverlayRow::Unchanged {
-                line_number: 1,
-                content: "fn a() {}".to_string(),
-            },
-            OverlayRow::Added {
-                line_number: 2,
-                content: "fn b() {}".to_string(),
-            },
-            OverlayRow::Unchanged {
-                line_number: 3,
-                content: "fn c() {}".to_string(),
-            },
-        ];
-        let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_insert_removed_row_immediately_before_its_new_side_position() {
-        let source_lines = vec!["fn a() {}".to_string(), "fn c() {}".to_string()];
-        let hunks = file_hunks(vec![Hunk {
-            header: "@@ -1,3 +1,2 @@".to_string(),
-            new_range: Some((1, 2)),
-            lines: vec![
-                diff_line(DiffLineKind::Context, "fn a() {}"),
-                diff_line(DiffLineKind::Removed, "fn old() {}"),
-                diff_line(DiffLineKind::Context, "fn c() {}"),
-            ],
-        }]);
-
-        let expected = vec![
-            OverlayRow::Unchanged {
-                line_number: 1,
-                content: "fn a() {}".to_string(),
-            },
-            OverlayRow::Removed {
-                content: "fn old() {}".to_string(),
-            },
-            OverlayRow::Unchanged {
-                line_number: 2,
-                content: "fn c() {}".to_string(),
-            },
-        ];
-        let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_append_removed_rows_at_the_tail_when_deletion_is_at_file_end() {
-        let source_lines = vec!["fn a() {}".to_string(), "fn b() {}".to_string()];
-        let hunks = file_hunks(vec![Hunk {
-            header: "@@ -1,3 +1,2 @@".to_string(),
-            new_range: Some((3, 2)),
-            lines: vec![diff_line(DiffLineKind::Removed, "fn tail() {}")],
-        }]);
-
-        let expected = vec![
-            OverlayRow::Unchanged {
-                line_number: 1,
-                content: "fn a() {}".to_string(),
-            },
-            OverlayRow::Unchanged {
-                line_number: 2,
-                content: "fn b() {}".to_string(),
-            },
-            OverlayRow::Removed {
-                content: "fn tail() {}".to_string(),
-            },
-        ];
-        let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_composite_multiple_hunks_across_the_same_file() {
-        let source_lines = vec![
-            "fn a() {}".to_string(),
-            "fn b() {}".to_string(),
-            "fn x() {}".to_string(),
-            "fn y() {}".to_string(),
-        ];
-        let hunks = file_hunks(vec![
-            Hunk {
-                header: "@@ -1,1 +1,2 @@".to_string(),
-                new_range: Some((1, 2)),
-                lines: vec![
-                    diff_line(DiffLineKind::Context, "fn a() {}"),
-                    diff_line(DiffLineKind::Added, "fn b() {}"),
-                ],
-            },
-            Hunk {
-                header: "@@ -8,1 +9,2 @@".to_string(),
-                new_range: Some((3, 4)),
-                lines: vec![
-                    diff_line(DiffLineKind::Context, "fn x() {}"),
-                    diff_line(DiffLineKind::Added, "fn y() {}"),
-                ],
-            },
-        ]);
-
-        let expected = vec![
-            OverlayRow::Unchanged {
-                line_number: 1,
-                content: "fn a() {}".to_string(),
-            },
-            OverlayRow::Added {
-                line_number: 2,
-                content: "fn b() {}".to_string(),
-            },
-            OverlayRow::Unchanged {
-                line_number: 3,
-                content: "fn x() {}".to_string(),
-            },
-            OverlayRow::Added {
-                line_number: 4,
-                content: "fn y() {}".to_string(),
-            },
-        ];
-        let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn should_return_none_when_context_line_does_not_match_source_at_its_position() {
-        let source_lines = vec!["fn a_edited() {}".to_string(), "fn c() {}".to_string()];
-        let hunks = file_hunks(vec![Hunk {
-            header: "@@ -1,2 +1,2 @@".to_string(),
-            new_range: Some((1, 2)),
-            lines: vec![
-                diff_line(DiffLineKind::Context, "fn a() {}"),
-                diff_line(DiffLineKind::Context, "fn c() {}"),
-            ],
-        }]);
-
-        let actual = overlay_source_lines(&source_lines, &hunks);
-
-        assert_eq!(None, actual);
-    }
-
-    #[test]
-    fn should_return_none_when_context_line_position_is_past_the_end_of_source() {
-        let source_lines = vec!["fn a() {}".to_string()];
-        let hunks = file_hunks(vec![Hunk {
-            header: "@@ -1,1 +1,2 @@".to_string(),
-            new_range: Some((1, 2)),
-            lines: vec![
-                diff_line(DiffLineKind::Context, "fn a() {}"),
-                diff_line(DiffLineKind::Context, "fn missing() {}"),
-            ],
-        }]);
-
-        let actual = overlay_source_lines(&source_lines, &hunks);
-
-        assert_eq!(None, actual);
-    }
 }

--- a/rinkaku-tui/src/source_diff.rs
+++ b/rinkaku-tui/src/source_diff.rs
@@ -1,0 +1,526 @@
+//! Overlays a file's diff hunks onto its full-file source view (ADR 0046),
+//! reusing [`crate::diff_view`]'s already-parsed [`Hunk`]s rather than
+//! re-diffing or growing the diff pane's own hunk-relative coordinate
+//! space (ADR 0046's Context section explains why the diff pane itself was
+//! rejected as the home for this).
+
+use crate::diff_view::{DiffLineKind, FileHunks, Hunk};
+
+/// One diff-only line an overlay adds beyond what [`crate::source::SourceView`]
+/// already renders, either a new-side line already present in the source
+/// (`Added`) or a line that no longer exists there (`Removed`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverlayLineKind {
+    Added,
+    Removed,
+}
+
+/// One [`Hunk`] line's position in the overlaid file, in the same 1-based
+/// new-side numbering [`crate::source::SourceView`] uses for its own lines.
+///
+/// `Removed` carries the new-side line number it sits *before* — the same
+/// "deletion is a position, not a line" convention
+/// [`crate::diff_view::hunk_intersects`] already uses for a pure-deletion
+/// hunk's `new_range` (this module's own doc comment), reused here rather
+/// than inventing a second one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HunkOverlayLine {
+    pub position: usize,
+    pub kind: OverlayLineKind,
+    pub content: String,
+}
+
+/// Walks `hunk.lines`, computing each `Added`/`Removed` line's position in
+/// the overlaid file. `Context` lines are dropped from the result — the
+/// source view's own lines already render them, so the overlay only needs
+/// to add information for lines the diff actually changed.
+///
+/// Returns an empty `Vec` when `hunk.new_range` is `None` (an unreadable
+/// header, or a deletion at new-side line 0 — [`Hunk::new_range`]'s own doc
+/// comment): neither case has a position to seed the walk from.
+pub fn hunk_overlay_lines(hunk: &Hunk) -> Vec<HunkOverlayLine> {
+    let Some((range_start, _)) = hunk.new_range else {
+        return Vec::new();
+    };
+
+    let mut position = range_start;
+    let mut result = Vec::new();
+    for line in &hunk.lines {
+        match line.kind {
+            DiffLineKind::Added => {
+                result.push(HunkOverlayLine {
+                    position,
+                    kind: OverlayLineKind::Added,
+                    content: line.content.clone(),
+                });
+                position += 1;
+            }
+            DiffLineKind::Context => {
+                position += 1;
+            }
+            DiffLineKind::Removed => {
+                result.push(HunkOverlayLine {
+                    position,
+                    kind: OverlayLineKind::Removed,
+                    content: line.content.clone(),
+                });
+            }
+        }
+    }
+    result
+}
+
+/// One display row of the overlaid source view: either an unmodified source
+/// line (`line_number` is that line's 1-based number in
+/// [`crate::source::SourceView::lines`]), a source line the diff added, or a
+/// diff-removed line inserted between two source lines (no `line_number` of
+/// its own — [`HunkOverlayLine`]'s own doc comment on why a deletion has a
+/// position but not a line).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OverlayRow {
+    Unchanged { line_number: usize, content: String },
+    Added { line_number: usize, content: String },
+    Removed { content: String },
+}
+
+/// Composites every hunk in `file_hunks` onto `source_lines` (1-based
+/// numbering, matching [`crate::source::SourceView::lines`]'s own
+/// convention), producing one [`OverlayRow`] per output row: one entry per
+/// source line (tagged `Added` when a hunk claims that new-side line
+/// number, `Unchanged` otherwise) plus one extra `Removed` entry
+/// immediately before the added/unchanged row a deletion's position points
+/// at.
+///
+/// Returns `None` when a hunk's `Context` lines don't match `source_lines`
+/// at the position the hunk claims — the file on disk has drifted from the
+/// diff (ADR 0046 decision 5) — since composing with a wrong position
+/// mapping would place colored lines in the wrong place, worse than no
+/// overlay at all.
+pub fn overlay_source_lines(
+    source_lines: &[String],
+    file_hunks: &FileHunks,
+) -> Option<Vec<OverlayRow>> {
+    for hunk in &file_hunks.hunks {
+        if !hunk_matches_source(hunk, source_lines) {
+            return None;
+        }
+    }
+
+    let mut removed_before: std::collections::HashMap<usize, Vec<String>> =
+        std::collections::HashMap::new();
+    let mut added_at: std::collections::HashMap<usize, String> = std::collections::HashMap::new();
+    for hunk in &file_hunks.hunks {
+        for overlay_line in hunk_overlay_lines(hunk) {
+            match overlay_line.kind {
+                OverlayLineKind::Added => {
+                    added_at.insert(overlay_line.position, overlay_line.content);
+                }
+                OverlayLineKind::Removed => {
+                    removed_before
+                        .entry(overlay_line.position)
+                        .or_default()
+                        .push(overlay_line.content);
+                }
+            }
+        }
+    }
+
+    let mut rows = Vec::new();
+    for (index, content) in source_lines.iter().enumerate() {
+        let line_number = index + 1;
+        if let Some(removed) = removed_before.remove(&line_number) {
+            rows.extend(
+                removed
+                    .into_iter()
+                    .map(|content| OverlayRow::Removed { content }),
+            );
+        }
+        rows.push(if added_at.contains_key(&line_number) {
+            OverlayRow::Added {
+                line_number,
+                content: content.clone(),
+            }
+        } else {
+            OverlayRow::Unchanged {
+                line_number,
+                content: content.clone(),
+            }
+        });
+    }
+    // A deletion positioned at (source_lines.len() + 1) — the end of the
+    // file — has no `Unchanged`/`Added` row above to anchor before; drain
+    // whatever remains in source line order for a deterministic tail.
+    let mut trailing_positions: Vec<usize> = removed_before.keys().copied().collect();
+    trailing_positions.sort_unstable();
+    for position in trailing_positions {
+        if let Some(removed) = removed_before.remove(&position) {
+            rows.extend(
+                removed
+                    .into_iter()
+                    .map(|content| OverlayRow::Removed { content }),
+            );
+        }
+    }
+
+    Some(rows)
+}
+
+/// Whether every `Context` line in `hunk` matches `source_lines` at the
+/// position [`hunk_overlay_lines`]'s own walk would place it — the drift
+/// check backing [`overlay_source_lines`]'s `None` return (ADR 0046
+/// decision 5).
+fn hunk_matches_source(hunk: &Hunk, source_lines: &[String]) -> bool {
+    let Some((range_start, _)) = hunk.new_range else {
+        // No position to check against; `hunk_overlay_lines` already
+        // returns nothing for this hunk, so it cannot introduce a drifted
+        // row either.
+        return true;
+    };
+
+    let mut position = range_start;
+    for line in &hunk.lines {
+        match line.kind {
+            DiffLineKind::Context => {
+                let Some(actual) = source_lines.get(position - 1) else {
+                    return false;
+                };
+                if actual != &line.content {
+                    return false;
+                }
+                position += 1;
+            }
+            DiffLineKind::Added => position += 1,
+            DiffLineKind::Removed => {}
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff_view::DiffLine;
+    use pretty_assertions::assert_eq;
+
+    fn diff_line(kind: DiffLineKind, content: &str) -> DiffLine {
+        DiffLine {
+            kind,
+            content: content.to_string(),
+        }
+    }
+
+    // --- hunk_overlay_lines ---
+
+    #[test]
+    fn should_return_empty_when_hunk_has_no_new_range() {
+        let hunk = Hunk {
+            header: "@@ garbage @@".to_string(),
+            new_range: None,
+            lines: vec![diff_line(DiffLineKind::Context, "fn a() {}")],
+        };
+
+        let actual = hunk_overlay_lines(&hunk);
+
+        assert_eq!(Vec::<HunkOverlayLine>::new(), actual);
+    }
+
+    #[test]
+    fn should_position_added_lines_by_new_side_line_number_for_a_pure_addition() {
+        let hunk = Hunk {
+            header: "@@ -1,1 +1,3 @@".to_string(),
+            new_range: Some((1, 3)),
+            lines: vec![
+                diff_line(DiffLineKind::Context, "fn a() {}"),
+                diff_line(DiffLineKind::Added, "fn b() {}"),
+                diff_line(DiffLineKind::Added, "fn c() {}"),
+            ],
+        };
+
+        let expected = vec![
+            HunkOverlayLine {
+                position: 2,
+                kind: OverlayLineKind::Added,
+                content: "fn b() {}".to_string(),
+            },
+            HunkOverlayLine {
+                position: 3,
+                kind: OverlayLineKind::Added,
+                content: "fn c() {}".to_string(),
+            },
+        ];
+        let actual = hunk_overlay_lines(&hunk);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_position_removed_lines_before_the_new_side_line_they_used_to_precede() {
+        let hunk = Hunk {
+            header: "@@ -1,3 +1,2 @@".to_string(),
+            new_range: Some((1, 2)),
+            lines: vec![
+                diff_line(DiffLineKind::Context, "fn a() {}"),
+                diff_line(DiffLineKind::Removed, "fn old() {}"),
+                diff_line(DiffLineKind::Context, "fn c() {}"),
+            ],
+        };
+
+        let expected = vec![HunkOverlayLine {
+            position: 2,
+            kind: OverlayLineKind::Removed,
+            content: "fn old() {}".to_string(),
+        }];
+        let actual = hunk_overlay_lines(&hunk);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_position_removed_line_at_file_end_when_hunk_is_a_trailing_pure_deletion() {
+        let hunk = Hunk {
+            header: "@@ -3,1 +2,0 @@".to_string(),
+            new_range: Some((3, 2)),
+            lines: vec![diff_line(DiffLineKind::Removed, "fn tail() {}")],
+        };
+
+        let expected = vec![HunkOverlayLine {
+            position: 3,
+            kind: OverlayLineKind::Removed,
+            content: "fn tail() {}".to_string(),
+        }];
+        let actual = hunk_overlay_lines(&hunk);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_position_mixed_added_and_removed_lines_in_one_replace_hunk() {
+        let hunk = Hunk {
+            header: "@@ -1,3 +1,3 @@".to_string(),
+            new_range: Some((1, 3)),
+            lines: vec![
+                diff_line(DiffLineKind::Context, "fn a() {}"),
+                diff_line(DiffLineKind::Removed, "fn old() {}"),
+                diff_line(DiffLineKind::Added, "fn new() {}"),
+                diff_line(DiffLineKind::Context, "fn c() {}"),
+            ],
+        };
+
+        let expected = vec![
+            HunkOverlayLine {
+                position: 2,
+                kind: OverlayLineKind::Removed,
+                content: "fn old() {}".to_string(),
+            },
+            HunkOverlayLine {
+                position: 2,
+                kind: OverlayLineKind::Added,
+                content: "fn new() {}".to_string(),
+            },
+        ];
+        let actual = hunk_overlay_lines(&hunk);
+
+        assert_eq!(expected, actual);
+    }
+
+    // --- overlay_source_lines ---
+
+    fn file_hunks(hunks: Vec<Hunk>) -> FileHunks {
+        FileHunks {
+            path: "src/lib.rs".to_string(),
+            hunks,
+        }
+    }
+
+    #[test]
+    fn should_return_empty_rows_when_file_has_no_hunks() {
+        let source_lines = vec!["fn a() {}".to_string()];
+        let hunks = file_hunks(vec![]);
+
+        let expected = vec![OverlayRow::Unchanged {
+            line_number: 1,
+            content: "fn a() {}".to_string(),
+        }];
+        let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_tag_a_pure_addition_as_added_rows_at_their_source_positions() {
+        let source_lines = vec![
+            "fn a() {}".to_string(),
+            "fn b() {}".to_string(),
+            "fn c() {}".to_string(),
+        ];
+        let hunks = file_hunks(vec![Hunk {
+            header: "@@ -1,2 +1,3 @@".to_string(),
+            new_range: Some((1, 3)),
+            lines: vec![
+                diff_line(DiffLineKind::Context, "fn a() {}"),
+                diff_line(DiffLineKind::Added, "fn b() {}"),
+                diff_line(DiffLineKind::Context, "fn c() {}"),
+            ],
+        }]);
+
+        let expected = vec![
+            OverlayRow::Unchanged {
+                line_number: 1,
+                content: "fn a() {}".to_string(),
+            },
+            OverlayRow::Added {
+                line_number: 2,
+                content: "fn b() {}".to_string(),
+            },
+            OverlayRow::Unchanged {
+                line_number: 3,
+                content: "fn c() {}".to_string(),
+            },
+        ];
+        let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_insert_removed_row_immediately_before_its_new_side_position() {
+        let source_lines = vec!["fn a() {}".to_string(), "fn c() {}".to_string()];
+        let hunks = file_hunks(vec![Hunk {
+            header: "@@ -1,3 +1,2 @@".to_string(),
+            new_range: Some((1, 2)),
+            lines: vec![
+                diff_line(DiffLineKind::Context, "fn a() {}"),
+                diff_line(DiffLineKind::Removed, "fn old() {}"),
+                diff_line(DiffLineKind::Context, "fn c() {}"),
+            ],
+        }]);
+
+        let expected = vec![
+            OverlayRow::Unchanged {
+                line_number: 1,
+                content: "fn a() {}".to_string(),
+            },
+            OverlayRow::Removed {
+                content: "fn old() {}".to_string(),
+            },
+            OverlayRow::Unchanged {
+                line_number: 2,
+                content: "fn c() {}".to_string(),
+            },
+        ];
+        let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_append_removed_rows_at_the_tail_when_deletion_is_at_file_end() {
+        let source_lines = vec!["fn a() {}".to_string(), "fn b() {}".to_string()];
+        let hunks = file_hunks(vec![Hunk {
+            header: "@@ -1,3 +1,2 @@".to_string(),
+            new_range: Some((3, 2)),
+            lines: vec![diff_line(DiffLineKind::Removed, "fn tail() {}")],
+        }]);
+
+        let expected = vec![
+            OverlayRow::Unchanged {
+                line_number: 1,
+                content: "fn a() {}".to_string(),
+            },
+            OverlayRow::Unchanged {
+                line_number: 2,
+                content: "fn b() {}".to_string(),
+            },
+            OverlayRow::Removed {
+                content: "fn tail() {}".to_string(),
+            },
+        ];
+        let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_composite_multiple_hunks_across_the_same_file() {
+        let source_lines = vec![
+            "fn a() {}".to_string(),
+            "fn b() {}".to_string(),
+            "fn x() {}".to_string(),
+            "fn y() {}".to_string(),
+        ];
+        let hunks = file_hunks(vec![
+            Hunk {
+                header: "@@ -1,1 +1,2 @@".to_string(),
+                new_range: Some((1, 2)),
+                lines: vec![
+                    diff_line(DiffLineKind::Context, "fn a() {}"),
+                    diff_line(DiffLineKind::Added, "fn b() {}"),
+                ],
+            },
+            Hunk {
+                header: "@@ -8,1 +9,2 @@".to_string(),
+                new_range: Some((3, 4)),
+                lines: vec![
+                    diff_line(DiffLineKind::Context, "fn x() {}"),
+                    diff_line(DiffLineKind::Added, "fn y() {}"),
+                ],
+            },
+        ]);
+
+        let expected = vec![
+            OverlayRow::Unchanged {
+                line_number: 1,
+                content: "fn a() {}".to_string(),
+            },
+            OverlayRow::Added {
+                line_number: 2,
+                content: "fn b() {}".to_string(),
+            },
+            OverlayRow::Unchanged {
+                line_number: 3,
+                content: "fn x() {}".to_string(),
+            },
+            OverlayRow::Added {
+                line_number: 4,
+                content: "fn y() {}".to_string(),
+            },
+        ];
+        let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_return_none_when_context_line_does_not_match_source_at_its_position() {
+        let source_lines = vec!["fn a_edited() {}".to_string(), "fn c() {}".to_string()];
+        let hunks = file_hunks(vec![Hunk {
+            header: "@@ -1,2 +1,2 @@".to_string(),
+            new_range: Some((1, 2)),
+            lines: vec![
+                diff_line(DiffLineKind::Context, "fn a() {}"),
+                diff_line(DiffLineKind::Context, "fn c() {}"),
+            ],
+        }]);
+
+        let actual = overlay_source_lines(&source_lines, &hunks);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_return_none_when_context_line_position_is_past_the_end_of_source() {
+        let source_lines = vec!["fn a() {}".to_string()];
+        let hunks = file_hunks(vec![Hunk {
+            header: "@@ -1,1 +1,2 @@".to_string(),
+            new_range: Some((1, 2)),
+            lines: vec![
+                diff_line(DiffLineKind::Context, "fn a() {}"),
+                diff_line(DiffLineKind::Context, "fn missing() {}"),
+            ],
+        }]);
+
+        let actual = overlay_source_lines(&source_lines, &hunks);
+
+        assert_eq!(None, actual);
+    }
+}

--- a/rinkaku-tui/src/source_diff/tests.rs
+++ b/rinkaku-tui/src/source_diff/tests.rs
@@ -1,0 +1,463 @@
+use super::*;
+use crate::diff_view::DiffLine;
+use pretty_assertions::assert_eq;
+
+fn diff_line(kind: DiffLineKind, content: &str) -> DiffLine {
+    DiffLine {
+        kind,
+        content: content.to_string(),
+    }
+}
+
+// --- hunk_overlay_lines ---
+
+#[test]
+fn should_return_empty_when_hunk_has_no_new_range() {
+    let hunk = Hunk {
+        header: "@@ garbage @@".to_string(),
+        new_range: None,
+        lines: vec![diff_line(DiffLineKind::Context, "fn a() {}")],
+    };
+
+    let actual = hunk_overlay_lines(&hunk);
+
+    assert_eq!(Vec::<HunkOverlayLine>::new(), actual);
+}
+
+#[test]
+fn should_position_added_lines_by_new_side_line_number_for_a_pure_addition() {
+    let hunk = Hunk {
+        header: "@@ -1,1 +1,3 @@".to_string(),
+        new_range: Some((1, 3)),
+        lines: vec![
+            diff_line(DiffLineKind::Context, "fn a() {}"),
+            diff_line(DiffLineKind::Added, "fn b() {}"),
+            diff_line(DiffLineKind::Added, "fn c() {}"),
+        ],
+    };
+
+    let expected = vec![
+        HunkOverlayLine {
+            position: 2,
+            kind: OverlayLineKind::Added,
+            content: "fn b() {}".to_string(),
+        },
+        HunkOverlayLine {
+            position: 3,
+            kind: OverlayLineKind::Added,
+            content: "fn c() {}".to_string(),
+        },
+    ];
+    let actual = hunk_overlay_lines(&hunk);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_position_removed_lines_before_the_new_side_line_they_used_to_precede() {
+    let hunk = Hunk {
+        header: "@@ -1,3 +1,2 @@".to_string(),
+        new_range: Some((1, 2)),
+        lines: vec![
+            diff_line(DiffLineKind::Context, "fn a() {}"),
+            diff_line(DiffLineKind::Removed, "fn old() {}"),
+            diff_line(DiffLineKind::Context, "fn c() {}"),
+        ],
+    };
+
+    let expected = vec![HunkOverlayLine {
+        position: 2,
+        kind: OverlayLineKind::Removed,
+        content: "fn old() {}".to_string(),
+    }];
+    let actual = hunk_overlay_lines(&hunk);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_position_removed_line_at_file_end_when_hunk_is_a_trailing_pure_deletion() {
+    let hunk = Hunk {
+        header: "@@ -3,1 +2,0 @@".to_string(),
+        new_range: Some((3, 2)),
+        lines: vec![diff_line(DiffLineKind::Removed, "fn tail() {}")],
+    };
+
+    let expected = vec![HunkOverlayLine {
+        position: 3,
+        kind: OverlayLineKind::Removed,
+        content: "fn tail() {}".to_string(),
+    }];
+    let actual = hunk_overlay_lines(&hunk);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_position_mixed_added_and_removed_lines_in_one_replace_hunk() {
+    let hunk = Hunk {
+        header: "@@ -1,3 +1,3 @@".to_string(),
+        new_range: Some((1, 3)),
+        lines: vec![
+            diff_line(DiffLineKind::Context, "fn a() {}"),
+            diff_line(DiffLineKind::Removed, "fn old() {}"),
+            diff_line(DiffLineKind::Added, "fn new() {}"),
+            diff_line(DiffLineKind::Context, "fn c() {}"),
+        ],
+    };
+
+    let expected = vec![
+        HunkOverlayLine {
+            position: 2,
+            kind: OverlayLineKind::Removed,
+            content: "fn old() {}".to_string(),
+        },
+        HunkOverlayLine {
+            position: 2,
+            kind: OverlayLineKind::Added,
+            content: "fn new() {}".to_string(),
+        },
+    ];
+    let actual = hunk_overlay_lines(&hunk);
+
+    assert_eq!(expected, actual);
+}
+
+// --- overlay_source_lines ---
+
+fn file_hunks(hunks: Vec<Hunk>) -> FileHunks {
+    FileHunks {
+        path: "src/lib.rs".to_string(),
+        hunks,
+    }
+}
+
+#[test]
+fn should_return_empty_rows_when_file_has_no_hunks() {
+    let source_lines = vec!["fn a() {}".to_string()];
+    let hunks = file_hunks(vec![]);
+
+    let expected = vec![OverlayRow::Unchanged {
+        line_number: 1,
+        content: "fn a() {}".to_string(),
+    }];
+    let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_tag_a_pure_addition_as_added_rows_at_their_source_positions() {
+    let source_lines = vec![
+        "fn a() {}".to_string(),
+        "fn b() {}".to_string(),
+        "fn c() {}".to_string(),
+    ];
+    let hunks = file_hunks(vec![Hunk {
+        header: "@@ -1,2 +1,3 @@".to_string(),
+        new_range: Some((1, 3)),
+        lines: vec![
+            diff_line(DiffLineKind::Context, "fn a() {}"),
+            diff_line(DiffLineKind::Added, "fn b() {}"),
+            diff_line(DiffLineKind::Context, "fn c() {}"),
+        ],
+    }]);
+
+    let expected = vec![
+        OverlayRow::Unchanged {
+            line_number: 1,
+            content: "fn a() {}".to_string(),
+        },
+        OverlayRow::Added {
+            line_number: 2,
+            content: "fn b() {}".to_string(),
+        },
+        OverlayRow::Unchanged {
+            line_number: 3,
+            content: "fn c() {}".to_string(),
+        },
+    ];
+    let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_insert_removed_row_immediately_before_its_new_side_position() {
+    let source_lines = vec!["fn a() {}".to_string(), "fn c() {}".to_string()];
+    let hunks = file_hunks(vec![Hunk {
+        header: "@@ -1,3 +1,2 @@".to_string(),
+        new_range: Some((1, 2)),
+        lines: vec![
+            diff_line(DiffLineKind::Context, "fn a() {}"),
+            diff_line(DiffLineKind::Removed, "fn old() {}"),
+            diff_line(DiffLineKind::Context, "fn c() {}"),
+        ],
+    }]);
+
+    let expected = vec![
+        OverlayRow::Unchanged {
+            line_number: 1,
+            content: "fn a() {}".to_string(),
+        },
+        OverlayRow::Removed {
+            content: "fn old() {}".to_string(),
+        },
+        OverlayRow::Unchanged {
+            line_number: 2,
+            content: "fn c() {}".to_string(),
+        },
+    ];
+    let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_append_removed_rows_at_the_tail_when_deletion_is_at_file_end() {
+    let source_lines = vec!["fn a() {}".to_string(), "fn b() {}".to_string()];
+    let hunks = file_hunks(vec![Hunk {
+        header: "@@ -1,3 +1,2 @@".to_string(),
+        new_range: Some((3, 2)),
+        lines: vec![diff_line(DiffLineKind::Removed, "fn tail() {}")],
+    }]);
+
+    let expected = vec![
+        OverlayRow::Unchanged {
+            line_number: 1,
+            content: "fn a() {}".to_string(),
+        },
+        OverlayRow::Unchanged {
+            line_number: 2,
+            content: "fn b() {}".to_string(),
+        },
+        OverlayRow::Removed {
+            content: "fn tail() {}".to_string(),
+        },
+    ];
+    let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_composite_multiple_hunks_across_the_same_file() {
+    let source_lines = vec![
+        "fn a() {}".to_string(),
+        "fn b() {}".to_string(),
+        "fn x() {}".to_string(),
+        "fn y() {}".to_string(),
+    ];
+    let hunks = file_hunks(vec![
+        Hunk {
+            header: "@@ -1,1 +1,2 @@".to_string(),
+            new_range: Some((1, 2)),
+            lines: vec![
+                diff_line(DiffLineKind::Context, "fn a() {}"),
+                diff_line(DiffLineKind::Added, "fn b() {}"),
+            ],
+        },
+        Hunk {
+            header: "@@ -8,1 +9,2 @@".to_string(),
+            new_range: Some((3, 4)),
+            lines: vec![
+                diff_line(DiffLineKind::Context, "fn x() {}"),
+                diff_line(DiffLineKind::Added, "fn y() {}"),
+            ],
+        },
+    ]);
+
+    let expected = vec![
+        OverlayRow::Unchanged {
+            line_number: 1,
+            content: "fn a() {}".to_string(),
+        },
+        OverlayRow::Added {
+            line_number: 2,
+            content: "fn b() {}".to_string(),
+        },
+        OverlayRow::Unchanged {
+            line_number: 3,
+            content: "fn x() {}".to_string(),
+        },
+        OverlayRow::Added {
+            line_number: 4,
+            content: "fn y() {}".to_string(),
+        },
+    ];
+    let actual = overlay_source_lines(&source_lines, &hunks).expect("no drift to detect");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_return_none_when_context_line_does_not_match_source_at_its_position() {
+    let source_lines = vec!["fn a_edited() {}".to_string(), "fn c() {}".to_string()];
+    let hunks = file_hunks(vec![Hunk {
+        header: "@@ -1,2 +1,2 @@".to_string(),
+        new_range: Some((1, 2)),
+        lines: vec![
+            diff_line(DiffLineKind::Context, "fn a() {}"),
+            diff_line(DiffLineKind::Context, "fn c() {}"),
+        ],
+    }]);
+
+    let actual = overlay_source_lines(&source_lines, &hunks);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_return_none_when_context_line_position_is_past_the_end_of_source() {
+    let source_lines = vec!["fn a() {}".to_string()];
+    let hunks = file_hunks(vec![Hunk {
+        header: "@@ -1,1 +1,2 @@".to_string(),
+        new_range: Some((1, 2)),
+        lines: vec![
+            diff_line(DiffLineKind::Context, "fn a() {}"),
+            diff_line(DiffLineKind::Context, "fn missing() {}"),
+        ],
+    }]);
+
+    let actual = overlay_source_lines(&source_lines, &hunks);
+
+    assert_eq!(None, actual);
+}
+
+// --- rows_in_source_range ---
+
+#[test]
+fn should_return_empty_slice_when_rows_is_empty() {
+    let rows: Vec<OverlayRow> = vec![];
+
+    let actual = rows_in_source_range(&rows, 1, 10);
+
+    assert_eq!(Vec::<OverlayRow>::new(), actual.to_vec());
+}
+
+#[test]
+fn should_slice_rows_to_the_requested_source_line_range() {
+    let rows = vec![
+        OverlayRow::Unchanged {
+            line_number: 1,
+            content: "a".to_string(),
+        },
+        OverlayRow::Unchanged {
+            line_number: 2,
+            content: "b".to_string(),
+        },
+        OverlayRow::Unchanged {
+            line_number: 3,
+            content: "c".to_string(),
+        },
+    ];
+
+    let actual = rows_in_source_range(&rows, 2, 2);
+
+    assert_eq!(
+        vec![OverlayRow::Unchanged {
+            line_number: 2,
+            content: "b".to_string(),
+        }],
+        actual.to_vec()
+    );
+}
+
+#[test]
+fn should_include_a_removed_row_anchored_to_an_in_range_row() {
+    let rows = vec![
+        OverlayRow::Unchanged {
+            line_number: 1,
+            content: "a".to_string(),
+        },
+        OverlayRow::Removed {
+            content: "old".to_string(),
+        },
+        OverlayRow::Unchanged {
+            line_number: 2,
+            content: "b".to_string(),
+        },
+    ];
+
+    let actual = rows_in_source_range(&rows, 2, 2);
+
+    assert_eq!(
+        vec![
+            OverlayRow::Removed {
+                content: "old".to_string(),
+            },
+            OverlayRow::Unchanged {
+                line_number: 2,
+                content: "b".to_string(),
+            },
+        ],
+        actual.to_vec()
+    );
+}
+
+#[test]
+fn should_exclude_a_removed_row_anchored_to_an_out_of_range_row() {
+    let rows = vec![
+        OverlayRow::Unchanged {
+            line_number: 1,
+            content: "a".to_string(),
+        },
+        OverlayRow::Removed {
+            content: "old".to_string(),
+        },
+        OverlayRow::Unchanged {
+            line_number: 2,
+            content: "b".to_string(),
+        },
+    ];
+
+    let actual = rows_in_source_range(&rows, 1, 1);
+
+    assert_eq!(
+        vec![OverlayRow::Unchanged {
+            line_number: 1,
+            content: "a".to_string(),
+        }],
+        actual.to_vec()
+    );
+}
+
+#[test]
+fn should_include_trailing_removed_rows_when_range_covers_the_last_source_line() {
+    let rows = vec![
+        OverlayRow::Unchanged {
+            line_number: 1,
+            content: "a".to_string(),
+        },
+        OverlayRow::Removed {
+            content: "tail".to_string(),
+        },
+    ];
+
+    let actual = rows_in_source_range(&rows, 1, 1);
+
+    assert_eq!(
+        vec![
+            OverlayRow::Unchanged {
+                line_number: 1,
+                content: "a".to_string(),
+            },
+            OverlayRow::Removed {
+                content: "tail".to_string(),
+            },
+        ],
+        actual.to_vec()
+    );
+}
+
+#[test]
+fn should_return_empty_slice_when_start_line_is_past_every_row() {
+    let rows = vec![OverlayRow::Unchanged {
+        line_number: 1,
+        content: "a".to_string(),
+    }];
+
+    let actual = rows_in_source_range(&rows, 5, 10);
+
+    assert_eq!(Vec::<OverlayRow>::new(), actual.to_vec());
+}

--- a/rinkaku-tui/src/ui/blast_radius.rs
+++ b/rinkaku-tui/src/ui/blast_radius.rs
@@ -215,6 +215,7 @@ mod tests {
                     &[],
                     &blast_radius_selection,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -243,6 +244,7 @@ mod tests {
                     &[],
                     &blast_radius_selection,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -286,6 +288,7 @@ mod tests {
                     &[],
                     &blast_radius_selection,
                     None,
+                    &[],
                 );
             })
             .expect("draw");

--- a/rinkaku-tui/src/ui/detail_pane_tests/content_by_row_kind.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/content_by_row_kind.rs
@@ -33,6 +33,7 @@ fn should_draw_placeholder_message_when_there_are_no_rows_at_all() {
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -79,6 +80,7 @@ fn should_draw_dir_detail_content_when_cursor_is_on_a_directory_row() {
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -130,6 +132,7 @@ fn should_draw_symbols_label_without_changed_wording_when_origin_is_repo_outline
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -163,6 +166,7 @@ fn should_draw_skip_reason_in_detail_pane_when_cursor_is_on_a_skipped_file_row()
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -194,6 +198,7 @@ fn should_draw_test_symbol_count_in_detail_pane_when_cursor_is_on_a_whole_test_f
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -253,6 +258,7 @@ fn should_draw_both_test_note_and_real_symbols_in_detail_pane_when_file_is_mixed
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -284,6 +290,7 @@ fn should_draw_detail_pane_content_when_cursor_is_on_a_symbol_row() {
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/detail_pane_tests/scroll_behavior.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/scroll_behavior.rs
@@ -24,6 +24,7 @@ fn should_show_overflow_indicator_in_detail_pane_title_when_content_exceeds_view
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -55,6 +56,7 @@ fn should_not_show_overflow_indicator_when_content_fits_the_viewport() {
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -88,6 +90,7 @@ fn should_scroll_detail_pane_content_down_when_scroll_down_is_pressed() {
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -127,6 +130,7 @@ fn should_clamp_detail_pane_scroll_at_the_last_page() {
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -167,6 +171,7 @@ fn should_return_the_clamped_scroll_from_draw_when_requested_scroll_overshoots()
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -208,6 +213,7 @@ fn should_reset_scroll_indicator_when_cursor_moves_to_a_different_row() {
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/detail_pane_tests/wrap_reachability.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/wrap_reachability.rs
@@ -56,6 +56,7 @@ fn should_reach_the_last_wrapped_line_of_content_via_scrolling_when_a_logical_li
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -107,6 +108,7 @@ fn should_report_indicator_total_as_wrapped_row_count_not_logical_line_count_whe
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/diff_pane_tests/row_kinds.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/row_kinds.rs
@@ -30,6 +30,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -93,6 +94,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -162,6 +164,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -229,6 +232,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -291,6 +295,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
@@ -35,6 +35,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -86,6 +87,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -201,6 +203,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -249,6 +252,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
@@ -31,6 +31,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -77,6 +78,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -116,6 +118,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -162,6 +165,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");
@@ -226,6 +230,7 @@ index e69de29..4b825dc 100644
                 &diff_highlights,
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/entry.rs
+++ b/rinkaku-tui/src/ui/entry.rs
@@ -239,6 +239,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -286,6 +287,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -315,6 +317,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -354,6 +357,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -408,6 +412,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -468,6 +473,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -499,6 +505,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -531,6 +538,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");

--- a/rinkaku-tui/src/ui/mod.rs
+++ b/rinkaku-tui/src/ui/mod.rs
@@ -20,6 +20,7 @@ mod status;
 mod style;
 
 use crate::app::{App, BlastRadiusSelection, Screen};
+use crate::diff_view::FileHunks;
 use crate::highlight::HighlightedFile;
 use crate::source::HighlightedSourceView;
 use entry::draw_entry_screen;
@@ -120,6 +121,15 @@ pub struct DrawOutcome {
 /// is underneath — `outcome`'s `clamped_right_pane_scroll`/
 /// `scroll_viewport_height` pair (whichever screen set it) is left
 /// untouched by this step.
+///
+/// `diff_hunks` (ADR 0046) is the same `diff_view::parse_diff_hunks` output
+/// that already seeds `diff_highlights` above, passed through unchanged so
+/// the source screen can composite it onto the drilled-into symbol's file
+/// as an added/removed overlay.
+// Each parameter is a distinct once-per-session/once-per-key computation a
+// prior ADR deliberately keeps outside this render loop; grouping them into
+// a struct is a bigger refactor than this ADR's own scope.
+#[allow(clippy::too_many_arguments)]
 pub fn draw(
     frame: &mut Frame,
     app: &App,
@@ -128,6 +138,7 @@ pub fn draw(
     diff_highlights: &[HighlightedFile],
     blast_radius_selection: &BlastRadiusSelection,
     source_content: Option<&Result<HighlightedSourceView, String>>,
+    diff_hunks: &[FileHunks],
 ) -> DrawOutcome {
     let area = frame.area();
     let [body, status_area] =
@@ -168,7 +179,14 @@ pub fn draw(
             scroll_top,
         } => {
             let inner_height = body.height.saturating_sub(2) as usize;
-            draw_source_screen(frame, symbol_id, *scroll_top, source_content, body);
+            draw_source_screen(
+                frame,
+                symbol_id,
+                *scroll_top,
+                source_content,
+                diff_hunks,
+                body,
+            );
             DrawOutcome {
                 clamped_right_pane_scroll: None,
                 scroll_viewport_height: Some(inner_height),

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -637,6 +637,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -679,6 +680,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -713,6 +715,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -753,6 +756,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -777,6 +781,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -812,6 +817,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -854,6 +860,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");
@@ -912,6 +919,7 @@ mod tests {
                         &[],
                         &BlastRadiusSelection::NotApplicable,
                         None,
+                        &[],
                     );
                 })
                 .expect("draw");
@@ -942,6 +950,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");

--- a/rinkaku-tui/src/ui/source_screen.rs
+++ b/rinkaku-tui/src/ui/source_screen.rs
@@ -3,9 +3,9 @@
 //! tint" composition with the diff pane, ADR 0046 for the diff overlay
 //! composited on top of that).
 
-use super::diff_pane::{ADDED_BG, REMOVED_BG};
+use super::diff_pane::{ADDED_BG, REMOVED_BG, marker_span};
 use super::style::{gap_span, pane_border_style, styled_content_spans};
-use crate::diff_view::FileHunks;
+use crate::diff_view::{DiffLineKind, FileHunks};
 use crate::source::{HighlightedSourceView, SourceView};
 use crate::source_diff::{OverlayRow, overlay_source_lines, rows_in_source_range};
 use ratatui::Frame;
@@ -202,15 +202,17 @@ pub(crate) fn source_lines(
             OverlayRow::Unchanged {
                 line_number,
                 content,
-            }
-            | OverlayRow::Added {
+            } => unchanged_line(source, token_highlights, line_number - 1, content, None),
+            OverlayRow::Added {
                 line_number,
                 content,
-            } => {
-                let line_index = line_number - 1;
-                let added_bg = matches!(row, OverlayRow::Added { .. }).then_some(ADDED_BG);
-                unchanged_line(source, token_highlights, line_index, content, added_bg)
-            }
+            } => unchanged_line(
+                source,
+                token_highlights,
+                line_number - 1,
+                content,
+                Some(ADDED_BG),
+            ),
             OverlayRow::Removed { content } => removed_line(content),
         })
         .collect()
@@ -221,7 +223,10 @@ pub(crate) fn source_lines(
 /// step [`source_lines`] uses for both an unmodified line and a diff-added
 /// line, which differ only in `diff_bg` (ADR 0046 decision 6: an added
 /// line's tint wins over the symbol-range tint when both would apply,
-/// achieved simply by `diff_bg` taking priority in the `or` below).
+/// achieved simply by `diff_bg` taking priority in the `or` below). A
+/// `diff_bg` of `Some(ADDED_BG)` also swaps the gutter's usual blank space
+/// for [`marker_span`]'s `+` glyph, pairing this line's gutter with
+/// [`removed_line`]'s own `-` gutter for the same diff signal.
 fn unchanged_line(
     source: &SourceView,
     token_highlights: &[crate::highlight::LineHighlight],
@@ -233,9 +238,15 @@ fn unchanged_line(
     let is_highlighted =
         line_number >= source.highlight_start && line_number <= source.highlight_end;
     let bg = diff_bg.or(is_highlighted.then_some(SOURCE_HIGHLIGHT_BG));
+    let is_added = diff_bg == Some(ADDED_BG);
 
-    let gutter = format!("{line_number:>5} | ");
-    let mut spans = vec![gap_span(&gutter, bg)];
+    let mut spans = vec![gap_span(&format!("{line_number:>5}"), bg)];
+    spans.push(if is_added {
+        marker_span(DiffLineKind::Added, bg)
+    } else {
+        gap_span(" ", bg)
+    });
+    spans.push(gap_span("| ", bg));
     match token_highlights.get(line_index).cloned().flatten() {
         Some(token_spans) => {
             spans.extend(styled_content_spans(text, &token_spans, bg));
@@ -247,12 +258,17 @@ fn unchanged_line(
 
 /// Renders a diff-removed line with no source line number of its own
 /// (`OverlayRow::Removed`'s own doc comment) — a `-` gutter matching the
-/// `{line_number:>5} | ` width of an ordinary line, [`REMOVED_BG`] applied
-/// uniformly, and no token highlighting (the text is the diff's recorded
-/// old-side content, not a line `crate::highlight::highlight_source_lines`
-/// ever parsed).
+/// width of an ordinary line's `{line_number:>5} | ` gutter,
+/// [`marker_span`] for the same bold-red `-` glyph the diff pane uses,
+/// [`REMOVED_BG`] applied uniformly, and no token highlighting (the text is
+/// the diff's recorded old-side content, not a line
+/// `crate::highlight::highlight_source_lines` ever parsed).
 fn removed_line(content: &str) -> Line<'static> {
-    let gutter = format!("{:>5} | ", "-");
     let bg = Some(REMOVED_BG);
-    Line::from(vec![gap_span(&gutter, bg), gap_span(content, bg)])
+    Line::from(vec![
+        gap_span("     ", bg),
+        marker_span(DiffLineKind::Removed, bg),
+        gap_span("| ", bg),
+        gap_span(content, bg),
+    ])
 }

--- a/rinkaku-tui/src/ui/source_screen.rs
+++ b/rinkaku-tui/src/ui/source_screen.rs
@@ -1,14 +1,22 @@
 //! Source drill-down screen (ADR 0026 for the reviewer-driven scroll,
 //! ADR 0018/0020 for the shared "token foreground + line-level background
-//! tint" composition with the diff pane).
+//! tint" composition with the diff pane, ADR 0046 for the diff overlay
+//! composited on top of that).
 
+use super::diff_pane::{ADDED_BG, REMOVED_BG};
 use super::style::{gap_span, pane_border_style, styled_content_spans};
+use crate::diff_view::FileHunks;
 use crate::source::{HighlightedSourceView, SourceView};
+use crate::source_diff::{OverlayRow, overlay_source_lines, rows_in_source_range};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::Color;
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Paragraph, Wrap};
+
+#[cfg(test)]
+#[path = "source_screen/tests.rs"]
+mod tests;
 
 /// Background tint for a source-screen line inside the drilled-into symbol's
 /// own range — reused as the uniform `bg` for [`styled_content_spans`] the
@@ -45,25 +53,28 @@ pub(crate) const SOURCE_HIGHLIGHT_BG: Color = Color::DarkGray;
 /// the point of computing it (defensive — `draw`'s own `Screen::Source` arm
 /// is the only caller, and it always has a symbol id in hand by then); drawn
 /// as a bare bordered box with no body in that case, rather than panicking.
+///
+/// `diff_hunks` is `crate::run_app`'s once-per-session
+/// `diff_view::parse_diff_hunks` output (ADR 0046): when the drilled-into
+/// symbol's file has an entry there, its hunks are composited onto the
+/// source view as an always-on added/removed overlay
+/// (`crate::source_diff::overlay_source_lines`), unless the file has
+/// drifted from the diff on disk, in which case the pane falls back to its
+/// plain rendering with a one-line note in the title (ADR 0046 decision 5).
 pub(crate) fn draw_source_screen(
     frame: &mut Frame,
     symbol_id: &str,
     scroll_top: usize,
     source_content: Option<&Result<HighlightedSourceView, String>>,
+    diff_hunks: &[FileHunks],
     area: Rect,
 ) {
-    let title = format!(" Source: {symbol_id} ");
-    // Always drawn as focused: this screen replaces the whole entry view
-    // (tree + right pane) while open, so there is no sibling pane it needs
-    // to be visually distinguished from (`render_scrollable_pane`'s own doc
-    // comment makes the same call for the `?` help overlay).
-    let block = Block::bordered()
-        .title(title)
-        .border_style(pane_border_style(true));
-
     let highlighted = match source_content {
         Some(Ok(highlighted)) => highlighted,
         Some(Err(message)) => {
+            let block = Block::bordered()
+                .title(format!(" Source: {symbol_id} "))
+                .border_style(pane_border_style(true));
             // `.wrap(Wrap { trim: false })`: the error message (full path +
             // io error + the "not present in the working tree" hint added
             // alongside repo-root resolution) routinely exceeds one line at
@@ -80,16 +91,42 @@ pub(crate) fn draw_source_screen(
             return;
         }
         None => {
+            let block = Block::bordered()
+                .title(format!(" Source: {symbol_id} "))
+                .border_style(pane_border_style(true));
             frame.render_widget(Paragraph::new("").block(block), area);
             return;
         }
     };
     let source = &highlighted.view;
 
+    let file_hunks = crate::diff_view::file_hunks(diff_hunks, &source.path);
+    let overlay = file_hunks.and_then(|file_hunks| overlay_source_lines(&source.lines, file_hunks));
+    let title = if file_hunks.is_some() && overlay.is_none() {
+        format!(
+            " Source: {symbol_id} (diff overlay unavailable — file on disk doesn't match the diff) "
+        )
+    } else {
+        format!(" Source: {symbol_id} ")
+    };
+    // Always drawn as focused: this screen replaces the whole entry view
+    // (tree + right pane) while open, so there is no sibling pane it needs
+    // to be visually distinguished from (`render_scrollable_pane`'s own doc
+    // comment makes the same call for the `?` help overlay).
+    let block = Block::bordered()
+        .title(title)
+        .border_style(pane_border_style(true));
+
     let viewport_height = area.height.saturating_sub(2) as usize; // borders
     let (start, end) = clamped_window(source.lines.len(), scroll_top, viewport_height);
 
-    let lines = source_lines(source, &highlighted.token_highlights, start, end);
+    let lines = source_lines(
+        source,
+        &highlighted.token_highlights,
+        overlay.as_deref(),
+        start,
+        end,
+    );
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
 }
@@ -120,405 +157,102 @@ pub(crate) fn clamped_window(
     (start, end)
 }
 
-/// Renders `source.lines[start..end]` with a `{line_number:>5} | ` gutter,
-/// each line's code tokens colored per `token_highlights[i]` (`None` falls
-/// back to the plain unstyled line this screen always had, same contract as
-/// [`super::diff_pane::diff_line`]'s own fallback) and the symbol's own highlighted range
+/// Renders `source.lines[start..end]` (1-based line range `[start+1, end]`)
+/// with a `{line_number:>5} | ` gutter, each line's code tokens colored per
+/// `token_highlights[i]` (`None` falls back to the plain unstyled line this
+/// screen always had, same contract as [`super::diff_pane::diff_line`]'s own
+/// fallback) and the symbol's own highlighted range
 /// (`source.highlight_start..=source.highlight_end`) composited on top as a
 /// background tint — mirrors the diff pane's own "token foreground + line-
 /// level background tint" composition rather than inventing a second scheme
 /// for this screen.
+///
+/// `overlay` is `crate::source_diff::overlay_source_lines`'s result for this
+/// file (ADR 0046), `None` when the file has no diff or the overlay was
+/// dropped for drift (`draw_source_screen`'s own doc comment). When present,
+/// `crate::source_diff::rows_in_source_range` slices it to the same
+/// `[start, end)` window and each row drives its own line: an `Added` row's
+/// `ADDED_BG` background wins over the symbol-range tint (ADR 0046 decision
+/// 6 — the more specific signal for a reviewer who followed the symbol into
+/// its file specifically to see what changed); a `Removed` row inserts an
+/// extra `-`-gutter line with `REMOVED_BG`, no line number (nothing in
+/// `source.lines` for it to point at) and no token highlighting (the text
+/// comes from the diff, not a parsed source line).
 pub(crate) fn source_lines(
     source: &SourceView,
     token_highlights: &[crate::highlight::LineHighlight],
+    overlay: Option<&[OverlayRow]>,
     start: usize,
     end: usize,
 ) -> Vec<Line<'static>> {
-    source.lines[start..end]
-        .iter()
-        .enumerate()
-        .map(|(offset, text)| {
-            let line_index = start + offset;
-            let line_number = line_index + 1;
-            let is_highlighted =
-                line_number >= source.highlight_start && line_number <= source.highlight_end;
-            let bg = is_highlighted.then_some(SOURCE_HIGHLIGHT_BG);
+    let Some(overlay) = overlay else {
+        return source.lines[start..end]
+            .iter()
+            .enumerate()
+            .map(|(offset, text)| {
+                let line_index = start + offset;
+                unchanged_line(source, token_highlights, line_index, text, None)
+            })
+            .collect();
+    };
 
-            let gutter = format!("{line_number:>5} | ");
-            let mut spans = vec![gap_span(&gutter, bg)];
-            match token_highlights.get(line_index).cloned().flatten() {
-                Some(token_spans) => {
-                    spans.extend(styled_content_spans(text, &token_spans, bg));
-                }
-                None => spans.push(gap_span(text, bg)),
+    rows_in_source_range(overlay, start + 1, end)
+        .iter()
+        .map(|row| match row {
+            OverlayRow::Unchanged {
+                line_number,
+                content,
             }
-            Line::from(spans)
+            | OverlayRow::Added {
+                line_number,
+                content,
+            } => {
+                let line_index = line_number - 1;
+                let added_bg = matches!(row, OverlayRow::Added { .. }).then_some(ADDED_BG);
+                unchanged_line(source, token_highlights, line_index, content, added_bg)
+            }
+            OverlayRow::Removed { content } => removed_line(content),
         })
         .collect()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::app::{App, BlastRadiusSelection};
-    use crate::ui::{DrawOutcome, draw};
-    use ratatui::Terminal;
-    use ratatui::backend::TestBackend;
-    use ratatui::style::Style;
-    use rinkaku_core::diff::LineRange;
-    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
-    use rinkaku_core::graph::SymbolGraph;
-    use rinkaku_core::render::{FileReport, Report};
+/// Renders one source-file line (`text`, at 0-based `line_index`) with its
+/// gutter, token highlighting, and background tint — the common rendering
+/// step [`source_lines`] uses for both an unmodified line and a diff-added
+/// line, which differ only in `diff_bg` (ADR 0046 decision 6: an added
+/// line's tint wins over the symbol-range tint when both would apply,
+/// achieved simply by `diff_bg` taking priority in the `or` below).
+fn unchanged_line(
+    source: &SourceView,
+    token_highlights: &[crate::highlight::LineHighlight],
+    line_index: usize,
+    text: &str,
+    diff_bg: Option<Color>,
+) -> Line<'static> {
+    let line_number = line_index + 1;
+    let is_highlighted =
+        line_number >= source.highlight_start && line_number <= source.highlight_end;
+    let bg = diff_bg.or(is_highlighted.then_some(SOURCE_HIGHLIGHT_BG));
 
-    fn symbol(id: &str, name: &str) -> ExtractedSymbol {
-        ExtractedSymbol {
-            id: id.to_string(),
-            name: name.to_string(),
-            kind: SymbolKind::Function,
-            signature: format!("fn {name}()"),
-            range: LineRange { start: 1, end: 1 },
-            container: None,
-            referenced_names: vec![],
-            dependencies: vec![],
-            omitted_dependency_matches: 0,
-            is_test: false,
-            classification: None,
-            previous_signature: None,
+    let gutter = format!("{line_number:>5} | ");
+    let mut spans = vec![gap_span(&gutter, bg)];
+    match token_highlights.get(line_index).cloned().flatten() {
+        Some(token_spans) => {
+            spans.extend(styled_content_spans(text, &token_spans, bg));
         }
+        None => spans.push(gap_span(text, bg)),
     }
+    Line::from(spans)
+}
 
-    fn report_with_one_symbol() -> Report {
-        Report {
-            origin: rinkaku_core::render::ReportOrigin::Diff,
-            files: vec![FileReport {
-                path: "lib.rs".to_string(),
-                symbols: vec![symbol("lib.rs::foo", "foo")],
-            }],
-            skipped: vec![],
-            graph: SymbolGraph {
-                nodes: vec![],
-                edges: vec![],
-                roots: vec![],
-            },
-            tests: vec![],
-            fan_ins: vec![],
-            file_size_warnings: vec![],
-            file_size_bands: vec![],
-            removed: vec![],
-        }
-    }
-
-    fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
-        let buffer = terminal.backend().buffer();
-        let area = buffer.area;
-        (0..area.height)
-            .map(|y| {
-                (0..area.width)
-                    .map(|x| buffer[(x, y)].symbol().to_string())
-                    .collect::<String>()
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
-    fn find_cell_style(terminal: &Terminal<TestBackend>, line_needle: &str, token: &str) -> Style {
-        let buffer = terminal.backend().buffer();
-        let area = buffer.area;
-        for y in 0..area.height {
-            let row: String = (0..area.width)
-                .map(|x| buffer[(x, y)].symbol().to_string())
-                .collect();
-            let Some(needle_byte_offset) = row.find(line_needle) else {
-                continue;
-            };
-            let Some(token_byte_offset) = row[needle_byte_offset..].find(token) else {
-                continue;
-            };
-            let byte_offset = needle_byte_offset + token_byte_offset;
-            let column = row[..byte_offset].chars().count() as u16;
-            return buffer[(column, y)].style();
-        }
-        panic!("expected to find {token:?} within a row containing {line_needle:?}");
-    }
-
-    /// A real `Err` from `crate::source::load_symbol_source`/
-    /// `load_highlighted_symbol_source`, produced by actually attempting a
-    /// read under a placeholder repo root nothing on disk matches — used to
-    /// build `source_content` for `draw_source_screen` tests below rather
-    /// than fabricating the error string by hand, so these tests stay
-    /// pinned to the real message format `crate::source` produces.
-    fn missing_file_source_content(
-        report: &Report,
-        symbol_id: &str,
-    ) -> Option<Result<crate::source::HighlightedSourceView, String>> {
-        Some(crate::source::load_highlighted_symbol_source(
-            report,
-            symbol_id,
-            std::path::Path::new("/repo"),
-        ))
-    }
-
-    #[test]
-    fn should_draw_source_screen_title_and_error_message_when_file_is_missing() {
-        let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::Source);
-        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
-        let source_content = missing_file_source_content(&report, "lib.rs::foo");
-
-        terminal
-            .draw(|frame| {
-                draw(
-                    frame,
-                    &app,
-                    &report,
-                    &crate::diff_shape::DiffPaneContent::Empty,
-                    &[],
-                    &BlastRadiusSelection::NotApplicable,
-                    source_content.as_ref(),
-                );
-            })
-            .expect("draw");
-
-        // "lib.rs" does not exist under the placeholder repo root above, so
-        // this exercises `draw_source_screen`'s error-message fallback path
-        // rather than needing a real file on disk.
-        let text = buffer_text(&terminal);
-        assert!(text.contains("Source: lib.rs::foo"));
-        assert!(text.contains("failed to read"));
-        assert!(text.contains("back"));
-    }
-
-    #[test]
-    fn should_wrap_source_error_message_instead_of_truncating_it_in_a_narrow_pane() {
-        // Regression test: `source::load_symbol_source`'s error message
-        // (full path + io error + the "not present in the working tree"
-        // hint) routinely exceeds one line, and `Paragraph` without
-        // `.wrap(...)` silently truncates rather than overflowing — cutting
-        // the hint off exactly where it explains the failure. A narrow
-        // (40-column) pane makes the message wrap across multiple rows
-        // whether or not `.wrap(...)` is set, but only *with* it does the
-        // hint's text actually appear anywhere in the buffer; without it,
-        // the trailing text is simply dropped.
-        let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::Source);
-        let mut terminal = Terminal::new(TestBackend::new(40, 20)).expect("terminal");
-        let source_content = missing_file_source_content(&report, "lib.rs::foo");
-
-        terminal
-            .draw(|frame| {
-                draw(
-                    frame,
-                    &app,
-                    &report,
-                    &crate::diff_shape::DiffPaneContent::Empty,
-                    &[],
-                    &BlastRadiusSelection::NotApplicable,
-                    source_content.as_ref(),
-                );
-            })
-            .expect("draw");
-
-        // `buffer_text` joins rows with `\n`, so a phrase that happens to
-        // wrap exactly at a row boundary (as "in the" / "present" do at
-        // this width) would not appear as one contiguous substring even
-        // though every word is visible — asserting on words rather than a
-        // multi-word phrase keeps this test robust to exactly where the
-        // wrap point falls, while still failing if `.wrap(...)` were
-        // removed (the words after "working tree" would be dropped
-        // entirely, not just split across rows).
-        let text = buffer_text(&terminal);
-        assert!(text.contains("Source: lib.rs::foo"));
-        assert!(text.contains("present"));
-        assert!(text.contains("working tree"));
-        assert!(text.contains("historical commit not checked out"));
-        assert!(text.contains("locally)"));
-    }
-
-    // --- draw_source_screen: syntax highlighting ---
-
-    #[test]
-    fn should_apply_keyword_foreground_and_symbol_range_background_in_source_screen() {
-        let dir = tempfile::tempdir().expect("create temp dir");
-        std::fs::write(dir.path().join("lib.rs"), "fn a() {}\nfn foo() {}\n").expect("write file");
-
-        let report = Report {
-            origin: rinkaku_core::render::ReportOrigin::Diff,
-            files: vec![FileReport {
-                path: "lib.rs".to_string(),
-                symbols: vec![ExtractedSymbol {
-                    range: LineRange { start: 2, end: 2 },
-                    ..symbol("lib.rs::foo", "foo")
-                }],
-            }],
-            skipped: vec![],
-            graph: SymbolGraph {
-                nodes: vec![],
-                edges: vec![],
-                roots: vec![],
-            },
-            tests: vec![],
-            fan_ins: vec![],
-            file_size_warnings: vec![],
-            file_size_bands: vec![],
-            removed: vec![],
-        };
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::Source);
-        let source_content = Some(crate::source::load_highlighted_symbol_source(
-            &report,
-            "lib.rs::foo",
-            dir.path(),
-        ));
-        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
-
-        terminal
-            .draw(|frame| {
-                draw(
-                    frame,
-                    &app,
-                    &report,
-                    &crate::diff_shape::DiffPaneContent::Empty,
-                    &[],
-                    &BlastRadiusSelection::NotApplicable,
-                    source_content.as_ref(),
-                );
-            })
-            .expect("draw");
-
-        // Line 2 ("fn foo() {}") is the symbol's own highlighted range: its
-        // "fn" keyword must carry both signals composited together — the
-        // token's own foreground color (ADR 0018's palette, extended to
-        // this screen) *and* the symbol-range background tint — mirroring
-        // how the diff pane composites a token's foreground with its
-        // added/removed background rather than one replacing the other.
-        let keyword_style = find_cell_style(&terminal, "2 | fn foo() {}", "fn");
-        assert_eq!(Some(Color::Magenta), keyword_style.fg);
-        assert_eq!(Some(SOURCE_HIGHLIGHT_BG), keyword_style.bg);
-
-        // Line 1 ("fn a() {}") is outside the symbol's range: its own "fn"
-        // keyword must still be colored (highlighting applies to every
-        // line, not just the highlighted range) but without the background
-        // tint, since only the drilled-into symbol's own lines get it.
-        // `Style::bg` reports an unset background as `Some(Color::Reset)`,
-        // not `None` (ratatui's own `Cell` default — see
-        // `should_keep_context_line_unstyled_background_in_diff_pane`'s own
-        // doc comment for this same convention on the diff pane).
-        let outside_range_style = find_cell_style(&terminal, "1 | fn a() {}", "fn");
-        assert_eq!(Some(Color::Magenta), outside_range_style.fg);
-        assert_eq!(Some(Color::Reset), outside_range_style.bg);
-    }
-
-    #[test]
-    fn should_fall_back_to_plain_source_style_when_file_extension_is_unrecognized() {
-        let dir = tempfile::tempdir().expect("create temp dir");
-        std::fs::write(dir.path().join("config.yaml"), "key: value\n").expect("write file");
-
-        let report = Report {
-            origin: rinkaku_core::render::ReportOrigin::Diff,
-            files: vec![FileReport {
-                path: "config.yaml".to_string(),
-                symbols: vec![symbol("config.yaml::foo", "foo")],
-            }],
-            skipped: vec![],
-            graph: SymbolGraph {
-                nodes: vec![],
-                edges: vec![],
-                roots: vec![],
-            },
-            tests: vec![],
-            fan_ins: vec![],
-            file_size_warnings: vec![],
-            file_size_bands: vec![],
-            removed: vec![],
-        };
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::Source);
-        let source_content = Some(crate::source::load_highlighted_symbol_source(
-            &report,
-            "config.yaml::foo",
-            dir.path(),
-        ));
-        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
-
-        terminal
-            .draw(|frame| {
-                draw(
-                    frame,
-                    &app,
-                    &report,
-                    &crate::diff_shape::DiffPaneContent::Empty,
-                    &[],
-                    &BlastRadiusSelection::NotApplicable,
-                    source_content.as_ref(),
-                );
-            })
-            .expect("draw");
-
-        // No highlight configuration exists for `.yaml`
-        // (`highlight::config_for_path`), so the line still renders — with
-        // the symbol-range background tint (highlighting failing must never
-        // regress the pane below its pre-ADR-0018 plain style) but no
-        // per-token foreground coloring (`Style::fg` reports an unset
-        // foreground as `Some(Color::Reset)`, not `None` — same ratatui
-        // `Cell` default convention as `bg`, see the test above).
-        let text = buffer_text(&terminal);
-        assert!(text.contains("key: value"));
-        let style = find_cell_style(&terminal, "1 | key: value", "key");
-        assert_eq!(Some(SOURCE_HIGHLIGHT_BG), style.bg);
-        assert_eq!(Some(Color::Reset), style.fg);
-    }
-
-    #[test]
-    fn should_report_none_clamped_scroll_but_source_viewport_height_when_source_screen_is_open() {
-        // ADR 0026: the source screen scrolls via its own
-        // `Screen::Source::scroll_top`, not `App::right_pane_scroll`, so
-        // `DrawOutcome::clamped_right_pane_scroll` must stay `None` on this
-        // screen (otherwise `crate::run_app`'s
-        // `clamp_right_pane_scroll_after_draw` would fold a source-screen
-        // offset back into the wrong field). At the same time the source
-        // pane's inner height must be surfaced via
-        // `scroll_viewport_height` — otherwise `Ctrl-d`/`Ctrl-u`/`G` from
-        // the source screen would have no viewport to size their step
-        // against, defaulting to `DEFAULT_SOURCE_VIEWPORT_HEIGHT`.
-        let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::Source);
-        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
-
-        let mut actual = DrawOutcome {
-            clamped_right_pane_scroll: Some(999),
-            scroll_viewport_height: None,
-            clamped_help_scroll: None,
-            help_scroll_viewport_height: None,
-        };
-        terminal
-            .draw(|frame| {
-                actual = draw(
-                    frame,
-                    &app,
-                    &report,
-                    &crate::diff_shape::DiffPaneContent::Empty,
-                    &[],
-                    &BlastRadiusSelection::NotApplicable,
-                    None,
-                );
-            })
-            .expect("draw");
-
-        assert_eq!(None, actual.clamped_right_pane_scroll);
-        // A 20-row terminal with a 1-row status line leaves 19 rows for
-        // the body; the source pane's bordered box takes 2 of them,
-        // leaving 17 rows inside. Pinned exactly (rather than a range)
-        // so a future layout refactor that silently changes the split
-        // is caught, matching the specificity `ADR 0020`'s own
-        // `right_pane_viewport_height` shares with `draw_entry_screen`.
-        assert_eq!(Some(17), actual.scroll_viewport_height);
-    }
+/// Renders a diff-removed line with no source line number of its own
+/// (`OverlayRow::Removed`'s own doc comment) — a `-` gutter matching the
+/// `{line_number:>5} | ` width of an ordinary line, [`REMOVED_BG`] applied
+/// uniformly, and no token highlighting (the text is the diff's recorded
+/// old-side content, not a line `crate::highlight::highlight_source_lines`
+/// ever parsed).
+fn removed_line(content: &str) -> Line<'static> {
+    let gutter = format!("{:>5} | ", "-");
+    let bg = Some(REMOVED_BG);
+    Line::from(vec![gap_span(&gutter, bg), gap_span(content, bg)])
 }

--- a/rinkaku-tui/src/ui/source_screen/tests.rs
+++ b/rinkaku-tui/src/ui/source_screen/tests.rs
@@ -365,3 +365,152 @@ fn should_report_none_clamped_scroll_but_source_viewport_height_when_source_scre
     // `right_pane_viewport_height` shares with `draw_entry_screen`.
     assert_eq!(Some(17), actual.scroll_viewport_height);
 }
+
+// --- diff overlay (ADR 0046) ---
+
+use crate::diff_view::{DiffLine, DiffLineKind, FileHunks, Hunk};
+
+fn diff_line(kind: DiffLineKind, content: &str) -> DiffLine {
+    DiffLine {
+        kind,
+        content: content.to_string(),
+    }
+}
+
+fn draw_source_screen_for_test(
+    report: &Report,
+    repo_root: &std::path::Path,
+    diff_hunks: &[FileHunks],
+) -> Terminal<TestBackend> {
+    let app = App::new(report)
+        .handle_key(crate::app::InputKey::Down)
+        .handle_key(crate::app::InputKey::Source);
+    let source_content = Some(crate::source::load_highlighted_symbol_source(
+        report,
+        "lib.rs::foo",
+        repo_root,
+    ));
+    let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                source_content.as_ref(),
+                diff_hunks,
+            );
+        })
+        .expect("draw");
+
+    terminal
+}
+
+#[test]
+fn should_apply_added_background_and_marker_when_line_was_added_by_the_diff() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(dir.path().join("lib.rs"), "fn a() {}\nfn foo() {}\n").expect("write file");
+    let report = report_with_one_symbol();
+    let diff_hunks = vec![FileHunks {
+        path: "lib.rs".to_string(),
+        hunks: vec![Hunk {
+            header: "@@ -1,1 +1,2 @@".to_string(),
+            new_range: Some((1, 2)),
+            lines: vec![
+                diff_line(DiffLineKind::Added, "fn a() {}"),
+                diff_line(DiffLineKind::Context, "fn foo() {}"),
+            ],
+        }],
+    }];
+
+    let terminal = draw_source_screen_for_test(&report, dir.path(), &diff_hunks);
+
+    let style = find_cell_style(&terminal, "1 |", "fn a");
+    assert_eq!(Some(ADDED_BG), style.bg);
+}
+
+#[test]
+fn should_render_removed_row_with_dash_gutter_and_removed_background() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(dir.path().join("lib.rs"), "fn foo() {}\n").expect("write file");
+    let report = report_with_one_symbol();
+    let diff_hunks = vec![FileHunks {
+        path: "lib.rs".to_string(),
+        hunks: vec![Hunk {
+            header: "@@ -1,2 +1,1 @@".to_string(),
+            new_range: Some((1, 1)),
+            lines: vec![
+                diff_line(DiffLineKind::Removed, "fn old() {}"),
+                diff_line(DiffLineKind::Context, "fn foo() {}"),
+            ],
+        }],
+    }];
+
+    let terminal = draw_source_screen_for_test(&report, dir.path(), &diff_hunks);
+
+    let text = buffer_text(&terminal);
+    assert!(text.contains("fn old() {}"));
+    let style = find_cell_style(&terminal, "-", "fn old");
+    assert_eq!(Some(REMOVED_BG), style.bg);
+}
+
+#[test]
+fn should_render_plainly_with_no_diff_entry_for_the_file() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    // Two lines so line 2 falls outside `report_with_one_symbol`'s symbol
+    // range (`LineRange { start: 1, end: 1 }`) — line 1 always carries
+    // `SOURCE_HIGHLIGHT_BG` regardless of any diff overlay, so asserting
+    // "no diff background" needs a line the symbol-range tint doesn't
+    // already touch.
+    std::fs::write(dir.path().join("lib.rs"), "fn foo() {}\nfn bar() {}\n").expect("write file");
+    let report = report_with_one_symbol();
+
+    let terminal = draw_source_screen_for_test(&report, dir.path(), &[]);
+
+    let text = buffer_text(&terminal);
+    assert!(text.contains("fn bar() {}"));
+    assert!(!text.contains("diff overlay unavailable"));
+    let style = find_cell_style(&terminal, "2 |", "fn bar");
+    assert_eq!(Some(Color::Reset), style.bg);
+}
+
+#[test]
+fn should_fall_back_to_plain_rendering_with_a_title_note_when_file_has_drifted() {
+    // The hunk's `Context` line claims line 2 is `fn foo() {}`, but the
+    // file on disk (written below) has since diverged at that exact line —
+    // `overlay_source_lines` must detect this and drop the overlay (ADR
+    // 0046 decision 5) rather than compositing a wrong mapping. `Added`
+    // lines are never drift-checked (nothing in the working tree for them
+    // to match against), so the corruption must land on a `Context` line
+    // specifically to exercise the check.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        dir.path().join("lib.rs"),
+        "fn a() {}\nfn edited_since_diff() {}\n",
+    )
+    .expect("write file");
+    let report = report_with_one_symbol();
+    let diff_hunks = vec![FileHunks {
+        path: "lib.rs".to_string(),
+        hunks: vec![Hunk {
+            header: "@@ -1,1 +1,2 @@".to_string(),
+            new_range: Some((1, 2)),
+            lines: vec![
+                diff_line(DiffLineKind::Added, "fn a() {}"),
+                diff_line(DiffLineKind::Context, "fn foo() {}"),
+            ],
+        }],
+    }];
+
+    let terminal = draw_source_screen_for_test(&report, dir.path(), &diff_hunks);
+
+    let text = buffer_text(&terminal);
+    assert!(text.contains("diff overlay unavailable"));
+    assert!(text.contains("fn edited_since_diff() {}"));
+    let style = find_cell_style(&terminal, "1 |", "fn a");
+    assert_eq!(Some(SOURCE_HIGHLIGHT_BG), style.bg);
+}

--- a/rinkaku-tui/src/ui/source_screen/tests.rs
+++ b/rinkaku-tui/src/ui/source_screen/tests.rs
@@ -1,0 +1,367 @@
+use super::*;
+use crate::app::{App, BlastRadiusSelection};
+use crate::ui::{DrawOutcome, draw};
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::style::Style;
+use rinkaku_core::diff::LineRange;
+use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+use rinkaku_core::graph::SymbolGraph;
+use rinkaku_core::render::{FileReport, Report};
+
+fn symbol(id: &str, name: &str) -> ExtractedSymbol {
+    ExtractedSymbol {
+        id: id.to_string(),
+        name: name.to_string(),
+        kind: SymbolKind::Function,
+        signature: format!("fn {name}()"),
+        range: LineRange { start: 1, end: 1 },
+        container: None,
+        referenced_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }
+}
+
+fn report_with_one_symbol() -> Report {
+    Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![symbol("lib.rs::foo", "foo")],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    }
+}
+
+fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    (0..area.height)
+        .map(|y| {
+            (0..area.width)
+                .map(|x| buffer[(x, y)].symbol().to_string())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn find_cell_style(terminal: &Terminal<TestBackend>, line_needle: &str, token: &str) -> Style {
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    for y in 0..area.height {
+        let row: String = (0..area.width)
+            .map(|x| buffer[(x, y)].symbol().to_string())
+            .collect();
+        let Some(needle_byte_offset) = row.find(line_needle) else {
+            continue;
+        };
+        let Some(token_byte_offset) = row[needle_byte_offset..].find(token) else {
+            continue;
+        };
+        let byte_offset = needle_byte_offset + token_byte_offset;
+        let column = row[..byte_offset].chars().count() as u16;
+        return buffer[(column, y)].style();
+    }
+    panic!("expected to find {token:?} within a row containing {line_needle:?}");
+}
+
+/// A real `Err` from `crate::source::load_symbol_source`/
+/// `load_highlighted_symbol_source`, produced by actually attempting a
+/// read under a placeholder repo root nothing on disk matches — used to
+/// build `source_content` for `draw_source_screen` tests below rather
+/// than fabricating the error string by hand, so these tests stay
+/// pinned to the real message format `crate::source` produces.
+fn missing_file_source_content(
+    report: &Report,
+    symbol_id: &str,
+) -> Option<Result<crate::source::HighlightedSourceView, String>> {
+    Some(crate::source::load_highlighted_symbol_source(
+        report,
+        symbol_id,
+        std::path::Path::new("/repo"),
+    ))
+}
+
+#[test]
+fn should_draw_source_screen_title_and_error_message_when_file_is_missing() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(crate::app::InputKey::Down)
+        .handle_key(crate::app::InputKey::Source);
+    let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+    let source_content = missing_file_source_content(&report, "lib.rs::foo");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                source_content.as_ref(),
+                &[],
+            );
+        })
+        .expect("draw");
+
+    // "lib.rs" does not exist under the placeholder repo root above, so
+    // this exercises `draw_source_screen`'s error-message fallback path
+    // rather than needing a real file on disk.
+    let text = buffer_text(&terminal);
+    assert!(text.contains("Source: lib.rs::foo"));
+    assert!(text.contains("failed to read"));
+    assert!(text.contains("back"));
+}
+
+#[test]
+fn should_wrap_source_error_message_instead_of_truncating_it_in_a_narrow_pane() {
+    // Regression test: `source::load_symbol_source`'s error message
+    // (full path + io error + the "not present in the working tree"
+    // hint) routinely exceeds one line, and `Paragraph` without
+    // `.wrap(...)` silently truncates rather than overflowing — cutting
+    // the hint off exactly where it explains the failure. A narrow
+    // (40-column) pane makes the message wrap across multiple rows
+    // whether or not `.wrap(...)` is set, but only *with* it does the
+    // hint's text actually appear anywhere in the buffer; without it,
+    // the trailing text is simply dropped.
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(crate::app::InputKey::Down)
+        .handle_key(crate::app::InputKey::Source);
+    let mut terminal = Terminal::new(TestBackend::new(40, 20)).expect("terminal");
+    let source_content = missing_file_source_content(&report, "lib.rs::foo");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                source_content.as_ref(),
+                &[],
+            );
+        })
+        .expect("draw");
+
+    // `buffer_text` joins rows with `\n`, so a phrase that happens to
+    // wrap exactly at a row boundary (as "in the" / "present" do at
+    // this width) would not appear as one contiguous substring even
+    // though every word is visible — asserting on words rather than a
+    // multi-word phrase keeps this test robust to exactly where the
+    // wrap point falls, while still failing if `.wrap(...)` were
+    // removed (the words after "working tree" would be dropped
+    // entirely, not just split across rows).
+    let text = buffer_text(&terminal);
+    assert!(text.contains("Source: lib.rs::foo"));
+    assert!(text.contains("present"));
+    assert!(text.contains("working tree"));
+    assert!(text.contains("historical commit not checked out"));
+    assert!(text.contains("locally)"));
+}
+
+// --- draw_source_screen: syntax highlighting ---
+
+#[test]
+fn should_apply_keyword_foreground_and_symbol_range_background_in_source_screen() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(dir.path().join("lib.rs"), "fn a() {}\nfn foo() {}\n").expect("write file");
+
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![ExtractedSymbol {
+                range: LineRange { start: 2, end: 2 },
+                ..symbol("lib.rs::foo", "foo")
+            }],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+    let app = App::new(&report)
+        .handle_key(crate::app::InputKey::Down)
+        .handle_key(crate::app::InputKey::Source);
+    let source_content = Some(crate::source::load_highlighted_symbol_source(
+        &report,
+        "lib.rs::foo",
+        dir.path(),
+    ));
+    let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                source_content.as_ref(),
+                &[],
+            );
+        })
+        .expect("draw");
+
+    // Line 2 ("fn foo() {}") is the symbol's own highlighted range: its
+    // "fn" keyword must carry both signals composited together — the
+    // token's own foreground color (ADR 0018's palette, extended to
+    // this screen) *and* the symbol-range background tint — mirroring
+    // how the diff pane composites a token's foreground with its
+    // added/removed background rather than one replacing the other.
+    let keyword_style = find_cell_style(&terminal, "2 | fn foo() {}", "fn");
+    assert_eq!(Some(Color::Magenta), keyword_style.fg);
+    assert_eq!(Some(SOURCE_HIGHLIGHT_BG), keyword_style.bg);
+
+    // Line 1 ("fn a() {}") is outside the symbol's range: its own "fn"
+    // keyword must still be colored (highlighting applies to every
+    // line, not just the highlighted range) but without the background
+    // tint, since only the drilled-into symbol's own lines get it.
+    // `Style::bg` reports an unset background as `Some(Color::Reset)`,
+    // not `None` (ratatui's own `Cell` default — see
+    // `should_keep_context_line_unstyled_background_in_diff_pane`'s own
+    // doc comment for this same convention on the diff pane).
+    let outside_range_style = find_cell_style(&terminal, "1 | fn a() {}", "fn");
+    assert_eq!(Some(Color::Magenta), outside_range_style.fg);
+    assert_eq!(Some(Color::Reset), outside_range_style.bg);
+}
+
+#[test]
+fn should_fall_back_to_plain_source_style_when_file_extension_is_unrecognized() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(dir.path().join("config.yaml"), "key: value\n").expect("write file");
+
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "config.yaml".to_string(),
+            symbols: vec![symbol("config.yaml::foo", "foo")],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+    let app = App::new(&report)
+        .handle_key(crate::app::InputKey::Down)
+        .handle_key(crate::app::InputKey::Source);
+    let source_content = Some(crate::source::load_highlighted_symbol_source(
+        &report,
+        "config.yaml::foo",
+        dir.path(),
+    ));
+    let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                source_content.as_ref(),
+                &[],
+            );
+        })
+        .expect("draw");
+
+    // No highlight configuration exists for `.yaml`
+    // (`highlight::config_for_path`), so the line still renders — with
+    // the symbol-range background tint (highlighting failing must never
+    // regress the pane below its pre-ADR-0018 plain style) but no
+    // per-token foreground coloring (`Style::fg` reports an unset
+    // foreground as `Some(Color::Reset)`, not `None` — same ratatui
+    // `Cell` default convention as `bg`, see the test above).
+    let text = buffer_text(&terminal);
+    assert!(text.contains("key: value"));
+    let style = find_cell_style(&terminal, "1 | key: value", "key");
+    assert_eq!(Some(SOURCE_HIGHLIGHT_BG), style.bg);
+    assert_eq!(Some(Color::Reset), style.fg);
+}
+
+#[test]
+fn should_report_none_clamped_scroll_but_source_viewport_height_when_source_screen_is_open() {
+    // ADR 0026: the source screen scrolls via its own
+    // `Screen::Source::scroll_top`, not `App::right_pane_scroll`, so
+    // `DrawOutcome::clamped_right_pane_scroll` must stay `None` on this
+    // screen (otherwise `crate::run_app`'s
+    // `clamp_right_pane_scroll_after_draw` would fold a source-screen
+    // offset back into the wrong field). At the same time the source
+    // pane's inner height must be surfaced via
+    // `scroll_viewport_height` — otherwise `Ctrl-d`/`Ctrl-u`/`G` from
+    // the source screen would have no viewport to size their step
+    // against, defaulting to `DEFAULT_SOURCE_VIEWPORT_HEIGHT`.
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(crate::app::InputKey::Down)
+        .handle_key(crate::app::InputKey::Source);
+    let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+    let mut actual = DrawOutcome {
+        clamped_right_pane_scroll: Some(999),
+        scroll_viewport_height: None,
+        clamped_help_scroll: None,
+        help_scroll_viewport_height: None,
+    };
+    terminal
+        .draw(|frame| {
+            actual = draw(
+                frame,
+                &app,
+                &report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                None,
+                &[],
+            );
+        })
+        .expect("draw");
+
+    assert_eq!(None, actual.clamped_right_pane_scroll);
+    // A 20-row terminal with a 1-row status line leaves 19 rows for
+    // the body; the source pane's bordered box takes 2 of them,
+    // leaving 17 rows inside. Pinned exactly (rather than a range)
+    // so a future layout refactor that silently changes the split
+    // is caught, matching the specificity `ADR 0020`'s own
+    // `right_pane_viewport_height` shares with `draw_entry_screen`.
+    assert_eq!(Some(17), actual.scroll_viewport_height);
+}

--- a/rinkaku-tui/src/ui/source_screen/tests.rs
+++ b/rinkaku-tui/src/ui/source_screen/tests.rs
@@ -429,8 +429,12 @@ fn should_apply_added_background_and_marker_when_line_was_added_by_the_diff() {
 
     let terminal = draw_source_screen_for_test(&report, dir.path(), &diff_hunks);
 
-    let style = find_cell_style(&terminal, "1 |", "fn a");
+    let text = buffer_text(&terminal);
+    assert!(text.contains("1+|"));
+    let style = find_cell_style(&terminal, "1+|", "fn a");
     assert_eq!(Some(ADDED_BG), style.bg);
+    let marker_style = find_cell_style(&terminal, "1+|", "+");
+    assert_eq!(Some(Color::Green), marker_style.fg);
 }
 
 #[test]
@@ -480,13 +484,9 @@ fn should_render_plainly_with_no_diff_entry_for_the_file() {
 
 #[test]
 fn should_fall_back_to_plain_rendering_with_a_title_note_when_file_has_drifted() {
-    // The hunk's `Context` line claims line 2 is `fn foo() {}`, but the
-    // file on disk (written below) has since diverged at that exact line —
-    // `overlay_source_lines` must detect this and drop the overlay (ADR
-    // 0046 decision 5) rather than compositing a wrong mapping. `Added`
-    // lines are never drift-checked (nothing in the working tree for them
-    // to match against), so the corruption must land on a `Context` line
-    // specifically to exercise the check.
+    // Corruption must land on the `Context` line (line 2): `Added` lines
+    // are never drift-checked, so only a mismatched `Context` line exercises
+    // the detection this test targets.
     let dir = tempfile::tempdir().expect("create temp dir");
     std::fs::write(
         dir.path().join("lib.rs"),

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -224,6 +224,7 @@ mod tests {
                     &[],
                     &BlastRadiusSelection::NotApplicable,
                     None,
+                    &[],
                 );
             })
             .expect("draw");


### PR DESCRIPTION
## Summary

Adds full-file diff context to the TUI's source view (`s` on a symbol row): when the drilled-into symbol's file has diff hunks, they're composited directly onto the full-file rendering — added lines get a green background and a `+` gutter, removed lines render as extra red-background rows with a `-` gutter inserted at the position they used to occupy. This gives a reviewer the diff pane's signal in the context of the whole file, which the diff pane itself deliberately never shows (it only renders hunks touching the selected row).

Design rationale is recorded in [`docs/adr/0046-source-view-diff-overlay.md`](docs/adr/0046-source-view-diff-overlay.md): the source view (not a diff-pane full-file mode) was chosen specifically to avoid doubling the diff pane's hunk-relative line-index coordinate space that prior ADRs (0027/0030/0044) already depend on for scroll-sync and split-view pairing.

The overlay is always on (no toggle) for a file with diff hunks. If the file on disk no longer matches the diff — edited since it was produced, or diffed against a different revision — the overlay is dropped for the whole file and the pane falls back to its plain, unhighlighted rendering with a note in the pane title (`(diff overlay unavailable — file on disk doesn't match the diff)`), rather than composing a partially-wrong mapping.

## Known limitation

`Added` lines are never drift-checked against the working tree (there's nothing in the file for them to match against before they exist) — only `Context` lines participate in drift detection. This is a deliberate trade-off recorded in the ADR, not an oversight: it means a diff whose only problem is a stale `Added` line's *content* (not its position) won't trigger the fallback, but a position-level mismatch always will via the surrounding `Context` lines.

## QA

- `make test`: 1288 tests pass across the workspace (`rinkaku` 176, `rinkaku-core` 399, `rinkaku-tui` 713).
- `make lint`: clean (`cargo fmt --check` + `cargo clippy -D warnings`).
- Static review (2 passes) found one should-fix: the `+` gutter for added lines was missing despite the ADR and docs describing it. Fixed by reusing `ui::diff_pane::marker_span` (the same bold-green `+`/bold-red `-` the diff pane itself uses) for both `Added` and `Removed` rows, and strengthened the corresponding test to assert the glyph and its color, not just the background.
- Dynamic verification (tmux, real terminal, raw escape-sequence capture to confirm actual colors/glyphs):
  - Real diff on this branch: added/removed/unchanged lines render with correct background tint, gutter marker, and composited syntax-highlighting foreground.
  - Fixture coverage: pure addition, pure deletion, mixed replace hunk, deletion at end of file, deletion mid-file, multiple hunks in one file — all via unit tests plus manual TUI verification.
  - 6000-line synthetic file with hunks scattered across it (mid-file inserts, mid-file deletes, a tail-of-file insert): `+`/`-` gutters render at the correct line positions, `gg`/`G`/`ctrl-d` scroll instantly with no perceptible lag.
  - Drift reproduction: corrupting a hunk's `Context` line relative to the file on disk correctly drops the overlay and shows the pane-title note; corrupting only an `Added` line's content does not (the documented limitation above).
  - Failure modes: empty diff (`note: diff is empty, nothing to analyze`, exit 0) and non-TTY stdin with `--tui` (`Error: Device not configured`, exit 1) both match pre-existing `main` behavior — not regressions.

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] Manual TUI verification (tmux) of added/removed/unchanged rendering, large-file scroll performance, and drift fallback