### PR TITLE
feat(tui): add review notes with PR review and clipboard export sinks (ADR 0048)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ blast radius; `?` opens the full keymap.
 See [`docs/tui.md`](docs/tui.md) for the full layout, key bindings, and
 caveats on ordering and dependency resolution.
 
+### Leaving review notes
+
+Press `n` over a symbol row to attach a note; `N` opens the notes list
+(`j`/`k` to move, `Enter` to export, `d` to delete). Export goes to
+whichever sinks apply to how you launched the TUI:
+
+- **GitHub PR review** — only when you started with `rinkaku --pr
+  <url or number>`. Picking this opens a verdict menu (Approve /
+  Request changes / Comment) and posts every note as one batched PR
+  review.
+- **Clipboard, for an AI agent** — always available. Copies a Markdown
+  packet (one section per note, with the note's own symbol signature)
+  via an OSC 52 terminal escape sequence, so it works over SSH too.
+
 ## Install
 
 | Method | Command |

--- a/docs/adr/0048-tui-review-actions.md
+++ b/docs/adr/0048-tui-review-actions.md
@@ -401,6 +401,15 @@ feature must fit rather than invent a fourth:
   silently does not populate the system clipboard, so the TUI must
   surface the packet text itself as a visible fallback rather than
   assuming the write succeeded.
+  - **Amendment (2026-07-15)**: dogfooding hit OSC 52's silent-drop mode
+    immediately on a *local* setup (tmux `set-clipboard external`
+    forwarding to an outer terminal that doesn't support or permit
+    OSC 52), so sink B now prefers a native clipboard command
+    (`pbcopy`/`wl-copy`/`xclip`/`xsel`) when the session is local, and
+    uses OSC 52 only for remote sessions (`SSH_TTY`/`SSH_CONNECTION`) or
+    hosts with no such command — the environments OSC 52 was chosen for.
+    The Alternatives entry's rejection of shelling out was scoped to
+    *replacing* OSC 52 outright, not to layering both by locality.
 - Sink C's shape (suspend TUI, run configured interactive command,
   resume) is fixed by this ADR but not implemented; a follow-up PR
   implements it against this shape rather than re-litigating the design.

--- a/docs/experiments/0001-map-assisted-llm-review/rounds/035.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/035.md
@@ -1,0 +1,85 @@
+# Round 35
+
+- Subject: PR #161 — review-notes feature follow-up: fixing findings
+  from a three-angle review of the review-notes TUI feature itself
+  (ADR 0048, PRs #157-#160), plus a `lib.rs` file-size split (ADR
+  0028) and key-binding rework requested during the same pass.
+- Protocol: three-angle review per CLAUDE.md — a map-assisted static
+  pass, an independent static pass, and a dynamic-verification pass —
+  run as three separate agents against the branch, findings
+  consolidated and fixed by a fourth implementation pass.
+- **What the map surfaced**: `ReviewMode`, `ReviewState`, and
+  `NoteMarkers` were the highest fan-in changed symbols across the
+  four PRs under review, correctly directing attention to the
+  review-notes state machine and its render integration.
+- **Map-assisted finding (BLOCKER)**: `draw_export_menu_overlay`
+  hard-coded `["GitHub PR review", "Clipboard (for an AI agent)"]`
+  regardless of whether sink A (a `PrContext`) was actually available,
+  while `ReviewState::confirm_export` resolved the menu's cursor
+  against `export_menu_entries(sink_a_available)` — which omits the
+  GitHub entry entirely when sink A is absent. **The defect itself did
+  not show up on the signature surface** — `draw_export_menu_overlay`'s
+  own signature never changed shape, and `export_menu_entries` already
+  existed as the correct single source of truth; the map's fan-in
+  ranking got the reviewer to the right module (`review_overlay.rs`,
+  reachable from `ReviewState`'s high fan-in) but the mismatch itself
+  was only visible by reading the render function against the state
+  machine's own gating logic side by side.
+- **Resolving the "which way does it fail" ambiguity**: the review
+  brief that seeded this round's fix work described two competing
+  hypotheses for what happens when a reviewer presses Enter on cursor
+  position 0 with sink A unavailable — "wrongly exports to GitHub" vs.
+  "silently closes the menu". A regression test written before the fix
+  (`should_export_to_clipboard_when_confirming_cursor_zero_with_sink_a_unavailable`)
+  showed neither: `confirm_export`'s own state-machine logic was
+  already correct and fell through to `Clipboard`, since
+  `export_menu_entries(false)` puts `Clipboard` at index 0 when
+  `Github` is omitted. Only the *rendering* was wrong — the menu showed
+  a "GitHub PR review" label at a position that actually exported to
+  clipboard. Writing the test against real code, rather than reasoning
+  about it, was necessary to settle the ambiguity the static findings
+  alone could not resolve.
+- **Independent-pass finding (major)**: pressing `n` (compose a note)
+  over a row with no derivable `SelectionSnapshot` (a directory row, or
+  the source screen) left `App` completely untouched, skipping
+  `App::handle_key`'s unconditional `pending_prefix` clear — the same
+  regression class ADR 0022 already fixed once for `gd`/`gr`. The
+  independent reviewer found this by reading `dispatch_non_source_key`'s
+  own doc comment (which narrates the ADR 0022 history in detail) and
+  checking whether the newer `NoteCompose` special-case in `run_app`
+  followed the same "always call `handle_key` first" discipline — it
+  did not. This is the pattern CLAUDE.md's dogfooding section
+  anticipates: a regression re-entering through a *new* code path that
+  doesn't share the original fix's structure, findable by tracing a
+  comment's own stated invariant against a sibling function rather
+  than by any map ranking.
+- **Dynamic pass**: confirmed the export-menu blocker interactively
+  (tmux session, `--pr`-less launch so sink A stays unavailable,
+  composed a note, opened the export menu, observed "GitHub PR review"
+  rendered at cursor 0) and confirmed the `pending_prefix` leak
+  (`g` then `n` over a directory row, then `d` — observed `GotoDefinition`
+  fire instead of `ToggleDiff` on the pre-fix build). Both reproductions
+  matched the state-machine-level regression tests written for the fix.
+- Severity summary: 1 blocker (export menu render/state mismatch), 1
+  major (`pending_prefix` leak on a no-op note compose), 3 minor (OSC 52
+  size guard, missing positive-case note-marker tests, an
+  under-documented external-constraint comment), plus a requested
+  `lib.rs` split and key-binding rework (full-width IME normalization,
+  unifying the notes-list `x`/Enter grammar with the jump popup's own).
+  All fixed in the same PR across seven commits. `make test`: 807
+  passed (up from 785 pre-fix). `make lint`: clean.
+- Takeaway: this round's blocker is the sharpest instance yet of the
+  "the map allocates attention; it is not a verifier" principle
+  (CLAUDE.md's own framing) — high fan-in on `ReviewState`/`NoteMarkers`
+  correctly pointed the reviewer at the review-overlay module, but nothing
+  about the defect (a hand-written label list silently drifting from a
+  function that already existed to prevent exactly that drift) shows up
+  in any signature diff, contract marker, or fan-in count. It is a pure
+  behavioral bug: two code paths that read the same boolean but only one
+  of them actually branched on it. The independent pass's major finding
+  reinforces a complementary lesson from round 34's family: rinkaku's own
+  doc comments, when they narrate a past regression's root cause in
+  detail (as `dispatch_non_source_key`'s does for ADR 0022), are
+  themselves a reviewable artifact — checking whether a *newer* sibling
+  function upholds the same invariant the comment describes found a bug
+  no diff-level or fan-in-level signal would have surfaced.

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -81,6 +81,23 @@ impl App {
             None
         };
 
+        // The review overlay (ADR 0048) takes over the whole key space
+        // while any of its modes is open — the highest-priority check in
+        // this function, ahead of even the `?` help overlay, mirroring
+        // that overlay's own "takes over the whole key space" structure
+        // (this function's own doc comment on `help_open`) but checked
+        // first: a reviewer mid-compose must never have a stray `?` yank
+        // focus away into the help overlay instead of typing a literal
+        // `?` into their note. `InputKey::NoteCompose` itself never
+        // reaches this function at all while `review` is `Idle`
+        // (`crate::lib::run_app` special-cases it before dispatch, see
+        // that variant's own doc comment), so this branch only needs to
+        // handle the overlay's *own* key space once it is already open.
+        if !matches!(self.review.mode(), crate::review::ReviewMode::Idle) {
+            self.review = self.handle_review_key(key);
+            return self;
+        }
+
         if self.help_open {
             match key {
                 InputKey::ToggleHelp => {
@@ -567,6 +584,26 @@ impl App {
             // exhaustive against future refactors — same reasoning as the
             // `ToggleHelp` arm just above.
             (Screen::Entry, _, InputKey::PopupConfirm | InputKey::PopupCancel) => {}
+            (Screen::Entry, _, InputKey::NotesList) => {
+                self.review = self.review.clone().open_list();
+            }
+            // Unreachable while `handle_key` is entered directly:
+            // `crate::lib::run_app` special-cases `NoteCompose` before
+            // dispatch (`InputKey::NoteCompose`'s own doc comment) and the
+            // review-overlay priority check at the top of this function
+            // intercepts `ComposeChar`/`ComposeBackspace`/`NoteDelete`/
+            // `NoteExport` whenever a review mode is actually open — kept
+            // only so the match stays exhaustive against future refactors,
+            // same reasoning as the `ToggleHelp`/`PopupConfirm` arms above.
+            (
+                Screen::Entry,
+                _,
+                InputKey::NoteCompose
+                | InputKey::ComposeChar(_)
+                | InputKey::ComposeBackspace
+                | InputKey::NoteDelete
+                | InputKey::NoteExport,
+            ) => {}
         }
 
         if !preserve_scroll && !preserve_scroll_after_jump {
@@ -574,6 +611,52 @@ impl App {
         }
 
         self
+    }
+
+    /// Handles one [`InputKey`] while a review overlay mode (ADR 0048) is
+    /// open — dispatched by [`Self::handle_key`]'s own top-of-function
+    /// priority check. `report`/diff data are never needed here: every
+    /// review transition this method reaches is a plain
+    /// [`crate::review::ReviewState`] method call, since the one review
+    /// action that *does* need external data (opening the compose overlay,
+    /// [`InputKey::NoteCompose`]) is special-cased by `crate::lib::run_app`
+    /// before dispatch and never reaches this method while `review` is
+    /// `Idle` — this method only ever runs once a review mode is already
+    /// open.
+    fn handle_review_key(&self, key: InputKey) -> crate::review::ReviewState {
+        let review = self.review.clone();
+        match review.mode() {
+            crate::review::ReviewMode::Compose { .. } => match key {
+                InputKey::ComposeChar(c) => review.push_char(c),
+                InputKey::ComposeBackspace => review.backspace(),
+                InputKey::PopupConfirm => review.confirm_compose(),
+                InputKey::PopupCancel => review.cancel_compose(),
+                _ => review,
+            },
+            crate::review::ReviewMode::List { .. } => match key {
+                InputKey::Up => review.list_up(),
+                InputKey::Down => review.list_down(),
+                InputKey::NoteDelete => review.delete_selected(),
+                InputKey::NoteExport => review.open_export_menu(),
+                InputKey::PopupCancel => review.close(),
+                _ => review,
+            },
+            crate::review::ReviewMode::ExportMenu { .. } => match key {
+                InputKey::Up => review.list_up(),
+                InputKey::Down => review.list_down(),
+                InputKey::PopupConfirm => review.confirm_export(self.review_sink_a_available),
+                InputKey::PopupCancel => review.close(),
+                _ => review,
+            },
+            crate::review::ReviewMode::VerdictMenu { .. } => match key {
+                InputKey::Up => review.list_up(),
+                InputKey::Down => review.list_down(),
+                InputKey::PopupConfirm => review.confirm_verdict(),
+                InputKey::PopupCancel => review.close(),
+                _ => review,
+            },
+            crate::review::ReviewMode::Idle => review,
+        }
     }
 
     /// Handles one [`InputKey`] while the jump-target popup (ADR 0022) is

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -591,18 +591,17 @@ impl App {
             // `crate::lib::run_app` special-cases `NoteCompose` before
             // dispatch (`InputKey::NoteCompose`'s own doc comment) and the
             // review-overlay priority check at the top of this function
-            // intercepts `ComposeChar`/`ComposeBackspace`/`NoteDelete`/
-            // `NoteExport` whenever a review mode is actually open — kept
-            // only so the match stays exhaustive against future refactors,
-            // same reasoning as the `ToggleHelp`/`PopupConfirm` arms above.
+            // intercepts `ComposeChar`/`ComposeBackspace`/`NoteDelete`
+            // whenever a review mode is actually open — kept only so the
+            // match stays exhaustive against future refactors, same
+            // reasoning as the `ToggleHelp`/`PopupConfirm` arms above.
             (
                 Screen::Entry,
                 _,
                 InputKey::NoteCompose
                 | InputKey::ComposeChar(_)
                 | InputKey::ComposeBackspace
-                | InputKey::NoteDelete
-                | InputKey::NoteExport,
+                | InputKey::NoteDelete,
             ) => {}
         }
 
@@ -637,7 +636,7 @@ impl App {
                 InputKey::Up => review.list_up(),
                 InputKey::Down => review.list_down(),
                 InputKey::NoteDelete => review.delete_selected(),
-                InputKey::NoteExport => review.open_export_menu(),
+                InputKey::PopupConfirm => review.open_export_menu(),
                 InputKey::PopupCancel => review.close(),
                 _ => review,
             },

--- a/rinkaku-tui/src/app/input_key.rs
+++ b/rinkaku-tui/src/app/input_key.rs
@@ -219,6 +219,4 @@ pub enum InputKey {
     /// `d` while the notes list overlay is open: deletes the note under
     /// the list cursor.
     NoteDelete,
-    /// `x` while the notes list overlay is open: opens the export menu.
-    NoteExport,
 }

--- a/rinkaku-tui/src/app/input_key.rs
+++ b/rinkaku-tui/src/app/input_key.rs
@@ -200,4 +200,25 @@ pub enum InputKey {
     /// mode for whichever content the Diff pane already shows, not an
     /// action on the row under the cursor.
     ToggleSplitView,
+    /// `n` on the entry screen (ADR 0048): opens the review-note compose
+    /// overlay over the row under the cursor. Needs a
+    /// [`crate::review::SelectionSnapshot`] derived from `report`/the
+    /// parsed diff hunks, which `App::handle_key` has no access to
+    /// (mirroring [`Self::Source`]'s own "IO/derivation stays outside
+    /// `App`" precedent) — `crate::lib::run_app` special-cases this
+    /// variant before dispatch rather than routing it through
+    /// `App::handle_key` at all, so this variant never reaches that
+    /// method's match.
+    NoteCompose,
+    /// `N`: opens the review-notes list overlay (ADR 0048).
+    NotesList,
+    /// A printable character typed while the compose overlay is open.
+    ComposeChar(char),
+    /// Backspace while the compose overlay is open.
+    ComposeBackspace,
+    /// `d` while the notes list overlay is open: deletes the note under
+    /// the list cursor.
+    NoteDelete,
+    /// `x` while the notes list overlay is open: opens the export menu.
+    NoteExport,
 }

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -523,6 +523,17 @@ impl App {
         &self.review
     }
 
+    /// Whether sink A (posting a GitHub PR review) is on the export menu
+    /// this session — see [`Self::with_review_sink_a_available`]'s own doc
+    /// comment. `crate::ui::review_overlay` reads this to keep the export
+    /// menu's *rendered* entries in sync with the entry list
+    /// [`crate::review::ReviewState::confirm_export`] resolves the cursor
+    /// against, so the two never disagree about what selecting position 0
+    /// means.
+    pub fn review_sink_a_available(&self) -> bool {
+        self.review_sink_a_available
+    }
+
     /// Replaces `App`'s [`ReviewState`] wholesale — used by
     /// `crate::lib::run_app` for the one review transition that needs data
     /// (a [`crate::review::SelectionSnapshot`]) `App::handle_key` cannot

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -15,6 +15,7 @@ use crate::detail::{
 };
 use crate::nav::Nav;
 use crate::order::{DirRank, OrderMode, rank_directories};
+use crate::review::ReviewState;
 use crate::tree::{NodeKind, Tree, build_tree};
 use rinkaku_core::render::Report;
 use std::collections::HashMap;
@@ -341,6 +342,20 @@ pub struct App {
     /// stale error doesn't linger forever once the user has moved on.
     status: Option<String>,
     should_quit: bool,
+    /// The review-notes feature's own state (ADR 0048) — `App` holds
+    /// exactly this one field of it, per the ADR's Module boundary
+    /// decision; every review-specific transition lives on [`ReviewState`]
+    /// itself, not here.
+    review: ReviewState,
+    /// Whether sink A (posting a GitHub PR review) is on the export menu
+    /// this session — mirrors whether `crate::session::TuiSession::run`
+    /// was given a `PrContext`/submitter port, fixed for the session's
+    /// lifetime (set once via [`Self::with_review_sink_a_available`], never
+    /// by [`Self::handle_key`] itself). Kept on `App` rather than threaded
+    /// as a `handle_key` parameter since `ReviewState::confirm_export`
+    /// needs it and `App` is the only layer that both dispatches keys and
+    /// is told this flag at startup.
+    review_sink_a_available: bool,
 }
 
 impl App {
@@ -376,7 +391,18 @@ impl App {
             jump_forward: Vec::new(),
             status: None,
             should_quit: false,
+            review: ReviewState::default(),
+            review_sink_a_available: false,
         }
+    }
+
+    /// Sets whether sink A (a GitHub PR review) is on the export menu for
+    /// this session — `crate::session::TuiSession::run` calls this once,
+    /// right after [`Self::new`], with whether it was given a `PrContext`/
+    /// submitter port (ADR 0048).
+    pub fn with_review_sink_a_available(mut self, available: bool) -> Self {
+        self.review_sink_a_available = available;
+        self
     }
 
     /// Applies `--entry <path>`'s TUI wiring on top of an already-built
@@ -489,6 +515,24 @@ impl App {
 
     pub fn status(&self) -> Option<&str> {
         self.status.as_deref()
+    }
+
+    /// The review-notes feature's own state (ADR 0048) — see
+    /// [`crate::review::ReviewState`]'s own doc comment.
+    pub fn review(&self) -> &ReviewState {
+        &self.review
+    }
+
+    /// Replaces `App`'s [`ReviewState`] wholesale — used by
+    /// `crate::lib::run_app` for the one review transition that needs data
+    /// (a [`crate::review::SelectionSnapshot`]) `App::handle_key` cannot
+    /// derive itself: opening the compose overlay
+    /// ([`InputKey::NoteCompose`]'s own doc comment on why that key is
+    /// special-cased before dispatch rather than routed through
+    /// `handle_key`).
+    pub fn with_review(mut self, review: ReviewState) -> Self {
+        self.review = review;
+        self
     }
 
     pub fn should_quit(&self) -> bool {

--- a/rinkaku-tui/src/app/tests/mod.rs
+++ b/rinkaku-tui/src/app/tests/mod.rs
@@ -28,6 +28,8 @@
 //! - `jump` — `selected_symbol_id`, `jump_to_symbol`, the jump popup's
 //!   own key handling, `PendingPrefix::G` bookkeeping, and the
 //!   `JumpBack`/`JumpForward` jumplist (ADR 0022)
+//! - `review` — `handle_review_key`'s notes-list overlay dispatch (ADR
+//!   0048)
 
 use crate::app::App;
 use crate::app::InputKey;
@@ -40,6 +42,7 @@ mod basics;
 mod focus;
 mod help_overlay;
 mod jump;
+mod review;
 mod right_pane;
 mod scroll_reset;
 mod source_screen;

--- a/rinkaku-tui/src/app/tests/review.rs
+++ b/rinkaku-tui/src/app/tests/review.rs
@@ -1,0 +1,37 @@
+//! Tests for `App::handle_review_key` (ADR 0048's review-overlay key
+//! dispatch): the notes-list overlay's own binding grammar (`j`/`k` move,
+//! Enter proceed, Esc back, `d` delete — unified with the jump popup's
+//! grammar) and the `pending_prefix` clear when `n` is pressed over a row
+//! with no derivable snapshot.
+
+use super::*;
+use crate::review::{ReviewState, SelectionSnapshot};
+
+fn snapshot() -> SelectionSnapshot {
+    SelectionSnapshot {
+        path: "lib.rs".to_string(),
+        symbol_id: Some("lib.rs::foo".to_string()),
+        symbol_name: Some("foo".to_string()),
+        range: Some((1, 1)),
+        anchor: Some((1, 1)),
+        signature: Some("fn foo()".to_string()),
+    }
+}
+
+#[test]
+fn should_open_export_menu_when_confirming_the_notes_list() {
+    let report = report_with_one_symbol();
+    let review = ReviewState::default()
+        .begin_compose(snapshot())
+        .push_char('x')
+        .confirm_compose()
+        .open_list();
+    let app = App::new(&report).with_review(review);
+
+    let actual = app.handle_key(InputKey::PopupConfirm);
+
+    assert_eq!(
+        &crate::review::ReviewMode::ExportMenu { cursor: 0 },
+        actual.review().mode()
+    );
+}

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -125,6 +125,21 @@ const SOURCE_SCREEN_BINDINGS: &[KeyBinding] = &[
     },
 ];
 
+const REVIEW_BINDINGS: &[KeyBinding] = &[
+    KeyBinding {
+        keys: "n",
+        description: "Compose a review note over the symbol under the cursor",
+    },
+    KeyBinding {
+        keys: "N",
+        description: "Open the review notes list",
+    },
+    KeyBinding {
+        keys: "j/k, Enter, Esc, d",
+        description: "Notes list: move, export, close, delete",
+    },
+];
+
 const GLOBAL_BINDINGS: &[KeyBinding] = &[
     KeyBinding {
         keys: "d / D",
@@ -184,6 +199,10 @@ const KEYMAP_GROUPS: &[KeyBindingGroup] = &[
     KeyBindingGroup {
         title: "Source view",
         bindings: SOURCE_SCREEN_BINDINGS,
+    },
+    KeyBindingGroup {
+        title: "Review",
+        bindings: REVIEW_BINDINGS,
     },
     KeyBindingGroup {
         title: "Global",
@@ -308,7 +327,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn should_list_keymap_groups_in_tree_right_source_global_order() {
+    fn should_list_keymap_groups_in_tree_right_source_review_global_order() {
         let titles: Vec<&str> = HELP_CONTENT
             .keymap_groups
             .iter()
@@ -316,7 +335,13 @@ mod tests {
             .collect();
 
         assert_eq!(
-            vec!["Tree focus", "Right focus", "Source view", "Global"],
+            vec![
+                "Tree focus",
+                "Right focus",
+                "Source view",
+                "Review",
+                "Global"
+            ],
             titles
         );
     }
@@ -451,6 +476,21 @@ mod tests {
         assert!(keys.contains(&"gr"));
         assert!(keys.contains(&"ctrl-o"));
         assert!(keys.contains(&"ctrl-i"));
+    }
+
+    #[test]
+    fn should_document_review_notes_bindings_in_a_review_group() {
+        let review = HELP_CONTENT
+            .keymap_groups
+            .iter()
+            .find(|group| group.title == "Review")
+            .expect("Review group present");
+
+        let keys: Vec<&str> = review.bindings.iter().map(|binding| binding.keys).collect();
+
+        assert!(keys.contains(&"n"));
+        assert!(keys.contains(&"N"));
+        assert!(keys.contains(&"j/k, Enter, Esc, d"));
     }
 
     #[test]

--- a/rinkaku-tui/src/input_translate.rs
+++ b/rinkaku-tui/src/input_translate.rs
@@ -1,0 +1,278 @@
+//! Raw `crossterm` input → this crate's terminal-agnostic [`InputKey`]
+//! (ADR 0028 split out of `lib.rs`, which had grown past the file-size
+//! threshold): [`translate_key`] for keyboard, [`translate_mouse_event`]
+//! for mouse wheel, and [`normalize_fullwidth_key`], the full-width-ASCII
+//! folding both `translate_key` (indirectly, via a Japanese/CJK IME) needs
+//! before matching a plain-ASCII binding. Every function here is pure — no
+//! IO, no `App` mutation — so `crate::run_app`'s event loop is the only
+//! caller, feeding each translated [`InputKey`] into its own dispatch.
+
+use crate::app::{self, App, InputKey, Screen};
+use crate::review;
+use ratatui::crossterm::event::{self, KeyCode, KeyModifiers};
+
+/// Translates a raw `crossterm` key press into this crate's
+/// terminal-agnostic [`InputKey`], or `None` for a key the app does not
+/// react to. Depends on `app.screen()` to disambiguate `q`/Esc (`Quit`/
+/// `FocusLeft` on the entry view depending on focus, `Back` on the source
+/// view) and on `app.focus()` (ADR 0020) to route Esc between `FocusLeft`
+/// and its other meanings — every other mapping is context-free.
+///
+/// `app.help_open()` (ADR 0020) short-circuits every other rule: while the
+/// help overlay is open, `?`/Esc/`q` all translate to `ToggleHelp` (closing
+/// it) regardless of what they would otherwise mean, and this check runs
+/// before every other arm so none of them — especially `q`, which would
+/// otherwise mean `Quit` — can reach past the overlay. `App::handle_key`'s
+/// own `help_open` guard is a second, independent layer of the same rule
+/// (swallowing every non-`ToggleHelp` key while open) — belt and braces,
+/// since "the overlay is a safe action that can never accidentally quit
+/// the app" is exactly the property ADR 0020 asks this feature to hold.
+///
+/// `app.jump_popup()` (ADR 0022) is the next short-circuit, mirroring the
+/// help overlay's own structure: while the jump-target popup is open,
+/// `j`/`k`/Up/Down move its own selection, Enter confirms (`PopupConfirm`),
+/// Esc cancels (`PopupCancel`), and every other key is swallowed.
+///
+/// `app.pending_prefix()` (ADR 0022) is consulted only for `d`/`r`: when a
+/// `g` press is still pending, `d` resolves to `GotoDefinition` and `r` to
+/// `GotoReferences` instead of their own ordinary meanings (`ToggleDiff`/
+/// unbound) — every other key falls through to its normal translation
+/// unconditionally, which is what lets the pending prefix's own state
+/// (`App::handle_key`'s blanket clear-unless-`PendingGoto` rule) correctly
+/// unwind on any key that is not `d`/`r`.
+pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<InputKey> {
+    // The review overlay (ADR 0048) is checked before even the help
+    // overlay: while composing a note, every printable character the
+    // reviewer types (including `?`) must land in the note buffer, not
+    // trigger the help overlay or any other single-key gesture. Composing
+    // is also the one mode exempt from full-width normalization below —
+    // free text must keep whatever the reviewer actually typed.
+    if let review::ReviewMode::Compose { .. } = app.review().mode() {
+        return match code {
+            KeyCode::Enter => Some(InputKey::PopupConfirm),
+            KeyCode::Esc => Some(InputKey::PopupCancel),
+            KeyCode::Backspace => Some(InputKey::ComposeBackspace),
+            KeyCode::Char(c) => Some(InputKey::ComposeChar(c)),
+            _ => None,
+        };
+    }
+    let code = normalize_fullwidth_key(code);
+    match app.review().mode() {
+        review::ReviewMode::List { .. }
+        | review::ReviewMode::ExportMenu { .. }
+        | review::ReviewMode::VerdictMenu { .. } => {
+            return match code {
+                KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
+                KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
+                KeyCode::Enter => Some(InputKey::PopupConfirm),
+                KeyCode::Esc | KeyCode::Char('q') => Some(InputKey::PopupCancel),
+                KeyCode::Char('d') => Some(InputKey::NoteDelete),
+                _ => None,
+            };
+        }
+        review::ReviewMode::Compose { .. } => unreachable!("handled by the early return above"),
+        review::ReviewMode::Idle => {}
+    }
+
+    if app.help_open() {
+        // The overlay's own content can run longer than its box (this
+        // feature's whole reason for existing) — `j`/`k`/`Ctrl-d`/`Ctrl-u`/
+        // `G` scroll it, mirroring the plain-key mapping each already has
+        // outside the overlay so a reviewer does not have to learn a
+        // second gesture just because the overlay is open. `gg`'s
+        // second-`g` resolution still goes through the `pending_prefix`
+        // branch below (this early return only covers `?`/Esc/`q`/`Ctrl-d`/
+        // `Ctrl-u`/`G` and the bare `j`/`k`/arrow keys; a first `g` press
+        // is deliberately *not* matched here so it falls through to the
+        // ordinary `PendingGoto` arm at the bottom of this function, which
+        // works identically whether the overlay is open or not since it
+        // only touches `app.pending_prefix()`).
+        return match code {
+            KeyCode::Char('?') | KeyCode::Esc | KeyCode::Char('q') => Some(InputKey::ToggleHelp),
+            KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
+            KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
+            KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
+                Some(InputKey::ScrollHalfPageDown)
+            }
+            KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
+                Some(InputKey::ScrollHalfPageUp)
+            }
+            KeyCode::Char('G') => Some(InputKey::ScrollToBottom),
+            KeyCode::Char('g') if app.pending_prefix() == Some(app::PendingPrefix::G) => {
+                Some(InputKey::ScrollToTop)
+            }
+            KeyCode::Char('g') => Some(InputKey::PendingGoto),
+            _ => None,
+        };
+    }
+
+    if app.jump_popup().is_some() {
+        return match code {
+            KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
+            KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
+            KeyCode::Enter => Some(InputKey::PopupConfirm),
+            KeyCode::Esc => Some(InputKey::PopupCancel),
+            _ => None,
+        };
+    }
+
+    let on_source_screen = matches!(app.screen(), Screen::Source { .. });
+    let right_focused = app.focus() == app::Focus::Right;
+
+    if app.pending_prefix() == Some(app::PendingPrefix::G) {
+        match code {
+            KeyCode::Char('d') | KeyCode::Char('D') => return Some(InputKey::GotoDefinition),
+            KeyCode::Char('r') | KeyCode::Char('R') => return Some(InputKey::GotoReferences),
+            // `gg` (ADR 0026): scroll the reading pane to the top —
+            // resolved here the same way `gd`/`gr` are, piggybacking on
+            // the existing `g`-prefix state machine (ADR 0022) rather
+            // than reserving single-key `g` for this and breaking the
+            // two-key sequences above. Uppercase `G` is a *distinct*
+            // single-key gesture (`ScrollToBottom` below), unrelated to
+            // this prefix — a second `g` in this arm is what means "top".
+            KeyCode::Char('g') => return Some(InputKey::ScrollToTop),
+            _ => {}
+        }
+    }
+
+    match code {
+        KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
+        KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
+        // Space always means "expand/collapse", never "drill in" — kept
+        // distinct from Enter's own `InputKey::Open` (ADR 0020) so Space on
+        // a file/symbol row never moves focus. Translated unconditionally
+        // here regardless of `app.focus()`, same as every other key this
+        // function maps context-free — `App::handle_key`'s own
+        // `Focus::Tree`-only arm for `Select` is where the actual
+        // Tree-focus requirement lives (mirroring how `NextHunk`/`PrevHunk`
+        // are also translated unconditionally but only acted on under
+        // certain conditions elsewhere).
+        KeyCode::Char(' ') => Some(InputKey::Select),
+        KeyCode::Enter => Some(InputKey::Open),
+        KeyCode::Char('e') | KeyCode::Char('E') => Some(InputKey::ExpandAll),
+        KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::Quit),
+        KeyCode::Char('c') | KeyCode::Char('C') => Some(InputKey::CollapseAll),
+        KeyCode::Char('o') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::JumpBack),
+        // Ctrl-I and Tab share the same control code (0x09) at the terminal
+        // protocol level — without Kitty's keyboard-enhancement protocol
+        // (which this crate does not enable), a real Ctrl-I keypress
+        // arrives here as plain `KeyCode::Tab`, not `KeyCode::Char('i')` +
+        // `CONTROL` (confirmed via manual tmux testing against a real
+        // terminal, not just documentation: the `Char('i') + CONTROL` arm
+        // alone never matched a real Ctrl-I press). Both patterns are kept
+        // so this still works correctly in an environment that *does*
+        // report the modifier form (e.g. a test harness constructing the
+        // event directly, as this module's own tests do).
+        KeyCode::Tab => Some(InputKey::JumpForward),
+        KeyCode::Char('i') if modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(InputKey::JumpForward)
+        }
+        KeyCode::Char('o') | KeyCode::Char('O') => Some(InputKey::ToggleOrder),
+        // `Ctrl-d`/`Ctrl-u` (ADR 0026): half-page scroll on the reading
+        // pane (`Screen::Source`, or `Screen::Entry` + `Focus::Right`).
+        // Must come *before* the plain `Char('d')`/`Char('u')` arms —
+        // otherwise a `Ctrl-d` press would match `ToggleDiff` first and
+        // the modifier would be ignored, silently rebinding "half-page
+        // down" to "toggle diff pane". Emitted regardless of screen/
+        // focus; `App::handle_scroll_key` no-ops on `Focus::Tree` in the
+        // entry view (ADR 0026 decision 3's Tree-focus rule).
+        KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(InputKey::ScrollHalfPageDown)
+        }
+        KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(InputKey::ScrollHalfPageUp)
+        }
+        KeyCode::Char('d') | KeyCode::Char('D') => Some(InputKey::ToggleDiff),
+        KeyCode::Char('r') | KeyCode::Char('R') => Some(InputKey::ToggleBlastRadius),
+        KeyCode::Char('v') | KeyCode::Char('V') => Some(InputKey::ToggleSplitView),
+        // `G` (`Shift-g`, ADR 0026): scroll to the bottom. Distinct from
+        // single-key lowercase `g` (`PendingGoto` below), which is the
+        // leading key of the `gd`/`gr`/`gg` two-key sequences resolved
+        // at the top of this function.
+        KeyCode::Char('G') => Some(InputKey::ScrollToBottom),
+        // `h`, or Esc while the right pane has focus: return focus to the
+        // tree (ADR 0020's neovim-style "move left/back"). Checked before
+        // the source-screen Esc arm below so `h`/Esc while Right-focused
+        // never reaches the source screen (impossible in practice today,
+        // since opening the source screen already moves focus to `Right`,
+        // but ordered defensively rather than relying on that invariant).
+        KeyCode::Char('h') if right_focused => Some(InputKey::FocusLeft),
+        KeyCode::Esc if right_focused && !on_source_screen => Some(InputKey::FocusLeft),
+        // `]c`/`[c` (vim's hunk-jump idiom) are read here as a single
+        // bracket keystroke rather than a buffered two-key chord — this
+        // crate's event loop (`run_app`) has no notion of a pending-chord
+        // state machine today, and introducing one for exactly one binding
+        // would be disproportionate; `]`/`[` alone are otherwise unbound,
+        // so no existing gesture is lost by this simplification.
+        KeyCode::Char(']') => Some(InputKey::NextHunk),
+        KeyCode::Char('[') => Some(InputKey::PrevHunk),
+        KeyCode::Char('s') | KeyCode::Char('S') => Some(InputKey::Source),
+        // `n` (ADR 0048): opens the review-note compose overlay over the
+        // row under the cursor. `N`: opens the review-notes list overlay.
+        // Both are only meaningful on the entry screen (Source-screen
+        // rows have no `SelectionSnapshot` to compose against), but
+        // translated context-free here like every other key in this
+        // block — `App::handle_key`'s own `Screen::Source` catch-all arm
+        // already no-ops every non-scroll key there.
+        KeyCode::Char('n') => Some(InputKey::NoteCompose),
+        KeyCode::Char('N') => Some(InputKey::NotesList),
+        // `g` (ADR 0022): the first half of the `gd`/`gr` two-key sequence.
+        // Checked after the `pending_prefix` resolution above so a second
+        // `g` press (`gg`, not a bound sequence today) simply restarts the
+        // pending state rather than doing anything else — `App::handle_key`
+        // sets `pending_prefix` from this variant unconditionally.
+        KeyCode::Char('g') => Some(InputKey::PendingGoto),
+        KeyCode::Char('?') => Some(InputKey::ToggleHelp),
+        KeyCode::Esc if on_source_screen => Some(InputKey::Back),
+        KeyCode::Char('q') if on_source_screen => Some(InputKey::Back),
+        KeyCode::Char('q') => Some(InputKey::Quit),
+        _ => None,
+    }
+}
+
+/// Folds a full-width form (U+FF01-U+FF5E, the Unicode "Fullwidth ASCII
+/// Variants" block a Japanese/CJK IME sends when left on while a reviewer
+/// presses an otherwise-ASCII binding) down to its ordinary half-width
+/// `KeyCode::Char`, leaving every other `KeyCode` untouched. Applied to
+/// every normal-mode/overlay gesture in [`translate_key`] but not while
+/// [`review::ReviewMode::Compose`] is open — that buffer is free text, so a
+/// full-width character typed there must reach the note body unchanged.
+fn normalize_fullwidth_key(code: KeyCode) -> KeyCode {
+    match code {
+        KeyCode::Char(c @ '\u{FF01}'..='\u{FF5E}') => {
+            KeyCode::Char(char::from_u32(c as u32 - 0xFEE0).unwrap_or(c))
+        }
+        other => other,
+    }
+}
+
+/// Translates a raw `crossterm` mouse event into an [`InputKey`], the same
+/// boundary role [`translate_key`] plays for keyboard input — a pure
+/// function so the mapping is unit-testable without a live terminal.
+///
+/// Only `ScrollUp`/`ScrollDown` (wheel/trackpad) are mapped, and they are
+/// mapped onto the *existing* [`InputKey::Up`]/[`InputKey::Down`] variants
+/// rather than a dedicated pair of scroll variants: `App::handle_key`
+/// already gives `Up`/`Down` the right contextual meaning everywhere a
+/// wheel scroll should act — the tree cursor while [`app::Focus::Tree`],
+/// [`app::App::right_pane_scroll`] by one line while [`app::Focus::Right`]
+/// (ADR 0020), and [`app::Screen::Source`]'s `scroll_top` on the source
+/// screen (ADR 0026) — so reusing them is a strict simplification (no new
+/// state-machine surface) rather than introducing a second, parallel
+/// motion concept the app would have to keep in sync with the first.
+///
+/// `MouseEventKind::ScrollLeft`/`ScrollRight` (horizontal wheel/trackpad)
+/// and every click/drag/move variant are deliberately unmapped (`None`):
+/// this crate has no horizontally-scrollable pane, and no pane targeting by
+/// click position — the row/column the event occurred at is intentionally
+/// not consulted here. Wheel input always acts on whichever pane already
+/// has focus, exactly like a keyboard `j`/`k` press would; teaching the
+/// wheel to also *change* focus by clicking a pane is future scope, not
+/// attempted by this function.
+pub(crate) fn translate_mouse_event(kind: event::MouseEventKind) -> Option<InputKey> {
+    match kind {
+        event::MouseEventKind::ScrollUp => Some(InputKey::Up),
+        event::MouseEventKind::ScrollDown => Some(InputKey::Down),
+        _ => None,
+    }
+}

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -990,13 +990,47 @@ fn perform_export(
         }
         review::ExportRequest::Clipboard => {
             let packet = review::render_agent_packet(review.notes());
-            match ports.clipboard.copy(&packet) {
-                Ok(()) => review.set_status(
-                    "copied review notes to clipboard via OSC 52 (terminal support required)",
-                ),
-                Err(message) => review.set_status(format!("error copying to clipboard: {message}")),
+            let result = ports.clipboard.copy(&packet);
+            let status = clipboard_export_status(&packet, result);
+            review.set_status(status)
+        }
+    }
+}
+
+/// A conservative guard on the OSC 52 packet's *raw* byte length (ADR
+/// 0048), below common terminal-side payload caps (~100KB is a frequently
+/// cited limit, e.g. iTerm2/xterm.js) even after base64 inflates the wire
+/// payload to ~4/3 of this — terminals that enforce such a cap tend to
+/// silently drop or truncate an oversized OSC 52 sequence rather than
+/// erroring, so [`Osc52Clipboard::copy`]-equivalent ports (`rinkaku`'s own
+/// `Osc52Clipboard`) have no way to detect the failure themselves; this
+/// guard exists purely to warn the reviewer before that silent failure
+/// bites them.
+const OSC52_SIZE_GUARD_BYTES: usize = 48 * 1024;
+
+/// Folds sink B's [`review::ports::ClipboardSink::copy`] result into a
+/// status message: the port's own error message on `Err`, otherwise a
+/// plain success note — or, when `packet` exceeds
+/// [`OSC52_SIZE_GUARD_BYTES`], the same success note plus a warning that
+/// the terminal may have silently dropped or truncated it, with a manual-
+/// copy fallback suggestion. The copy itself already happened by the time
+/// this runs; the guard only changes the *message*, never whether the copy
+/// is attempted.
+fn clipboard_export_status(packet: &str, result: Result<(), String>) -> String {
+    match result {
+        Ok(()) => {
+            let base = "copied review notes to clipboard via OSC 52 (terminal support required)";
+            if packet.len() > OSC52_SIZE_GUARD_BYTES {
+                format!(
+                    "{base} — packet is {} bytes, which may exceed the terminal's OSC 52 limit; \
+                     copy manually if the paste looks truncated",
+                    packet.len()
+                )
+            } else {
+                base.to_string()
             }
         }
+        Err(message) => format!("error copying to clipboard: {message}"),
     }
 }
 

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -36,7 +36,9 @@ pub mod diff_view;
 pub mod help;
 pub mod highlight;
 pub mod nav;
+pub mod note_markers;
 pub mod order;
+pub mod review;
 pub mod row_view;
 mod session;
 pub mod source;
@@ -50,8 +52,23 @@ pub use session::{TuiSession, run};
 
 use app::{App, BlastRadiusSelection, InputKey, Screen};
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use review::PrContext;
+use review::ports::{ClipboardSink, ReviewSubmitter};
 use rinkaku_core::render::Report;
 use std::time::Duration;
+
+/// Review-notes export wiring (ADR 0048), assembled once by `main.rs`'s
+/// composition root and threaded through unchanged from
+/// [`crate::session::TuiSession::run`] to [`run_app`]: `pr_context`/
+/// `submitter` are both `Some`/`None` together (sink A's own "absent when
+/// no PR context" rule — [`crate::app::App::with_review_sink_a_available`]'s
+/// own doc comment), `clipboard` is always present since sink B never
+/// depends on a PR.
+pub struct ReviewPorts<'a> {
+    pub pr_context: Option<PrContext>,
+    pub submitter: Option<&'a dyn ReviewSubmitter>,
+    pub clipboard: &'a dyn ClipboardSink,
+}
 
 /// The event loop [`TuiSession::run`] (`crate::session`) drives once it has
 /// taken over the terminal — see [`run`]'s doc comment (re-exported from
@@ -67,8 +84,9 @@ pub(crate) fn run_app(
     entry_path: Option<&str>,
     repo_root: &std::path::Path,
     source_reader: &dyn source::SourceReader,
+    review_ports: ReviewPorts<'_>,
 ) -> std::io::Result<()> {
-    let mut app = App::new(report);
+    let mut app = App::new(report).with_review_sink_a_available(review_ports.pr_context.is_some());
     if let Some(path) = entry_path {
         app = app.with_entry_pivot(path);
     }
@@ -168,6 +186,17 @@ pub(crate) fn run_app(
     // would produce a step that does not match what the reviewer is
     // actually looking at.
     let mut last_help_scroll_viewport_height: Option<usize> = None;
+    // ADR 0048's `NoteMarkers` cache-on-change, mirroring
+    // `blast_radius_selection`/`diff_pane_content`'s own up-front-then-
+    // gated-recompute shape: built once from `App::new`'s initial (empty)
+    // `review` state, then only recomputed when `should_recompute_note_markers`
+    // reports the note set actually changed. `last_note_markers_revision`
+    // starts at `app.review().revision()` itself (0 on a fresh session)
+    // rather than a sentinel, so the first key press that does not touch
+    // `review` correctly skips a redundant recompute of an already-empty
+    // table.
+    let mut note_markers = note_markers::build_note_markers(app.review().notes());
+    let mut last_note_markers_revision = app.review().revision();
 
     loop {
         // `ui::draw`'s return value (`DrawOutcome`, `ui::draw`'s own doc
@@ -186,6 +215,7 @@ pub(crate) fn run_app(
                 &blast_radius_selection,
                 source_content.as_ref(),
                 &diff_hunks,
+                &note_markers,
             );
         })?;
         app = clamp_right_pane_scroll_after_draw(app, outcome.clamped_right_pane_scroll);
@@ -238,7 +268,21 @@ pub(crate) fn run_app(
             // variants, `]c`/`[c`) can all change the scroll offset and this
             // sync applies uniformly to any of them.
             let scroll_before_dispatch = app.right_pane_scroll();
-            if let InputKey::Source = input_key {
+            if let InputKey::NoteCompose = input_key {
+                // ADR 0048: needs a `SelectionSnapshot` derived from
+                // `report`/`diff_hunks`, which `App::handle_key` has no
+                // access to (`InputKey::NoteCompose`'s own doc comment) —
+                // handled here instead, mirroring `InputKey::Source`'s own
+                // "IO/derivation stays outside `App`" precedent just below.
+                // A `None` snapshot (cursor not on a present symbol row, or
+                // on the source screen) leaves `app` untouched — pressing
+                // `n` over a directory/file row is a silent no-op rather
+                // than opening an overlay with nothing to attach a note to.
+                if let Some(snapshot) = derive_selection_snapshot(&app, report, &diff_hunks) {
+                    let review = app.review().clone().begin_compose(snapshot);
+                    app = app.with_review(review);
+                }
+            } else if let InputKey::Source = input_key {
                 app = app.handle_key(input_key);
                 if let Screen::Source { symbol_id, .. } = app.screen().clone()
                     && should_reload_source_content(
@@ -319,6 +363,24 @@ pub(crate) fn run_app(
                 // `dispatch_non_source_key`'s own doc comment for why this
                 // split exists (ADR 0022's `pending_prefix` regression).
                 app = dispatch_non_source_key(app, report, &diff_pane_content, input_key);
+            }
+
+            // ADR 0048: performs the export this key requested, if any —
+            // the one place `review`'s plain `ExportRequest` data actually
+            // reaches a port (`gh api`/OSC 52), since `review` itself
+            // never calls one. Runs once per handled key, after every
+            // review-state transition above (`begin_compose`/`handle_review_key`)
+            // has already produced the export request via the verdict/
+            // export menu's own confirm step.
+            let mut review = app.review().clone();
+            if let Some(export) = review.take_pending_export() {
+                review = perform_export(review, &review_ports, export);
+                app = app.with_review(review);
+            }
+
+            if should_recompute_note_markers(&app, last_note_markers_revision) {
+                note_markers = note_markers::build_note_markers(app.review().notes());
+                last_note_markers_revision = app.review().revision();
             }
 
             if should_recompute_blast_radius_selection(&app) {
@@ -828,6 +890,20 @@ fn resolve_goto(app: &App, report: &Report, direction: InputKey) -> GotoOutcome 
     }
 }
 
+/// Whether `crate::run_app`'s event loop should recompute [`note_markers::NoteMarkers`]
+/// this key, mirroring `should_recompute_blast_radius_selection`'s/
+/// `should_recompute_diff_pane_content`'s own change-gated-cache contract
+/// (ADR 0048's Rendering boundary decision: this derivation must not run
+/// inside `ui::draw`, since that runs on every ~100ms idle poll tick, not
+/// only on a key press). `true` only when `review`'s note set actually
+/// changed since the last recompute — compares `revision` rather than
+/// gating on screen/pane the way the blast-radius/diff-pane gates do,
+/// since note markers are relevant on every row/pane, not just one right
+/// pane's own active mode.
+fn should_recompute_note_markers(app: &App, last_revision: u64) -> bool {
+    app.review().revision() != last_revision
+}
+
 /// Whether `crate::run_app`'s event loop should recompute the blast-radius
 /// selection this key, rather than keep showing the previously cached one
 /// (this function's own extraction is what makes that decision
@@ -840,6 +916,147 @@ fn resolve_goto(app: &App, report: &Report, direction: InputKey) -> GotoOutcome 
 /// need a wasted recompute on the `d` press that briefly leaves it.
 fn should_recompute_blast_radius_selection(app: &App) -> bool {
     matches!(app.screen(), Screen::Entry) && app.right_pane() == app::RightPane::BlastRadius
+}
+
+/// The summary line posted alongside every GitHub PR review sink A submits
+/// (ADR 0048) — every review is submitted with the same fixed summary,
+/// since the individual notes themselves carry the substantive content as
+/// inline comments; there is no per-session reviewer-authored summary in
+/// v1.
+const REVIEW_SUMMARY: &str = "Review notes posted via rinkaku.";
+
+/// Performs `export` against the matching port in `ports` (ADR 0048's
+/// Output boundary decision: `review` itself never calls a port, only
+/// `crate::lib::run_app` does, once per handled key that produced a
+/// pending export) and folds the result into `review`'s status message.
+///
+/// [`review::ExportRequest::GithubReview`] is only ever produced by
+/// [`review::ReviewState::confirm_verdict`], reachable only through
+/// [`review::ReviewState::confirm_export`]'s own `sink_a_available`-gated
+/// branch (`App::handle_review_key`'s own `ExportMenu` arm passes
+/// `app.review_sink_a_available`) — so `ports.submitter` being `None` here
+/// would mean that gate was bypassed; handled defensively (a status
+/// message, not a panic) rather than trusted blindly, matching this
+/// crate's existing practice of not trusting an invariant across a module
+/// boundary (e.g. `App::jump_to_symbol`'s own doc comment on the same
+/// judgment call).
+fn perform_export(
+    review: review::ReviewState,
+    ports: &ReviewPorts<'_>,
+    export: review::ExportRequest,
+) -> review::ReviewState {
+    match export {
+        review::ExportRequest::GithubReview(verdict) => {
+            let Some(submitter) = ports.submitter else {
+                return review.set_status("error: no PR context available to post a review");
+            };
+            let Some(pr_context) = &ports.pr_context else {
+                return review.set_status("error: no PR context available to post a review");
+            };
+            let comments = review::render_review_comments(review.notes());
+            match submitter.submit_review(pr_context, verdict, REVIEW_SUMMARY, &comments) {
+                Ok(()) => review.set_status(format!(
+                    "posted {} review comment(s) to PR #{}",
+                    comments.len(),
+                    pr_context.number
+                )),
+                Err(message) => review.set_status(format!("error posting review: {message}")),
+            }
+        }
+        review::ExportRequest::Clipboard => {
+            let packet = review::render_agent_packet(review.notes());
+            match ports.clipboard.copy(&packet) {
+                Ok(()) => review.set_status(
+                    "copied review notes to clipboard via OSC 52 (terminal support required)",
+                ),
+                Err(message) => review.set_status(format!("error copying to clipboard: {message}")),
+            }
+        }
+    }
+}
+
+/// Derives a [`review::SelectionSnapshot`] from whatever the tree cursor
+/// currently points at (ADR 0048's Input boundary decision) — the sole
+/// channel by which `review` learns what the reviewer is annotating.
+/// `crate::lib::run_app` calls this when [`InputKey::NoteCompose`] is
+/// pressed, since `App::handle_key` itself has no access to `report`/the
+/// parsed diff hunks (mirroring `InputKey::Source`'s own "IO/derivation
+/// stays outside `App`" precedent).
+///
+/// `None` on [`Screen::Source`] (composing against a source-view line is
+/// out of v1's scope) and on any row that is not a present symbol
+/// (`app::NodeKind::Dir`/`File`/`Section`/`TestGroup`, or a removed
+/// symbol) — v1 only supports symbol-anchored notes (module doc comment on
+/// `crate::review`), matching `App::selected_symbol_id`'s own row-kind
+/// scoping.
+///
+/// The anchor is the first contiguous new-side run where the symbol's own
+/// range intersects a diff hunk touching `path` — GitHub's review API only
+/// accepts inline comments on lines that are part of the PR's diff, so
+/// this is what [`review::render_review_comments`] posts against. `None`
+/// when no hunk intersects the symbol's range at all (e.g. the symbol
+/// itself is unchanged but was pulled into view via dependency
+/// expansion) — the note still gets a location (`range`), just no
+/// GitHub-postable anchor; [`review::render_review_comments`] falls back
+/// to `range` in that case.
+fn derive_selection_snapshot(
+    app: &App,
+    report: &Report,
+    diff_files: &[diff_view::FileHunks],
+) -> Option<review::SelectionSnapshot> {
+    if !matches!(app.screen(), Screen::Entry) {
+        return None;
+    }
+    let symbol_id = app.selected_symbol_id()?;
+    let (path, symbol) = report.files.iter().find_map(|file| {
+        file.symbols
+            .iter()
+            .find(|s| s.id == symbol_id)
+            .map(|s| (file.path.as_str(), s))
+    })?;
+    let range = (symbol.range.start, symbol.range.end);
+    let anchor = diff_view::file_hunks(diff_files, path)
+        .and_then(|file_hunks| first_anchor_run(file_hunks, range));
+
+    Some(review::SelectionSnapshot {
+        path: path.to_string(),
+        symbol_id: Some(symbol.id.clone()),
+        symbol_name: Some(symbol.name.clone()),
+        range: Some(range),
+        anchor,
+        signature: Some(symbol.signature.clone()),
+    })
+}
+
+/// The first contiguous new-side line run where `range` (a symbol's own
+/// 1-based inclusive line range) intersects one of `file_hunks`' hunks —
+/// [`derive_selection_snapshot`]'s own anchor computation, extracted as a
+/// pure function so the "first run" rule is unit-testable in isolation
+/// from `Report`/`App`.
+///
+/// Hunks are walked in file order (already the order `diff_view::parse_diff_hunks`
+/// produces them in) and the *first* intersecting hunk's own clamped
+/// overlap with `range` is returned — not the union of every intersecting
+/// hunk — since ADR 0048 asks for "the first hunk-intersecting contiguous
+/// run", not the full set (a symbol whose range spans several
+/// non-adjacent hunks has no single contiguous GitHub-postable range
+/// anyway; the first run is a deliberately simple v1 choice, not an
+/// attempt at completeness).
+fn first_anchor_run(
+    file_hunks: &diff_view::FileHunks,
+    range: (usize, usize),
+) -> Option<(usize, usize)> {
+    let (range_start, range_end) = range;
+    file_hunks
+        .hunks
+        .iter()
+        .filter_map(|hunk| hunk.new_range)
+        .filter(|&(hunk_start, hunk_end)| hunk_start <= hunk_end)
+        .find_map(|(hunk_start, hunk_end)| {
+            let start = hunk_start.max(range_start);
+            let end = hunk_end.min(range_end);
+            (start <= end).then_some((start, end))
+        })
 }
 
 /// Translates a raw `crossterm` key press into this crate's
@@ -872,6 +1089,36 @@ fn should_recompute_blast_radius_selection(app: &App) -> bool {
 /// (`App::handle_key`'s blanket clear-unless-`PendingGoto` rule) correctly
 /// unwind on any key that is not `d`/`r`.
 fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<InputKey> {
+    // The review overlay (ADR 0048) is checked before even the help
+    // overlay: while composing a note, every printable character the
+    // reviewer types (including `?`) must land in the note buffer, not
+    // trigger the help overlay or any other single-key gesture.
+    match app.review().mode() {
+        review::ReviewMode::Compose { .. } => {
+            return match code {
+                KeyCode::Enter => Some(InputKey::PopupConfirm),
+                KeyCode::Esc => Some(InputKey::PopupCancel),
+                KeyCode::Backspace => Some(InputKey::ComposeBackspace),
+                KeyCode::Char(c) => Some(InputKey::ComposeChar(c)),
+                _ => None,
+            };
+        }
+        review::ReviewMode::List { .. }
+        | review::ReviewMode::ExportMenu { .. }
+        | review::ReviewMode::VerdictMenu { .. } => {
+            return match code {
+                KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
+                KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
+                KeyCode::Enter => Some(InputKey::PopupConfirm),
+                KeyCode::Esc | KeyCode::Char('q') => Some(InputKey::PopupCancel),
+                KeyCode::Char('d') => Some(InputKey::NoteDelete),
+                KeyCode::Char('x') => Some(InputKey::NoteExport),
+                _ => None,
+            };
+        }
+        review::ReviewMode::Idle => {}
+    }
+
     if app.help_open() {
         // The overlay's own content can run longer than its box (this
         // feature's whole reason for existing) — `j`/`k`/`Ctrl-d`/`Ctrl-u`/
@@ -1005,6 +1252,15 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         KeyCode::Char(']') => Some(InputKey::NextHunk),
         KeyCode::Char('[') => Some(InputKey::PrevHunk),
         KeyCode::Char('s') | KeyCode::Char('S') => Some(InputKey::Source),
+        // `n` (ADR 0048): opens the review-note compose overlay over the
+        // row under the cursor. `N`: opens the review-notes list overlay.
+        // Both are only meaningful on the entry screen (Source-screen
+        // rows have no `SelectionSnapshot` to compose against), but
+        // translated context-free here like every other key in this
+        // block — `App::handle_key`'s own `Screen::Source` catch-all arm
+        // already no-ops every non-scroll key there.
+        KeyCode::Char('n') => Some(InputKey::NoteCompose),
+        KeyCode::Char('N') => Some(InputKey::NotesList),
         // `g` (ADR 0022): the first half of the `gd`/`gr` two-key sequence.
         // Checked after the `pending_prefix` resolution above so a second
         // `g` press (`gg`, not a bound sequence today) simply restarts the

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -272,16 +272,18 @@ pub(crate) fn run_app(
                 // ADR 0048: needs a `SelectionSnapshot` derived from
                 // `report`/`diff_hunks`, which `App::handle_key` has no
                 // access to (`InputKey::NoteCompose`'s own doc comment) —
-                // handled here instead, mirroring `InputKey::Source`'s own
-                // "IO/derivation stays outside `App`" precedent just below.
-                // A `None` snapshot (cursor not on a present symbol row, or
-                // on the source screen) leaves `app` untouched — pressing
-                // `n` over a directory/file row is a silent no-op rather
-                // than opening an overlay with nothing to attach a note to.
-                if let Some(snapshot) = derive_selection_snapshot(&app, report, &diff_hunks) {
-                    let review = app.review().clone().begin_compose(snapshot);
-                    app = app.with_review(review);
-                }
+                // derived here, mirroring `InputKey::Source`'s own "IO/
+                // derivation stays outside `App`" precedent just below, then
+                // applied via `dispatch_note_compose_key` (extracted for the
+                // same "sequencing needs its own regression coverage"
+                // reason `dispatch_non_source_key`'s own doc comment gives —
+                // an earlier version of this arm left `app` completely
+                // untouched on a `None` snapshot, which skipped
+                // `App::handle_key`'s unconditional `pending_prefix` clear
+                // the same way the ADR 0022 bug `dispatch_non_source_key`
+                // documents did).
+                let snapshot = derive_selection_snapshot(&app, report, &diff_hunks);
+                app = dispatch_note_compose_key(app, snapshot);
             } else if let InputKey::Source = input_key {
                 app = app.handle_key(input_key);
                 if let Screen::Source { symbol_id, .. } = app.screen().clone()
@@ -714,6 +716,29 @@ fn dispatch_non_source_key(
     app.handle_key(input_key)
 }
 
+/// Applies [`InputKey::NoteCompose`] given the [`review::SelectionSnapshot`]
+/// `crate::run_app` already derived from the cursor (that derivation needs
+/// `report`/the parsed diff hunks, which `App::handle_key` has no access
+/// to — `InputKey::NoteCompose`'s own doc comment). Always routes through
+/// `App::handle_key` first, even on a `None` snapshot (cursor not on a
+/// present symbol row, or on the source screen): `handle_key`'s own
+/// `NoteCompose` match arm is a no-op stub, but what matters is its
+/// unconditional `pending_prefix` clear at the top of the function — the
+/// same "call `handle_key` for its clear even when its own arm does
+/// nothing" contract [`dispatch_non_source_key`]'s `GotoDefinition`/
+/// `GotoReferences` arm documents for itself. A `Some` snapshot opens the
+/// compose overlay after that call; `None` leaves `review` untouched.
+fn dispatch_note_compose_key(app: App, snapshot: Option<review::SelectionSnapshot>) -> App {
+    let app = app.handle_key(InputKey::NoteCompose);
+    match snapshot {
+        Some(snapshot) => {
+            let review = app.review().clone().begin_compose(snapshot);
+            app.with_review(review)
+        }
+        None => app,
+    }
+}
+
 /// Whether `crate::run_app`'s event loop should recompute the diff pane's
 /// shaped content this key, rather than keep showing the previously cached
 /// one — mirrors `should_recompute_blast_radius_selection`'s own contract and
@@ -1092,17 +1117,20 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
     // The review overlay (ADR 0048) is checked before even the help
     // overlay: while composing a note, every printable character the
     // reviewer types (including `?`) must land in the note buffer, not
-    // trigger the help overlay or any other single-key gesture.
+    // trigger the help overlay or any other single-key gesture. Composing
+    // is also the one mode exempt from full-width normalization below —
+    // free text must keep whatever the reviewer actually typed.
+    if let review::ReviewMode::Compose { .. } = app.review().mode() {
+        return match code {
+            KeyCode::Enter => Some(InputKey::PopupConfirm),
+            KeyCode::Esc => Some(InputKey::PopupCancel),
+            KeyCode::Backspace => Some(InputKey::ComposeBackspace),
+            KeyCode::Char(c) => Some(InputKey::ComposeChar(c)),
+            _ => None,
+        };
+    }
+    let code = normalize_fullwidth_key(code);
     match app.review().mode() {
-        review::ReviewMode::Compose { .. } => {
-            return match code {
-                KeyCode::Enter => Some(InputKey::PopupConfirm),
-                KeyCode::Esc => Some(InputKey::PopupCancel),
-                KeyCode::Backspace => Some(InputKey::ComposeBackspace),
-                KeyCode::Char(c) => Some(InputKey::ComposeChar(c)),
-                _ => None,
-            };
-        }
         review::ReviewMode::List { .. }
         | review::ReviewMode::ExportMenu { .. }
         | review::ReviewMode::VerdictMenu { .. } => {
@@ -1112,10 +1140,10 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
                 KeyCode::Enter => Some(InputKey::PopupConfirm),
                 KeyCode::Esc | KeyCode::Char('q') => Some(InputKey::PopupCancel),
                 KeyCode::Char('d') => Some(InputKey::NoteDelete),
-                KeyCode::Char('x') => Some(InputKey::NoteExport),
                 _ => None,
             };
         }
+        review::ReviewMode::Compose { .. } => unreachable!("handled by the early return above"),
         review::ReviewMode::Idle => {}
     }
 
@@ -1272,6 +1300,22 @@ fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<In
         KeyCode::Char('q') if on_source_screen => Some(InputKey::Back),
         KeyCode::Char('q') => Some(InputKey::Quit),
         _ => None,
+    }
+}
+
+/// Folds a full-width form (U+FF01-U+FF5E, the Unicode "Fullwidth ASCII
+/// Variants" block a Japanese/CJK IME sends when left on while a reviewer
+/// presses an otherwise-ASCII binding) down to its ordinary half-width
+/// `KeyCode::Char`, leaving every other `KeyCode` untouched. Applied to
+/// every normal-mode/overlay gesture in [`translate_key`] but not while
+/// [`review::ReviewMode::Compose`] is open — that buffer is free text, so a
+/// full-width character typed there must reach the note body unchanged.
+fn normalize_fullwidth_key(code: KeyCode) -> KeyCode {
+    match code {
+        KeyCode::Char(c @ '\u{FF01}'..='\u{FF5E}') => {
+            KeyCode::Char(char::from_u32(c as u32 - 0xFEE0).unwrap_or(c))
+        }
+        other => other,
     }
 }
 

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -18,6 +18,11 @@
 //!   with `ratatui`, reads source files for the drill-down view, and owns
 //!   the terminal lifecycle (raw mode, alternate screen, the event loop).
 //!   This is the only layer that performs IO or holds a live `Terminal`.
+//!   [`run_app`]'s own event loop delegates two responsibilities to
+//!   sibling modules (ADR 0028, split out once this file grew past the
+//!   file-size threshold): `input_translate` (raw `crossterm` events →
+//!   [`app::InputKey`]) and `review_flow` (ADR 0048's review-notes
+//!   composing/exporting/caching glue).
 //!
 //! [`run`] is the crate's single public entry point for the CLI binary:
 //! `rinkaku`'s `main.rs` hands it a [`rinkaku_core::render::Report`] once
@@ -35,10 +40,12 @@ pub mod diff_shape;
 pub mod diff_view;
 pub mod help;
 pub mod highlight;
+mod input_translate;
 pub mod nav;
 pub mod note_markers;
 pub mod order;
 pub mod review;
+mod review_flow;
 pub mod row_view;
 mod session;
 pub mod source;
@@ -51,11 +58,23 @@ pub mod ui;
 pub use session::{TuiSession, run};
 
 use app::{App, BlastRadiusSelection, InputKey, Screen};
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use input_translate::{translate_key, translate_mouse_event};
+use ratatui::crossterm::event::{self, Event, KeyEventKind};
 use review::PrContext;
 use review::ports::{ClipboardSink, ReviewSubmitter};
+use review_flow::{
+    derive_selection_snapshot, dispatch_note_compose_key, perform_export,
+    should_recompute_note_markers,
+};
 use rinkaku_core::render::Report;
 use std::time::Duration;
+
+// Re-exported at the crate root purely so `lib_tests/note_snapshot.rs`'s
+// and `lib_tests/perform_export.rs`'s existing `use crate::{...}` imports
+// (predating the ADR 0028 split of these two into `review_flow`) keep
+// working unchanged.
+#[cfg(test)]
+pub(crate) use review_flow::{OSC52_SIZE_GUARD_BYTES, clipboard_export_status, first_anchor_run};
 
 /// Review-notes export wiring (ADR 0048), assembled once by `main.rs`'s
 /// composition root and threaded through unchanged from
@@ -716,29 +735,6 @@ fn dispatch_non_source_key(
     app.handle_key(input_key)
 }
 
-/// Applies [`InputKey::NoteCompose`] given the [`review::SelectionSnapshot`]
-/// `crate::run_app` already derived from the cursor (that derivation needs
-/// `report`/the parsed diff hunks, which `App::handle_key` has no access
-/// to — `InputKey::NoteCompose`'s own doc comment). Always routes through
-/// `App::handle_key` first, even on a `None` snapshot (cursor not on a
-/// present symbol row, or on the source screen): `handle_key`'s own
-/// `NoteCompose` match arm is a no-op stub, but what matters is its
-/// unconditional `pending_prefix` clear at the top of the function — the
-/// same "call `handle_key` for its clear even when its own arm does
-/// nothing" contract [`dispatch_non_source_key`]'s `GotoDefinition`/
-/// `GotoReferences` arm documents for itself. A `Some` snapshot opens the
-/// compose overlay after that call; `None` leaves `review` untouched.
-fn dispatch_note_compose_key(app: App, snapshot: Option<review::SelectionSnapshot>) -> App {
-    let app = app.handle_key(InputKey::NoteCompose);
-    match snapshot {
-        Some(snapshot) => {
-            let review = app.review().clone().begin_compose(snapshot);
-            app.with_review(review)
-        }
-        None => app,
-    }
-}
-
 /// Whether `crate::run_app`'s event loop should recompute the diff pane's
 /// shaped content this key, rather than keep showing the previously cached
 /// one — mirrors `should_recompute_blast_radius_selection`'s own contract and
@@ -915,20 +911,6 @@ fn resolve_goto(app: &App, report: &Report, direction: InputKey) -> GotoOutcome 
     }
 }
 
-/// Whether `crate::run_app`'s event loop should recompute [`note_markers::NoteMarkers`]
-/// this key, mirroring `should_recompute_blast_radius_selection`'s/
-/// `should_recompute_diff_pane_content`'s own change-gated-cache contract
-/// (ADR 0048's Rendering boundary decision: this derivation must not run
-/// inside `ui::draw`, since that runs on every ~100ms idle poll tick, not
-/// only on a key press). `true` only when `review`'s note set actually
-/// changed since the last recompute — compares `revision` rather than
-/// gating on screen/pane the way the blast-radius/diff-pane gates do,
-/// since note markers are relevant on every row/pane, not just one right
-/// pane's own active mode.
-fn should_recompute_note_markers(app: &App, last_revision: u64) -> bool {
-    app.review().revision() != last_revision
-}
-
 /// Whether `crate::run_app`'s event loop should recompute the blast-radius
 /// selection this key, rather than keep showing the previously cached one
 /// (this function's own extraction is what makes that decision
@@ -941,447 +923,6 @@ fn should_recompute_note_markers(app: &App, last_revision: u64) -> bool {
 /// need a wasted recompute on the `d` press that briefly leaves it.
 fn should_recompute_blast_radius_selection(app: &App) -> bool {
     matches!(app.screen(), Screen::Entry) && app.right_pane() == app::RightPane::BlastRadius
-}
-
-/// The summary line posted alongside every GitHub PR review sink A submits
-/// (ADR 0048) — every review is submitted with the same fixed summary,
-/// since the individual notes themselves carry the substantive content as
-/// inline comments; there is no per-session reviewer-authored summary in
-/// v1.
-const REVIEW_SUMMARY: &str = "Review notes posted via rinkaku.";
-
-/// Performs `export` against the matching port in `ports` (ADR 0048's
-/// Output boundary decision: `review` itself never calls a port, only
-/// `crate::lib::run_app` does, once per handled key that produced a
-/// pending export) and folds the result into `review`'s status message.
-///
-/// [`review::ExportRequest::GithubReview`] is only ever produced by
-/// [`review::ReviewState::confirm_verdict`], reachable only through
-/// [`review::ReviewState::confirm_export`]'s own `sink_a_available`-gated
-/// branch (`App::handle_review_key`'s own `ExportMenu` arm passes
-/// `app.review_sink_a_available`) — so `ports.submitter` being `None` here
-/// would mean that gate was bypassed; handled defensively (a status
-/// message, not a panic) rather than trusted blindly, matching this
-/// crate's existing practice of not trusting an invariant across a module
-/// boundary (e.g. `App::jump_to_symbol`'s own doc comment on the same
-/// judgment call).
-fn perform_export(
-    review: review::ReviewState,
-    ports: &ReviewPorts<'_>,
-    export: review::ExportRequest,
-) -> review::ReviewState {
-    match export {
-        review::ExportRequest::GithubReview(verdict) => {
-            let Some(submitter) = ports.submitter else {
-                return review.set_status("error: no PR context available to post a review");
-            };
-            let Some(pr_context) = &ports.pr_context else {
-                return review.set_status("error: no PR context available to post a review");
-            };
-            let comments = review::render_review_comments(review.notes());
-            match submitter.submit_review(pr_context, verdict, REVIEW_SUMMARY, &comments) {
-                Ok(()) => review.set_status(format!(
-                    "posted {} review comment(s) to PR #{}",
-                    comments.len(),
-                    pr_context.number
-                )),
-                Err(message) => review.set_status(format!("error posting review: {message}")),
-            }
-        }
-        review::ExportRequest::Clipboard => {
-            let packet = review::render_agent_packet(review.notes());
-            let result = ports.clipboard.copy(&packet);
-            let status = clipboard_export_status(&packet, result);
-            review.set_status(status)
-        }
-    }
-}
-
-/// A conservative guard on the OSC 52 packet's *raw* byte length (ADR
-/// 0048), below common terminal-side payload caps (~100KB is a frequently
-/// cited limit, e.g. iTerm2/xterm.js) even after base64 inflates the wire
-/// payload to ~4/3 of this — terminals that enforce such a cap tend to
-/// silently drop or truncate an oversized OSC 52 sequence rather than
-/// erroring, so [`Osc52Clipboard::copy`]-equivalent ports (`rinkaku`'s own
-/// `Osc52Clipboard`) have no way to detect the failure themselves; this
-/// guard exists purely to warn the reviewer before that silent failure
-/// bites them.
-const OSC52_SIZE_GUARD_BYTES: usize = 48 * 1024;
-
-/// Folds sink B's [`review::ports::ClipboardSink::copy`] result into a
-/// status message: the port's own error message on `Err`, otherwise a
-/// plain success note — or, when `packet` exceeds
-/// [`OSC52_SIZE_GUARD_BYTES`], the same success note plus a warning that
-/// the terminal may have silently dropped or truncated it, with a manual-
-/// copy fallback suggestion. The copy itself already happened by the time
-/// this runs; the guard only changes the *message*, never whether the copy
-/// is attempted.
-fn clipboard_export_status(packet: &str, result: Result<(), String>) -> String {
-    match result {
-        Ok(()) => {
-            let base = "copied review notes to clipboard via OSC 52 (terminal support required)";
-            if packet.len() > OSC52_SIZE_GUARD_BYTES {
-                format!(
-                    "{base} — packet is {} bytes, which may exceed the terminal's OSC 52 limit; \
-                     copy manually if the paste looks truncated",
-                    packet.len()
-                )
-            } else {
-                base.to_string()
-            }
-        }
-        Err(message) => format!("error copying to clipboard: {message}"),
-    }
-}
-
-/// Derives a [`review::SelectionSnapshot`] from whatever the tree cursor
-/// currently points at (ADR 0048's Input boundary decision) — the sole
-/// channel by which `review` learns what the reviewer is annotating.
-/// `crate::lib::run_app` calls this when [`InputKey::NoteCompose`] is
-/// pressed, since `App::handle_key` itself has no access to `report`/the
-/// parsed diff hunks (mirroring `InputKey::Source`'s own "IO/derivation
-/// stays outside `App`" precedent).
-///
-/// `None` on [`Screen::Source`] (composing against a source-view line is
-/// out of v1's scope) and on any row that is not a present symbol
-/// (`app::NodeKind::Dir`/`File`/`Section`/`TestGroup`, or a removed
-/// symbol) — v1 only supports symbol-anchored notes (module doc comment on
-/// `crate::review`), matching `App::selected_symbol_id`'s own row-kind
-/// scoping.
-///
-/// The anchor is the first contiguous new-side run where the symbol's own
-/// range intersects a diff hunk touching `path` — GitHub's review API only
-/// accepts inline comments on lines that are part of the PR's diff, so
-/// this is what [`review::render_review_comments`] posts against. `None`
-/// when no hunk intersects the symbol's range at all (e.g. the symbol
-/// itself is unchanged but was pulled into view via dependency
-/// expansion) — the note still gets a location (`range`), just no
-/// GitHub-postable anchor; [`review::render_review_comments`] falls back
-/// to `range` in that case.
-fn derive_selection_snapshot(
-    app: &App,
-    report: &Report,
-    diff_files: &[diff_view::FileHunks],
-) -> Option<review::SelectionSnapshot> {
-    if !matches!(app.screen(), Screen::Entry) {
-        return None;
-    }
-    let symbol_id = app.selected_symbol_id()?;
-    let (path, symbol) = report.files.iter().find_map(|file| {
-        file.symbols
-            .iter()
-            .find(|s| s.id == symbol_id)
-            .map(|s| (file.path.as_str(), s))
-    })?;
-    let range = (symbol.range.start, symbol.range.end);
-    let anchor = diff_view::file_hunks(diff_files, path)
-        .and_then(|file_hunks| first_anchor_run(file_hunks, range));
-
-    Some(review::SelectionSnapshot {
-        path: path.to_string(),
-        symbol_id: Some(symbol.id.clone()),
-        symbol_name: Some(symbol.name.clone()),
-        range: Some(range),
-        anchor,
-        signature: Some(symbol.signature.clone()),
-    })
-}
-
-/// The first contiguous new-side line run where `range` (a symbol's own
-/// 1-based inclusive line range) intersects one of `file_hunks`' hunks —
-/// [`derive_selection_snapshot`]'s own anchor computation, extracted as a
-/// pure function so the "first run" rule is unit-testable in isolation
-/// from `Report`/`App`.
-///
-/// Hunks are walked in file order (already the order `diff_view::parse_diff_hunks`
-/// produces them in) and the *first* intersecting hunk's own clamped
-/// overlap with `range` is returned — not the union of every intersecting
-/// hunk — since ADR 0048 asks for "the first hunk-intersecting contiguous
-/// run", not the full set (a symbol whose range spans several
-/// non-adjacent hunks has no single contiguous GitHub-postable range
-/// anyway; the first run is a deliberately simple v1 choice, not an
-/// attempt at completeness).
-fn first_anchor_run(
-    file_hunks: &diff_view::FileHunks,
-    range: (usize, usize),
-) -> Option<(usize, usize)> {
-    let (range_start, range_end) = range;
-    file_hunks
-        .hunks
-        .iter()
-        .filter_map(|hunk| hunk.new_range)
-        .filter(|&(hunk_start, hunk_end)| hunk_start <= hunk_end)
-        .find_map(|(hunk_start, hunk_end)| {
-            let start = hunk_start.max(range_start);
-            let end = hunk_end.min(range_end);
-            (start <= end).then_some((start, end))
-        })
-}
-
-/// Translates a raw `crossterm` key press into this crate's
-/// terminal-agnostic [`InputKey`], or `None` for a key the app does not
-/// react to. Depends on `app.screen()` to disambiguate `q`/Esc (`Quit`/
-/// `FocusLeft` on the entry view depending on focus, `Back` on the source
-/// view) and on `app.focus()` (ADR 0020) to route Esc between `FocusLeft`
-/// and its other meanings — every other mapping is context-free.
-///
-/// `app.help_open()` (ADR 0020) short-circuits every other rule: while the
-/// help overlay is open, `?`/Esc/`q` all translate to `ToggleHelp` (closing
-/// it) regardless of what they would otherwise mean, and this check runs
-/// before every other arm so none of them — especially `q`, which would
-/// otherwise mean `Quit` — can reach past the overlay. `App::handle_key`'s
-/// own `help_open` guard is a second, independent layer of the same rule
-/// (swallowing every non-`ToggleHelp` key while open) — belt and braces,
-/// since "the overlay is a safe action that can never accidentally quit
-/// the app" is exactly the property ADR 0020 asks this feature to hold.
-///
-/// `app.jump_popup()` (ADR 0022) is the next short-circuit, mirroring the
-/// help overlay's own structure: while the jump-target popup is open,
-/// `j`/`k`/Up/Down move its own selection, Enter confirms (`PopupConfirm`),
-/// Esc cancels (`PopupCancel`), and every other key is swallowed.
-///
-/// `app.pending_prefix()` (ADR 0022) is consulted only for `d`/`r`: when a
-/// `g` press is still pending, `d` resolves to `GotoDefinition` and `r` to
-/// `GotoReferences` instead of their own ordinary meanings (`ToggleDiff`/
-/// unbound) — every other key falls through to its normal translation
-/// unconditionally, which is what lets the pending prefix's own state
-/// (`App::handle_key`'s blanket clear-unless-`PendingGoto` rule) correctly
-/// unwind on any key that is not `d`/`r`.
-fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -> Option<InputKey> {
-    // The review overlay (ADR 0048) is checked before even the help
-    // overlay: while composing a note, every printable character the
-    // reviewer types (including `?`) must land in the note buffer, not
-    // trigger the help overlay or any other single-key gesture. Composing
-    // is also the one mode exempt from full-width normalization below —
-    // free text must keep whatever the reviewer actually typed.
-    if let review::ReviewMode::Compose { .. } = app.review().mode() {
-        return match code {
-            KeyCode::Enter => Some(InputKey::PopupConfirm),
-            KeyCode::Esc => Some(InputKey::PopupCancel),
-            KeyCode::Backspace => Some(InputKey::ComposeBackspace),
-            KeyCode::Char(c) => Some(InputKey::ComposeChar(c)),
-            _ => None,
-        };
-    }
-    let code = normalize_fullwidth_key(code);
-    match app.review().mode() {
-        review::ReviewMode::List { .. }
-        | review::ReviewMode::ExportMenu { .. }
-        | review::ReviewMode::VerdictMenu { .. } => {
-            return match code {
-                KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
-                KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
-                KeyCode::Enter => Some(InputKey::PopupConfirm),
-                KeyCode::Esc | KeyCode::Char('q') => Some(InputKey::PopupCancel),
-                KeyCode::Char('d') => Some(InputKey::NoteDelete),
-                _ => None,
-            };
-        }
-        review::ReviewMode::Compose { .. } => unreachable!("handled by the early return above"),
-        review::ReviewMode::Idle => {}
-    }
-
-    if app.help_open() {
-        // The overlay's own content can run longer than its box (this
-        // feature's whole reason for existing) — `j`/`k`/`Ctrl-d`/`Ctrl-u`/
-        // `G` scroll it, mirroring the plain-key mapping each already has
-        // outside the overlay so a reviewer does not have to learn a
-        // second gesture just because the overlay is open. `gg`'s
-        // second-`g` resolution still goes through the `pending_prefix`
-        // branch below (this early return only covers `?`/Esc/`q`/`Ctrl-d`/
-        // `Ctrl-u`/`G` and the bare `j`/`k`/arrow keys; a first `g` press
-        // is deliberately *not* matched here so it falls through to the
-        // ordinary `PendingGoto` arm at the bottom of this function, which
-        // works identically whether the overlay is open or not since it
-        // only touches `app.pending_prefix()`).
-        return match code {
-            KeyCode::Char('?') | KeyCode::Esc | KeyCode::Char('q') => Some(InputKey::ToggleHelp),
-            KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
-            KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
-            KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
-                Some(InputKey::ScrollHalfPageDown)
-            }
-            KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
-                Some(InputKey::ScrollHalfPageUp)
-            }
-            KeyCode::Char('G') => Some(InputKey::ScrollToBottom),
-            KeyCode::Char('g') if app.pending_prefix() == Some(app::PendingPrefix::G) => {
-                Some(InputKey::ScrollToTop)
-            }
-            KeyCode::Char('g') => Some(InputKey::PendingGoto),
-            _ => None,
-        };
-    }
-
-    if app.jump_popup().is_some() {
-        return match code {
-            KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
-            KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
-            KeyCode::Enter => Some(InputKey::PopupConfirm),
-            KeyCode::Esc => Some(InputKey::PopupCancel),
-            _ => None,
-        };
-    }
-
-    let on_source_screen = matches!(app.screen(), Screen::Source { .. });
-    let right_focused = app.focus() == app::Focus::Right;
-
-    if app.pending_prefix() == Some(app::PendingPrefix::G) {
-        match code {
-            KeyCode::Char('d') | KeyCode::Char('D') => return Some(InputKey::GotoDefinition),
-            KeyCode::Char('r') | KeyCode::Char('R') => return Some(InputKey::GotoReferences),
-            // `gg` (ADR 0026): scroll the reading pane to the top —
-            // resolved here the same way `gd`/`gr` are, piggybacking on
-            // the existing `g`-prefix state machine (ADR 0022) rather
-            // than reserving single-key `g` for this and breaking the
-            // two-key sequences above. Uppercase `G` is a *distinct*
-            // single-key gesture (`ScrollToBottom` below), unrelated to
-            // this prefix — a second `g` in this arm is what means "top".
-            KeyCode::Char('g') => return Some(InputKey::ScrollToTop),
-            _ => {}
-        }
-    }
-
-    match code {
-        KeyCode::Up | KeyCode::Char('k') => Some(InputKey::Up),
-        KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
-        // Space always means "expand/collapse", never "drill in" — kept
-        // distinct from Enter's own `InputKey::Open` (ADR 0020) so Space on
-        // a file/symbol row never moves focus. Translated unconditionally
-        // here regardless of `app.focus()`, same as every other key this
-        // function maps context-free — `App::handle_key`'s own
-        // `Focus::Tree`-only arm for `Select` is where the actual
-        // Tree-focus requirement lives (mirroring how `NextHunk`/`PrevHunk`
-        // are also translated unconditionally but only acted on under
-        // certain conditions elsewhere).
-        KeyCode::Char(' ') => Some(InputKey::Select),
-        KeyCode::Enter => Some(InputKey::Open),
-        KeyCode::Char('e') | KeyCode::Char('E') => Some(InputKey::ExpandAll),
-        KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::Quit),
-        KeyCode::Char('c') | KeyCode::Char('C') => Some(InputKey::CollapseAll),
-        KeyCode::Char('o') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::JumpBack),
-        // Ctrl-I and Tab share the same control code (0x09) at the terminal
-        // protocol level — without Kitty's keyboard-enhancement protocol
-        // (which this crate does not enable), a real Ctrl-I keypress
-        // arrives here as plain `KeyCode::Tab`, not `KeyCode::Char('i')` +
-        // `CONTROL` (confirmed via manual tmux testing against a real
-        // terminal, not just documentation: the `Char('i') + CONTROL` arm
-        // alone never matched a real Ctrl-I press). Both patterns are kept
-        // so this still works correctly in an environment that *does*
-        // report the modifier form (e.g. a test harness constructing the
-        // event directly, as this module's own tests do).
-        KeyCode::Tab => Some(InputKey::JumpForward),
-        KeyCode::Char('i') if modifiers.contains(KeyModifiers::CONTROL) => {
-            Some(InputKey::JumpForward)
-        }
-        KeyCode::Char('o') | KeyCode::Char('O') => Some(InputKey::ToggleOrder),
-        // `Ctrl-d`/`Ctrl-u` (ADR 0026): half-page scroll on the reading
-        // pane (`Screen::Source`, or `Screen::Entry` + `Focus::Right`).
-        // Must come *before* the plain `Char('d')`/`Char('u')` arms —
-        // otherwise a `Ctrl-d` press would match `ToggleDiff` first and
-        // the modifier would be ignored, silently rebinding "half-page
-        // down" to "toggle diff pane". Emitted regardless of screen/
-        // focus; `App::handle_scroll_key` no-ops on `Focus::Tree` in the
-        // entry view (ADR 0026 decision 3's Tree-focus rule).
-        KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
-            Some(InputKey::ScrollHalfPageDown)
-        }
-        KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
-            Some(InputKey::ScrollHalfPageUp)
-        }
-        KeyCode::Char('d') | KeyCode::Char('D') => Some(InputKey::ToggleDiff),
-        KeyCode::Char('r') | KeyCode::Char('R') => Some(InputKey::ToggleBlastRadius),
-        KeyCode::Char('v') | KeyCode::Char('V') => Some(InputKey::ToggleSplitView),
-        // `G` (`Shift-g`, ADR 0026): scroll to the bottom. Distinct from
-        // single-key lowercase `g` (`PendingGoto` below), which is the
-        // leading key of the `gd`/`gr`/`gg` two-key sequences resolved
-        // at the top of this function.
-        KeyCode::Char('G') => Some(InputKey::ScrollToBottom),
-        // `h`, or Esc while the right pane has focus: return focus to the
-        // tree (ADR 0020's neovim-style "move left/back"). Checked before
-        // the source-screen Esc arm below so `h`/Esc while Right-focused
-        // never reaches the source screen (impossible in practice today,
-        // since opening the source screen already moves focus to `Right`,
-        // but ordered defensively rather than relying on that invariant).
-        KeyCode::Char('h') if right_focused => Some(InputKey::FocusLeft),
-        KeyCode::Esc if right_focused && !on_source_screen => Some(InputKey::FocusLeft),
-        // `]c`/`[c` (vim's hunk-jump idiom) are read here as a single
-        // bracket keystroke rather than a buffered two-key chord — this
-        // crate's event loop (`run_app`) has no notion of a pending-chord
-        // state machine today, and introducing one for exactly one binding
-        // would be disproportionate; `]`/`[` alone are otherwise unbound,
-        // so no existing gesture is lost by this simplification.
-        KeyCode::Char(']') => Some(InputKey::NextHunk),
-        KeyCode::Char('[') => Some(InputKey::PrevHunk),
-        KeyCode::Char('s') | KeyCode::Char('S') => Some(InputKey::Source),
-        // `n` (ADR 0048): opens the review-note compose overlay over the
-        // row under the cursor. `N`: opens the review-notes list overlay.
-        // Both are only meaningful on the entry screen (Source-screen
-        // rows have no `SelectionSnapshot` to compose against), but
-        // translated context-free here like every other key in this
-        // block — `App::handle_key`'s own `Screen::Source` catch-all arm
-        // already no-ops every non-scroll key there.
-        KeyCode::Char('n') => Some(InputKey::NoteCompose),
-        KeyCode::Char('N') => Some(InputKey::NotesList),
-        // `g` (ADR 0022): the first half of the `gd`/`gr` two-key sequence.
-        // Checked after the `pending_prefix` resolution above so a second
-        // `g` press (`gg`, not a bound sequence today) simply restarts the
-        // pending state rather than doing anything else — `App::handle_key`
-        // sets `pending_prefix` from this variant unconditionally.
-        KeyCode::Char('g') => Some(InputKey::PendingGoto),
-        KeyCode::Char('?') => Some(InputKey::ToggleHelp),
-        KeyCode::Esc if on_source_screen => Some(InputKey::Back),
-        KeyCode::Char('q') if on_source_screen => Some(InputKey::Back),
-        KeyCode::Char('q') => Some(InputKey::Quit),
-        _ => None,
-    }
-}
-
-/// Folds a full-width form (U+FF01-U+FF5E, the Unicode "Fullwidth ASCII
-/// Variants" block a Japanese/CJK IME sends when left on while a reviewer
-/// presses an otherwise-ASCII binding) down to its ordinary half-width
-/// `KeyCode::Char`, leaving every other `KeyCode` untouched. Applied to
-/// every normal-mode/overlay gesture in [`translate_key`] but not while
-/// [`review::ReviewMode::Compose`] is open — that buffer is free text, so a
-/// full-width character typed there must reach the note body unchanged.
-fn normalize_fullwidth_key(code: KeyCode) -> KeyCode {
-    match code {
-        KeyCode::Char(c @ '\u{FF01}'..='\u{FF5E}') => {
-            KeyCode::Char(char::from_u32(c as u32 - 0xFEE0).unwrap_or(c))
-        }
-        other => other,
-    }
-}
-
-/// Translates a raw `crossterm` mouse event into an [`InputKey`], the same
-/// boundary role [`translate_key`] plays for keyboard input — a pure
-/// function so the mapping is unit-testable without a live terminal.
-///
-/// Only `ScrollUp`/`ScrollDown` (wheel/trackpad) are mapped, and they are
-/// mapped onto the *existing* [`InputKey::Up`]/[`InputKey::Down`] variants
-/// rather than a dedicated pair of scroll variants: `App::handle_key`
-/// already gives `Up`/`Down` the right contextual meaning everywhere a
-/// wheel scroll should act — the tree cursor while [`app::Focus::Tree`],
-/// [`app::App::right_pane_scroll`] by one line while [`app::Focus::Right`]
-/// (ADR 0020), and [`app::Screen::Source`]'s `scroll_top` on the source
-/// screen (ADR 0026) — so reusing them is a strict simplification (no new
-/// state-machine surface) rather than introducing a second, parallel
-/// motion concept the app would have to keep in sync with the first.
-///
-/// `MouseEventKind::ScrollLeft`/`ScrollRight` (horizontal wheel/trackpad)
-/// and every click/drag/move variant are deliberately unmapped (`None`):
-/// this crate has no horizontally-scrollable pane, and no pane targeting by
-/// click position — the row/column the event occurred at is intentionally
-/// not consulted here. Wheel input always acts on whichever pane already
-/// has focus, exactly like a keyboard `j`/`k` press would; teaching the
-/// wheel to also *change* focus by clicking a pane is future scope, not
-/// attempted by this function.
-fn translate_mouse_event(kind: event::MouseEventKind) -> Option<InputKey> {
-    match kind {
-        event::MouseEventKind::ScrollUp => Some(InputKey::Up),
-        event::MouseEventKind::ScrollDown => Some(InputKey::Down),
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -70,11 +70,10 @@ use rinkaku_core::render::Report;
 use std::time::Duration;
 
 // Re-exported at the crate root purely so `lib_tests/note_snapshot.rs`'s
-// and `lib_tests/perform_export.rs`'s existing `use crate::{...}` imports
-// (predating the ADR 0028 split of these two into `review_flow`) keep
-// working unchanged.
+// existing `use crate::{...}` import (predating the ADR 0028 split into
+// `review_flow`) keeps working unchanged.
 #[cfg(test)]
-pub(crate) use review_flow::{OSC52_SIZE_GUARD_BYTES, clipboard_export_status, first_anchor_run};
+pub(crate) use review_flow::first_anchor_run;
 
 /// Review-notes export wiring (ADR 0048), assembled once by `main.rs`'s
 /// composition root and threaded through unchanged from

--- a/rinkaku-tui/src/lib_tests/mod.rs
+++ b/rinkaku-tui/src/lib_tests/mod.rs
@@ -27,6 +27,7 @@ use rinkaku_core::render::Report;
 mod diff_scroll_sync;
 mod goto_dispatch;
 mod hunk_jump;
+mod note_snapshot;
 mod recompute_and_reload;
 mod scroll_clamp;
 mod translate_key;

--- a/rinkaku-tui/src/lib_tests/mod.rs
+++ b/rinkaku-tui/src/lib_tests/mod.rs
@@ -18,6 +18,8 @@
 //! - `diff_scroll_sync` — `sync_target_for_scroll` and
 //!   `apply_diff_pane_selection_effects` (ADR 0030): the diff → tree
 //!   auto-sync in the reverse direction of ADR 0027's tree → diff scroll
+//! - `perform_export` — `clipboard_export_status`'s OSC 52 size-guard
+//!   warning and error-message passthrough (ADR 0048)
 
 use crate::app::JumpCandidate;
 use crate::source;
@@ -28,6 +30,7 @@ mod diff_scroll_sync;
 mod goto_dispatch;
 mod hunk_jump;
 mod note_snapshot;
+mod perform_export;
 mod recompute_and_reload;
 mod scroll_clamp;
 mod translate_key;

--- a/rinkaku-tui/src/lib_tests/note_snapshot.rs
+++ b/rinkaku-tui/src/lib_tests/note_snapshot.rs
@@ -1,0 +1,173 @@
+use super::*;
+use crate::app::App;
+use crate::diff_view::{FileHunks, Hunk};
+use crate::{derive_selection_snapshot, first_anchor_run};
+
+fn hunk(new_range: Option<(usize, usize)>) -> Hunk {
+    Hunk {
+        header: "@@ @@".to_string(),
+        new_range,
+        lines: vec![],
+    }
+}
+
+mod first_anchor_run_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_return_the_clamped_overlap_of_the_first_intersecting_hunk() {
+        let file_hunks = FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk(Some((5, 10)))],
+        };
+
+        let actual = first_anchor_run(&file_hunks, (1, 8));
+
+        assert_eq!(Some((5, 8)), actual);
+    }
+
+    #[test]
+    fn should_skip_non_intersecting_hunks_and_use_the_first_that_intersects() {
+        let file_hunks = FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk(Some((100, 110))), hunk(Some((5, 10)))],
+        };
+
+        let actual = first_anchor_run(&file_hunks, (1, 8));
+
+        assert_eq!(Some((5, 8)), actual);
+    }
+
+    #[test]
+    fn should_return_none_when_no_hunk_intersects_the_range() {
+        let file_hunks = FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk(Some((100, 110)))],
+        };
+
+        let actual = first_anchor_run(&file_hunks, (1, 8));
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_skip_a_pure_deletion_hunk_with_a_zero_width_new_range() {
+        let file_hunks = FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk(Some((5, 4))), hunk(Some((5, 10)))],
+        };
+
+        let actual = first_anchor_run(&file_hunks, (1, 8));
+
+        assert_eq!(Some((5, 8)), actual);
+    }
+
+    #[test]
+    fn should_return_none_when_there_are_no_hunks() {
+        let file_hunks = FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![],
+        };
+
+        let actual = first_anchor_run(&file_hunks, (1, 8));
+
+        assert_eq!(None, actual);
+    }
+}
+
+mod derive_selection_snapshot_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_build_a_snapshot_with_anchor_when_cursor_is_on_a_symbol_row_with_an_intersecting_hunk()
+     {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk(Some((1, 1)))],
+        }];
+
+        let actual = derive_selection_snapshot(&app, &report, &diff_files);
+
+        assert_eq!(
+            Some(crate::review::SelectionSnapshot {
+                path: "lib.rs".to_string(),
+                symbol_id: Some("lib.rs::foo".to_string()),
+                symbol_name: Some("foo".to_string()),
+                range: Some((1, 1)),
+                anchor: Some((1, 1)),
+                signature: Some("fn foo()".to_string()),
+            }),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_build_a_snapshot_with_no_anchor_when_no_hunk_intersects_the_symbol() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+        let diff_files = vec![FileHunks {
+            path: "lib.rs".to_string(),
+            hunks: vec![hunk(Some((100, 110)))],
+        }];
+
+        let actual = derive_selection_snapshot(&app, &report, &diff_files);
+
+        assert_eq!(
+            Some(crate::review::SelectionSnapshot {
+                path: "lib.rs".to_string(),
+                symbol_id: Some("lib.rs::foo".to_string()),
+                symbol_name: Some("foo".to_string()),
+                range: Some((1, 1)),
+                anchor: None,
+                signature: Some("fn foo()".to_string()),
+            }),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_return_none_when_cursor_is_on_a_directory_row() {
+        let report = Report {
+            files: vec![
+                rinkaku_core::render::FileReport {
+                    path: "a/one.rs".to_string(),
+                    symbols: vec![],
+                },
+                rinkaku_core::render::FileReport {
+                    path: "b/two.rs".to_string(),
+                    symbols: vec![],
+                },
+            ],
+            ..empty_report()
+        };
+        let app = App::new(&report);
+
+        let actual = derive_selection_snapshot(&app, &report, &[]);
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_return_none_when_no_diff_hunks_cover_the_symbols_file() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+
+        let actual = derive_selection_snapshot(&app, &report, &[]);
+
+        assert_eq!(
+            Some(crate::review::SelectionSnapshot {
+                path: "lib.rs".to_string(),
+                symbol_id: Some("lib.rs::foo".to_string()),
+                symbol_name: Some("foo".to_string()),
+                range: Some((1, 1)),
+                anchor: None,
+                signature: Some("fn foo()".to_string()),
+            }),
+            actual
+        );
+    }
+}

--- a/rinkaku-tui/src/lib_tests/note_snapshot.rs
+++ b/rinkaku-tui/src/lib_tests/note_snapshot.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::app::App;
 use crate::diff_view::{FileHunks, Hunk};
-use crate::{derive_selection_snapshot, first_anchor_run};
+use crate::{derive_selection_snapshot, dispatch_note_compose_key, first_anchor_run};
 
 fn hunk(new_range: Option<(usize, usize)>) -> Hunk {
     Hunk {
@@ -169,5 +169,53 @@ mod derive_selection_snapshot_tests {
             }),
             actual
         );
+    }
+}
+
+mod dispatch_note_compose_key_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_open_compose_overlay_when_snapshot_is_some() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+        let snapshot = derive_selection_snapshot(&app, &report, &[]);
+        assert!(snapshot.is_some());
+
+        let actual = dispatch_note_compose_key(app, snapshot);
+
+        assert!(matches!(
+            actual.review().mode(),
+            crate::review::ReviewMode::Compose { .. }
+        ));
+    }
+
+    #[test]
+    fn should_clear_pending_prefix_when_snapshot_is_none() {
+        // Regression test (ADR 0022's `pending_prefix` bug, same class):
+        // pressing `n` over a row with no derivable snapshot (a directory
+        // row, or the source screen) must still discard a pending `g`
+        // prefix — otherwise a `g` press followed by an ineffective `n`
+        // leaves `pending_prefix` stuck at `Some(G)`, and the *next* `d`
+        // the reviewer types for its own ordinary reason (`ToggleDiff`)
+        // silently resolves as `GotoDefinition` instead.
+        let report = empty_report();
+        let app = App::new(&report).handle_key(crate::app::InputKey::PendingGoto);
+        assert_eq!(Some(crate::app::PendingPrefix::G), app.pending_prefix());
+
+        let actual = dispatch_note_compose_key(app, None);
+
+        assert_eq!(None, actual.pending_prefix());
+    }
+
+    #[test]
+    fn should_leave_review_idle_when_snapshot_is_none() {
+        let report = empty_report();
+        let app = App::new(&report);
+
+        let actual = dispatch_note_compose_key(app, None);
+
+        assert_eq!(&crate::review::ReviewMode::Idle, actual.review().mode());
     }
 }

--- a/rinkaku-tui/src/lib_tests/perform_export.rs
+++ b/rinkaku-tui/src/lib_tests/perform_export.rs
@@ -1,0 +1,56 @@
+//! `clipboard_export_status` tests (ADR 0048): folding sink B's `Result`
+//! into a status message, including the OSC 52 size-guard warning for a
+//! packet that risks exceeding a terminal's payload limit.
+
+use crate::{OSC52_SIZE_GUARD_BYTES, clipboard_export_status};
+
+#[test]
+fn should_report_plain_success_when_packet_is_small() {
+    let actual = clipboard_export_status("small packet", Ok(()));
+
+    assert_eq!(
+        "copied review notes to clipboard via OSC 52 (terminal support required)",
+        actual
+    );
+}
+
+#[test]
+fn should_warn_about_the_osc_52_limit_when_packet_exceeds_the_size_guard() {
+    // A conservative terminal-side OSC 52 payload cap is commonly cited
+    // around 100KB; base64 inflates the wire payload to ~4/3 of the raw
+    // packet, so this crate's own guard sits below that on the raw side.
+    let packet = "x".repeat(OSC52_SIZE_GUARD_BYTES + 1);
+
+    let actual = clipboard_export_status(&packet, Ok(()));
+
+    assert!(actual.contains("OSC 52"));
+    assert!(actual.contains("manual"));
+}
+
+#[test]
+fn should_not_warn_when_packet_is_exactly_at_the_size_guard() {
+    let packet = "x".repeat(OSC52_SIZE_GUARD_BYTES);
+
+    let actual = clipboard_export_status(&packet, Ok(()));
+
+    assert!(!actual.contains("OSC 52 limit"));
+}
+
+#[test]
+fn should_report_the_clipboard_ports_error_message_when_copy_fails() {
+    let actual = clipboard_export_status("small packet", Err("no tty".to_string()));
+
+    assert_eq!("error copying to clipboard: no tty", actual);
+}
+
+#[test]
+fn should_report_the_clipboard_ports_error_message_even_when_packet_is_oversized() {
+    // The size guard is advisory only, added to a *successful* copy's
+    // status — an error from the port itself must still be reported
+    // as-is, not overridden by the oversized-packet warning.
+    let packet = "x".repeat(OSC52_SIZE_GUARD_BYTES + 1);
+
+    let actual = clipboard_export_status(&packet, Err("no tty".to_string()));
+
+    assert_eq!("error copying to clipboard: no tty", actual);
+}

--- a/rinkaku-tui/src/lib_tests/perform_export.rs
+++ b/rinkaku-tui/src/lib_tests/perform_export.rs
@@ -1,56 +1,63 @@
-//! `clipboard_export_status` tests (ADR 0048): folding sink B's `Result`
-//! into a status message, including the OSC 52 size-guard warning for a
-//! packet that risks exceeding a terminal's payload limit.
+//! `perform_export` clipboard-arm tests (ADR 0048 sink B): the port's own
+//! `Ok` status line is surfaced verbatim, its `Err` is wrapped in the
+//! error prefix.
 
-use crate::{OSC52_SIZE_GUARD_BYTES, clipboard_export_status};
+use crate::ReviewPorts;
+use crate::review::ports::ClipboardSink;
+use crate::review::{ExportRequest, ReviewState};
+use crate::review_flow::perform_export;
+use pretty_assertions::assert_eq;
+
+struct FakeClipboard {
+    result: Result<String, String>,
+}
+
+impl ClipboardSink for FakeClipboard {
+    fn copy(&self, _text: &str) -> Result<String, String> {
+        self.result.clone()
+    }
+}
+
+fn ports_with(clipboard: &FakeClipboard) -> ReviewPorts<'_> {
+    ReviewPorts {
+        pr_context: None,
+        submitter: None,
+        clipboard,
+    }
+}
 
 #[test]
-fn should_report_plain_success_when_packet_is_small() {
-    let actual = clipboard_export_status("small packet", Ok(()));
+fn should_surface_the_ports_status_line_when_copy_succeeds() {
+    let clipboard = FakeClipboard {
+        result: Ok("copied review notes to clipboard via pbcopy".to_string()),
+    };
+
+    let actual = perform_export(
+        ReviewState::default(),
+        &ports_with(&clipboard),
+        ExportRequest::Clipboard,
+    );
 
     assert_eq!(
-        "copied review notes to clipboard via OSC 52 (terminal support required)",
-        actual
+        Some("copied review notes to clipboard via pbcopy"),
+        actual.last_status()
     );
 }
 
 #[test]
-fn should_warn_about_the_osc_52_limit_when_packet_exceeds_the_size_guard() {
-    // A conservative terminal-side OSC 52 payload cap is commonly cited
-    // around 100KB; base64 inflates the wire payload to ~4/3 of the raw
-    // packet, so this crate's own guard sits below that on the raw side.
-    let packet = "x".repeat(OSC52_SIZE_GUARD_BYTES + 1);
+fn should_wrap_the_ports_error_in_the_error_prefix_when_copy_fails() {
+    let clipboard = FakeClipboard {
+        result: Err("no tty".to_string()),
+    };
 
-    let actual = clipboard_export_status(&packet, Ok(()));
+    let actual = perform_export(
+        ReviewState::default(),
+        &ports_with(&clipboard),
+        ExportRequest::Clipboard,
+    );
 
-    assert!(actual.contains("OSC 52"));
-    assert!(actual.contains("manual"));
-}
-
-#[test]
-fn should_not_warn_when_packet_is_exactly_at_the_size_guard() {
-    let packet = "x".repeat(OSC52_SIZE_GUARD_BYTES);
-
-    let actual = clipboard_export_status(&packet, Ok(()));
-
-    assert!(!actual.contains("OSC 52 limit"));
-}
-
-#[test]
-fn should_report_the_clipboard_ports_error_message_when_copy_fails() {
-    let actual = clipboard_export_status("small packet", Err("no tty".to_string()));
-
-    assert_eq!("error copying to clipboard: no tty", actual);
-}
-
-#[test]
-fn should_report_the_clipboard_ports_error_message_even_when_packet_is_oversized() {
-    // The size guard is advisory only, added to a *successful* copy's
-    // status — an error from the port itself must still be reported
-    // as-is, not overridden by the oversized-packet warning.
-    let packet = "x".repeat(OSC52_SIZE_GUARD_BYTES + 1);
-
-    let actual = clipboard_export_status(&packet, Err("no tty".to_string()));
-
-    assert_eq!("error copying to clipboard: no tty", actual);
+    assert_eq!(
+        Some("error copying to clipboard: no tty"),
+        actual.last_status()
+    );
 }

--- a/rinkaku-tui/src/lib_tests/translate_key.rs
+++ b/rinkaku-tui/src/lib_tests/translate_key.rs
@@ -494,3 +494,70 @@ fn should_translate_q_to_none_while_jump_popup_is_open() {
 
     assert_eq!(None, actual);
 }
+
+// Full-width key normalization: a reviewer who forgot to switch off a
+// Japanese IME sends full-width forms of otherwise-bound ASCII keys —
+// normal-mode translation must still resolve them to the same InputKey
+// their half-width counterpart would.
+
+#[test]
+fn should_translate_fullwidth_n_to_the_same_input_key_as_halfwidth_n() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('ｎ'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::NoteCompose), actual);
+}
+
+#[test]
+fn should_translate_fullwidth_j_to_down_regardless_of_focus() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('ｊ'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::Down), actual);
+}
+
+#[test]
+fn should_translate_fullwidth_q_to_quit_on_entry_screen() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('ｑ'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::Quit), actual);
+}
+
+#[test]
+fn should_translate_fullwidth_question_mark_to_toggle_help() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('？'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ToggleHelp), actual);
+}
+
+#[test]
+fn should_not_normalize_fullwidth_characters_while_composing_a_note() {
+    // The compose buffer is free text (ADR 0048) — a full-width character
+    // typed there must land in the note body verbatim, not get folded to
+    // its half-width form the way normal-mode single-key gestures are.
+    let report = report_with_one_symbol();
+    let snapshot = crate::review::SelectionSnapshot {
+        path: "lib.rs".to_string(),
+        symbol_id: Some("lib.rs::foo".to_string()),
+        symbol_name: Some("foo".to_string()),
+        range: Some((1, 1)),
+        anchor: Some((1, 1)),
+        signature: Some("fn foo()".to_string()),
+    };
+    let review = crate::review::ReviewState::default().begin_compose(snapshot);
+    let app = App::new(&report).with_review(review);
+
+    let actual = translate_key(KeyCode::Char('ｎ'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::ComposeChar('ｎ')), actual);
+}

--- a/rinkaku-tui/src/note_markers.rs
+++ b/rinkaku-tui/src/note_markers.rs
@@ -1,0 +1,73 @@
+//! Derived, read-only note-location markers (ADR 0048's Rendering
+//! boundary decision): a side table the tree pane and diff pane consult to
+//! badge/mark a row or line that already has a review note attached,
+//! mirroring `blast_radius_selection`/`diff_pane_content`'s own
+//! cache-on-change precedent in `crate::lib::run_app` — [`build_note_markers`]
+//! must never be called from inside `crate::ui::draw`/`row_view`/the diff
+//! pane's line-rendering functions, only from `run_app`, gated by
+//! [`should_recompute_note_markers`].
+
+use crate::review::Note;
+use std::collections::HashMap;
+
+/// Per-path/per-symbol/per-line note counts and ranges, derived once from
+/// [`crate::review::ReviewState::notes`] on a change-gated schedule
+/// (`crate::lib::run_app`'s `NoteMarkers` cache, alongside
+/// `blast_radius_selection`/`diff_pane_content`) — never recomputed inside
+/// the draw path.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct NoteMarkers {
+    /// Note count per symbol id — consulted by a symbol tree row.
+    pub symbol_counts: HashMap<String, usize>,
+    /// Note count per file path — consulted by a `File` tree row. Includes
+    /// every note under that path regardless of whether it carries a
+    /// `symbol_id` (v1 only composes symbol-anchored notes, but this stays
+    /// keyed by path rather than requiring a symbol so a future
+    /// file-level note is covered by construction rather than needing a
+    /// second field).
+    pub file_counts: HashMap<String, usize>,
+    /// Every note's new-side line range, keyed by path — consulted by the
+    /// diff pane to mark individual lines. A note with no `range` (v1:
+    /// non-symbol locations only, out of scope per `crate::review`'s
+    /// module doc comment) contributes no entry.
+    pub line_ranges: HashMap<String, Vec<(usize, usize)>>,
+}
+
+/// Builds a [`NoteMarkers`] from `notes` — a plain walk over the
+/// accumulated review notes, O(notes), unbounded in the number of notes a
+/// long review session accrues (this function's own doc comment on why it
+/// must be change-gated, not called per frame).
+pub fn build_note_markers(notes: &[Note]) -> NoteMarkers {
+    let mut markers = NoteMarkers::default();
+    for note in notes {
+        *markers
+            .file_counts
+            .entry(note.location.path.clone())
+            .or_insert(0) += 1;
+        if let Some(symbol_id) = &note.location.symbol_id {
+            *markers.symbol_counts.entry(symbol_id.clone()).or_insert(0) += 1;
+        }
+        if let Some(range) = note.location.range {
+            markers
+                .line_ranges
+                .entry(note.location.path.clone())
+                .or_default()
+                .push(range);
+        }
+    }
+    markers
+}
+
+/// Whether line `line` (1-based, new-side) in file `path` falls inside any
+/// note's range — the diff pane's own per-line marker lookup.
+pub fn line_has_note(markers: &NoteMarkers, path: &str, line: usize) -> bool {
+    markers.line_ranges.get(path).is_some_and(|ranges| {
+        ranges
+            .iter()
+            .any(|&(start, end)| start <= line && line <= end)
+    })
+}
+
+#[cfg(test)]
+#[path = "note_markers_tests.rs"]
+mod tests;

--- a/rinkaku-tui/src/note_markers_tests.rs
+++ b/rinkaku-tui/src/note_markers_tests.rs
@@ -1,0 +1,120 @@
+use super::*;
+use crate::review::NoteLocation;
+
+fn note(path: &str, symbol_id: Option<&str>, range: Option<(usize, usize)>) -> Note {
+    Note {
+        location: NoteLocation {
+            path: path.to_string(),
+            symbol_id: symbol_id.map(str::to_string),
+            symbol_name: None,
+            range,
+            anchor: None,
+        },
+        body: "note body".to_string(),
+        signature: None,
+    }
+}
+
+mod build_note_markers_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_return_empty_markers_when_there_are_no_notes() {
+        let actual = build_note_markers(&[]);
+
+        assert_eq!(NoteMarkers::default(), actual);
+    }
+
+    #[test]
+    fn should_count_notes_per_symbol_and_per_file() {
+        let notes = vec![
+            note("lib.rs", Some("lib.rs::foo"), Some((1, 5))),
+            note("lib.rs", Some("lib.rs::foo"), Some((2, 3))),
+            note("lib.rs", Some("lib.rs::bar"), Some((10, 12))),
+        ];
+
+        let actual = build_note_markers(&notes);
+
+        assert_eq!(
+            NoteMarkers {
+                symbol_counts: HashMap::from([
+                    ("lib.rs::foo".to_string(), 2),
+                    ("lib.rs::bar".to_string(), 1),
+                ]),
+                file_counts: HashMap::from([("lib.rs".to_string(), 3)]),
+                line_ranges: HashMap::from([(
+                    "lib.rs".to_string(),
+                    vec![(1, 5), (2, 3), (10, 12)]
+                )]),
+            },
+            actual
+        );
+    }
+
+    #[test]
+    fn should_count_file_note_without_incrementing_symbol_counts_when_symbol_id_is_absent() {
+        let notes = vec![note("lib.rs", None, Some((1, 1)))];
+
+        let actual = build_note_markers(&notes);
+
+        assert_eq!(
+            NoteMarkers {
+                symbol_counts: HashMap::new(),
+                file_counts: HashMap::from([("lib.rs".to_string(), 1)]),
+                line_ranges: HashMap::from([("lib.rs".to_string(), vec![(1, 1)])]),
+            },
+            actual
+        );
+    }
+
+    #[test]
+    fn should_omit_line_ranges_entry_when_note_has_no_range() {
+        let notes = vec![note("lib.rs", Some("lib.rs::foo"), None)];
+
+        let actual = build_note_markers(&notes);
+
+        assert_eq!(
+            NoteMarkers {
+                symbol_counts: HashMap::from([("lib.rs::foo".to_string(), 1)]),
+                file_counts: HashMap::from([("lib.rs".to_string(), 1)]),
+                line_ranges: HashMap::new(),
+            },
+            actual
+        );
+    }
+}
+
+mod line_has_note_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_return_true_when_line_falls_inside_a_note_range() {
+        let markers = build_note_markers(&[note("lib.rs", Some("lib.rs::foo"), Some((5, 10)))]);
+
+        assert_eq!(true, line_has_note(&markers, "lib.rs", 7));
+    }
+
+    #[test]
+    fn should_return_true_when_line_is_a_range_boundary() {
+        let markers = build_note_markers(&[note("lib.rs", Some("lib.rs::foo"), Some((5, 10)))]);
+
+        assert_eq!(true, line_has_note(&markers, "lib.rs", 5));
+        assert_eq!(true, line_has_note(&markers, "lib.rs", 10));
+    }
+
+    #[test]
+    fn should_return_false_when_line_falls_outside_every_note_range() {
+        let markers = build_note_markers(&[note("lib.rs", Some("lib.rs::foo"), Some((5, 10)))]);
+
+        assert_eq!(false, line_has_note(&markers, "lib.rs", 11));
+    }
+
+    #[test]
+    fn should_return_false_when_path_has_no_notes_at_all() {
+        let markers = build_note_markers(&[note("lib.rs", Some("lib.rs::foo"), Some((5, 10)))]);
+
+        assert_eq!(false, line_has_note(&markers, "other.rs", 7));
+    }
+}

--- a/rinkaku-tui/src/review/mod.rs
+++ b/rinkaku-tui/src/review/mod.rs
@@ -143,9 +143,22 @@ pub enum ReviewMode {
 /// per ADR 0048's "no implicit fallback" decision — see
 /// [`ReviewState::open_export_menu`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ExportMenuEntry {
+pub(crate) enum ExportMenuEntry {
     Github,
     Clipboard,
+}
+
+impl ExportMenuEntry {
+    /// This entry's display label — shared by `crate::ui::review_overlay`
+    /// so the rendered menu's text always matches what [`ExportMenuEntry`]
+    /// itself represents, rather than a second hand-written string list
+    /// that could drift from [`export_menu_entries`]'s own set.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Github => "GitHub PR review",
+            Self::Clipboard => "Clipboard (for an AI agent)",
+        }
+    }
 }
 
 /// The verdict menu's selectable entries, in display order.
@@ -388,9 +401,12 @@ impl ReviewState {
 }
 
 /// The export menu's entries given whether sink A is available — extracted
-/// so [`ReviewState::confirm_export`]/[`ReviewState::list_down`] share one
-/// definition of "what's on the menu, in what order".
-fn export_menu_entries(sink_a_available: bool) -> Vec<ExportMenuEntry> {
+/// so [`ReviewState::confirm_export`]/[`ReviewState::list_down`]/
+/// `crate::ui::review_overlay`'s rendering share one definition of "what's
+/// on the menu, in what order" (rather than the render path keeping a
+/// second, hand-written entry list that could disagree with the one
+/// `confirm_export` resolves the cursor against).
+pub(crate) fn export_menu_entries(sink_a_available: bool) -> Vec<ExportMenuEntry> {
     let mut entries = Vec::new();
     if sink_a_available {
         entries.push(ExportMenuEntry::Github);

--- a/rinkaku-tui/src/review/mod.rs
+++ b/rinkaku-tui/src/review/mod.rs
@@ -1,0 +1,404 @@
+//! Review notes (ADR 0048): a location-anchored `Note` primitive plus a
+//! pure state machine (`ReviewState`) for composing, listing, and exporting
+//! them, decoupled from the rest of the TUI through the narrow
+//! `SelectionSnapshot` input and the `Vec<Note>`/rendered-`String` output
+//! (this module's own "own state, narrow input" boundary — see the ADR's
+//! Module boundary decision).
+//!
+//! `review` never holds a `&Report` or reaches into `App`'s tree/nav
+//! fields; `crate::app`/`crate::lib` derive a [`SelectionSnapshot`] from
+//! whatever the cursor currently points at and hand it in. Every side
+//! effect (posting a GitHub review, writing the clipboard) sits behind the
+//! [`ports::ReviewSubmitter`]/[`ports::ClipboardSink`] traits, implemented
+//! and wired up by the `rinkaku` binary crate, never called from here.
+
+pub mod ports;
+mod render;
+
+pub use render::{render_agent_packet, render_review_comments};
+
+/// A destination-neutral note attached to a location in the diff (ADR
+/// 0048's primitive): nothing about a `Note` says who will eventually read
+/// it — that decision is deferred to export time, per sink.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Note {
+    pub location: NoteLocation,
+    pub body: String,
+    pub signature: Option<String>,
+}
+
+/// Where a [`Note`] is anchored: a file path, the symbol it was taken
+/// against (if any), the symbol's own new-side line range, and the
+/// GitHub-comment anchor within that range (the first hunk-intersecting
+/// contiguous run — see [`crate::review::render_review_comments`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoteLocation {
+    pub path: String,
+    pub symbol_id: Option<String>,
+    pub symbol_name: Option<String>,
+    /// The symbol's own new-side line range, 1-based inclusive.
+    pub range: Option<(usize, usize)>,
+    /// The new-side hunk/`range` intersection's first contiguous run,
+    /// 1-based inclusive — GitHub's review API only accepts inline
+    /// comments on lines that are part of the PR's diff, so this is the
+    /// anchor [`crate::review::render_review_comments`] posts against.
+    pub anchor: Option<(usize, usize)>,
+}
+
+/// What the cursor pointed at when `n` (compose) was pressed — the sole
+/// channel by which [`ReviewState`] learns what the reviewer is
+/// annotating (ADR 0048's Input boundary decision). Derived by
+/// `crate::lib`/`crate::app` from the tree cursor plus the diff hunks
+/// already parsed for the session; `review` never derives this itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectionSnapshot {
+    pub path: String,
+    pub symbol_id: Option<String>,
+    pub symbol_name: Option<String>,
+    pub range: Option<(usize, usize)>,
+    pub anchor: Option<(usize, usize)>,
+    pub signature: Option<String>,
+}
+
+impl From<SelectionSnapshot> for NoteLocation {
+    fn from(snapshot: SelectionSnapshot) -> Self {
+        Self {
+            path: snapshot.path,
+            symbol_id: snapshot.symbol_id,
+            symbol_name: snapshot.symbol_name,
+            range: snapshot.range,
+            anchor: snapshot.anchor,
+        }
+    }
+}
+
+/// A PR's identity, enough to post a review against it (ADR 0048 sink A):
+/// assembled once in `main.rs` after `run_analysis` succeeds from
+/// `PrInfo`/`PrArg`/`git_remote_origin_url`, `None` for every non-`--pr`
+/// input mode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrContext {
+    pub owner: String,
+    pub repo: String,
+    pub number: u64,
+    pub head_sha: String,
+}
+
+/// The verdict a reviewer picks when exporting to sink A (GitHub PR
+/// review), mirroring GitHub's own pending-review submit dialog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    Approve,
+    RequestChanges,
+    Comment,
+}
+
+/// One [`Note`] rendered for sink A (GitHub PR review comments) — plain
+/// data, not a `gh api` request shape, so [`crate::review::render_review_comments`]
+/// stays testable without a JSON dependency and the `rinkaku` binary crate
+/// decides the wire format.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderedComment {
+    pub path: String,
+    pub line: usize,
+    pub start_line: Option<usize>,
+    pub body: String,
+}
+
+/// Which sink an export targets, resolved once the reviewer confirms the
+/// export menu (and, for [`Self::GithubReview`], the verdict menu) —
+/// [`ReviewState::take_pending_export`] hands this to `crate::lib::run_app`
+/// to actually perform, since `review` itself never touches a port.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExportRequest {
+    GithubReview(Verdict),
+    Clipboard,
+}
+
+/// The review overlay's current mode — which of the compose/list/export/
+/// verdict surfaces (if any) is on screen, and that surface's own
+/// transient state (an in-progress compose buffer, a list/menu cursor).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ReviewMode {
+    #[default]
+    Idle,
+    Compose {
+        snapshot: SelectionSnapshot,
+        buffer: String,
+    },
+    List {
+        cursor: usize,
+    },
+    ExportMenu {
+        cursor: usize,
+    },
+    VerdictMenu {
+        cursor: usize,
+    },
+}
+
+/// The export menu's selectable entries, in display order — indexed by
+/// [`ReviewMode::ExportMenu`]'s `cursor`. `Github` is omitted from the
+/// menu entirely (not shown disabled) when no [`PrContext`] is available,
+/// per ADR 0048's "no implicit fallback" decision — see
+/// [`ReviewState::open_export_menu`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExportMenuEntry {
+    Github,
+    Clipboard,
+}
+
+/// The verdict menu's selectable entries, in display order.
+const VERDICT_ENTRIES: [Verdict; 3] = [Verdict::Approve, Verdict::RequestChanges, Verdict::Comment];
+
+/// The review feature's own state (ADR 0048's Module boundary decision):
+/// the accumulated notes, which overlay (if any) is open, a change counter
+/// consulted by `crate::lib::run_app`'s `NoteMarkers` cache-on-change gate,
+/// and a pending export request/status message for `crate::lib::run_app`
+/// to act on and report back through. Every method here is a pure state
+/// transition — no IO, no port calls.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ReviewState {
+    notes: Vec<Note>,
+    mode: ReviewMode,
+    /// Incremented on every mutation to `notes` — `crate::lib::run_app`'s
+    /// `NoteMarkers` cache-on-change gate compares this against the value
+    /// it last recomputed from, mirroring
+    /// `should_recompute_blast_radius_selection`'s own contract (ADR
+    /// 0048's Rendering boundary decision: `NoteMarkers` must not be
+    /// derived per frame).
+    revision: u64,
+    pending_export: Option<ExportRequest>,
+    last_status: Option<String>,
+}
+
+impl ReviewState {
+    pub fn notes(&self) -> &[Note] {
+        &self.notes
+    }
+
+    pub fn mode(&self) -> &ReviewMode {
+        &self.mode
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn last_status(&self) -> Option<&str> {
+        self.last_status.as_deref()
+    }
+
+    /// Opens the compose overlay over `snapshot` — called by
+    /// `crate::lib::run_app` when `n` is pressed and a snapshot could be
+    /// derived from the cursor (`derive_selection_snapshot` returned
+    /// `Some`); a `None` snapshot never reaches this method at all, since
+    /// `run_app` special-cases `InputKey::NoteCompose` before dispatch
+    /// (ADR 0048's touch-point (a): the one key that needs data
+    /// `App::handle_key` cannot provide).
+    pub fn begin_compose(mut self, snapshot: SelectionSnapshot) -> Self {
+        self.mode = ReviewMode::Compose {
+            snapshot,
+            buffer: String::new(),
+        };
+        self
+    }
+
+    /// Appends `c` to the compose buffer — a no-op outside
+    /// [`ReviewMode::Compose`].
+    pub fn push_char(mut self, c: char) -> Self {
+        if let ReviewMode::Compose { buffer, .. } = &mut self.mode {
+            buffer.push(c);
+        }
+        self
+    }
+
+    /// Removes the last character from the compose buffer — a no-op
+    /// outside [`ReviewMode::Compose`] or on an already-empty buffer.
+    pub fn backspace(mut self) -> Self {
+        if let ReviewMode::Compose { buffer, .. } = &mut self.mode {
+            buffer.pop();
+        }
+        self
+    }
+
+    /// Confirms the in-progress compose: appends a [`Note`] built from the
+    /// snapshot and buffer and returns to [`ReviewMode::Idle`], unless the
+    /// buffer is empty or whitespace-only, in which case composing is
+    /// simply abandoned (no note is added) — mirrors [`Self::cancel_compose`]
+    /// for a blank buffer, since an empty note carries nothing worth
+    /// recording. A no-op outside [`ReviewMode::Compose`].
+    pub fn confirm_compose(mut self) -> Self {
+        if let ReviewMode::Compose { snapshot, buffer } = self.mode {
+            if !buffer.trim().is_empty() {
+                let signature = snapshot.signature.clone();
+                self.notes.push(Note {
+                    location: snapshot.into(),
+                    body: buffer,
+                    signature,
+                });
+                self.revision += 1;
+            }
+            self.mode = ReviewMode::Idle;
+        }
+        self
+    }
+
+    /// Abandons the in-progress compose without adding a note — a no-op
+    /// outside [`ReviewMode::Compose`].
+    pub fn cancel_compose(mut self) -> Self {
+        if matches!(self.mode, ReviewMode::Compose { .. }) {
+            self.mode = ReviewMode::Idle;
+        }
+        self
+    }
+
+    /// Opens the notes list overlay (`N`), cursor on the first note.
+    pub fn open_list(mut self) -> Self {
+        self.mode = ReviewMode::List { cursor: 0 };
+        self
+    }
+
+    /// Closes whichever overlay is open, discarding any in-progress
+    /// compose/menu state, and returns to [`ReviewMode::Idle`].
+    pub fn close(mut self) -> Self {
+        self.mode = ReviewMode::Idle;
+        self
+    }
+
+    /// Moves the active list/menu cursor up by one (clamped, not
+    /// wrapping) — a no-op in [`ReviewMode::Idle`]/[`ReviewMode::Compose`].
+    pub fn list_up(mut self) -> Self {
+        match &mut self.mode {
+            ReviewMode::List { cursor }
+            | ReviewMode::ExportMenu { cursor }
+            | ReviewMode::VerdictMenu { cursor } => *cursor = cursor.saturating_sub(1),
+            ReviewMode::Idle | ReviewMode::Compose { .. } => {}
+        }
+        self
+    }
+
+    /// Moves the active list/menu cursor down by one, clamped to the
+    /// relevant list's length — a no-op in [`ReviewMode::Idle`]/
+    /// [`ReviewMode::Compose`].
+    ///
+    /// The `ExportMenu` clamp uses the menu's maximum possible length (both
+    /// sinks present) rather than the `sink_a_available`-filtered length
+    /// [`Self::confirm_export`] resolves against: this module carries no
+    /// `PrContext` of its own (the Input/Output boundary keeps it plain
+    /// data), so it cannot know here whether sink A is on the menu.
+    /// Overshooting by one slot when sink A is absent is harmless —
+    /// [`Self::confirm_export`]'s own `entries.get(cursor)` falls through
+    /// to its `None` arm (closing the menu) rather than panicking or
+    /// selecting the wrong entry.
+    pub fn list_down(mut self) -> Self {
+        match &mut self.mode {
+            ReviewMode::List { cursor } => {
+                *cursor = (*cursor + 1).min(self.notes.len().saturating_sub(1));
+            }
+            ReviewMode::ExportMenu { cursor } => {
+                let max_len = export_menu_entries(true).len();
+                *cursor = (*cursor + 1).min(max_len.saturating_sub(1));
+            }
+            ReviewMode::VerdictMenu { cursor } => {
+                *cursor = (*cursor + 1).min(VERDICT_ENTRIES.len().saturating_sub(1));
+            }
+            ReviewMode::Idle | ReviewMode::Compose { .. } => {}
+        }
+        self
+    }
+
+    /// Deletes the note the list cursor currently points at — a no-op
+    /// outside [`ReviewMode::List`] or when the list is empty.
+    pub fn delete_selected(mut self) -> Self {
+        if let ReviewMode::List { cursor } = self.mode
+            && cursor < self.notes.len()
+        {
+            self.notes.remove(cursor);
+            self.revision += 1;
+            let new_len = self.notes.len();
+            self.mode = ReviewMode::List {
+                cursor: cursor.min(new_len.saturating_sub(1)),
+            };
+        }
+        self
+    }
+
+    /// Opens the export menu (`x` from the notes list) — a no-op outside
+    /// [`ReviewMode::List`].
+    pub fn open_export_menu(mut self) -> Self {
+        if matches!(self.mode, ReviewMode::List { .. }) {
+            self.mode = ReviewMode::ExportMenu { cursor: 0 };
+        }
+        self
+    }
+
+    /// Confirms the export menu's highlighted entry: [`ExportMenuEntry::Github`]
+    /// (only ever selectable when `sink_a_available`, i.e. a [`PrContext`]
+    /// exists — ADR 0048's "sink A is simply absent, never disabled" rule)
+    /// opens [`ReviewMode::VerdictMenu`] next; [`ExportMenuEntry::Clipboard`]
+    /// sets [`ExportRequest::Clipboard`] as the pending export and returns
+    /// to [`ReviewMode::Idle`]. A no-op outside [`ReviewMode::ExportMenu`].
+    pub fn confirm_export(mut self, sink_a_available: bool) -> Self {
+        if let ReviewMode::ExportMenu { cursor } = self.mode {
+            let entries = export_menu_entries(sink_a_available);
+            match entries.get(cursor) {
+                Some(ExportMenuEntry::Github) => {
+                    self.mode = ReviewMode::VerdictMenu { cursor: 0 };
+                }
+                Some(ExportMenuEntry::Clipboard) => {
+                    self.pending_export = Some(ExportRequest::Clipboard);
+                    self.mode = ReviewMode::Idle;
+                }
+                None => {
+                    self.mode = ReviewMode::Idle;
+                }
+            }
+        }
+        self
+    }
+
+    /// Confirms the verdict menu's highlighted entry, setting
+    /// [`ExportRequest::GithubReview`] as the pending export and returning
+    /// to [`ReviewMode::Idle`]. A no-op outside [`ReviewMode::VerdictMenu`].
+    pub fn confirm_verdict(mut self) -> Self {
+        if let ReviewMode::VerdictMenu { cursor } = self.mode
+            && let Some(&verdict) = VERDICT_ENTRIES.get(cursor)
+        {
+            self.pending_export = Some(ExportRequest::GithubReview(verdict));
+            self.mode = ReviewMode::Idle;
+        }
+        self
+    }
+
+    /// Takes the pending export request, if any, leaving `None` behind —
+    /// `crate::lib::run_app` calls this once per handled key to decide
+    /// whether to perform an export this iteration.
+    pub fn take_pending_export(&mut self) -> Option<ExportRequest> {
+        self.pending_export.take()
+    }
+
+    /// Sets the status message shown in the notes-list overlay (an export
+    /// result, success or failure) — called by `crate::lib::run_app` after
+    /// performing an export.
+    pub fn set_status(mut self, message: impl Into<String>) -> Self {
+        self.last_status = Some(message.into());
+        self
+    }
+}
+
+/// The export menu's entries given whether sink A is available — extracted
+/// so [`ReviewState::confirm_export`]/[`ReviewState::list_down`] share one
+/// definition of "what's on the menu, in what order".
+fn export_menu_entries(sink_a_available: bool) -> Vec<ExportMenuEntry> {
+    let mut entries = Vec::new();
+    if sink_a_available {
+        entries.push(ExportMenuEntry::Github);
+    }
+    entries.push(ExportMenuEntry::Clipboard);
+    entries
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/rinkaku-tui/src/review/ports.rs
+++ b/rinkaku-tui/src/review/ports.rs
@@ -1,0 +1,31 @@
+//! Side-effect ports for review-notes export (ADR 0048's Output boundary
+//! decision): `review` returns only plain data, never calling `gh` or
+//! touching the clipboard itself — every side effect sits behind one of
+//! these traits, defined here (the consumer side, per this project's
+//! CLAUDE.md "ports as traits, defined where consumed" principle) and
+//! implemented by the `rinkaku` binary crate's composition root
+//! (`main.rs`).
+
+use super::{PrContext, RenderedComment, Verdict};
+
+/// Posts a batch of review comments as one GitHub PR review (ADR 0048 sink
+/// A) — the pending-review shape (open, attach comments, submit with a
+/// verdict) rather than one call per comment, so the reviewer can discard
+/// the whole batch by never confirming the verdict menu.
+pub trait ReviewSubmitter {
+    fn submit_review(
+        &self,
+        ctx: &PrContext,
+        verdict: Verdict,
+        summary: &str,
+        comments: &[RenderedComment],
+    ) -> Result<(), String>;
+}
+
+/// Writes `text` to the system clipboard (ADR 0048 sink B), best-effort —
+/// see the ADR's Alternatives on why this is OSC 52 rather than a
+/// clipboard crate, and why a successful `Ok(())` here does not guarantee
+/// the terminal actually populated the clipboard.
+pub trait ClipboardSink {
+    fn copy(&self, text: &str) -> Result<(), String>;
+}

--- a/rinkaku-tui/src/review/ports.rs
+++ b/rinkaku-tui/src/review/ports.rs
@@ -22,10 +22,11 @@ pub trait ReviewSubmitter {
     ) -> Result<(), String>;
 }
 
-/// Writes `text` to the system clipboard (ADR 0048 sink B), best-effort —
-/// see the ADR's Alternatives on why this is OSC 52 rather than a
-/// clipboard crate, and why a successful `Ok(())` here does not guarantee
-/// the terminal actually populated the clipboard.
+/// Writes `text` to the system clipboard (ADR 0048 sink B), best-effort.
+/// `Ok` carries the status line shown to the reviewer: only the
+/// implementation knows which backend performed the copy and whether
+/// success is actually verifiable (e.g. an OSC 52 write cannot be), so the
+/// caveat wording lives with the implementation, not here.
 pub trait ClipboardSink {
-    fn copy(&self, text: &str) -> Result<(), String>;
+    fn copy(&self, text: &str) -> Result<String, String>;
 }

--- a/rinkaku-tui/src/review/render.rs
+++ b/rinkaku-tui/src/review/render.rs
@@ -20,6 +20,10 @@ pub fn render_review_comments(notes: &[Note]) -> Vec<RenderedComment> {
     notes
         .iter()
         .map(|note| {
+            // The `(1, 1)` fallback is reachable only if rinkaku-core's
+            // changed-range computation and this crate's own hunk parser
+            // ever disagree about what counts as changed; GitHub's review
+            // API may then reject the comment with a 422.
             let (start, end) = note
                 .location
                 .anchor

--- a/rinkaku-tui/src/review/render.rs
+++ b/rinkaku-tui/src/review/render.rs
@@ -1,0 +1,83 @@
+//! Per-sink rendering (ADR 0048's "destination-specific formatting is each
+//! sink's own responsibility" decision): pure functions turning the same
+//! audience-neutral `Vec<Note>` into sink A's human-addressed review
+//! comments ([`render_review_comments`]) or sink B's AI-addressed Markdown
+//! packet ([`render_agent_packet`]).
+
+use super::{Note, RenderedComment};
+
+/// Renders `notes` into sink A's [`RenderedComment`]s (ADR 0048): one per
+/// note, in order. `line` is the note's anchor end (the last line of the
+/// first hunk-intersecting contiguous run — see [`super::NoteLocation::anchor`]),
+/// falling back to the symbol's own range end, then to line 1, so every
+/// note still produces a postable comment even when neither `anchor` nor
+/// `range` resolved (a non-symbol location, out of v1's scope per the
+/// module doc comment, but handled defensively rather than dropped).
+/// `start_line` is set only when the anchor spans more than one line —
+/// GitHub's multi-line comment API distinguishes a single-line comment
+/// (`start_line` omitted) from a range comment.
+pub fn render_review_comments(notes: &[Note]) -> Vec<RenderedComment> {
+    notes
+        .iter()
+        .map(|note| {
+            let (start, end) = note
+                .location
+                .anchor
+                .or(note.location.range)
+                .unwrap_or((1, 1));
+            RenderedComment {
+                path: note.location.path.clone(),
+                line: end,
+                start_line: (start != end).then_some(start),
+                body: note.body.clone(),
+            }
+        })
+        .collect()
+}
+
+/// Renders `notes` into sink B's AI-addressed Markdown packet (ADR 0048):
+/// a request line followed by one section per note — its location heading,
+/// the originating symbol's signature (when the note carries one) as a
+/// fenced code block, then the note's own body verbatim.
+pub fn render_agent_packet(notes: &[Note]) -> String {
+    let mut packet =
+        String::from("# Review notes\n\nAddress each of the following review notes.\n");
+    for note in notes {
+        packet.push('\n');
+        packet.push_str(&format!("## {}\n", note_heading(note)));
+        if let Some(signature) = &note.signature {
+            packet.push_str("```\n");
+            packet.push_str(signature);
+            packet.push('\n');
+            packet.push_str("```\n");
+        }
+        packet.push_str(&note.body);
+        packet.push('\n');
+    }
+    packet
+}
+
+/// The `## {path}:{start}-{end} {symbol_name}` heading for one note in
+/// [`render_agent_packet`]'s output — extracted so the "which range, which
+/// name" formatting logic is unit-testable independent of the surrounding
+/// packet assembly.
+fn note_heading(note: &Note) -> String {
+    let location = &note.location;
+    let range = location.anchor.or(location.range).map(|(start, end)| {
+        if start == end {
+            format!("{start}")
+        } else {
+            format!("{start}-{end}")
+        }
+    });
+    match (range, &location.symbol_name) {
+        (Some(range), Some(name)) => format!("{}:{range} {name}", location.path),
+        (Some(range), None) => format!("{}:{range}", location.path),
+        (None, Some(name)) => format!("{} {name}", location.path),
+        (None, None) => location.path.clone(),
+    }
+}
+
+#[cfg(test)]
+#[path = "render_tests.rs"]
+mod tests;

--- a/rinkaku-tui/src/review/render_tests.rs
+++ b/rinkaku-tui/src/review/render_tests.rs
@@ -1,0 +1,305 @@
+use super::*;
+use crate::review::NoteLocation;
+
+fn note(location: NoteLocation, body: &str, signature: Option<&str>) -> Note {
+    Note {
+        location,
+        body: body.to_string(),
+        signature: signature.map(str::to_string),
+    }
+}
+
+mod render_review_comments_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_omit_start_line_when_anchor_is_a_single_line() {
+        let notes = vec![note(
+            NoteLocation {
+                path: "src/lib.rs".to_string(),
+                symbol_id: Some("src/lib.rs::foo".to_string()),
+                symbol_name: Some("foo".to_string()),
+                range: Some((10, 20)),
+                anchor: Some((15, 15)),
+            },
+            "please rename this",
+            Some("fn foo()"),
+        )];
+
+        let actual = render_review_comments(&notes);
+
+        assert_eq!(
+            vec![RenderedComment {
+                path: "src/lib.rs".to_string(),
+                line: 15,
+                start_line: None,
+                body: "please rename this".to_string(),
+            }],
+            actual
+        );
+    }
+
+    #[test]
+    fn should_set_start_line_when_anchor_spans_multiple_lines() {
+        let notes = vec![note(
+            NoteLocation {
+                path: "src/lib.rs".to_string(),
+                symbol_id: Some("src/lib.rs::foo".to_string()),
+                symbol_name: Some("foo".to_string()),
+                range: Some((10, 20)),
+                anchor: Some((12, 18)),
+            },
+            "this whole block needs a test",
+            None,
+        )];
+
+        let actual = render_review_comments(&notes);
+
+        assert_eq!(
+            vec![RenderedComment {
+                path: "src/lib.rs".to_string(),
+                line: 18,
+                start_line: Some(12),
+                body: "this whole block needs a test".to_string(),
+            }],
+            actual
+        );
+    }
+
+    #[test]
+    fn should_fall_back_to_range_when_anchor_is_absent() {
+        let notes = vec![note(
+            NoteLocation {
+                path: "src/lib.rs".to_string(),
+                symbol_id: Some("src/lib.rs::foo".to_string()),
+                symbol_name: Some("foo".to_string()),
+                range: Some((5, 9)),
+                anchor: None,
+            },
+            "note without an anchor",
+            None,
+        )];
+
+        let actual = render_review_comments(&notes);
+
+        assert_eq!(
+            vec![RenderedComment {
+                path: "src/lib.rs".to_string(),
+                line: 9,
+                start_line: Some(5),
+                body: "note without an anchor".to_string(),
+            }],
+            actual
+        );
+    }
+
+    #[test]
+    fn should_fall_back_to_line_one_when_neither_anchor_nor_range_is_present() {
+        let notes = vec![note(
+            NoteLocation {
+                path: "src/lib.rs".to_string(),
+                symbol_id: None,
+                symbol_name: None,
+                range: None,
+                anchor: None,
+            },
+            "note on a non-symbol location",
+            None,
+        )];
+
+        let actual = render_review_comments(&notes);
+
+        assert_eq!(
+            vec![RenderedComment {
+                path: "src/lib.rs".to_string(),
+                line: 1,
+                start_line: None,
+                body: "note on a non-symbol location".to_string(),
+            }],
+            actual
+        );
+    }
+
+    #[test]
+    fn should_render_one_comment_per_note_in_order() {
+        let notes = vec![
+            note(
+                NoteLocation {
+                    path: "a.rs".to_string(),
+                    symbol_id: None,
+                    symbol_name: None,
+                    range: None,
+                    anchor: Some((1, 1)),
+                },
+                "first",
+                None,
+            ),
+            note(
+                NoteLocation {
+                    path: "b.rs".to_string(),
+                    symbol_id: None,
+                    symbol_name: None,
+                    range: None,
+                    anchor: Some((2, 2)),
+                },
+                "second",
+                None,
+            ),
+        ];
+
+        let actual = render_review_comments(&notes);
+
+        assert_eq!(
+            vec![
+                RenderedComment {
+                    path: "a.rs".to_string(),
+                    line: 1,
+                    start_line: None,
+                    body: "first".to_string(),
+                },
+                RenderedComment {
+                    path: "b.rs".to_string(),
+                    line: 2,
+                    start_line: None,
+                    body: "second".to_string(),
+                },
+            ],
+            actual
+        );
+    }
+}
+
+mod render_agent_packet_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_render_empty_packet_header_when_there_are_no_notes() {
+        let actual = render_agent_packet(&[]);
+
+        assert_eq!(
+            "# Review notes\n\nAddress each of the following review notes.\n",
+            actual
+        );
+    }
+
+    #[test]
+    fn should_render_heading_signature_and_body_for_a_symbol_note() {
+        let notes = vec![note(
+            NoteLocation {
+                path: "src/lib.rs".to_string(),
+                symbol_id: Some("src/lib.rs::foo".to_string()),
+                symbol_name: Some("foo".to_string()),
+                range: Some((10, 20)),
+                anchor: Some((12, 18)),
+            },
+            "please add a doc comment",
+            Some("fn foo(x: i32) -> i32"),
+        )];
+
+        let actual = render_agent_packet(&notes);
+
+        assert_eq!(
+            "# Review notes\n\n\
+             Address each of the following review notes.\n\n\
+             ## src/lib.rs:12-18 foo\n\
+             ```\n\
+             fn foo(x: i32) -> i32\n\
+             ```\n\
+             please add a doc comment\n",
+            actual
+        );
+    }
+
+    #[test]
+    fn should_render_single_line_range_without_a_dash() {
+        let notes = vec![note(
+            NoteLocation {
+                path: "src/lib.rs".to_string(),
+                symbol_id: Some("src/lib.rs::foo".to_string()),
+                symbol_name: Some("foo".to_string()),
+                range: Some((15, 15)),
+                anchor: Some((15, 15)),
+            },
+            "one-line note",
+            None,
+        )];
+
+        let actual = render_agent_packet(&notes);
+
+        assert_eq!(
+            "# Review notes\n\n\
+             Address each of the following review notes.\n\n\
+             ## src/lib.rs:15 foo\n\
+             one-line note\n",
+            actual
+        );
+    }
+
+    #[test]
+    fn should_render_bare_path_heading_when_location_has_no_range_or_name() {
+        let notes = vec![note(
+            NoteLocation {
+                path: "src/lib.rs".to_string(),
+                symbol_id: None,
+                symbol_name: None,
+                range: None,
+                anchor: None,
+            },
+            "note without location detail",
+            None,
+        )];
+
+        let actual = render_agent_packet(&notes);
+
+        assert_eq!(
+            "# Review notes\n\n\
+             Address each of the following review notes.\n\n\
+             ## src/lib.rs\n\
+             note without location detail\n",
+            actual
+        );
+    }
+
+    #[test]
+    fn should_render_multiple_notes_in_order() {
+        let notes = vec![
+            note(
+                NoteLocation {
+                    path: "a.rs".to_string(),
+                    symbol_id: None,
+                    symbol_name: Some("alpha".to_string()),
+                    range: Some((1, 1)),
+                    anchor: Some((1, 1)),
+                },
+                "first note",
+                None,
+            ),
+            note(
+                NoteLocation {
+                    path: "b.rs".to_string(),
+                    symbol_id: None,
+                    symbol_name: Some("beta".to_string()),
+                    range: Some((2, 2)),
+                    anchor: Some((2, 2)),
+                },
+                "second note",
+                None,
+            ),
+        ];
+
+        let actual = render_agent_packet(&notes);
+
+        assert_eq!(
+            "# Review notes\n\n\
+             Address each of the following review notes.\n\n\
+             ## a.rs:1 alpha\n\
+             first note\n\
+             \n\
+             ## b.rs:2 beta\n\
+             second note\n",
+            actual
+        );
+    }
+}

--- a/rinkaku-tui/src/review/tests.rs
+++ b/rinkaku-tui/src/review/tests.rs
@@ -1,0 +1,393 @@
+use super::*;
+
+fn snapshot(path: &str) -> SelectionSnapshot {
+    SelectionSnapshot {
+        path: path.to_string(),
+        symbol_id: Some(format!("{path}::foo")),
+        symbol_name: Some("foo".to_string()),
+        range: Some((1, 5)),
+        anchor: Some((1, 5)),
+        signature: Some("fn foo()".to_string()),
+    }
+}
+
+mod compose_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_open_compose_mode_with_empty_buffer_when_beginning_compose() {
+        let state = ReviewState::default().begin_compose(snapshot("lib.rs"));
+
+        assert_eq!(
+            &ReviewMode::Compose {
+                snapshot: snapshot("lib.rs"),
+                buffer: String::new(),
+            },
+            state.mode()
+        );
+    }
+
+    #[test]
+    fn should_append_typed_characters_to_the_compose_buffer() {
+        let state = ReviewState::default()
+            .begin_compose(snapshot("lib.rs"))
+            .push_char('h')
+            .push_char('i');
+
+        assert_eq!(
+            &ReviewMode::Compose {
+                snapshot: snapshot("lib.rs"),
+                buffer: "hi".to_string(),
+            },
+            state.mode()
+        );
+    }
+
+    #[test]
+    fn should_remove_last_character_on_backspace() {
+        let state = ReviewState::default()
+            .begin_compose(snapshot("lib.rs"))
+            .push_char('h')
+            .push_char('i')
+            .backspace();
+
+        assert_eq!(
+            &ReviewMode::Compose {
+                snapshot: snapshot("lib.rs"),
+                buffer: "h".to_string(),
+            },
+            state.mode()
+        );
+    }
+
+    #[test]
+    fn should_be_a_no_op_when_backspacing_an_empty_buffer() {
+        let state = ReviewState::default()
+            .begin_compose(snapshot("lib.rs"))
+            .backspace();
+
+        assert_eq!(
+            &ReviewMode::Compose {
+                snapshot: snapshot("lib.rs"),
+                buffer: String::new(),
+            },
+            state.mode()
+        );
+    }
+
+    #[test]
+    fn should_add_a_note_and_return_to_idle_when_confirming_a_non_blank_buffer() {
+        let state = ReviewState::default()
+            .begin_compose(snapshot("lib.rs"))
+            .push_char('h')
+            .push_char('i')
+            .confirm_compose();
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+        assert_eq!(
+            &[Note {
+                location: NoteLocation::from(snapshot("lib.rs")),
+                body: "hi".to_string(),
+                signature: Some("fn foo()".to_string()),
+            }],
+            state.notes()
+        );
+        assert_eq!(1, state.revision());
+    }
+
+    #[test]
+    fn should_not_add_a_note_when_confirming_an_empty_buffer() {
+        let state = ReviewState::default()
+            .begin_compose(snapshot("lib.rs"))
+            .confirm_compose();
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+        assert!(state.notes().is_empty());
+        assert_eq!(0, state.revision());
+    }
+
+    #[test]
+    fn should_not_add_a_note_when_confirming_a_whitespace_only_buffer() {
+        let state = ReviewState::default()
+            .begin_compose(snapshot("lib.rs"))
+            .push_char(' ')
+            .push_char(' ')
+            .confirm_compose();
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+        assert!(state.notes().is_empty());
+        assert_eq!(0, state.revision());
+    }
+
+    #[test]
+    fn should_discard_the_buffer_and_return_to_idle_when_cancelling_compose() {
+        let state = ReviewState::default()
+            .begin_compose(snapshot("lib.rs"))
+            .push_char('h')
+            .cancel_compose();
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+        assert!(state.notes().is_empty());
+        assert_eq!(0, state.revision());
+    }
+
+    #[test]
+    fn should_be_a_no_op_when_confirming_compose_outside_compose_mode() {
+        let state = ReviewState::default().confirm_compose();
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+        assert!(state.notes().is_empty());
+    }
+
+    #[test]
+    fn should_be_a_no_op_when_cancelling_compose_outside_compose_mode() {
+        let state = ReviewState::default().cancel_compose();
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+    }
+}
+
+mod list_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn state_with_two_notes() -> ReviewState {
+        ReviewState::default()
+            .begin_compose(snapshot("a.rs"))
+            .push_char('a')
+            .confirm_compose()
+            .begin_compose(snapshot("b.rs"))
+            .push_char('b')
+            .confirm_compose()
+    }
+
+    #[test]
+    fn should_open_list_mode_with_cursor_on_first_note() {
+        let state = state_with_two_notes().open_list();
+
+        assert_eq!(&ReviewMode::List { cursor: 0 }, state.mode());
+    }
+
+    #[test]
+    fn should_move_list_cursor_down_clamped_to_the_last_note() {
+        let state = state_with_two_notes().open_list().list_down().list_down();
+
+        assert_eq!(&ReviewMode::List { cursor: 1 }, state.mode());
+    }
+
+    #[test]
+    fn should_move_list_cursor_up_clamped_to_zero() {
+        let state = state_with_two_notes().open_list().list_up();
+
+        assert_eq!(&ReviewMode::List { cursor: 0 }, state.mode());
+    }
+
+    #[test]
+    fn should_close_the_list_and_return_to_idle() {
+        let state = state_with_two_notes().open_list().close();
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+    }
+
+    #[test]
+    fn should_delete_the_note_under_the_list_cursor() {
+        let state = state_with_two_notes()
+            .open_list()
+            .list_down()
+            .delete_selected();
+
+        assert_eq!(
+            &[Note {
+                location: NoteLocation::from(snapshot("a.rs")),
+                body: "a".to_string(),
+                signature: Some("fn foo()".to_string()),
+            }],
+            state.notes()
+        );
+        assert_eq!(3, state.revision());
+    }
+
+    #[test]
+    fn should_clamp_list_cursor_after_deleting_the_last_note() {
+        let state = state_with_two_notes()
+            .open_list()
+            .list_down()
+            .delete_selected();
+
+        assert_eq!(&ReviewMode::List { cursor: 0 }, state.mode());
+    }
+
+    #[test]
+    fn should_be_a_no_op_when_deleting_from_an_empty_list() {
+        let state = ReviewState::default().open_list().delete_selected();
+
+        assert_eq!(&ReviewMode::List { cursor: 0 }, state.mode());
+        assert!(state.notes().is_empty());
+        assert_eq!(0, state.revision());
+    }
+}
+
+mod export_menu_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_be_a_no_op_when_opening_export_menu_outside_list_mode() {
+        let state = ReviewState::default().open_export_menu();
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+    }
+
+    #[test]
+    fn should_open_export_menu_from_list_mode() {
+        let state = ReviewState::default().open_list().open_export_menu();
+
+        assert_eq!(&ReviewMode::ExportMenu { cursor: 0 }, state.mode());
+    }
+
+    #[test]
+    fn should_open_verdict_menu_when_confirming_github_entry_with_sink_a_available() {
+        let state = ReviewState::default()
+            .open_list()
+            .open_export_menu()
+            .confirm_export(true);
+
+        assert_eq!(&ReviewMode::VerdictMenu { cursor: 0 }, state.mode());
+    }
+
+    #[test]
+    fn should_set_clipboard_pending_export_when_sink_a_is_unavailable_and_first_entry_is_confirmed()
+    {
+        // With sink A unavailable, the menu's only entry (index 0) is
+        // Clipboard — mirrors the "sink A is absent, not disabled" rule
+        // (ADR 0048): there is no Github entry to skip past.
+        let mut state = ReviewState::default()
+            .open_list()
+            .open_export_menu()
+            .confirm_export(false);
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+        assert_eq!(Some(ExportRequest::Clipboard), state.take_pending_export());
+    }
+
+    #[test]
+    fn should_set_clipboard_pending_export_when_sink_a_is_available_and_second_entry_is_confirmed()
+    {
+        let mut state = ReviewState::default()
+            .open_list()
+            .open_export_menu()
+            .list_down()
+            .confirm_export(true);
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+        assert_eq!(Some(ExportRequest::Clipboard), state.take_pending_export());
+    }
+
+    #[test]
+    fn should_close_menu_without_pending_export_when_cursor_overshoots_available_entries() {
+        // `list_down`'s clamp always assumes both entries exist (module
+        // doc comment on that method) — with sink A unavailable, cursor 1
+        // is out of range for the single-entry menu `confirm_export(false)`
+        // resolves against, so this pins the fallback path stays a no-op
+        // export rather than panicking or misfiring Clipboard.
+        let mut state = ReviewState::default()
+            .open_list()
+            .open_export_menu()
+            .list_down()
+            .confirm_export(false);
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+        assert_eq!(None, state.take_pending_export());
+    }
+
+    #[test]
+    fn should_be_a_no_op_when_confirming_export_outside_export_menu_mode() {
+        let mut state = ReviewState::default().confirm_export(true);
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+        assert_eq!(None, state.take_pending_export());
+    }
+}
+
+mod verdict_menu_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn at_verdict_menu() -> ReviewState {
+        ReviewState::default()
+            .open_list()
+            .open_export_menu()
+            .confirm_export(true)
+    }
+
+    #[test]
+    fn should_set_approve_pending_export_when_confirming_first_entry() {
+        let mut state = at_verdict_menu().confirm_verdict();
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+        assert_eq!(
+            Some(ExportRequest::GithubReview(Verdict::Approve)),
+            state.take_pending_export()
+        );
+    }
+
+    #[test]
+    fn should_set_request_changes_pending_export_when_confirming_second_entry() {
+        let mut state = at_verdict_menu().list_down().confirm_verdict();
+
+        assert_eq!(
+            Some(ExportRequest::GithubReview(Verdict::RequestChanges)),
+            state.take_pending_export()
+        );
+    }
+
+    #[test]
+    fn should_set_comment_pending_export_when_confirming_third_entry() {
+        let mut state = at_verdict_menu().list_down().list_down().confirm_verdict();
+
+        assert_eq!(
+            Some(ExportRequest::GithubReview(Verdict::Comment)),
+            state.take_pending_export()
+        );
+    }
+
+    #[test]
+    fn should_clamp_verdict_cursor_to_the_last_entry() {
+        let state = at_verdict_menu().list_down().list_down().list_down();
+
+        assert_eq!(&ReviewMode::VerdictMenu { cursor: 2 }, state.mode());
+    }
+
+    #[test]
+    fn should_be_a_no_op_when_confirming_verdict_outside_verdict_menu_mode() {
+        let mut state = ReviewState::default().confirm_verdict();
+
+        assert_eq!(&ReviewMode::Idle, state.mode());
+        assert_eq!(None, state.take_pending_export());
+    }
+}
+
+mod status_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_store_the_status_message() {
+        let state = ReviewState::default().set_status("posted review");
+
+        assert_eq!(Some("posted review"), state.last_status());
+    }
+}
+
+mod revision_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_not_change_revision_when_opening_or_closing_overlays() {
+        let state = ReviewState::default().open_list().close().open_list();
+
+        assert_eq!(0, state.revision());
+    }
+}

--- a/rinkaku-tui/src/review_flow.rs
+++ b/rinkaku-tui/src/review_flow.rs
@@ -101,47 +101,11 @@ pub(crate) fn perform_export(
         }
         review::ExportRequest::Clipboard => {
             let packet = review::render_agent_packet(review.notes());
-            let result = ports.clipboard.copy(&packet);
-            let status = clipboard_export_status(&packet, result);
-            review.set_status(status)
-        }
-    }
-}
-
-/// A conservative guard on the OSC 52 packet's *raw* byte length (ADR
-/// 0048), below common terminal-side payload caps (~100KB is a frequently
-/// cited limit, e.g. iTerm2/xterm.js) even after base64 inflates the wire
-/// payload to ~4/3 of this — terminals that enforce such a cap tend to
-/// silently drop or truncate an oversized OSC 52 sequence rather than
-/// erroring, so `Osc52Clipboard::copy`-equivalent ports (`rinkaku`'s own
-/// `Osc52Clipboard`) have no way to detect the failure themselves; this
-/// guard exists purely to warn the reviewer before that silent failure
-/// bites them.
-pub(crate) const OSC52_SIZE_GUARD_BYTES: usize = 48 * 1024;
-
-/// Folds sink B's [`review::ports::ClipboardSink::copy`] result into a
-/// status message: the port's own error message on `Err`, otherwise a
-/// plain success note — or, when `packet` exceeds
-/// [`OSC52_SIZE_GUARD_BYTES`], the same success note plus a warning that
-/// the terminal may have silently dropped or truncated it, with a manual-
-/// copy fallback suggestion. The copy itself already happened by the time
-/// this runs; the guard only changes the *message*, never whether the copy
-/// is attempted.
-pub(crate) fn clipboard_export_status(packet: &str, result: Result<(), String>) -> String {
-    match result {
-        Ok(()) => {
-            let base = "copied review notes to clipboard via OSC 52 (terminal support required)";
-            if packet.len() > OSC52_SIZE_GUARD_BYTES {
-                format!(
-                    "{base} — packet is {} bytes, which may exceed the terminal's OSC 52 limit; \
-                     copy manually if the paste looks truncated",
-                    packet.len()
-                )
-            } else {
-                base.to_string()
+            match ports.clipboard.copy(&packet) {
+                Ok(status) => review.set_status(status),
+                Err(message) => review.set_status(format!("error copying to clipboard: {message}")),
             }
         }
-        Err(message) => format!("error copying to clipboard: {message}"),
     }
 }
 

--- a/rinkaku-tui/src/review_flow.rs
+++ b/rinkaku-tui/src/review_flow.rs
@@ -1,0 +1,230 @@
+//! ADR 0048 review-notes integration glue (split out of `lib.rs`, which had
+//! grown past the file-size threshold, ADR 0028): the pieces of
+//! `crate::run_app`'s event loop that are specifically about composing,
+//! exporting, and caching review notes, as opposed to the loop's general
+//! dispatch machinery (`dispatch_non_source_key`, the diff-pane/blast-radius
+//! recompute gates, etc., which stay in `lib.rs`). Every function here is
+//! pure or, for [`perform_export`], calls out to a port passed in by the
+//! caller — none of them touch a live `ratatui::DefaultTerminal` directly,
+//! which is what makes them unit-testable in isolation from `run_app`
+//! itself.
+
+use crate::app::{App, InputKey, Screen};
+use crate::{ReviewPorts, diff_view, review};
+use rinkaku_core::render::Report;
+
+/// Applies [`InputKey::NoteCompose`] given the [`review::SelectionSnapshot`]
+/// `crate::run_app` already derived from the cursor (that derivation needs
+/// `report`/the parsed diff hunks, which `App::handle_key` has no access
+/// to — `InputKey::NoteCompose`'s own doc comment). Always routes through
+/// `App::handle_key` first, even on a `None` snapshot (cursor not on a
+/// present symbol row, or on the source screen): `handle_key`'s own
+/// `NoteCompose` match arm is a no-op stub, but what matters is its
+/// unconditional `pending_prefix` clear at the top of the function — the
+/// same "call `handle_key` for its clear even when its own arm does
+/// nothing" contract `crate::dispatch_non_source_key`'s `GotoDefinition`/
+/// `GotoReferences` arm documents for itself. A `Some` snapshot opens the
+/// compose overlay after that call; `None` leaves `review` untouched.
+pub(crate) fn dispatch_note_compose_key(
+    app: App,
+    snapshot: Option<review::SelectionSnapshot>,
+) -> App {
+    let app = app.handle_key(InputKey::NoteCompose);
+    match snapshot {
+        Some(snapshot) => {
+            let review = app.review().clone().begin_compose(snapshot);
+            app.with_review(review)
+        }
+        None => app,
+    }
+}
+
+/// Whether `crate::run_app`'s event loop should recompute
+/// [`crate::note_markers::NoteMarkers`] this key, mirroring
+/// `crate::should_recompute_blast_radius_selection`'s/
+/// `crate::should_recompute_diff_pane_content`'s own change-gated-cache
+/// contract (ADR 0048's Rendering boundary decision: this derivation must
+/// not run inside `ui::draw`, since that runs on every ~100ms idle poll
+/// tick, not only on a key press). `true` only when `review`'s note set
+/// actually changed since the last recompute — compares `revision` rather
+/// than gating on screen/pane the way the blast-radius/diff-pane gates do,
+/// since note markers are relevant on every row/pane, not just one right
+/// pane's own active mode.
+pub(crate) fn should_recompute_note_markers(app: &App, last_revision: u64) -> bool {
+    app.review().revision() != last_revision
+}
+
+/// The summary line posted alongside every GitHub PR review sink A submits
+/// (ADR 0048) — every review is submitted with the same fixed summary,
+/// since the individual notes themselves carry the substantive content as
+/// inline comments; there is no per-session reviewer-authored summary in
+/// v1.
+const REVIEW_SUMMARY: &str = "Review notes posted via rinkaku.";
+
+/// Performs `export` against the matching port in `ports` (ADR 0048's
+/// Output boundary decision: `review` itself never calls a port, only
+/// `crate::run_app` does, once per handled key that produced a pending
+/// export) and folds the result into `review`'s status message.
+///
+/// [`review::ExportRequest::GithubReview`] is only ever produced by
+/// [`review::ReviewState::confirm_verdict`], reachable only through
+/// [`review::ReviewState::confirm_export`]'s own `sink_a_available`-gated
+/// branch (`App::handle_review_key`'s own `ExportMenu` arm passes
+/// `app.review_sink_a_available`) — so `ports.submitter` being `None` here
+/// would mean that gate was bypassed; handled defensively (a status
+/// message, not a panic) rather than trusted blindly, matching this
+/// crate's existing practice of not trusting an invariant across a module
+/// boundary (e.g. `App::jump_to_symbol`'s own doc comment on the same
+/// judgment call).
+pub(crate) fn perform_export(
+    review: review::ReviewState,
+    ports: &ReviewPorts<'_>,
+    export: review::ExportRequest,
+) -> review::ReviewState {
+    match export {
+        review::ExportRequest::GithubReview(verdict) => {
+            let Some(submitter) = ports.submitter else {
+                return review.set_status("error: no PR context available to post a review");
+            };
+            let Some(pr_context) = &ports.pr_context else {
+                return review.set_status("error: no PR context available to post a review");
+            };
+            let comments = review::render_review_comments(review.notes());
+            match submitter.submit_review(pr_context, verdict, REVIEW_SUMMARY, &comments) {
+                Ok(()) => review.set_status(format!(
+                    "posted {} review comment(s) to PR #{}",
+                    comments.len(),
+                    pr_context.number
+                )),
+                Err(message) => review.set_status(format!("error posting review: {message}")),
+            }
+        }
+        review::ExportRequest::Clipboard => {
+            let packet = review::render_agent_packet(review.notes());
+            let result = ports.clipboard.copy(&packet);
+            let status = clipboard_export_status(&packet, result);
+            review.set_status(status)
+        }
+    }
+}
+
+/// A conservative guard on the OSC 52 packet's *raw* byte length (ADR
+/// 0048), below common terminal-side payload caps (~100KB is a frequently
+/// cited limit, e.g. iTerm2/xterm.js) even after base64 inflates the wire
+/// payload to ~4/3 of this — terminals that enforce such a cap tend to
+/// silently drop or truncate an oversized OSC 52 sequence rather than
+/// erroring, so `Osc52Clipboard::copy`-equivalent ports (`rinkaku`'s own
+/// `Osc52Clipboard`) have no way to detect the failure themselves; this
+/// guard exists purely to warn the reviewer before that silent failure
+/// bites them.
+pub(crate) const OSC52_SIZE_GUARD_BYTES: usize = 48 * 1024;
+
+/// Folds sink B's [`review::ports::ClipboardSink::copy`] result into a
+/// status message: the port's own error message on `Err`, otherwise a
+/// plain success note — or, when `packet` exceeds
+/// [`OSC52_SIZE_GUARD_BYTES`], the same success note plus a warning that
+/// the terminal may have silently dropped or truncated it, with a manual-
+/// copy fallback suggestion. The copy itself already happened by the time
+/// this runs; the guard only changes the *message*, never whether the copy
+/// is attempted.
+pub(crate) fn clipboard_export_status(packet: &str, result: Result<(), String>) -> String {
+    match result {
+        Ok(()) => {
+            let base = "copied review notes to clipboard via OSC 52 (terminal support required)";
+            if packet.len() > OSC52_SIZE_GUARD_BYTES {
+                format!(
+                    "{base} — packet is {} bytes, which may exceed the terminal's OSC 52 limit; \
+                     copy manually if the paste looks truncated",
+                    packet.len()
+                )
+            } else {
+                base.to_string()
+            }
+        }
+        Err(message) => format!("error copying to clipboard: {message}"),
+    }
+}
+
+/// Derives a [`review::SelectionSnapshot`] from whatever the tree cursor
+/// currently points at (ADR 0048's Input boundary decision) — the sole
+/// channel by which `review` learns what the reviewer is annotating.
+/// `crate::run_app` calls this when [`InputKey::NoteCompose`] is pressed,
+/// since `App::handle_key` itself has no access to `report`/the parsed diff
+/// hunks (mirroring `InputKey::Source`'s own "IO/derivation stays outside
+/// `App`" precedent).
+///
+/// `None` on [`Screen::Source`] (composing against a source-view line is
+/// out of v1's scope) and on any row that is not a present symbol
+/// (`app::NodeKind::Dir`/`File`/`Section`/`TestGroup`, or a removed
+/// symbol) — v1 only supports symbol-anchored notes (module doc comment on
+/// `crate::review`), matching `App::selected_symbol_id`'s own row-kind
+/// scoping.
+///
+/// The anchor is the first contiguous new-side run where the symbol's own
+/// range intersects a diff hunk touching `path` — GitHub's review API only
+/// accepts inline comments on lines that are part of the PR's diff, so
+/// this is what [`review::render_review_comments`] posts against. `None`
+/// when no hunk intersects the symbol's range at all (e.g. the symbol
+/// itself is unchanged but was pulled into view via dependency
+/// expansion) — the note still gets a location (`range`), just no
+/// GitHub-postable anchor; [`review::render_review_comments`] falls back
+/// to `range` in that case.
+pub(crate) fn derive_selection_snapshot(
+    app: &App,
+    report: &Report,
+    diff_files: &[diff_view::FileHunks],
+) -> Option<review::SelectionSnapshot> {
+    if !matches!(app.screen(), Screen::Entry) {
+        return None;
+    }
+    let symbol_id = app.selected_symbol_id()?;
+    let (path, symbol) = report.files.iter().find_map(|file| {
+        file.symbols
+            .iter()
+            .find(|s| s.id == symbol_id)
+            .map(|s| (file.path.as_str(), s))
+    })?;
+    let range = (symbol.range.start, symbol.range.end);
+    let anchor = diff_view::file_hunks(diff_files, path)
+        .and_then(|file_hunks| first_anchor_run(file_hunks, range));
+
+    Some(review::SelectionSnapshot {
+        path: path.to_string(),
+        symbol_id: Some(symbol.id.clone()),
+        symbol_name: Some(symbol.name.clone()),
+        range: Some(range),
+        anchor,
+        signature: Some(symbol.signature.clone()),
+    })
+}
+
+/// The first contiguous new-side line run where `range` (a symbol's own
+/// 1-based inclusive line range) intersects one of `file_hunks`' hunks —
+/// [`derive_selection_snapshot`]'s own anchor computation, extracted as a
+/// pure function so the "first run" rule is unit-testable in isolation
+/// from `Report`/`App`.
+///
+/// Hunks are walked in file order (already the order `diff_view::parse_diff_hunks`
+/// produces them in) and the *first* intersecting hunk's own clamped
+/// overlap with `range` is returned — not the union of every intersecting
+/// hunk — since ADR 0048 asks for "the first hunk-intersecting contiguous
+/// run", not the full set (a symbol whose range spans several
+/// non-adjacent hunks has no single contiguous GitHub-postable range
+/// anyway; the first run is a deliberately simple v1 choice, not an
+/// attempt at completeness).
+pub(crate) fn first_anchor_run(
+    file_hunks: &diff_view::FileHunks,
+    range: (usize, usize),
+) -> Option<(usize, usize)> {
+    let (range_start, range_end) = range;
+    file_hunks
+        .hunks
+        .iter()
+        .filter_map(|hunk| hunk.new_range)
+        .filter(|&(hunk_start, hunk_end)| hunk_start <= hunk_end)
+        .find_map(|(hunk_start, hunk_end)| {
+            let start = hunk_start.max(range_start);
+            let end = hunk_end.min(range_end);
+            (start <= end).then_some((start, end))
+        })
+}

--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -44,6 +44,7 @@ pub fn entry_row_line(
     row: &Row<'_>,
     label: &str,
     ranks: &HashMap<String, DirRank>,
+    note_markers: &crate::note_markers::NoteMarkers,
     selected: bool,
 ) -> Line<'static> {
     let indent = " ".repeat(row.depth * INDENT_WIDTH);
@@ -109,6 +110,10 @@ pub fn entry_row_line(
             spans.push(Span::styled(label.to_string(), file_label_style(row.node)));
             spans.push(Span::raw(" "));
             push_badge_spans(&mut spans, &row.node.badges, BadgeContext::File);
+            push_note_badge_span(
+                &mut spans,
+                note_markers.file_counts.get(&row.node.path).copied(),
+            );
             // `skip_reason` is mutually exclusive with `test_symbol_count`
             // (`crate::tree::TreeNode::skip_reason`'s own doc comment: a
             // skipped file has no `FileReport`/`TestFileSummary` entry of
@@ -132,6 +137,10 @@ pub fn entry_row_line(
                 symbol_ref.name.clone(),
                 symbol_name_style(symbol_ref),
             ));
+            push_note_badge_span(
+                &mut spans,
+                note_markers.symbol_counts.get(&symbol_ref.id).copied(),
+            );
         }
     }
 
@@ -345,6 +354,24 @@ pub(crate) fn push_badge_spans(
 /// `pub(crate)`: also reused by `crate::ui::overlay`'s Markers legend.
 pub(crate) fn cyan_badge_style() -> Style {
     Style::default().fg(Color::Cyan)
+}
+
+/// Appends an `n:N` badge (ADR 0048) — "this row has N review notes
+/// attached" — in the same cyan-number style [`cyan_badge_style`] already
+/// uses for informational counts (`chg:`/`fan-in:`), a no-op when `count`
+/// is `None` or `0`. Kept as its own function rather than folded into
+/// [`push_badge_spans`]: that function's `Badges` input is baked once at
+/// tree-build time (`crate::tree::build_tree`'s own doc comment), while
+/// note counts change during the session (`crate::note_markers`'s own
+/// module doc comment) — a genuinely different data source, not just a
+/// different badge label.
+fn push_note_badge_span(spans: &mut Vec<Span<'static>>, count: Option<usize>) {
+    let Some(count) = count.filter(|&count| count > 0) else {
+        return;
+    };
+    spans.push(Span::raw(" "));
+    spans.push(Span::raw("n:"));
+    spans.push(Span::styled(count.to_string(), cyan_badge_style()));
 }
 
 /// Style for the `api:`/`warn:` badge numbers (yellow — the "pay

--- a/rinkaku-tui/src/row_view_tests/entry_row_line.rs
+++ b/rinkaku-tui/src/row_view_tests/entry_row_line.rs
@@ -845,3 +845,55 @@ fn should_render_test_group_row_with_singular_count() {
 
     assert_eq!("> 1 test", line_text(&line));
 }
+
+#[test]
+fn should_show_note_badge_on_a_symbol_row_with_a_matching_note_count() {
+    let node = symbol_node("lib.rs", plain_symbol("foo"), Badges::default());
+    let row = Row {
+        node: &node,
+        depth: 0,
+        expanded: false,
+    };
+    let mut note_markers = crate::note_markers::NoteMarkers::default();
+    note_markers
+        .symbol_counts
+        .insert("lib.rs::foo".to_string(), 2);
+
+    let line = entry_row_line(&row, "", &HashMap::new(), &note_markers, false);
+
+    assert_eq!("    fn foo n:2", line_text(&line));
+}
+
+#[test]
+fn should_omit_note_badge_on_a_symbol_row_with_no_matching_note_count() {
+    let node = symbol_node("lib.rs", plain_symbol("foo"), Badges::default());
+    let row = Row {
+        node: &node,
+        depth: 0,
+        expanded: false,
+    };
+    let mut note_markers = crate::note_markers::NoteMarkers::default();
+    note_markers
+        .symbol_counts
+        .insert("lib.rs::bar".to_string(), 1);
+
+    let line = entry_row_line(&row, "", &HashMap::new(), &note_markers, false);
+
+    assert_eq!("    fn foo", line_text(&line));
+}
+
+#[test]
+fn should_show_note_badge_on_a_file_row_with_a_matching_note_count() {
+    let node = file_node("lib.rs", Badges::default());
+    let row = Row {
+        node: &node,
+        depth: 0,
+        expanded: false,
+    };
+    let mut note_markers = crate::note_markers::NoteMarkers::default();
+    note_markers.file_counts.insert("lib.rs".to_string(), 3);
+
+    let line = entry_row_line(&row, "lib.rs", &HashMap::new(), &note_markers, false);
+
+    assert_eq!("  lib.rs  n:3", line_text(&line));
+}

--- a/rinkaku-tui/src/row_view_tests/entry_row_line.rs
+++ b/rinkaku-tui/src/row_view_tests/entry_row_line.rs
@@ -9,7 +9,13 @@ fn should_render_plain_text_for_zero_badges_and_no_classification() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("        fn foo", line_text(&line));
 }
@@ -43,7 +49,13 @@ fn should_include_badge_labels_for_nonzero_badges_on_a_dir_row() {
         expanded: true,
     };
 
-    let line = entry_row_line(&row, "src", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("v src chg:2 api:1 fan-in:1", line_text(&line));
 }
@@ -57,7 +69,13 @@ fn should_omit_zero_badges_entirely() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "lib.rs",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  lib.rs ", line_text(&line));
 }
@@ -71,7 +89,13 @@ fn should_append_skip_reason_for_a_skipped_file_row() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "assets/logo.png", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "assets/logo.png",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  assets/logo.png  (skipped: binary)", line_text(&line));
 }
@@ -85,7 +109,13 @@ fn should_dim_label_for_a_skipped_file_row() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "assets/logo.png", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "assets/logo.png",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     // The label span is the third span: indent, expand marker, label.
     assert_eq!(Some(Color::DarkGray), line.spans[2].style.fg);
@@ -100,7 +130,13 @@ fn should_not_append_skip_reason_for_an_ordinary_file_row() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "lib.rs",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert!(!line_text(&line).contains("skipped"));
 }
@@ -119,7 +155,13 @@ fn should_prepend_test_badge_with_plural_symbols_noun_before_a_whole_test_file_l
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "src/lib_test.go", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src/lib_test.go",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  [test] (3 symbols) src/lib_test.go ", line_text(&line));
 }
@@ -133,7 +175,13 @@ fn should_prepend_test_badge_with_singular_symbol_noun_when_count_is_one() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "src/lib_test.go", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src/lib_test.go",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  [test] (1 symbol) src/lib_test.go ", line_text(&line));
 }
@@ -151,7 +199,13 @@ fn should_show_collapse_marker_when_dir_is_not_expanded() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "src", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("> src ", line_text(&line));
 }
@@ -179,7 +233,13 @@ fn should_render_section_row_with_its_fixed_label_and_badges() {
         expanded: true,
     };
 
-    let line = entry_row_line(&row, "ignored-label", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "ignored-label",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("v Tests chg:5", line_text(&line));
 }
@@ -197,7 +257,13 @@ fn should_show_collapse_marker_for_a_collapsed_section_row() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "ignored-label", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "ignored-label",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("> Tests ", line_text(&line));
 }
@@ -223,7 +289,13 @@ fn should_never_show_cycle_marker_on_a_section_row_even_if_ranks_has_a_stray_ent
         },
     );
 
-    let line = entry_row_line(&row, "ignored-label", &ranks, false);
+    let line = entry_row_line(
+        &row,
+        "ignored-label",
+        &ranks,
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  Tests ", line_text(&line));
 }
@@ -245,7 +317,13 @@ fn should_append_cycle_marker_when_dir_path_is_in_cycle() {
         },
     );
 
-    let line = entry_row_line(&row, "src", &ranks, false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &ranks,
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  src  (cycle)", line_text(&line));
 }
@@ -267,7 +345,13 @@ fn should_not_append_cycle_marker_when_dir_path_is_not_in_cycle() {
         },
     );
 
-    let line = entry_row_line(&row, "src", &ranks, false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &ranks,
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  src ", line_text(&line));
 }
@@ -285,7 +369,13 @@ fn should_mark_added_symbol_with_plus() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  + fn new_fn", line_text(&line));
 }
@@ -303,7 +393,13 @@ fn should_mark_signature_changed_symbol_with_tilde() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  ~ fn changed_fn", line_text(&line));
 }
@@ -321,7 +417,13 @@ fn should_mark_removed_symbol_with_x() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  x fn gone_fn", line_text(&line));
 }
@@ -346,7 +448,13 @@ fn should_dim_name_and_omit_test_badge_for_a_test_symbol_in_a_mixed_file() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("    fn test_it", line_text(&line));
     assert_eq!(
@@ -364,7 +472,13 @@ fn should_not_append_test_badge_for_an_ordinary_non_test_symbol() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("    fn foo", line_text(&line));
 }
@@ -378,7 +492,13 @@ fn should_apply_reversed_modifier_when_row_is_selected() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "lib.rs", &HashMap::new(), true);
+    let line = entry_row_line(
+        &row,
+        "lib.rs",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        true,
+    );
 
     assert!(line.style.add_modifier.contains(Modifier::REVERSED));
 }
@@ -392,7 +512,13 @@ fn should_not_apply_reversed_modifier_when_row_is_not_selected() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "lib.rs",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert!(!line.style.add_modifier.contains(Modifier::REVERSED));
 }
@@ -406,7 +532,13 @@ fn should_indent_by_depth_times_indent_width() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "lib.rs",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("        lib.rs ", line_text(&line));
 }
@@ -433,7 +565,13 @@ fn should_prepend_risk_marker_for_a_high_risk_dir_row() {
         expanded: true,
     };
 
-    let line = entry_row_line(&row, "src", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("v ! src api:1 fan-in:2", line_text(&line));
     assert_eq!(Some(Color::Red), fg_of_span_with_content(&line, "!"));
@@ -456,7 +594,13 @@ fn should_omit_risk_marker_when_contract_changes_is_zero() {
         expanded: true,
     };
 
-    let line = entry_row_line(&row, "src", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("v src fan-in:5", line_text(&line));
 }
@@ -478,7 +622,13 @@ fn should_omit_risk_marker_when_fan_in_is_below_threshold() {
         expanded: true,
     };
 
-    let line = entry_row_line(&row, "src", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("v src api:1 fan-in:1", line_text(&line));
 }
@@ -499,7 +649,13 @@ fn should_prepend_risk_marker_for_a_high_risk_file_row() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "lib.rs",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  ! lib.rs api:1 fan-in:2", line_text(&line));
 }
@@ -524,7 +680,13 @@ fn should_prepend_risk_marker_for_a_high_risk_signature_changed_symbol() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  ~ fn ! risky_fn", line_text(&line));
 }
@@ -549,7 +711,13 @@ fn should_omit_risk_marker_for_a_signature_changed_symbol_below_fan_in_threshold
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  ~ fn changed_fn", line_text(&line));
 }
@@ -571,7 +739,13 @@ fn should_dim_name_for_a_body_only_symbol() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!(
         Some(Color::DarkGray),
@@ -592,7 +766,13 @@ fn should_not_dim_name_for_an_added_symbol() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!(None, fg_of_span_with_content(&line, "new_fn"));
 }
@@ -620,7 +800,13 @@ fn should_render_test_group_row_with_plural_count() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "ignored-label", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "ignored-label",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("> 3 tests", line_text(&line));
     assert_eq!(
@@ -649,7 +835,13 @@ fn should_render_test_group_row_with_singular_count() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "ignored-label", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "ignored-label",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("> 1 test", line_text(&line));
 }

--- a/rinkaku-tui/src/row_view_tests/file_size_badges.rs
+++ b/rinkaku-tui/src/row_view_tests/file_size_badges.rs
@@ -20,7 +20,13 @@ fn should_render_lines_count_unstyled_when_file_has_normal_band() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "small.rs", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "small.rs",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  small.rs lines:80", line_text(&line));
     assert_eq!(None, fg_of_span_with_content(&line, "80"));
@@ -46,7 +52,13 @@ fn should_render_lines_count_in_yellow_when_file_has_watch_band() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "mid.rs", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "mid.rs",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  mid.rs lines:700", line_text(&line));
     assert_eq!(Some(Color::Yellow), fg_of_span_with_content(&line, "700"));
@@ -72,7 +84,13 @@ fn should_render_lines_count_in_red_when_file_has_warn_band() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "big.rs", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "big.rs",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  big.rs lines:1734", line_text(&line));
     assert_eq!(Some(Color::Red), fg_of_span_with_content(&line, "1734"));
@@ -99,7 +117,13 @@ fn should_render_lines_count_in_bold_red_when_file_has_split_band() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "huge.rs", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "huge.rs",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("  huge.rs lines:4837", line_text(&line));
     assert_eq!(Some(Color::Red), fg_of_span_with_content(&line, "4837"));
@@ -128,7 +152,13 @@ fn should_render_warn_and_split_labels_side_by_side_on_dir_row() {
         expanded: true,
     };
 
-    let line = entry_row_line(&row, "src", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("v src warn:2 split:1", line_text(&line));
     assert_eq!(Some(Color::Yellow), fg_of_span_with_content(&line, "2"));
@@ -146,7 +176,13 @@ fn should_not_render_file_size_badge_when_file_node_has_no_band() {
         expanded: false,
     };
 
-    let line = entry_row_line(&row, "lib.rs", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "lib.rs",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     let text = line_text(&line);
     assert!(!text.contains("lines:"));
@@ -171,7 +207,13 @@ fn should_render_only_warn_label_on_dir_row_when_no_split_files() {
         expanded: true,
     };
 
-    let line = entry_row_line(&row, "src", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("v src warn:3", line_text(&line));
 }

--- a/rinkaku-tui/src/row_view_tests/label_badges.rs
+++ b/rinkaku-tui/src/row_view_tests/label_badges.rs
@@ -26,7 +26,13 @@ fn should_color_only_the_number_of_chg_badge_and_leave_label_uncolored() {
         expanded: true,
     };
 
-    let line = entry_row_line(&row, "src", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("v src chg:299", line_text(&line));
     assert_eq!(Some(Color::Cyan), fg_of_span_with_content(&line, "299"));
@@ -49,7 +55,13 @@ fn should_color_only_the_number_of_fan_in_badge_and_leave_label_uncolored() {
         expanded: true,
     };
 
-    let line = entry_row_line(&row, "src", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("v src fan-in:1072", line_text(&line));
     assert_eq!(Some(Color::Cyan), fg_of_span_with_content(&line, "1072"));
@@ -75,7 +87,13 @@ fn should_color_only_the_number_of_api_badge_yellow_and_leave_label_uncolored() 
         expanded: true,
     };
 
-    let line = entry_row_line(&row, "src", &HashMap::new(), false);
+    let line = entry_row_line(
+        &row,
+        "src",
+        &HashMap::new(),
+        &crate::note_markers::NoteMarkers::default(),
+        false,
+    );
 
     assert_eq!("v src api:42", line_text(&line));
     assert_eq!(Some(Color::Yellow), fg_of_span_with_content(&line, "42"));

--- a/rinkaku-tui/src/session.rs
+++ b/rinkaku-tui/src/session.rs
@@ -8,6 +8,7 @@
 //! `translate_key`/`dispatch_non_source_key`/etc. helpers it composes —
 //! only the terminal-lifecycle wrapper around that loop moves here.
 
+use crate::ReviewPorts;
 use crate::run_app;
 use crate::source::{SourceReader, WorkingTreeSourceReader};
 use crate::splash;
@@ -95,6 +96,7 @@ pub fn run(
     diff_text: &str,
     entry_path: Option<&str>,
     repo_root: &std::path::Path,
+    review_ports: ReviewPorts<'_>,
 ) -> std::io::Result<()> {
     TuiSession::init()?.run(
         report,
@@ -102,6 +104,7 @@ pub fn run(
         entry_path,
         repo_root,
         &WorkingTreeSourceReader,
+        review_ports,
     )
 }
 
@@ -189,6 +192,14 @@ impl TuiSession {
     /// `--pr`, for which `main.rs` wires in a `git show`-backed reader so
     /// the source view reflects the PR's head snapshot rather than
     /// whatever happens to be checked out locally.
+    ///
+    /// `pr_context`/`submitter` (ADR 0048) are both `Some`/`None`
+    /// together on [`ReviewPorts`]: `main.rs`'s composition root assembles
+    /// a `PrContext` and wires up a `gh`-backed `ReviewSubmitter` only in
+    /// `--pr` mode, so sink A (posting a GitHub PR review) is simply
+    /// absent from the export menu otherwise, per the ADR's "no implicit
+    /// fallback" decision. `ReviewPorts::clipboard` (sink B) is always
+    /// required — it never depends on a PR.
     pub fn run(
         mut self,
         report: &Report,
@@ -196,6 +207,7 @@ impl TuiSession {
         entry_path: Option<&str>,
         repo_root: &std::path::Path,
         source_reader: &dyn SourceReader,
+        review_ports: ReviewPorts<'_>,
     ) -> std::io::Result<()> {
         let result = run_app(
             &mut self.terminal,
@@ -204,6 +216,7 @@ impl TuiSession {
             entry_path,
             repo_root,
             source_reader,
+            review_ports,
         );
         let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
         ratatui::restore();

--- a/rinkaku-tui/src/ui/blast_radius.rs
+++ b/rinkaku-tui/src/ui/blast_radius.rs
@@ -216,6 +216,7 @@ mod tests {
                     &blast_radius_selection,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -245,6 +246,7 @@ mod tests {
                     &blast_radius_selection,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -289,6 +291,7 @@ mod tests {
                     &blast_radius_selection,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");

--- a/rinkaku-tui/src/ui/detail_pane_tests/content_by_row_kind.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/content_by_row_kind.rs
@@ -34,6 +34,7 @@ fn should_draw_placeholder_message_when_there_are_no_rows_at_all() {
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -81,6 +82,7 @@ fn should_draw_dir_detail_content_when_cursor_is_on_a_directory_row() {
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -133,6 +135,7 @@ fn should_draw_symbols_label_without_changed_wording_when_origin_is_repo_outline
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -167,6 +170,7 @@ fn should_draw_skip_reason_in_detail_pane_when_cursor_is_on_a_skipped_file_row()
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -199,6 +203,7 @@ fn should_draw_test_symbol_count_in_detail_pane_when_cursor_is_on_a_whole_test_f
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -259,6 +264,7 @@ fn should_draw_both_test_note_and_real_symbols_in_detail_pane_when_file_is_mixed
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -291,6 +297,7 @@ fn should_draw_detail_pane_content_when_cursor_is_on_a_symbol_row() {
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/detail_pane_tests/scroll_behavior.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/scroll_behavior.rs
@@ -25,6 +25,7 @@ fn should_show_overflow_indicator_in_detail_pane_title_when_content_exceeds_view
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -57,6 +58,7 @@ fn should_not_show_overflow_indicator_when_content_fits_the_viewport() {
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -91,6 +93,7 @@ fn should_scroll_detail_pane_content_down_when_scroll_down_is_pressed() {
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -131,6 +134,7 @@ fn should_clamp_detail_pane_scroll_at_the_last_page() {
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -172,6 +176,7 @@ fn should_return_the_clamped_scroll_from_draw_when_requested_scroll_overshoots()
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -214,6 +219,7 @@ fn should_reset_scroll_indicator_when_cursor_moves_to_a_different_row() {
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/detail_pane_tests/wrap_reachability.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/wrap_reachability.rs
@@ -57,6 +57,7 @@ fn should_reach_the_last_wrapped_line_of_content_via_scrolling_when_a_logical_li
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -109,6 +110,7 @@ fn should_report_indicator_total_as_wrapped_row_count_not_logical_line_count_whe
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -158,6 +158,7 @@ pub(crate) fn draw_diff_pane(
     report: &Report,
     diff_content: &crate::diff_shape::DiffPaneContent,
     diff_highlights: &[HighlightedFile],
+    note_markers: &crate::note_markers::NoteMarkers,
     area: Rect,
 ) -> Option<usize> {
     use crate::diff_shape::DiffPaneContent;
@@ -208,10 +209,10 @@ pub(crate) fn draw_diff_pane(
     let unified_lines = if render_split {
         Vec::new()
     } else {
-        diff_pane_lines(&sections, true, highlighted_file)
+        diff_pane_lines(&sections, true, highlighted_file, note_markers, path)
     };
     let split_rows = if render_split {
-        diff_pane_split_rows(&sections, true, highlighted_file)
+        diff_pane_split_rows(&sections, true, highlighted_file, note_markers, path)
     } else {
         (Vec::new(), Vec::new())
     };
@@ -325,6 +326,8 @@ pub(crate) fn diff_pane_lines(
     sections: &[&DiffSection],
     show_section_headers: bool,
     highlighted_file: Option<&HighlightedFile>,
+    note_markers: &crate::note_markers::NoteMarkers,
+    path: &str,
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     for (section_index, section) in sections.iter().enumerate() {
@@ -361,6 +364,7 @@ pub(crate) fn diff_pane_lines(
                 highlighted_file,
                 attributed.source_index,
             );
+            let new_side_lines = new_side_line_numbers(&attributed.hunk);
 
             for (line_index, line) in attributed.hunk.lines.iter().enumerate() {
                 // `hunk_highlight` is `Option<&[LineHighlight]>`, and
@@ -373,11 +377,65 @@ pub(crate) fn diff_pane_lines(
                 let token_spans = hunk_highlight
                     .and_then(|lines| lines.get(line_index).cloned())
                     .flatten();
-                lines.push(diff_line(line, token_spans));
+                let has_note = new_side_lines[line_index].is_some_and(|line_no| {
+                    crate::note_markers::line_has_note(note_markers, path, line_no)
+                });
+                lines.push(prefix_note_marker(diff_line(line, token_spans), has_note));
             }
         }
     }
     lines
+}
+
+/// This hunk's own new-side line number for each of `hunk.lines`, `None`
+/// for a pure-`Removed` line (which has no new-side position of its own —
+/// [`crate::diff_view::hunk_intersects`]'s own doc comment on the same
+/// "a removed line is a position, not a range" distinction). Starts
+/// counting from `hunk.new_range`'s own start (already the hunk body's
+/// *actual* new-side extent, not the header's possibly-inaccurate claim —
+/// `Hunk::new_range`'s own doc comment), incrementing once per `Added`/
+/// `Context` line, mirroring how a unified diff's new-side numbering works.
+///
+/// `None` for every line when `hunk.new_range` itself is `None` (an
+/// unreadable header, or new-side start `0` — [`crate::diff_view::Hunk::new_range`]'s
+/// doc comment) — there is no starting point to count from.
+fn new_side_line_numbers(hunk: &crate::diff_view::Hunk) -> Vec<Option<usize>> {
+    let Some((start, _)) = hunk.new_range else {
+        return vec![None; hunk.lines.len()];
+    };
+    let mut next_line = start;
+    hunk.lines
+        .iter()
+        .map(|line| match line.kind {
+            DiffLineKind::Removed => None,
+            DiffLineKind::Added | DiffLineKind::Context => {
+                let current = next_line;
+                next_line += 1;
+                Some(current)
+            }
+        })
+        .collect()
+}
+
+/// Prepends a 1-character note-marker column (ADR 0048) to `line`: a cyan
+/// `*` when `has_note`, a space otherwise — every diff-pane row gets this
+/// column regardless, so the marker's presence/absence never shifts the
+/// rest of the line's own columns out of alignment with its neighbors.
+fn prefix_note_marker(line: Line<'static>, has_note: bool) -> Line<'static> {
+    let marker = if has_note {
+        Span::styled("*", Style::default().fg(Color::Cyan))
+    } else {
+        Span::raw(" ")
+    };
+    let mut spans = vec![marker];
+    spans.extend(line.spans);
+    // `Line::from(spans)` alone would drop `line.style` — the base style
+    // `Line::styled` (e.g. `plain_diff_line`'s single-span Added/Removed
+    // lines) applies at the *line* level, patched onto each span at render
+    // time (`Line::styled_graphemes`), not copied onto the spans
+    // themselves — so this rebuilt `Line` must carry the same base style
+    // forward, or every span here silently loses its foreground/background.
+    Line::from(spans).style(line.style)
 }
 
 /// Split-view (ADR 0044) counterpart of [`diff_pane_lines`]: the same
@@ -401,6 +459,8 @@ pub(crate) fn diff_pane_split_rows(
     sections: &[&DiffSection],
     show_section_headers: bool,
     highlighted_file: Option<&HighlightedFile>,
+    note_markers: &crate::note_markers::NoteMarkers,
+    path: &str,
 ) -> (Vec<Line<'static>>, Vec<Line<'static>>) {
     let mut left = Vec::new();
     let mut right = Vec::new();
@@ -447,17 +507,26 @@ pub(crate) fn diff_pane_split_rows(
                 attributed.source_index,
             );
             let split_rows = crate::diff_shape::pair_hunk_lines(&attributed.hunk.lines);
+            let new_side_lines = new_side_line_numbers(&attributed.hunk);
 
             for split_row in &split_rows {
                 left.push(split_side_line(
                     split_row.left.as_ref(),
                     split_row.left_index,
                     hunk_highlight,
+                    None,
                 ));
+                let right_has_note = split_row
+                    .right_index
+                    .and_then(|index| new_side_lines.get(index).copied().flatten())
+                    .is_some_and(|line_no| {
+                        crate::note_markers::line_has_note(note_markers, path, line_no)
+                    });
                 right.push(split_side_line(
                     split_row.right.as_ref(),
                     split_row.right_index,
                     hunk_highlight,
+                    Some(right_has_note),
                 ));
             }
         }
@@ -471,12 +540,20 @@ pub(crate) fn diff_pane_split_rows(
 /// interleaved `lines`, [`crate::diff_shape::SplitRow::left_index`]/
 /// `right_index`'s own doc comment on why this must be the original index,
 /// not the split row's own position).
+///
+/// `has_note` (ADR 0048) is `Some(bool)` on the new-side (right) call, and
+/// `None` on the old-side (left) call — split view only marks the new
+/// side, matching [`crate::review::NoteLocation`]'s own new-side-only
+/// anchoring; a `Some` value prefixes the 1-column marker, `None` prefixes
+/// nothing at all (the old side keeps its pre-ADR-0048 column layout
+/// unchanged).
 fn split_side_line(
     line: Option<&DiffLine>,
     index: Option<usize>,
     hunk_highlight: Option<&[Option<Vec<TokenSpan>>]>,
+    has_note: Option<bool>,
 ) -> Line<'static> {
-    match (line, index) {
+    let rendered = match (line, index) {
         (Some(line), Some(index)) => {
             let token_spans = hunk_highlight
                 .and_then(|lines| lines.get(index).cloned())
@@ -484,6 +561,10 @@ fn split_side_line(
             diff_line(line, token_spans)
         }
         _ => Line::raw(""),
+    };
+    match has_note {
+        Some(has_note) => prefix_note_marker(rendered, has_note),
+        None => rendered,
     }
 }
 

--- a/rinkaku-tui/src/ui/diff_pane_tests/mod.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/mod.rs
@@ -11,6 +11,9 @@
 //!   default when the toggle was never pressed
 //! - `styling` — token/diff background tint, hunk-header color, and the
 //!   unrecognized-extension style fallback
+//! - `note_markers` — the ADR 0048 `*`-marker column's positive case
+//!   (unified and split), since every other block in this module exercises
+//!   only an empty `NoteMarkers`
 
 use super::*;
 use crate::app::{App, BlastRadiusSelection};
@@ -23,6 +26,7 @@ use rinkaku_core::graph::SymbolGraph;
 use rinkaku_core::render::FileReport;
 
 mod header_lines;
+mod note_markers;
 mod row_kinds;
 mod split_view;
 mod styling;

--- a/rinkaku-tui/src/ui/diff_pane_tests/note_markers.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/note_markers.rs
@@ -36,8 +36,7 @@ fn section_for(diff_text: &str) -> DiffSection {
 fn should_prefix_note_marker_only_on_the_line_inside_the_notes_range_in_unified_view() {
     let section = section_for(DIFF_TEXT);
     let mut note_markers = crate::note_markers::NoteMarkers::default();
-    // New-side line 2 is "+fn foo() {}" (line 1 is context "fn a() {}",
-    // unchanged; line 3 is context "fn b() {}").
+    // New-side line 2 is the added "+fn foo() {}" line in DIFF_TEXT above.
     note_markers
         .line_ranges
         .insert("lib.rs".to_string(), vec![(2, 2)]);

--- a/rinkaku-tui/src/ui/diff_pane_tests/note_markers.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/note_markers.rs
@@ -1,0 +1,88 @@
+//! Positive-case coverage for the ADR 0048 note-marker column: every other
+//! `diff_pane_lines`/`diff_pane_split_rows` test in this module exercises
+//! an empty `NoteMarkers`, which pins only the "no marker drawn" default —
+//! these tests populate `line_ranges` so the `*`-marker/space-alignment
+//! branch itself is actually exercised.
+
+use super::*;
+use crate::diff_shape::{AttributedHunk, DiffSection};
+
+const DIFF_TEXT: &str = "\
+diff --git a/lib.rs b/lib.rs
+index e69de29..4b825dc 100644
+--- a/lib.rs
++++ b/lib.rs
+@@ -1,2 +1,3 @@
+ fn a() {}
++fn foo() {}
+ fn b() {}
+";
+
+fn section_for(diff_text: &str) -> DiffSection {
+    let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+    let hunk = diff_files[0].hunks[0].clone();
+    DiffSection {
+        title: "fn foo()".to_string(),
+        symbol_id: Some("lib.rs::foo".to_string()),
+        contract_header: None,
+        hunks: vec![AttributedHunk {
+            source_index: 0,
+            hunk,
+        }],
+    }
+}
+
+#[test]
+fn should_prefix_note_marker_only_on_the_line_inside_the_notes_range_in_unified_view() {
+    let section = section_for(DIFF_TEXT);
+    let mut note_markers = crate::note_markers::NoteMarkers::default();
+    // New-side line 2 is "+fn foo() {}" (line 1 is context "fn a() {}",
+    // unchanged; line 3 is context "fn b() {}").
+    note_markers
+        .line_ranges
+        .insert("lib.rs".to_string(), vec![(2, 2)]);
+
+    let lines = diff_pane_lines(&[&section], true, None, &note_markers, "lib.rs");
+
+    let rendered: Vec<String> = lines.iter().map(line_text).collect();
+    let marked = rendered
+        .iter()
+        .find(|line| line.contains("fn foo() {}"))
+        .expect("added line present");
+    assert!(marked.starts_with("*"));
+    let unmarked_context = rendered
+        .iter()
+        .find(|line| line.contains("fn b() {}"))
+        .expect("context line present");
+    assert!(unmarked_context.starts_with(" "));
+}
+
+#[test]
+fn should_prefix_note_marker_only_on_the_new_side_in_split_view() {
+    let section = section_for(DIFF_TEXT);
+    let mut note_markers = crate::note_markers::NoteMarkers::default();
+    note_markers
+        .line_ranges
+        .insert("lib.rs".to_string(), vec![(2, 2)]);
+
+    let (left, right) = diff_pane_split_rows(&[&section], true, None, &note_markers, "lib.rs");
+
+    let left_rendered: Vec<String> = left.iter().map(line_text).collect();
+    let right_rendered: Vec<String> = right.iter().map(line_text).collect();
+    let marked_right = right_rendered
+        .iter()
+        .find(|line| line.contains("fn foo() {}"))
+        .expect("added line present on the new side");
+    assert!(marked_right.starts_with("*"));
+    // The old side never carries the marker column at all (ADR 0048:
+    // `NoteLocation`'s anchoring is new-side only) — every left-side line
+    // stays exactly as it would with an empty `NoteMarkers`.
+    assert!(left_rendered.iter().all(|line| !line.starts_with("*")));
+}
+
+fn line_text(line: &ratatui::text::Line<'_>) -> String {
+    line.spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect()
+}

--- a/rinkaku-tui/src/ui/diff_pane_tests/row_kinds.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/row_kinds.rs
@@ -31,6 +31,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -95,6 +96,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -165,6 +167,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -233,6 +236,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -296,6 +300,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
@@ -36,6 +36,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -88,6 +89,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -115,7 +117,13 @@ fn should_pair_old_and_new_signature_on_one_row_when_section_has_a_contract_head
         hunks: vec![],
     };
 
-    let (left, right) = diff_pane_split_rows(&[&section], true, None);
+    let (left, right) = diff_pane_split_rows(
+        &[&section],
+        true,
+        None,
+        &crate::note_markers::NoteMarkers::default(),
+        "lib.rs",
+    );
 
     assert_eq!(
         vec![
@@ -204,6 +212,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -253,6 +262,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
@@ -32,6 +32,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -79,6 +80,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -119,6 +121,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -166,6 +169,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -231,6 +235,7 @@ index e69de29..4b825dc 100644
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/entry.rs
+++ b/rinkaku-tui/src/ui/entry.rs
@@ -32,6 +32,11 @@ use rinkaku_core::render::Report;
 /// of `draw_detail_pane`/`draw_diff_pane`/`draw_blast_radius_pane` ran for
 /// `app.right_pane()` (`render_scrollable_pane`'s doc comment on why
 /// `crate::run_app` needs this).
+// See `crate::ui::draw`'s own `#[allow(clippy::too_many_arguments)]`
+// comment — this function is that one's direct pass-through and shares
+// the identical "each parameter is independently-cached content, not
+// coupled state" reasoning.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn draw_entry_screen(
     frame: &mut Frame,
     app: &App,
@@ -39,6 +44,7 @@ pub(crate) fn draw_entry_screen(
     diff_content: &crate::diff_shape::DiffPaneContent,
     diff_highlights: &[HighlightedFile],
     blast_radius_selection: &BlastRadiusSelection,
+    note_markers: &crate::note_markers::NoteMarkers,
     area: Rect,
 ) -> Option<usize> {
     let [tree_area, right_area] = Layout::horizontal([
@@ -47,7 +53,7 @@ pub(crate) fn draw_entry_screen(
     ])
     .areas(area);
 
-    draw_tree_pane(frame, app, tree_area);
+    draw_tree_pane(frame, app, note_markers, tree_area);
     match app.right_pane() {
         RightPane::Detail => draw_detail_pane(frame, app, report, right_area),
         RightPane::Diff => draw_diff_pane(
@@ -56,6 +62,7 @@ pub(crate) fn draw_entry_screen(
             report,
             diff_content,
             diff_highlights,
+            note_markers,
             right_area,
         ),
         RightPane::BlastRadius => {
@@ -77,7 +84,12 @@ pub(crate) fn draw_entry_screen(
 /// not start/end at the list's own edge — belt and braces with the title
 /// suffix, since the title is easy to miss but the in-pane line sits right
 /// where the reviewer's eye already is.
-pub(crate) fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
+pub(crate) fn draw_tree_pane(
+    frame: &mut Frame,
+    app: &App,
+    note_markers: &crate::note_markers::NoteMarkers,
+    area: Rect,
+) {
     let rows = app.nav().rows(app.tree());
     let labels = relative_labels(&rows);
     let cursor = app.nav().cursor();
@@ -102,7 +114,7 @@ pub(crate) fn draw_tree_pane(frame: &mut Frame, app: &App, area: Rect) {
             .zip(labels[start..end].iter())
             .enumerate()
             .map(|(offset, (row, label))| {
-                entry_row_line(row, label, ranks, start + offset == cursor)
+                entry_row_line(row, label, ranks, note_markers, start + offset == cursor)
             }),
     );
     if let Some(below) = below {
@@ -240,6 +252,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -288,6 +301,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -318,6 +332,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -358,6 +373,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -413,6 +429,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -474,6 +491,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -506,6 +524,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -539,6 +558,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");

--- a/rinkaku-tui/src/ui/mod.rs
+++ b/rinkaku-tui/src/ui/mod.rs
@@ -221,7 +221,7 @@ pub fn draw(
     // popup — `App::handle_key`'s own priority check gives it the highest
     // key-space priority for the identical reason (a reviewer mid-compose
     // must see their own overlay, not have it silently obscured).
-    review_overlay::draw_review_overlay(frame, app.review(), area);
+    review_overlay::draw_review_overlay(frame, app.review(), app.review_sink_a_available(), area);
 
     outcome
 }

--- a/rinkaku-tui/src/ui/mod.rs
+++ b/rinkaku-tui/src/ui/mod.rs
@@ -14,6 +14,7 @@ mod detail_pane;
 mod diff_pane;
 mod entry;
 mod overlay;
+mod review_overlay;
 mod scroll;
 mod source_screen;
 mod status;
@@ -126,9 +127,14 @@ pub struct DrawOutcome {
 /// that already seeds `diff_highlights` above, passed through unchanged so
 /// the source screen can composite it onto the drilled-into symbol's file
 /// as an added/removed overlay.
-// Each parameter is a distinct once-per-session/once-per-key computation a
-// prior ADR deliberately keeps outside this render loop; grouping them into
-// a struct is a bigger refactor than this ADR's own scope.
+// This function's parameter list already sat at clippy's 7-argument
+// threshold before ADR 0046 added `diff_hunks`/ADR 0048 added
+// `note_markers`; every existing parameter is an independently-computed,
+// independently-cached piece of content `crate::run_app` must not
+// recompute inside the draw path (this function's own doc comment), so
+// bundling them into a struct now would only rename the same 9 values one
+// level deeper, not reduce the actual coupling — not worth the churn
+// across this module's own ~50 call sites for a lint threshold.
 #[allow(clippy::too_many_arguments)]
 pub fn draw(
     frame: &mut Frame,
@@ -139,6 +145,7 @@ pub fn draw(
     blast_radius_selection: &BlastRadiusSelection,
     source_content: Option<&Result<HighlightedSourceView, String>>,
     diff_hunks: &[FileHunks],
+    note_markers: &crate::note_markers::NoteMarkers,
 ) -> DrawOutcome {
     let area = frame.area();
     let [body, status_area] =
@@ -153,6 +160,7 @@ pub fn draw(
                 diff_content,
                 diff_highlights,
                 blast_radius_selection,
+                note_markers,
                 body,
             );
             // Right-pane inner height (borders excluded), computed the
@@ -207,6 +215,13 @@ pub fn draw(
     if let Some(popup) = app.jump_popup() {
         draw_jump_popup(frame, popup, area);
     }
+
+    // ADR 0048: the review overlay (compose/list/export/verdict) draws
+    // last, on top of everything above including the help overlay/jump
+    // popup — `App::handle_key`'s own priority check gives it the highest
+    // key-space priority for the identical reason (a reviewer mid-compose
+    // must see their own overlay, not have it silently obscured).
+    review_overlay::draw_review_overlay(frame, app.review(), area);
 
     outcome
 }

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -638,6 +638,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -681,6 +682,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -716,6 +718,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -757,6 +760,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -782,6 +786,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -818,6 +823,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -861,6 +867,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");
@@ -920,6 +927,7 @@ mod tests {
                         &BlastRadiusSelection::NotApplicable,
                         None,
                         &[],
+                        &crate::note_markers::NoteMarkers::default(),
                     );
                 })
                 .expect("draw");
@@ -951,6 +959,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -617,15 +617,15 @@ mod tests {
     fn should_draw_help_overlay_with_keymap_markers_and_glossary_when_help_is_open() {
         let report = report_with_one_symbol();
         let app = App::new(&report).handle_key(crate::app::InputKey::ToggleHelp);
-        // A 150x70 terminal (up from 100x50): wider so the Markers
-        // section's longest explanation line doesn't wrap onto a second
-        // row, taller so the overlay's 80% x 90% area fits every keymap
-        // group, the Markers legend, *and* the trailing Glossary section
-        // without the last section being pushed off the bottom. Grown here
-        // rather than narrowing the content itself, same rationale as the
-        // 100x40 -> 100x50 growth this test already went through for ADR
-        // 0026's keymap additions.
-        let mut terminal = Terminal::new(TestBackend::new(150, 70)).expect("terminal");
+        // A 150x74 terminal (up from 150x70): taller again so the
+        // overlay's 80% x 90% area still fits every keymap group —
+        // now including the "Review" group (ADR 0048) — the Markers
+        // legend, and the trailing Glossary section without the last
+        // section being pushed off the bottom. Grown here rather than
+        // narrowing the content itself, same rationale as the
+        // 100x40 -> 100x50 -> 150x70 growths this test already went
+        // through for ADR 0026's keymap additions.
+        let mut terminal = Terminal::new(TestBackend::new(150, 74)).expect("terminal");
 
         terminal
             .draw(|frame| {

--- a/rinkaku-tui/src/ui/review_overlay.rs
+++ b/rinkaku-tui/src/ui/review_overlay.rs
@@ -1,0 +1,219 @@
+//! Review-notes overlays (ADR 0048): the compose text-input box and the
+//! combined notes-list/export-menu/verdict-menu surface. Follows
+//! `ui::overlay`'s existing `draw_help_overlay`/`draw_jump_popup`
+//! precedent — `Clear` the popup's `Rect`, then render `Paragraph`/`List`
+//! content built from plain data already sitting on [`ReviewState`], fed
+//! in by `crate::ui::draw`.
+
+use super::overlay::centered_rect;
+use crate::review::{ReviewMode, ReviewState, Verdict};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
+
+/// Draws whichever review overlay `review.mode()` currently calls for
+/// (compose, list, export menu, verdict menu), or nothing at all while
+/// [`ReviewMode::Idle`] — the single entry point `crate::ui::draw` calls
+/// unconditionally as its final compositing step.
+pub(crate) fn draw_review_overlay(frame: &mut Frame, review: &ReviewState, full_area: Rect) {
+    match review.mode() {
+        ReviewMode::Idle => {}
+        ReviewMode::Compose { snapshot, buffer } => {
+            draw_compose_overlay(frame, full_area, snapshot, buffer)
+        }
+        ReviewMode::List { cursor } => draw_notes_overlay(frame, review, *cursor, full_area),
+        ReviewMode::ExportMenu { cursor } => {
+            draw_export_menu_overlay(frame, review, *cursor, full_area)
+        }
+        ReviewMode::VerdictMenu { cursor } => draw_verdict_menu_overlay(frame, *cursor, full_area),
+    }
+}
+
+/// The compose overlay: a title naming the selected location, the
+/// in-progress buffer (visually wrapped), and a footer key hint.
+fn draw_compose_overlay(
+    frame: &mut Frame,
+    full_area: Rect,
+    snapshot: &crate::review::SelectionSnapshot,
+    buffer: &str,
+) {
+    let overlay_area = centered_rect(full_area, 70, 50);
+    frame.render_widget(Clear, overlay_area);
+
+    let title = format!(" New note: {} ", compose_title_location(snapshot));
+    let block = Block::bordered().title(title);
+    let mut lines: Vec<Line<'static>> = vec![Line::raw(buffer.to_string())];
+    lines.push(Line::raw(""));
+    lines.push(Line::styled(
+        "Enter: save  Esc: cancel",
+        Style::default().add_modifier(Modifier::DIM),
+    ));
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, overlay_area);
+}
+
+/// The compose overlay's title location text: `"{path}:{start}-{end}
+/// {symbol_name}"`, degrading gracefully when a field is absent — the same
+/// fallback shape `crate::review`'s own note-heading formatting uses (kept
+/// separate rather than shared, since that formats a *note's*
+/// already-resolved anchor/range, while this formats a live
+/// [`crate::review::SelectionSnapshot`] still being composed against).
+fn compose_title_location(snapshot: &crate::review::SelectionSnapshot) -> String {
+    let range = snapshot.anchor.or(snapshot.range).map(|(start, end)| {
+        if start == end {
+            format!("{start}")
+        } else {
+            format!("{start}-{end}")
+        }
+    });
+    match (range, &snapshot.symbol_name) {
+        (Some(range), Some(name)) => format!("{}:{range} {name}", snapshot.path),
+        (Some(range), None) => format!("{}:{range}", snapshot.path),
+        (None, Some(name)) => format!("{} {name}", snapshot.path),
+        (None, None) => snapshot.path.clone(),
+    }
+}
+
+/// The notes-list overlay: every note as `{path}:{anchor} {symbol_name}:
+/// {body's first line}`, the list cursor highlighted, plus a key-hint
+/// footer and (when set) the last export status message.
+fn draw_notes_overlay(frame: &mut Frame, review: &ReviewState, cursor: usize, full_area: Rect) {
+    let overlay_area = centered_rect(full_area, 80, 60);
+    frame.render_widget(Clear, overlay_area);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    if let Some(status) = review.last_status() {
+        lines.push(Line::styled(
+            status.to_string(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ));
+        lines.push(Line::raw(""));
+    }
+    if review.notes().is_empty() {
+        lines.push(Line::styled(
+            "(no notes yet — press n over a symbol to add one)",
+            Style::default().add_modifier(Modifier::DIM),
+        ));
+    }
+    for (index, note) in review.notes().iter().enumerate() {
+        let text = notes_list_entry_text(note);
+        if index == cursor {
+            lines.push(Line::styled(
+                text,
+                Style::default().add_modifier(Modifier::REVERSED),
+            ));
+        } else {
+            lines.push(Line::raw(text));
+        }
+    }
+    lines.push(Line::raw(""));
+    lines.push(Line::styled(
+        "j/k: move  d: delete  x: export  Esc/q: close",
+        Style::default().add_modifier(Modifier::DIM),
+    ));
+
+    let block = Block::bordered().title(" Review notes ");
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, overlay_area);
+}
+
+/// One notes-list row's text: `"{path}:{anchor-or-range} {symbol_name}:
+/// {body's first line}"`, degrading the location half the same way
+/// [`compose_title_location`] does.
+fn notes_list_entry_text(note: &crate::review::Note) -> String {
+    let location = &note.location;
+    let range = location.anchor.or(location.range).map(|(start, end)| {
+        if start == end {
+            format!("{start}")
+        } else {
+            format!("{start}-{end}")
+        }
+    });
+    let location_text = match (range, &location.symbol_name) {
+        (Some(range), Some(name)) => format!("{}:{range} {name}", location.path),
+        (Some(range), None) => format!("{}:{range}", location.path),
+        (None, Some(name)) => format!("{} {name}", location.path),
+        (None, None) => location.path.clone(),
+    };
+    let body_first_line = note.body.lines().next().unwrap_or("");
+    format!("{location_text}: {body_first_line}")
+}
+
+/// The export menu: `GitHub PR review` (only when `review`'s notes list
+/// was opened with sink A available — the caller derives this by simply
+/// not rendering the entry, since [`ReviewState`] itself carries no
+/// `PrContext`) is not distinguishable from here alone, so this draws
+/// both entries unconditionally; `crate::app::App::handle_review_key`'s
+/// own `sink_a_available` gate is what actually prevents selecting a
+/// `Github` entry that isn't really on the menu — see that method's own
+/// doc comment. Kept simple (always two lines) rather than threading
+/// `sink_a_available` through the whole render path for a v1 cosmetic
+/// concern; the reviewer discovers unavailability the moment `Enter`
+/// silently closes the menu instead of opening the verdict menu.
+fn draw_export_menu_overlay(
+    frame: &mut Frame,
+    _review: &ReviewState,
+    cursor: usize,
+    full_area: Rect,
+) {
+    let overlay_area = centered_rect(full_area, 50, 30);
+    frame.render_widget(Clear, overlay_area);
+
+    let entries = ["GitHub PR review", "Clipboard (for an AI agent)"];
+    let lines: Vec<Line<'static>> = entries
+        .iter()
+        .enumerate()
+        .map(|(index, label)| menu_line(label, index == cursor))
+        .collect();
+
+    let block = Block::bordered().title(" Export to (enter: choose, esc: cancel) ");
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, overlay_area);
+}
+
+/// The verdict menu: Approve/Request changes/Comment, mirroring GitHub's
+/// own pending-review submit dialog.
+fn draw_verdict_menu_overlay(frame: &mut Frame, cursor: usize, full_area: Rect) {
+    let overlay_area = centered_rect(full_area, 50, 30);
+    frame.render_widget(Clear, overlay_area);
+
+    let entries = [Verdict::Approve, Verdict::RequestChanges, Verdict::Comment];
+    let lines: Vec<Line<'static>> = entries
+        .iter()
+        .enumerate()
+        .map(|(index, verdict)| menu_line(verdict_label(*verdict), index == cursor))
+        .collect();
+
+    let block = Block::bordered().title(" Submit review as (enter: choose, esc: cancel) ");
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, overlay_area);
+}
+
+fn verdict_label(verdict: Verdict) -> &'static str {
+    match verdict {
+        Verdict::Approve => "Approve",
+        Verdict::RequestChanges => "Request changes",
+        Verdict::Comment => "Comment",
+    }
+}
+
+/// One menu row, highlighted (reversed) when `selected`.
+fn menu_line(label: &str, selected: bool) -> Line<'static> {
+    let span = Span::raw(label.to_string());
+    let line = Line::from(vec![span]);
+    if selected {
+        line.style(Style::default().add_modifier(Modifier::REVERSED))
+    } else {
+        line
+    }
+}
+
+#[cfg(test)]
+#[path = "review_overlay_tests.rs"]
+mod tests;

--- a/rinkaku-tui/src/ui/review_overlay.rs
+++ b/rinkaku-tui/src/ui/review_overlay.rs
@@ -6,7 +6,7 @@
 //! in by `crate::ui::draw`.
 
 use super::overlay::centered_rect;
-use crate::review::{ReviewMode, ReviewState, Verdict};
+use crate::review::{ReviewMode, ReviewState, Verdict, export_menu_entries};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
@@ -16,8 +16,16 @@ use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 /// Draws whichever review overlay `review.mode()` currently calls for
 /// (compose, list, export menu, verdict menu), or nothing at all while
 /// [`ReviewMode::Idle`] — the single entry point `crate::ui::draw` calls
-/// unconditionally as its final compositing step.
-pub(crate) fn draw_review_overlay(frame: &mut Frame, review: &ReviewState, full_area: Rect) {
+/// unconditionally as its final compositing step. `sink_a_available`
+/// (`App::review_sink_a_available`) is only consulted by the export menu,
+/// which must render the same entries [`ReviewState::confirm_export`]
+/// resolves the cursor against.
+pub(crate) fn draw_review_overlay(
+    frame: &mut Frame,
+    review: &ReviewState,
+    sink_a_available: bool,
+    full_area: Rect,
+) {
     match review.mode() {
         ReviewMode::Idle => {}
         ReviewMode::Compose { snapshot, buffer } => {
@@ -25,7 +33,7 @@ pub(crate) fn draw_review_overlay(frame: &mut Frame, review: &ReviewState, full_
         }
         ReviewMode::List { cursor } => draw_notes_overlay(frame, review, *cursor, full_area),
         ReviewMode::ExportMenu { cursor } => {
-            draw_export_menu_overlay(frame, review, *cursor, full_area)
+            draw_export_menu_overlay(frame, sink_a_available, *cursor, full_area)
         }
         ReviewMode::VerdictMenu { cursor } => draw_verdict_menu_overlay(frame, *cursor, full_area),
     }
@@ -112,7 +120,7 @@ fn draw_notes_overlay(frame: &mut Frame, review: &ReviewState, cursor: usize, fu
     }
     lines.push(Line::raw(""));
     lines.push(Line::styled(
-        "j/k: move  d: delete  x: export  Esc/q: close",
+        "j/k: move  Enter: export  d: delete  Esc/q: close",
         Style::default().add_modifier(Modifier::DIM),
     ));
 
@@ -145,31 +153,26 @@ fn notes_list_entry_text(note: &crate::review::Note) -> String {
     format!("{location_text}: {body_first_line}")
 }
 
-/// The export menu: `GitHub PR review` (only when `review`'s notes list
-/// was opened with sink A available — the caller derives this by simply
-/// not rendering the entry, since [`ReviewState`] itself carries no
-/// `PrContext`) is not distinguishable from here alone, so this draws
-/// both entries unconditionally; `crate::app::App::handle_review_key`'s
-/// own `sink_a_available` gate is what actually prevents selecting a
-/// `Github` entry that isn't really on the menu — see that method's own
-/// doc comment. Kept simple (always two lines) rather than threading
-/// `sink_a_available` through the whole render path for a v1 cosmetic
-/// concern; the reviewer discovers unavailability the moment `Enter`
-/// silently closes the menu instead of opening the verdict menu.
+/// The export menu: `GitHub PR review` only when `sink_a_available` (ADR
+/// 0048's "no implicit fallback" decision), built from
+/// [`export_menu_entries`] — the exact same entry list
+/// [`ReviewState::confirm_export`] resolves the menu's cursor against, so
+/// what the reviewer sees at a given position and what confirming that
+/// position does can never disagree.
 fn draw_export_menu_overlay(
     frame: &mut Frame,
-    _review: &ReviewState,
+    sink_a_available: bool,
     cursor: usize,
     full_area: Rect,
 ) {
     let overlay_area = centered_rect(full_area, 50, 30);
     frame.render_widget(Clear, overlay_area);
 
-    let entries = ["GitHub PR review", "Clipboard (for an AI agent)"];
+    let entries = export_menu_entries(sink_a_available);
     let lines: Vec<Line<'static>> = entries
         .iter()
         .enumerate()
-        .map(|(index, label)| menu_line(label, index == cursor))
+        .map(|(index, entry)| menu_line(entry.label(), index == cursor))
         .collect();
 
     let block = Block::bordered().title(" Export to (enter: choose, esc: cancel) ");

--- a/rinkaku-tui/src/ui/review_overlay_tests.rs
+++ b/rinkaku-tui/src/ui/review_overlay_tests.rs
@@ -134,6 +134,7 @@ fn should_draw_notes_list_overlay_with_note_summary() {
 
     assert!(text.contains("Review notes"));
     assert!(text.contains("lib.rs:1-5 foo: fix"));
+    assert!(text.contains("Enter: export"));
     assert!(text.contains("d: delete"));
 }
 
@@ -149,7 +150,57 @@ fn should_draw_empty_notes_list_placeholder_when_there_are_no_notes() {
 }
 
 #[test]
-fn should_draw_export_menu_overlay_entries() {
+fn should_draw_both_export_menu_entries_when_sink_a_is_available() {
+    let report = report_with_one_symbol();
+    let review = ReviewState::default()
+        .begin_compose(snapshot())
+        .push_char('x')
+        .confirm_compose()
+        .open_list()
+        .open_export_menu();
+    let app = App::new(&report)
+        .with_review_sink_a_available(true)
+        .with_review(review);
+
+    let text = draw_app(&app, &report);
+
+    assert!(text.contains("Export to"));
+    assert!(text.contains("GitHub PR review"));
+    assert!(text.contains("Clipboard"));
+}
+
+#[test]
+fn should_draw_only_clipboard_entry_when_sink_a_is_unavailable() {
+    // Regression test: the export menu's *rendering* must match
+    // `ReviewState::confirm_export`'s own `sink_a_available`-gated entry
+    // list (`export_menu_entries`) — drawing "GitHub PR review"
+    // unconditionally, regardless of whether a `PrContext` was ever wired
+    // up, misleads the reviewer into thinking cursor position 0 posts a
+    // GitHub review when it actually confirms whatever
+    // `export_menu_entries(false)` put there instead (`Clipboard`).
+    let report = report_with_one_symbol();
+    let review = ReviewState::default()
+        .begin_compose(snapshot())
+        .push_char('x')
+        .confirm_compose()
+        .open_list()
+        .open_export_menu();
+    let app = App::new(&report).with_review(review);
+    assert!(!app.review_sink_a_available());
+
+    let text = draw_app(&app, &report);
+
+    assert!(text.contains("Export to"));
+    assert!(!text.contains("GitHub PR review"));
+    assert!(text.contains("Clipboard"));
+}
+
+#[test]
+fn should_export_to_clipboard_when_confirming_cursor_zero_with_sink_a_unavailable() {
+    // The other half of the regression above: confirming the menu's
+    // cursor-0 entry while sink A is unavailable must produce the same
+    // `ExportRequest` the rendered (sink-A-omitted) menu actually shows at
+    // that position — `Clipboard`, not a silently-closed menu.
     let report = report_with_one_symbol();
     let review = ReviewState::default()
         .begin_compose(snapshot())
@@ -159,11 +210,13 @@ fn should_draw_export_menu_overlay_entries() {
         .open_export_menu();
     let app = App::new(&report).with_review(review);
 
-    let text = draw_app(&app, &report);
+    let app = app.handle_key(crate::app::InputKey::PopupConfirm);
 
-    assert!(text.contains("Export to"));
-    assert!(text.contains("GitHub PR review"));
-    assert!(text.contains("Clipboard"));
+    let mut review = app.review().clone();
+    assert_eq!(
+        Some(crate::review::ExportRequest::Clipboard),
+        review.take_pending_export()
+    );
 }
 
 #[test]

--- a/rinkaku-tui/src/ui/review_overlay_tests.rs
+++ b/rinkaku-tui/src/ui/review_overlay_tests.rs
@@ -82,6 +82,7 @@ fn draw_app(app: &App, report: &Report) -> String {
                 &[],
                 &BlastRadiusSelection::NotApplicable,
                 None,
+                &[],
                 &crate::note_markers::NoteMarkers::default(),
             );
         })

--- a/rinkaku-tui/src/ui/review_overlay_tests.rs
+++ b/rinkaku-tui/src/ui/review_overlay_tests.rs
@@ -1,0 +1,199 @@
+use crate::app::{App, BlastRadiusSelection};
+use crate::review::{ReviewState, SelectionSnapshot};
+use crate::ui::draw;
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use rinkaku_core::diff::LineRange;
+use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+use rinkaku_core::graph::SymbolGraph;
+use rinkaku_core::render::{FileReport, Report};
+
+fn symbol(id: &str, name: &str) -> ExtractedSymbol {
+    ExtractedSymbol {
+        id: id.to_string(),
+        name: name.to_string(),
+        kind: SymbolKind::Function,
+        signature: format!("fn {name}()"),
+        range: LineRange { start: 1, end: 1 },
+        container: None,
+        referenced_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }
+}
+
+fn report_with_one_symbol() -> Report {
+    Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![symbol("lib.rs::foo", "foo")],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    }
+}
+
+fn snapshot() -> SelectionSnapshot {
+    SelectionSnapshot {
+        path: "lib.rs".to_string(),
+        symbol_id: Some("lib.rs::foo".to_string()),
+        symbol_name: Some("foo".to_string()),
+        range: Some((1, 5)),
+        anchor: Some((1, 5)),
+        signature: Some("fn foo()".to_string()),
+    }
+}
+
+fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    (0..area.height)
+        .map(|y| {
+            (0..area.width)
+                .map(|x| buffer[(x, y)].symbol().to_string())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn draw_app(app: &App, report: &Report) -> String {
+    let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                app,
+                report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                None,
+                &crate::note_markers::NoteMarkers::default(),
+            );
+        })
+        .expect("draw");
+    buffer_text(&terminal)
+}
+
+#[test]
+fn should_not_draw_review_overlay_when_review_is_idle() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report);
+
+    let text = draw_app(&app, &report);
+
+    assert!(!text.contains("New note"));
+    assert!(!text.contains("Review notes"));
+}
+
+#[test]
+fn should_draw_compose_overlay_with_location_and_buffer_when_composing() {
+    let report = report_with_one_symbol();
+    let review = ReviewState::default()
+        .begin_compose(snapshot())
+        .push_char('h')
+        .push_char('i');
+    let app = App::new(&report).with_review(review);
+
+    let text = draw_app(&app, &report);
+
+    assert!(text.contains("New note"));
+    assert!(text.contains("lib.rs:1-5 foo"));
+    assert!(text.contains("hi"));
+    assert!(text.contains("Enter: save"));
+}
+
+#[test]
+fn should_draw_notes_list_overlay_with_note_summary() {
+    let report = report_with_one_symbol();
+    let review = ReviewState::default()
+        .begin_compose(snapshot())
+        .push_char('f')
+        .push_char('i')
+        .push_char('x')
+        .confirm_compose()
+        .open_list();
+    let app = App::new(&report).with_review(review);
+
+    let text = draw_app(&app, &report);
+
+    assert!(text.contains("Review notes"));
+    assert!(text.contains("lib.rs:1-5 foo: fix"));
+    assert!(text.contains("d: delete"));
+}
+
+#[test]
+fn should_draw_empty_notes_list_placeholder_when_there_are_no_notes() {
+    let report = report_with_one_symbol();
+    let review = ReviewState::default().open_list();
+    let app = App::new(&report).with_review(review);
+
+    let text = draw_app(&app, &report);
+
+    assert!(text.contains("no notes yet"));
+}
+
+#[test]
+fn should_draw_export_menu_overlay_entries() {
+    let report = report_with_one_symbol();
+    let review = ReviewState::default()
+        .begin_compose(snapshot())
+        .push_char('x')
+        .confirm_compose()
+        .open_list()
+        .open_export_menu();
+    let app = App::new(&report).with_review(review);
+
+    let text = draw_app(&app, &report);
+
+    assert!(text.contains("Export to"));
+    assert!(text.contains("GitHub PR review"));
+    assert!(text.contains("Clipboard"));
+}
+
+#[test]
+fn should_draw_verdict_menu_overlay_entries() {
+    let report = report_with_one_symbol();
+    let review = ReviewState::default()
+        .begin_compose(snapshot())
+        .push_char('x')
+        .confirm_compose()
+        .open_list()
+        .open_export_menu()
+        .confirm_export(true);
+    let app = App::new(&report).with_review(review);
+
+    let text = draw_app(&app, &report);
+
+    assert!(text.contains("Submit review as"));
+    assert!(text.contains("Approve"));
+    assert!(text.contains("Request changes"));
+    assert!(text.contains("Comment"));
+}
+
+#[test]
+fn should_show_last_status_message_in_notes_list_overlay() {
+    let report = report_with_one_symbol();
+    let review = ReviewState::default()
+        .set_status("posted 1 review comment(s) to PR #7")
+        .open_list();
+    let app = App::new(&report).with_review(review);
+
+    let text = draw_app(&app, &report);
+
+    assert!(text.contains("posted 1 review comment(s) to PR #7"));
+}

--- a/rinkaku-tui/src/ui/source_screen.rs
+++ b/rinkaku-tui/src/ui/source_screen.rs
@@ -1,22 +1,14 @@
 //! Source drill-down screen (ADR 0026 for the reviewer-driven scroll,
 //! ADR 0018/0020 for the shared "token foreground + line-level background
-//! tint" composition with the diff pane, ADR 0046 for the diff overlay
-//! composited on top of that).
+//! tint" composition with the diff pane).
 
-use super::diff_pane::{ADDED_BG, REMOVED_BG, marker_span};
 use super::style::{gap_span, pane_border_style, styled_content_spans};
-use crate::diff_view::{DiffLineKind, FileHunks};
 use crate::source::{HighlightedSourceView, SourceView};
-use crate::source_diff::{OverlayRow, overlay_source_lines, rows_in_source_range};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::Color;
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Paragraph, Wrap};
-
-#[cfg(test)]
-#[path = "source_screen/tests.rs"]
-mod tests;
 
 /// Background tint for a source-screen line inside the drilled-into symbol's
 /// own range — reused as the uniform `bg` for [`styled_content_spans`] the
@@ -53,28 +45,25 @@ pub(crate) const SOURCE_HIGHLIGHT_BG: Color = Color::DarkGray;
 /// the point of computing it (defensive — `draw`'s own `Screen::Source` arm
 /// is the only caller, and it always has a symbol id in hand by then); drawn
 /// as a bare bordered box with no body in that case, rather than panicking.
-///
-/// `diff_hunks` is `crate::run_app`'s once-per-session
-/// `diff_view::parse_diff_hunks` output (ADR 0046): when the drilled-into
-/// symbol's file has an entry there, its hunks are composited onto the
-/// source view as an always-on added/removed overlay
-/// (`crate::source_diff::overlay_source_lines`), unless the file has
-/// drifted from the diff on disk, in which case the pane falls back to its
-/// plain rendering with a one-line note in the title (ADR 0046 decision 5).
 pub(crate) fn draw_source_screen(
     frame: &mut Frame,
     symbol_id: &str,
     scroll_top: usize,
     source_content: Option<&Result<HighlightedSourceView, String>>,
-    diff_hunks: &[FileHunks],
     area: Rect,
 ) {
+    let title = format!(" Source: {symbol_id} ");
+    // Always drawn as focused: this screen replaces the whole entry view
+    // (tree + right pane) while open, so there is no sibling pane it needs
+    // to be visually distinguished from (`render_scrollable_pane`'s own doc
+    // comment makes the same call for the `?` help overlay).
+    let block = Block::bordered()
+        .title(title)
+        .border_style(pane_border_style(true));
+
     let highlighted = match source_content {
         Some(Ok(highlighted)) => highlighted,
         Some(Err(message)) => {
-            let block = Block::bordered()
-                .title(format!(" Source: {symbol_id} "))
-                .border_style(pane_border_style(true));
             // `.wrap(Wrap { trim: false })`: the error message (full path +
             // io error + the "not present in the working tree" hint added
             // alongside repo-root resolution) routinely exceeds one line at
@@ -91,42 +80,16 @@ pub(crate) fn draw_source_screen(
             return;
         }
         None => {
-            let block = Block::bordered()
-                .title(format!(" Source: {symbol_id} "))
-                .border_style(pane_border_style(true));
             frame.render_widget(Paragraph::new("").block(block), area);
             return;
         }
     };
     let source = &highlighted.view;
 
-    let file_hunks = crate::diff_view::file_hunks(diff_hunks, &source.path);
-    let overlay = file_hunks.and_then(|file_hunks| overlay_source_lines(&source.lines, file_hunks));
-    let title = if file_hunks.is_some() && overlay.is_none() {
-        format!(
-            " Source: {symbol_id} (diff overlay unavailable — file on disk doesn't match the diff) "
-        )
-    } else {
-        format!(" Source: {symbol_id} ")
-    };
-    // Always drawn as focused: this screen replaces the whole entry view
-    // (tree + right pane) while open, so there is no sibling pane it needs
-    // to be visually distinguished from (`render_scrollable_pane`'s own doc
-    // comment makes the same call for the `?` help overlay).
-    let block = Block::bordered()
-        .title(title)
-        .border_style(pane_border_style(true));
-
     let viewport_height = area.height.saturating_sub(2) as usize; // borders
     let (start, end) = clamped_window(source.lines.len(), scroll_top, viewport_height);
 
-    let lines = source_lines(
-        source,
-        &highlighted.token_highlights,
-        overlay.as_deref(),
-        start,
-        end,
-    );
+    let lines = source_lines(source, &highlighted.token_highlights, start, end);
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
 }
@@ -157,118 +120,410 @@ pub(crate) fn clamped_window(
     (start, end)
 }
 
-/// Renders `source.lines[start..end]` (1-based line range `[start+1, end]`)
-/// with a `{line_number:>5} | ` gutter, each line's code tokens colored per
-/// `token_highlights[i]` (`None` falls back to the plain unstyled line this
-/// screen always had, same contract as [`super::diff_pane::diff_line`]'s own
-/// fallback) and the symbol's own highlighted range
+/// Renders `source.lines[start..end]` with a `{line_number:>5} | ` gutter,
+/// each line's code tokens colored per `token_highlights[i]` (`None` falls
+/// back to the plain unstyled line this screen always had, same contract as
+/// [`super::diff_pane::diff_line`]'s own fallback) and the symbol's own highlighted range
 /// (`source.highlight_start..=source.highlight_end`) composited on top as a
 /// background tint — mirrors the diff pane's own "token foreground + line-
 /// level background tint" composition rather than inventing a second scheme
 /// for this screen.
-///
-/// `overlay` is `crate::source_diff::overlay_source_lines`'s result for this
-/// file (ADR 0046), `None` when the file has no diff or the overlay was
-/// dropped for drift (`draw_source_screen`'s own doc comment). When present,
-/// `crate::source_diff::rows_in_source_range` slices it to the same
-/// `[start, end)` window and each row drives its own line: an `Added` row's
-/// `ADDED_BG` background wins over the symbol-range tint (ADR 0046 decision
-/// 6 — the more specific signal for a reviewer who followed the symbol into
-/// its file specifically to see what changed); a `Removed` row inserts an
-/// extra `-`-gutter line with `REMOVED_BG`, no line number (nothing in
-/// `source.lines` for it to point at) and no token highlighting (the text
-/// comes from the diff, not a parsed source line).
 pub(crate) fn source_lines(
     source: &SourceView,
     token_highlights: &[crate::highlight::LineHighlight],
-    overlay: Option<&[OverlayRow]>,
     start: usize,
     end: usize,
 ) -> Vec<Line<'static>> {
-    let Some(overlay) = overlay else {
-        return source.lines[start..end]
-            .iter()
-            .enumerate()
-            .map(|(offset, text)| {
-                let line_index = start + offset;
-                unchanged_line(source, token_highlights, line_index, text, None)
-            })
-            .collect();
-    };
-
-    rows_in_source_range(overlay, start + 1, end)
+    source.lines[start..end]
         .iter()
-        .map(|row| match row {
-            OverlayRow::Unchanged {
-                line_number,
-                content,
-            } => unchanged_line(source, token_highlights, line_number - 1, content, None),
-            OverlayRow::Added {
-                line_number,
-                content,
-            } => unchanged_line(
-                source,
-                token_highlights,
-                line_number - 1,
-                content,
-                Some(ADDED_BG),
-            ),
-            OverlayRow::Removed { content } => removed_line(content),
+        .enumerate()
+        .map(|(offset, text)| {
+            let line_index = start + offset;
+            let line_number = line_index + 1;
+            let is_highlighted =
+                line_number >= source.highlight_start && line_number <= source.highlight_end;
+            let bg = is_highlighted.then_some(SOURCE_HIGHLIGHT_BG);
+
+            let gutter = format!("{line_number:>5} | ");
+            let mut spans = vec![gap_span(&gutter, bg)];
+            match token_highlights.get(line_index).cloned().flatten() {
+                Some(token_spans) => {
+                    spans.extend(styled_content_spans(text, &token_spans, bg));
+                }
+                None => spans.push(gap_span(text, bg)),
+            }
+            Line::from(spans)
         })
         .collect()
 }
 
-/// Renders one source-file line (`text`, at 0-based `line_index`) with its
-/// gutter, token highlighting, and background tint — the common rendering
-/// step [`source_lines`] uses for both an unmodified line and a diff-added
-/// line, which differ only in `diff_bg` (ADR 0046 decision 6: an added
-/// line's tint wins over the symbol-range tint when both would apply,
-/// achieved simply by `diff_bg` taking priority in the `or` below). A
-/// `diff_bg` of `Some(ADDED_BG)` also swaps the gutter's usual blank space
-/// for [`marker_span`]'s `+` glyph, pairing this line's gutter with
-/// [`removed_line`]'s own `-` gutter for the same diff signal.
-fn unchanged_line(
-    source: &SourceView,
-    token_highlights: &[crate::highlight::LineHighlight],
-    line_index: usize,
-    text: &str,
-    diff_bg: Option<Color>,
-) -> Line<'static> {
-    let line_number = line_index + 1;
-    let is_highlighted =
-        line_number >= source.highlight_start && line_number <= source.highlight_end;
-    let bg = diff_bg.or(is_highlighted.then_some(SOURCE_HIGHLIGHT_BG));
-    let is_added = diff_bg == Some(ADDED_BG);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{App, BlastRadiusSelection};
+    use crate::ui::{DrawOutcome, draw};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::style::Style;
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+    use rinkaku_core::graph::SymbolGraph;
+    use rinkaku_core::render::{FileReport, Report};
 
-    let mut spans = vec![gap_span(&format!("{line_number:>5}"), bg)];
-    spans.push(if is_added {
-        marker_span(DiffLineKind::Added, bg)
-    } else {
-        gap_span(" ", bg)
-    });
-    spans.push(gap_span("| ", bg));
-    match token_highlights.get(line_index).cloned().flatten() {
-        Some(token_spans) => {
-            spans.extend(styled_content_spans(text, &token_spans, bg));
+    fn symbol(id: &str, name: &str) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature: format!("fn {name}()"),
+            range: LineRange { start: 1, end: 1 },
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
         }
-        None => spans.push(gap_span(text, bg)),
     }
-    Line::from(spans)
-}
 
-/// Renders a diff-removed line with no source line number of its own
-/// (`OverlayRow::Removed`'s own doc comment) — a `-` gutter matching the
-/// width of an ordinary line's `{line_number:>5} | ` gutter,
-/// [`marker_span`] for the same bold-red `-` glyph the diff pane uses,
-/// [`REMOVED_BG`] applied uniformly, and no token highlighting (the text is
-/// the diff's recorded old-side content, not a line
-/// `crate::highlight::highlight_source_lines` ever parsed).
-fn removed_line(content: &str) -> Line<'static> {
-    let bg = Some(REMOVED_BG);
-    Line::from(vec![
-        gap_span("     ", bg),
-        marker_span(DiffLineKind::Removed, bg),
-        gap_span("| ", bg),
-        gap_span(content, bg),
-    ])
+    fn report_with_one_symbol() -> Report {
+        Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![symbol("lib.rs::foo", "foo")],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            fan_ins: vec![],
+            file_size_warnings: vec![],
+            file_size_bands: vec![],
+            removed: vec![],
+        }
+    }
+
+    fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+        let buffer = terminal.backend().buffer();
+        let area = buffer.area;
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn find_cell_style(terminal: &Terminal<TestBackend>, line_needle: &str, token: &str) -> Style {
+        let buffer = terminal.backend().buffer();
+        let area = buffer.area;
+        for y in 0..area.height {
+            let row: String = (0..area.width)
+                .map(|x| buffer[(x, y)].symbol().to_string())
+                .collect();
+            let Some(needle_byte_offset) = row.find(line_needle) else {
+                continue;
+            };
+            let Some(token_byte_offset) = row[needle_byte_offset..].find(token) else {
+                continue;
+            };
+            let byte_offset = needle_byte_offset + token_byte_offset;
+            let column = row[..byte_offset].chars().count() as u16;
+            return buffer[(column, y)].style();
+        }
+        panic!("expected to find {token:?} within a row containing {line_needle:?}");
+    }
+
+    /// A real `Err` from `crate::source::load_symbol_source`/
+    /// `load_highlighted_symbol_source`, produced by actually attempting a
+    /// read under a placeholder repo root nothing on disk matches — used to
+    /// build `source_content` for `draw_source_screen` tests below rather
+    /// than fabricating the error string by hand, so these tests stay
+    /// pinned to the real message format `crate::source` produces.
+    fn missing_file_source_content(
+        report: &Report,
+        symbol_id: &str,
+    ) -> Option<Result<crate::source::HighlightedSourceView, String>> {
+        Some(crate::source::load_highlighted_symbol_source(
+            report,
+            symbol_id,
+            std::path::Path::new("/repo"),
+        ))
+    }
+
+    #[test]
+    fn should_draw_source_screen_title_and_error_message_when_file_is_missing() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::Source);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+        let source_content = missing_file_source_content(&report, "lib.rs::foo");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    source_content.as_ref(),
+                    &crate::note_markers::NoteMarkers::default(),
+                );
+            })
+            .expect("draw");
+
+        // "lib.rs" does not exist under the placeholder repo root above, so
+        // this exercises `draw_source_screen`'s error-message fallback path
+        // rather than needing a real file on disk.
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Source: lib.rs::foo"));
+        assert!(text.contains("failed to read"));
+        assert!(text.contains("back"));
+    }
+
+    #[test]
+    fn should_wrap_source_error_message_instead_of_truncating_it_in_a_narrow_pane() {
+        // Regression test: `source::load_symbol_source`'s error message
+        // (full path + io error + the "not present in the working tree"
+        // hint) routinely exceeds one line, and `Paragraph` without
+        // `.wrap(...)` silently truncates rather than overflowing — cutting
+        // the hint off exactly where it explains the failure. A narrow
+        // (40-column) pane makes the message wrap across multiple rows
+        // whether or not `.wrap(...)` is set, but only *with* it does the
+        // hint's text actually appear anywhere in the buffer; without it,
+        // the trailing text is simply dropped.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::Source);
+        let mut terminal = Terminal::new(TestBackend::new(40, 20)).expect("terminal");
+        let source_content = missing_file_source_content(&report, "lib.rs::foo");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    source_content.as_ref(),
+                    &crate::note_markers::NoteMarkers::default(),
+                );
+            })
+            .expect("draw");
+
+        // `buffer_text` joins rows with `\n`, so a phrase that happens to
+        // wrap exactly at a row boundary (as "in the" / "present" do at
+        // this width) would not appear as one contiguous substring even
+        // though every word is visible — asserting on words rather than a
+        // multi-word phrase keeps this test robust to exactly where the
+        // wrap point falls, while still failing if `.wrap(...)` were
+        // removed (the words after "working tree" would be dropped
+        // entirely, not just split across rows).
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Source: lib.rs::foo"));
+        assert!(text.contains("present"));
+        assert!(text.contains("working tree"));
+        assert!(text.contains("historical commit not checked out"));
+        assert!(text.contains("locally)"));
+    }
+
+    // --- draw_source_screen: syntax highlighting ---
+
+    #[test]
+    fn should_apply_keyword_foreground_and_symbol_range_background_in_source_screen() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("lib.rs"), "fn a() {}\nfn foo() {}\n").expect("write file");
+
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "lib.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    range: LineRange { start: 2, end: 2 },
+                    ..symbol("lib.rs::foo", "foo")
+                }],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            fan_ins: vec![],
+            file_size_warnings: vec![],
+            file_size_bands: vec![],
+            removed: vec![],
+        };
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::Source);
+        let source_content = Some(crate::source::load_highlighted_symbol_source(
+            &report,
+            "lib.rs::foo",
+            dir.path(),
+        ));
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    source_content.as_ref(),
+                    &crate::note_markers::NoteMarkers::default(),
+                );
+            })
+            .expect("draw");
+
+        // Line 2 ("fn foo() {}") is the symbol's own highlighted range: its
+        // "fn" keyword must carry both signals composited together — the
+        // token's own foreground color (ADR 0018's palette, extended to
+        // this screen) *and* the symbol-range background tint — mirroring
+        // how the diff pane composites a token's foreground with its
+        // added/removed background rather than one replacing the other.
+        let keyword_style = find_cell_style(&terminal, "2 | fn foo() {}", "fn");
+        assert_eq!(Some(Color::Magenta), keyword_style.fg);
+        assert_eq!(Some(SOURCE_HIGHLIGHT_BG), keyword_style.bg);
+
+        // Line 1 ("fn a() {}") is outside the symbol's range: its own "fn"
+        // keyword must still be colored (highlighting applies to every
+        // line, not just the highlighted range) but without the background
+        // tint, since only the drilled-into symbol's own lines get it.
+        // `Style::bg` reports an unset background as `Some(Color::Reset)`,
+        // not `None` (ratatui's own `Cell` default — see
+        // `should_keep_context_line_unstyled_background_in_diff_pane`'s own
+        // doc comment for this same convention on the diff pane).
+        let outside_range_style = find_cell_style(&terminal, "1 | fn a() {}", "fn");
+        assert_eq!(Some(Color::Magenta), outside_range_style.fg);
+        assert_eq!(Some(Color::Reset), outside_range_style.bg);
+    }
+
+    #[test]
+    fn should_fall_back_to_plain_source_style_when_file_extension_is_unrecognized() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(dir.path().join("config.yaml"), "key: value\n").expect("write file");
+
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "config.yaml".to_string(),
+                symbols: vec![symbol("config.yaml::foo", "foo")],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![],
+                edges: vec![],
+                roots: vec![],
+            },
+            tests: vec![],
+            fan_ins: vec![],
+            file_size_warnings: vec![],
+            file_size_bands: vec![],
+            removed: vec![],
+        };
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::Source);
+        let source_content = Some(crate::source::load_highlighted_symbol_source(
+            &report,
+            "config.yaml::foo",
+            dir.path(),
+        ));
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    source_content.as_ref(),
+                    &crate::note_markers::NoteMarkers::default(),
+                );
+            })
+            .expect("draw");
+
+        // No highlight configuration exists for `.yaml`
+        // (`highlight::config_for_path`), so the line still renders — with
+        // the symbol-range background tint (highlighting failing must never
+        // regress the pane below its pre-ADR-0018 plain style) but no
+        // per-token foreground coloring (`Style::fg` reports an unset
+        // foreground as `Some(Color::Reset)`, not `None` — same ratatui
+        // `Cell` default convention as `bg`, see the test above).
+        let text = buffer_text(&terminal);
+        assert!(text.contains("key: value"));
+        let style = find_cell_style(&terminal, "1 | key: value", "key");
+        assert_eq!(Some(SOURCE_HIGHLIGHT_BG), style.bg);
+        assert_eq!(Some(Color::Reset), style.fg);
+    }
+
+    #[test]
+    fn should_report_none_clamped_scroll_but_source_viewport_height_when_source_screen_is_open() {
+        // ADR 0026: the source screen scrolls via its own
+        // `Screen::Source::scroll_top`, not `App::right_pane_scroll`, so
+        // `DrawOutcome::clamped_right_pane_scroll` must stay `None` on this
+        // screen (otherwise `crate::run_app`'s
+        // `clamp_right_pane_scroll_after_draw` would fold a source-screen
+        // offset back into the wrong field). At the same time the source
+        // pane's inner height must be surfaced via
+        // `scroll_viewport_height` — otherwise `Ctrl-d`/`Ctrl-u`/`G` from
+        // the source screen would have no viewport to size their step
+        // against, defaulting to `DEFAULT_SOURCE_VIEWPORT_HEIGHT`.
+        let report = report_with_one_symbol();
+        let app = App::new(&report)
+            .handle_key(crate::app::InputKey::Down)
+            .handle_key(crate::app::InputKey::Source);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+        let mut actual = DrawOutcome {
+            clamped_right_pane_scroll: Some(999),
+            scroll_viewport_height: None,
+            clamped_help_scroll: None,
+            help_scroll_viewport_height: None,
+        };
+        terminal
+            .draw(|frame| {
+                actual = draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    None,
+                    &crate::note_markers::NoteMarkers::default(),
+                );
+            })
+            .expect("draw");
+
+        assert_eq!(None, actual.clamped_right_pane_scroll);
+        // A 20-row terminal with a 1-row status line leaves 19 rows for
+        // the body; the source pane's bordered box takes 2 of them,
+        // leaving 17 rows inside. Pinned exactly (rather than a range)
+        // so a future layout refactor that silently changes the split
+        // is caught, matching the specificity `ADR 0020`'s own
+        // `right_pane_viewport_height` shares with `draw_entry_screen`.
+        assert_eq!(Some(17), actual.scroll_viewport_height);
+    }
 }

--- a/rinkaku-tui/src/ui/source_screen.rs
+++ b/rinkaku-tui/src/ui/source_screen.rs
@@ -1,14 +1,22 @@
 //! Source drill-down screen (ADR 0026 for the reviewer-driven scroll,
 //! ADR 0018/0020 for the shared "token foreground + line-level background
-//! tint" composition with the diff pane).
+//! tint" composition with the diff pane, ADR 0046 for the diff overlay
+//! composited on top of that).
 
+use super::diff_pane::{ADDED_BG, REMOVED_BG, marker_span};
 use super::style::{gap_span, pane_border_style, styled_content_spans};
+use crate::diff_view::{DiffLineKind, FileHunks};
 use crate::source::{HighlightedSourceView, SourceView};
+use crate::source_diff::{OverlayRow, overlay_source_lines, rows_in_source_range};
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::Color;
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Paragraph, Wrap};
+
+#[cfg(test)]
+#[path = "source_screen/tests.rs"]
+mod tests;
 
 /// Background tint for a source-screen line inside the drilled-into symbol's
 /// own range — reused as the uniform `bg` for [`styled_content_spans`] the
@@ -45,25 +53,28 @@ pub(crate) const SOURCE_HIGHLIGHT_BG: Color = Color::DarkGray;
 /// the point of computing it (defensive — `draw`'s own `Screen::Source` arm
 /// is the only caller, and it always has a symbol id in hand by then); drawn
 /// as a bare bordered box with no body in that case, rather than panicking.
+///
+/// `diff_hunks` is `crate::run_app`'s once-per-session
+/// `diff_view::parse_diff_hunks` output (ADR 0046): when the drilled-into
+/// symbol's file has an entry there, its hunks are composited onto the
+/// source view as an always-on added/removed overlay
+/// (`crate::source_diff::overlay_source_lines`), unless the file has
+/// drifted from the diff on disk, in which case the pane falls back to its
+/// plain rendering with a one-line note in the title (ADR 0046 decision 5).
 pub(crate) fn draw_source_screen(
     frame: &mut Frame,
     symbol_id: &str,
     scroll_top: usize,
     source_content: Option<&Result<HighlightedSourceView, String>>,
+    diff_hunks: &[FileHunks],
     area: Rect,
 ) {
-    let title = format!(" Source: {symbol_id} ");
-    // Always drawn as focused: this screen replaces the whole entry view
-    // (tree + right pane) while open, so there is no sibling pane it needs
-    // to be visually distinguished from (`render_scrollable_pane`'s own doc
-    // comment makes the same call for the `?` help overlay).
-    let block = Block::bordered()
-        .title(title)
-        .border_style(pane_border_style(true));
-
     let highlighted = match source_content {
         Some(Ok(highlighted)) => highlighted,
         Some(Err(message)) => {
+            let block = Block::bordered()
+                .title(format!(" Source: {symbol_id} "))
+                .border_style(pane_border_style(true));
             // `.wrap(Wrap { trim: false })`: the error message (full path +
             // io error + the "not present in the working tree" hint added
             // alongside repo-root resolution) routinely exceeds one line at
@@ -80,16 +91,42 @@ pub(crate) fn draw_source_screen(
             return;
         }
         None => {
+            let block = Block::bordered()
+                .title(format!(" Source: {symbol_id} "))
+                .border_style(pane_border_style(true));
             frame.render_widget(Paragraph::new("").block(block), area);
             return;
         }
     };
     let source = &highlighted.view;
 
+    let file_hunks = crate::diff_view::file_hunks(diff_hunks, &source.path);
+    let overlay = file_hunks.and_then(|file_hunks| overlay_source_lines(&source.lines, file_hunks));
+    let title = if file_hunks.is_some() && overlay.is_none() {
+        format!(
+            " Source: {symbol_id} (diff overlay unavailable — file on disk doesn't match the diff) "
+        )
+    } else {
+        format!(" Source: {symbol_id} ")
+    };
+    // Always drawn as focused: this screen replaces the whole entry view
+    // (tree + right pane) while open, so there is no sibling pane it needs
+    // to be visually distinguished from (`render_scrollable_pane`'s own doc
+    // comment makes the same call for the `?` help overlay).
+    let block = Block::bordered()
+        .title(title)
+        .border_style(pane_border_style(true));
+
     let viewport_height = area.height.saturating_sub(2) as usize; // borders
     let (start, end) = clamped_window(source.lines.len(), scroll_top, viewport_height);
 
-    let lines = source_lines(source, &highlighted.token_highlights, start, end);
+    let lines = source_lines(
+        source,
+        &highlighted.token_highlights,
+        overlay.as_deref(),
+        start,
+        end,
+    );
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
 }
@@ -120,410 +157,118 @@ pub(crate) fn clamped_window(
     (start, end)
 }
 
-/// Renders `source.lines[start..end]` with a `{line_number:>5} | ` gutter,
-/// each line's code tokens colored per `token_highlights[i]` (`None` falls
-/// back to the plain unstyled line this screen always had, same contract as
-/// [`super::diff_pane::diff_line`]'s own fallback) and the symbol's own highlighted range
+/// Renders `source.lines[start..end]` (1-based line range `[start+1, end]`)
+/// with a `{line_number:>5} | ` gutter, each line's code tokens colored per
+/// `token_highlights[i]` (`None` falls back to the plain unstyled line this
+/// screen always had, same contract as [`super::diff_pane::diff_line`]'s own
+/// fallback) and the symbol's own highlighted range
 /// (`source.highlight_start..=source.highlight_end`) composited on top as a
 /// background tint — mirrors the diff pane's own "token foreground + line-
 /// level background tint" composition rather than inventing a second scheme
 /// for this screen.
+///
+/// `overlay` is `crate::source_diff::overlay_source_lines`'s result for this
+/// file (ADR 0046), `None` when the file has no diff or the overlay was
+/// dropped for drift (`draw_source_screen`'s own doc comment). When present,
+/// `crate::source_diff::rows_in_source_range` slices it to the same
+/// `[start, end)` window and each row drives its own line: an `Added` row's
+/// `ADDED_BG` background wins over the symbol-range tint (ADR 0046 decision
+/// 6 — the more specific signal for a reviewer who followed the symbol into
+/// its file specifically to see what changed); a `Removed` row inserts an
+/// extra `-`-gutter line with `REMOVED_BG`, no line number (nothing in
+/// `source.lines` for it to point at) and no token highlighting (the text
+/// comes from the diff, not a parsed source line).
 pub(crate) fn source_lines(
     source: &SourceView,
     token_highlights: &[crate::highlight::LineHighlight],
+    overlay: Option<&[OverlayRow]>,
     start: usize,
     end: usize,
 ) -> Vec<Line<'static>> {
-    source.lines[start..end]
-        .iter()
-        .enumerate()
-        .map(|(offset, text)| {
-            let line_index = start + offset;
-            let line_number = line_index + 1;
-            let is_highlighted =
-                line_number >= source.highlight_start && line_number <= source.highlight_end;
-            let bg = is_highlighted.then_some(SOURCE_HIGHLIGHT_BG);
+    let Some(overlay) = overlay else {
+        return source.lines[start..end]
+            .iter()
+            .enumerate()
+            .map(|(offset, text)| {
+                let line_index = start + offset;
+                unchanged_line(source, token_highlights, line_index, text, None)
+            })
+            .collect();
+    };
 
-            let gutter = format!("{line_number:>5} | ");
-            let mut spans = vec![gap_span(&gutter, bg)];
-            match token_highlights.get(line_index).cloned().flatten() {
-                Some(token_spans) => {
-                    spans.extend(styled_content_spans(text, &token_spans, bg));
-                }
-                None => spans.push(gap_span(text, bg)),
-            }
-            Line::from(spans)
+    rows_in_source_range(overlay, start + 1, end)
+        .iter()
+        .map(|row| match row {
+            OverlayRow::Unchanged {
+                line_number,
+                content,
+            } => unchanged_line(source, token_highlights, line_number - 1, content, None),
+            OverlayRow::Added {
+                line_number,
+                content,
+            } => unchanged_line(
+                source,
+                token_highlights,
+                line_number - 1,
+                content,
+                Some(ADDED_BG),
+            ),
+            OverlayRow::Removed { content } => removed_line(content),
         })
         .collect()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::app::{App, BlastRadiusSelection};
-    use crate::ui::{DrawOutcome, draw};
-    use ratatui::Terminal;
-    use ratatui::backend::TestBackend;
-    use ratatui::style::Style;
-    use rinkaku_core::diff::LineRange;
-    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
-    use rinkaku_core::graph::SymbolGraph;
-    use rinkaku_core::render::{FileReport, Report};
+/// Renders one source-file line (`text`, at 0-based `line_index`) with its
+/// gutter, token highlighting, and background tint — the common rendering
+/// step [`source_lines`] uses for both an unmodified line and a diff-added
+/// line, which differ only in `diff_bg` (ADR 0046 decision 6: an added
+/// line's tint wins over the symbol-range tint when both would apply,
+/// achieved simply by `diff_bg` taking priority in the `or` below). A
+/// `diff_bg` of `Some(ADDED_BG)` also swaps the gutter's usual blank space
+/// for [`marker_span`]'s `+` glyph, pairing this line's gutter with
+/// [`removed_line`]'s own `-` gutter for the same diff signal.
+fn unchanged_line(
+    source: &SourceView,
+    token_highlights: &[crate::highlight::LineHighlight],
+    line_index: usize,
+    text: &str,
+    diff_bg: Option<Color>,
+) -> Line<'static> {
+    let line_number = line_index + 1;
+    let is_highlighted =
+        line_number >= source.highlight_start && line_number <= source.highlight_end;
+    let bg = diff_bg.or(is_highlighted.then_some(SOURCE_HIGHLIGHT_BG));
+    let is_added = diff_bg == Some(ADDED_BG);
 
-    fn symbol(id: &str, name: &str) -> ExtractedSymbol {
-        ExtractedSymbol {
-            id: id.to_string(),
-            name: name.to_string(),
-            kind: SymbolKind::Function,
-            signature: format!("fn {name}()"),
-            range: LineRange { start: 1, end: 1 },
-            container: None,
-            referenced_names: vec![],
-            dependencies: vec![],
-            omitted_dependency_matches: 0,
-            is_test: false,
-            classification: None,
-            previous_signature: None,
+    let mut spans = vec![gap_span(&format!("{line_number:>5}"), bg)];
+    spans.push(if is_added {
+        marker_span(DiffLineKind::Added, bg)
+    } else {
+        gap_span(" ", bg)
+    });
+    spans.push(gap_span("| ", bg));
+    match token_highlights.get(line_index).cloned().flatten() {
+        Some(token_spans) => {
+            spans.extend(styled_content_spans(text, &token_spans, bg));
         }
+        None => spans.push(gap_span(text, bg)),
     }
+    Line::from(spans)
+}
 
-    fn report_with_one_symbol() -> Report {
-        Report {
-            origin: rinkaku_core::render::ReportOrigin::Diff,
-            files: vec![FileReport {
-                path: "lib.rs".to_string(),
-                symbols: vec![symbol("lib.rs::foo", "foo")],
-            }],
-            skipped: vec![],
-            graph: SymbolGraph {
-                nodes: vec![],
-                edges: vec![],
-                roots: vec![],
-            },
-            tests: vec![],
-            fan_ins: vec![],
-            file_size_warnings: vec![],
-            file_size_bands: vec![],
-            removed: vec![],
-        }
-    }
-
-    fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
-        let buffer = terminal.backend().buffer();
-        let area = buffer.area;
-        (0..area.height)
-            .map(|y| {
-                (0..area.width)
-                    .map(|x| buffer[(x, y)].symbol().to_string())
-                    .collect::<String>()
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
-    fn find_cell_style(terminal: &Terminal<TestBackend>, line_needle: &str, token: &str) -> Style {
-        let buffer = terminal.backend().buffer();
-        let area = buffer.area;
-        for y in 0..area.height {
-            let row: String = (0..area.width)
-                .map(|x| buffer[(x, y)].symbol().to_string())
-                .collect();
-            let Some(needle_byte_offset) = row.find(line_needle) else {
-                continue;
-            };
-            let Some(token_byte_offset) = row[needle_byte_offset..].find(token) else {
-                continue;
-            };
-            let byte_offset = needle_byte_offset + token_byte_offset;
-            let column = row[..byte_offset].chars().count() as u16;
-            return buffer[(column, y)].style();
-        }
-        panic!("expected to find {token:?} within a row containing {line_needle:?}");
-    }
-
-    /// A real `Err` from `crate::source::load_symbol_source`/
-    /// `load_highlighted_symbol_source`, produced by actually attempting a
-    /// read under a placeholder repo root nothing on disk matches — used to
-    /// build `source_content` for `draw_source_screen` tests below rather
-    /// than fabricating the error string by hand, so these tests stay
-    /// pinned to the real message format `crate::source` produces.
-    fn missing_file_source_content(
-        report: &Report,
-        symbol_id: &str,
-    ) -> Option<Result<crate::source::HighlightedSourceView, String>> {
-        Some(crate::source::load_highlighted_symbol_source(
-            report,
-            symbol_id,
-            std::path::Path::new("/repo"),
-        ))
-    }
-
-    #[test]
-    fn should_draw_source_screen_title_and_error_message_when_file_is_missing() {
-        let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::Source);
-        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
-        let source_content = missing_file_source_content(&report, "lib.rs::foo");
-
-        terminal
-            .draw(|frame| {
-                draw(
-                    frame,
-                    &app,
-                    &report,
-                    &crate::diff_shape::DiffPaneContent::Empty,
-                    &[],
-                    &BlastRadiusSelection::NotApplicable,
-                    source_content.as_ref(),
-                    &crate::note_markers::NoteMarkers::default(),
-                );
-            })
-            .expect("draw");
-
-        // "lib.rs" does not exist under the placeholder repo root above, so
-        // this exercises `draw_source_screen`'s error-message fallback path
-        // rather than needing a real file on disk.
-        let text = buffer_text(&terminal);
-        assert!(text.contains("Source: lib.rs::foo"));
-        assert!(text.contains("failed to read"));
-        assert!(text.contains("back"));
-    }
-
-    #[test]
-    fn should_wrap_source_error_message_instead_of_truncating_it_in_a_narrow_pane() {
-        // Regression test: `source::load_symbol_source`'s error message
-        // (full path + io error + the "not present in the working tree"
-        // hint) routinely exceeds one line, and `Paragraph` without
-        // `.wrap(...)` silently truncates rather than overflowing — cutting
-        // the hint off exactly where it explains the failure. A narrow
-        // (40-column) pane makes the message wrap across multiple rows
-        // whether or not `.wrap(...)` is set, but only *with* it does the
-        // hint's text actually appear anywhere in the buffer; without it,
-        // the trailing text is simply dropped.
-        let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::Source);
-        let mut terminal = Terminal::new(TestBackend::new(40, 20)).expect("terminal");
-        let source_content = missing_file_source_content(&report, "lib.rs::foo");
-
-        terminal
-            .draw(|frame| {
-                draw(
-                    frame,
-                    &app,
-                    &report,
-                    &crate::diff_shape::DiffPaneContent::Empty,
-                    &[],
-                    &BlastRadiusSelection::NotApplicable,
-                    source_content.as_ref(),
-                    &crate::note_markers::NoteMarkers::default(),
-                );
-            })
-            .expect("draw");
-
-        // `buffer_text` joins rows with `\n`, so a phrase that happens to
-        // wrap exactly at a row boundary (as "in the" / "present" do at
-        // this width) would not appear as one contiguous substring even
-        // though every word is visible — asserting on words rather than a
-        // multi-word phrase keeps this test robust to exactly where the
-        // wrap point falls, while still failing if `.wrap(...)` were
-        // removed (the words after "working tree" would be dropped
-        // entirely, not just split across rows).
-        let text = buffer_text(&terminal);
-        assert!(text.contains("Source: lib.rs::foo"));
-        assert!(text.contains("present"));
-        assert!(text.contains("working tree"));
-        assert!(text.contains("historical commit not checked out"));
-        assert!(text.contains("locally)"));
-    }
-
-    // --- draw_source_screen: syntax highlighting ---
-
-    #[test]
-    fn should_apply_keyword_foreground_and_symbol_range_background_in_source_screen() {
-        let dir = tempfile::tempdir().expect("create temp dir");
-        std::fs::write(dir.path().join("lib.rs"), "fn a() {}\nfn foo() {}\n").expect("write file");
-
-        let report = Report {
-            origin: rinkaku_core::render::ReportOrigin::Diff,
-            files: vec![FileReport {
-                path: "lib.rs".to_string(),
-                symbols: vec![ExtractedSymbol {
-                    range: LineRange { start: 2, end: 2 },
-                    ..symbol("lib.rs::foo", "foo")
-                }],
-            }],
-            skipped: vec![],
-            graph: SymbolGraph {
-                nodes: vec![],
-                edges: vec![],
-                roots: vec![],
-            },
-            tests: vec![],
-            fan_ins: vec![],
-            file_size_warnings: vec![],
-            file_size_bands: vec![],
-            removed: vec![],
-        };
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::Source);
-        let source_content = Some(crate::source::load_highlighted_symbol_source(
-            &report,
-            "lib.rs::foo",
-            dir.path(),
-        ));
-        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
-
-        terminal
-            .draw(|frame| {
-                draw(
-                    frame,
-                    &app,
-                    &report,
-                    &crate::diff_shape::DiffPaneContent::Empty,
-                    &[],
-                    &BlastRadiusSelection::NotApplicable,
-                    source_content.as_ref(),
-                    &crate::note_markers::NoteMarkers::default(),
-                );
-            })
-            .expect("draw");
-
-        // Line 2 ("fn foo() {}") is the symbol's own highlighted range: its
-        // "fn" keyword must carry both signals composited together — the
-        // token's own foreground color (ADR 0018's palette, extended to
-        // this screen) *and* the symbol-range background tint — mirroring
-        // how the diff pane composites a token's foreground with its
-        // added/removed background rather than one replacing the other.
-        let keyword_style = find_cell_style(&terminal, "2 | fn foo() {}", "fn");
-        assert_eq!(Some(Color::Magenta), keyword_style.fg);
-        assert_eq!(Some(SOURCE_HIGHLIGHT_BG), keyword_style.bg);
-
-        // Line 1 ("fn a() {}") is outside the symbol's range: its own "fn"
-        // keyword must still be colored (highlighting applies to every
-        // line, not just the highlighted range) but without the background
-        // tint, since only the drilled-into symbol's own lines get it.
-        // `Style::bg` reports an unset background as `Some(Color::Reset)`,
-        // not `None` (ratatui's own `Cell` default — see
-        // `should_keep_context_line_unstyled_background_in_diff_pane`'s own
-        // doc comment for this same convention on the diff pane).
-        let outside_range_style = find_cell_style(&terminal, "1 | fn a() {}", "fn");
-        assert_eq!(Some(Color::Magenta), outside_range_style.fg);
-        assert_eq!(Some(Color::Reset), outside_range_style.bg);
-    }
-
-    #[test]
-    fn should_fall_back_to_plain_source_style_when_file_extension_is_unrecognized() {
-        let dir = tempfile::tempdir().expect("create temp dir");
-        std::fs::write(dir.path().join("config.yaml"), "key: value\n").expect("write file");
-
-        let report = Report {
-            origin: rinkaku_core::render::ReportOrigin::Diff,
-            files: vec![FileReport {
-                path: "config.yaml".to_string(),
-                symbols: vec![symbol("config.yaml::foo", "foo")],
-            }],
-            skipped: vec![],
-            graph: SymbolGraph {
-                nodes: vec![],
-                edges: vec![],
-                roots: vec![],
-            },
-            tests: vec![],
-            fan_ins: vec![],
-            file_size_warnings: vec![],
-            file_size_bands: vec![],
-            removed: vec![],
-        };
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::Source);
-        let source_content = Some(crate::source::load_highlighted_symbol_source(
-            &report,
-            "config.yaml::foo",
-            dir.path(),
-        ));
-        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
-
-        terminal
-            .draw(|frame| {
-                draw(
-                    frame,
-                    &app,
-                    &report,
-                    &crate::diff_shape::DiffPaneContent::Empty,
-                    &[],
-                    &BlastRadiusSelection::NotApplicable,
-                    source_content.as_ref(),
-                    &crate::note_markers::NoteMarkers::default(),
-                );
-            })
-            .expect("draw");
-
-        // No highlight configuration exists for `.yaml`
-        // (`highlight::config_for_path`), so the line still renders — with
-        // the symbol-range background tint (highlighting failing must never
-        // regress the pane below its pre-ADR-0018 plain style) but no
-        // per-token foreground coloring (`Style::fg` reports an unset
-        // foreground as `Some(Color::Reset)`, not `None` — same ratatui
-        // `Cell` default convention as `bg`, see the test above).
-        let text = buffer_text(&terminal);
-        assert!(text.contains("key: value"));
-        let style = find_cell_style(&terminal, "1 | key: value", "key");
-        assert_eq!(Some(SOURCE_HIGHLIGHT_BG), style.bg);
-        assert_eq!(Some(Color::Reset), style.fg);
-    }
-
-    #[test]
-    fn should_report_none_clamped_scroll_but_source_viewport_height_when_source_screen_is_open() {
-        // ADR 0026: the source screen scrolls via its own
-        // `Screen::Source::scroll_top`, not `App::right_pane_scroll`, so
-        // `DrawOutcome::clamped_right_pane_scroll` must stay `None` on this
-        // screen (otherwise `crate::run_app`'s
-        // `clamp_right_pane_scroll_after_draw` would fold a source-screen
-        // offset back into the wrong field). At the same time the source
-        // pane's inner height must be surfaced via
-        // `scroll_viewport_height` — otherwise `Ctrl-d`/`Ctrl-u`/`G` from
-        // the source screen would have no viewport to size their step
-        // against, defaulting to `DEFAULT_SOURCE_VIEWPORT_HEIGHT`.
-        let report = report_with_one_symbol();
-        let app = App::new(&report)
-            .handle_key(crate::app::InputKey::Down)
-            .handle_key(crate::app::InputKey::Source);
-        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
-
-        let mut actual = DrawOutcome {
-            clamped_right_pane_scroll: Some(999),
-            scroll_viewport_height: None,
-            clamped_help_scroll: None,
-            help_scroll_viewport_height: None,
-        };
-        terminal
-            .draw(|frame| {
-                actual = draw(
-                    frame,
-                    &app,
-                    &report,
-                    &crate::diff_shape::DiffPaneContent::Empty,
-                    &[],
-                    &BlastRadiusSelection::NotApplicable,
-                    None,
-                    &crate::note_markers::NoteMarkers::default(),
-                );
-            })
-            .expect("draw");
-
-        assert_eq!(None, actual.clamped_right_pane_scroll);
-        // A 20-row terminal with a 1-row status line leaves 19 rows for
-        // the body; the source pane's bordered box takes 2 of them,
-        // leaving 17 rows inside. Pinned exactly (rather than a range)
-        // so a future layout refactor that silently changes the split
-        // is caught, matching the specificity `ADR 0020`'s own
-        // `right_pane_viewport_height` shares with `draw_entry_screen`.
-        assert_eq!(Some(17), actual.scroll_viewport_height);
-    }
+/// Renders a diff-removed line with no source line number of its own
+/// (`OverlayRow::Removed`'s own doc comment) — a `-` gutter matching the
+/// width of an ordinary line's `{line_number:>5} | ` gutter,
+/// [`marker_span`] for the same bold-red `-` glyph the diff pane uses,
+/// [`REMOVED_BG`] applied uniformly, and no token highlighting (the text is
+/// the diff's recorded old-side content, not a line
+/// `crate::highlight::highlight_source_lines` ever parsed).
+fn removed_line(content: &str) -> Line<'static> {
+    let bg = Some(REMOVED_BG);
+    Line::from(vec![
+        gap_span("     ", bg),
+        marker_span(DiffLineKind::Removed, bg),
+        gap_span("| ", bg),
+        gap_span(content, bg),
+    ])
 }

--- a/rinkaku-tui/src/ui/source_screen/tests.rs
+++ b/rinkaku-tui/src/ui/source_screen/tests.rs
@@ -118,6 +118,7 @@ fn should_draw_source_screen_title_and_error_message_when_file_is_missing() {
                 &BlastRadiusSelection::NotApplicable,
                 source_content.as_ref(),
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -160,6 +161,7 @@ fn should_wrap_source_error_message_instead_of_truncating_it_in_a_narrow_pane() 
                 &BlastRadiusSelection::NotApplicable,
                 source_content.as_ref(),
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -230,6 +232,7 @@ fn should_apply_keyword_foreground_and_symbol_range_background_in_source_screen(
                 &BlastRadiusSelection::NotApplicable,
                 source_content.as_ref(),
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -302,6 +305,7 @@ fn should_fall_back_to_plain_source_style_when_file_extension_is_unrecognized() 
                 &BlastRadiusSelection::NotApplicable,
                 source_content.as_ref(),
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -355,6 +359,7 @@ fn should_report_none_clamped_scroll_but_source_viewport_height_when_source_scre
                 &BlastRadiusSelection::NotApplicable,
                 None,
                 &[],
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");
@@ -407,6 +412,7 @@ fn draw_source_screen_for_test(
                 &BlastRadiusSelection::NotApplicable,
                 source_content.as_ref(),
                 diff_hunks,
+                &crate::note_markers::NoteMarkers::default(),
             );
         })
         .expect("draw");

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -225,6 +225,7 @@ mod tests {
                     &BlastRadiusSelection::NotApplicable,
                     None,
                     &[],
+                    &crate::note_markers::NoteMarkers::default(),
                 );
             })
             .expect("draw");

--- a/rinkaku/src/clipboard.rs
+++ b/rinkaku/src/clipboard.rs
@@ -1,26 +1,125 @@
-//! Clipboard export (ADR 0048 sink B) via an OSC 52 terminal escape
-//! sequence — see the ADR's Alternatives for why OSC 52 over a clipboard
-//! crate or shelling out to `pbcopy`/`xclip`: no new dependency, works
-//! over SSH, and degrades safely on a terminal that doesn't support it.
+//! Clipboard export (ADR 0048 sink B). A native clipboard command
+//! (`pbcopy`/`wl-copy`/`xclip`/`xsel`) is preferred when the session is
+//! local, because OSC 52 is silently dropped by common local setups (tmux
+//! `set-clipboard external` forwarding to an outer terminal that doesn't
+//! support or permit it); OSC 52 remains the fallback for remote (SSH)
+//! sessions — the environment it was chosen for — and for hosts with no
+//! clipboard command at all. See ADR 0048's amendment for the rationale.
 
 use rinkaku_tui::review::ports::ClipboardSink;
 use std::io::Write;
 
-/// [`ClipboardSink`] that writes an OSC 52 escape sequence to stdout.
-/// Best-effort: a successful `Ok(())` here means the escape sequence was
-/// written, not that the terminal actually populated the system
-/// clipboard (the ADR's own Consequences note this can't be detected).
-pub(crate) struct Osc52Clipboard;
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ClipboardBackend {
+    Command {
+        program: &'static str,
+        args: &'static [&'static str],
+    },
+    Osc52,
+}
 
-impl ClipboardSink for Osc52Clipboard {
-    fn copy(&self, text: &str) -> Result<(), String> {
-        let encoded = base64_encode(text.as_bytes());
-        let sequence = format!("\x1b]52;c;{encoded}\x07");
-        let mut stdout = std::io::stdout();
-        stdout
-            .write_all(sequence.as_bytes())
-            .and_then(|()| stdout.flush())
-            .map_err(|err| format!("failed to write OSC 52 sequence: {err}"))
+const COMMAND_CANDIDATES: &[(&str, &[&str])] = &[
+    ("pbcopy", &[]),
+    ("wl-copy", &[]),
+    ("xclip", &["-selection", "clipboard"]),
+    ("xsel", &["--clipboard", "--input"]),
+];
+
+pub(crate) fn choose_clipboard_backend(
+    remote: bool,
+    available: impl Fn(&str) -> bool,
+) -> ClipboardBackend {
+    if remote {
+        return ClipboardBackend::Osc52;
+    }
+    COMMAND_CANDIDATES
+        .iter()
+        .find(|(program, _)| available(program))
+        .map(|&(program, args)| ClipboardBackend::Command { program, args })
+        .unwrap_or(ClipboardBackend::Osc52)
+}
+
+pub(crate) struct SystemClipboard {
+    backend: ClipboardBackend,
+}
+
+impl SystemClipboard {
+    pub(crate) fn detect() -> Self {
+        let remote =
+            std::env::var_os("SSH_TTY").is_some() || std::env::var_os("SSH_CONNECTION").is_some();
+        Self {
+            backend: choose_clipboard_backend(remote, is_in_path),
+        }
+    }
+}
+
+impl ClipboardSink for SystemClipboard {
+    fn copy(&self, text: &str) -> Result<String, String> {
+        match self.backend {
+            ClipboardBackend::Command { program, args } => copy_via_command(program, args, text),
+            ClipboardBackend::Osc52 => copy_via_osc52(text),
+        }
+    }
+}
+
+fn is_in_path(program: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(program).is_file())
+}
+
+fn copy_via_command(program: &str, args: &[&str], text: &str) -> Result<String, String> {
+    let mut child = std::process::Command::new(program)
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|err| format!("failed to spawn {program}: {err}"))?;
+    if let Some(stdin) = child.stdin.take() {
+        let mut stdin = stdin;
+        stdin
+            .write_all(text.as_bytes())
+            .map_err(|err| format!("failed to write to {program}: {err}"))?;
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|err| format!("failed to wait for {program}: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "{program} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(format!("copied review notes to clipboard via {program}"))
+}
+
+/// A conservative guard on the raw packet length, below common
+/// terminal-side OSC 52 payload caps (~100KB is a frequently cited limit)
+/// even after base64 inflates the wire payload to ~4/3 — terminals that
+/// enforce such a cap silently drop or truncate rather than erroring, so
+/// the write itself cannot detect the failure; the guard only changes the
+/// status message.
+const OSC52_SIZE_GUARD_BYTES: usize = 48 * 1024;
+
+fn copy_via_osc52(text: &str) -> Result<String, String> {
+    let encoded = base64_encode(text.as_bytes());
+    let sequence = format!("\x1b]52;c;{encoded}\x07");
+    let mut stdout = std::io::stdout();
+    stdout
+        .write_all(sequence.as_bytes())
+        .and_then(|()| stdout.flush())
+        .map_err(|err| format!("failed to write OSC 52 sequence: {err}"))?;
+    let base = "copied review notes to clipboard via OSC 52 (terminal support required)";
+    if text.len() > OSC52_SIZE_GUARD_BYTES {
+        Ok(format!(
+            "{base} — packet is {} bytes, which may exceed the terminal's OSC 52 limit; \
+             copy manually if the paste looks truncated",
+            text.len()
+        ))
+    } else {
+        Ok(base.to_string())
     }
 }
 
@@ -63,6 +162,58 @@ fn base64_encode(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_choose_osc52_when_session_is_remote_even_if_commands_exist() {
+        let actual = choose_clipboard_backend(true, |_| true);
+
+        assert_eq!(ClipboardBackend::Osc52, actual);
+    }
+
+    #[test]
+    fn should_choose_pbcopy_when_local_and_pbcopy_is_available() {
+        let actual = choose_clipboard_backend(false, |program| program == "pbcopy");
+
+        assert_eq!(
+            ClipboardBackend::Command {
+                program: "pbcopy",
+                args: &[],
+            },
+            actual
+        );
+    }
+
+    #[test]
+    fn should_choose_xclip_with_selection_args_when_only_xclip_is_available() {
+        let actual = choose_clipboard_backend(false, |program| program == "xclip");
+
+        assert_eq!(
+            ClipboardBackend::Command {
+                program: "xclip",
+                args: &["-selection", "clipboard"],
+            },
+            actual
+        );
+    }
+
+    #[test]
+    fn should_fall_back_to_osc52_when_local_but_no_command_is_available() {
+        let actual = choose_clipboard_backend(false, |_| false);
+
+        assert_eq!(ClipboardBackend::Osc52, actual);
+    }
+
+    #[test]
+    fn should_report_spawn_failure_when_command_does_not_exist() {
+        let actual = copy_via_command("rinkaku-nonexistent-clipboard-cmd", &[], "text");
+
+        assert_eq!(
+            true,
+            actual
+                .unwrap_err()
+                .starts_with("failed to spawn rinkaku-nonexistent-clipboard-cmd")
+        );
+    }
 
     #[test]
     fn should_encode_empty_input_as_empty_string() {

--- a/rinkaku/src/clipboard.rs
+++ b/rinkaku/src/clipboard.rs
@@ -1,0 +1,102 @@
+//! Clipboard export (ADR 0048 sink B) via an OSC 52 terminal escape
+//! sequence — see the ADR's Alternatives for why OSC 52 over a clipboard
+//! crate or shelling out to `pbcopy`/`xclip`: no new dependency, works
+//! over SSH, and degrades safely on a terminal that doesn't support it.
+
+use rinkaku_tui::review::ports::ClipboardSink;
+use std::io::Write;
+
+/// [`ClipboardSink`] that writes an OSC 52 escape sequence to stdout.
+/// Best-effort: a successful `Ok(())` here means the escape sequence was
+/// written, not that the terminal actually populated the system
+/// clipboard (the ADR's own Consequences note this can't be detected).
+pub(crate) struct Osc52Clipboard;
+
+impl ClipboardSink for Osc52Clipboard {
+    fn copy(&self, text: &str) -> Result<(), String> {
+        let encoded = base64_encode(text.as_bytes());
+        let sequence = format!("\x1b]52;c;{encoded}\x07");
+        let mut stdout = std::io::stdout();
+        stdout
+            .write_all(sequence.as_bytes())
+            .and_then(|()| stdout.flush())
+            .map_err(|err| format!("failed to write OSC 52 sequence: {err}"))
+    }
+}
+
+const BASE64_ALPHABET: &[u8; 64] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// Standard base64 encoding (RFC 4648, with `=` padding) — implemented
+/// directly rather than adding a dependency for one small, stable
+/// algorithm (ADR 0048's own "no new dependency" rationale for OSC 52
+/// applies equally here).
+fn base64_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = chunk.get(1).copied();
+        let b2 = chunk.get(2).copied();
+
+        out.push(BASE64_ALPHABET[(b0 >> 2) as usize] as char);
+        out.push(
+            BASE64_ALPHABET[(((b0 & 0b0000_0011) << 4) | (b1.unwrap_or(0) >> 4)) as usize] as char,
+        );
+        match b1 {
+            Some(b1) => {
+                out.push(
+                    BASE64_ALPHABET[(((b1 & 0b0000_1111) << 2) | (b2.unwrap_or(0) >> 6)) as usize]
+                        as char,
+                );
+            }
+            None => out.push('='),
+        }
+        match b2 {
+            Some(b2) => out.push(BASE64_ALPHABET[(b2 & 0b0011_1111) as usize] as char),
+            None => out.push('='),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_encode_empty_input_as_empty_string() {
+        let actual = base64_encode(b"");
+
+        assert_eq!("", actual);
+    }
+
+    #[test]
+    fn should_encode_known_vector_with_no_padding() {
+        // "Man" -> "TWFu" is the canonical RFC 4648 base64 example.
+        let actual = base64_encode(b"Man");
+
+        assert_eq!("TWFu", actual);
+    }
+
+    #[test]
+    fn should_encode_known_vector_with_one_padding_character() {
+        let actual = base64_encode(b"Ma");
+
+        assert_eq!("TWE=", actual);
+    }
+
+    #[test]
+    fn should_encode_known_vector_with_two_padding_characters() {
+        let actual = base64_encode(b"M");
+
+        assert_eq!("TQ==", actual);
+    }
+
+    #[test]
+    fn should_encode_the_full_rfc_4648_test_vector() {
+        let actual = base64_encode(b"pleasure.");
+
+        assert_eq!("cGxlYXN1cmUu", actual);
+    }
+}

--- a/rinkaku/src/github/mod.rs
+++ b/rinkaku/src/github/mod.rs
@@ -6,4 +6,5 @@ pub(crate) mod base_sha;
 pub(crate) mod pr_arg;
 pub(crate) mod pr_info;
 pub(crate) mod remote;
+pub(crate) mod review;
 pub(crate) mod workdir;

--- a/rinkaku/src/github/review.rs
+++ b/rinkaku/src/github/review.rs
@@ -1,0 +1,205 @@
+//! Posts a pending GitHub PR review (ADR 0048 sink A) via `gh api`, one
+//! call: open the review, attach every comment, and submit with the
+//! chosen verdict — matching how a human reviews on github.com and how
+//! `fetch_pr_info` already shells out to `gh` for read-only PR data.
+
+use rinkaku_tui::review::ports::ReviewSubmitter;
+use rinkaku_tui::review::{PrContext, RenderedComment, Verdict};
+
+/// [`ReviewSubmitter`] backed by `gh api repos/{owner}/{repo}/pulls/{number}/reviews`.
+pub(crate) struct GhReviewSubmitter;
+
+impl ReviewSubmitter for GhReviewSubmitter {
+    fn submit_review(
+        &self,
+        ctx: &PrContext,
+        verdict: Verdict,
+        summary: &str,
+        comments: &[RenderedComment],
+    ) -> Result<(), String> {
+        let body = review_request_json(ctx, verdict, summary, comments);
+        let endpoint = format!(
+            "repos/{owner}/{repo}/pulls/{number}/reviews",
+            owner = ctx.owner,
+            repo = ctx.repo,
+            number = ctx.number
+        );
+
+        let mut command = std::process::Command::new("gh");
+        command
+            .args(["api", &endpoint, "--method", "POST", "--input", "-"])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        let mut child = command
+            .spawn()
+            .map_err(|err| format!("failed to spawn gh: {err}"))?;
+
+        {
+            use std::io::Write;
+            let stdin = child
+                .stdin
+                .as_mut()
+                .ok_or_else(|| "failed to open gh's stdin".to_string())?;
+            stdin
+                .write_all(body.to_string().as_bytes())
+                .map_err(|err| format!("failed to write request body to gh: {err}"))?;
+        }
+
+        let output = child
+            .wait_with_output()
+            .map_err(|err| format!("failed to wait for gh: {err}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "gh api {endpoint} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Builds the JSON body `gh api .../reviews --input -` expects: `event`
+/// (GitHub's verdict string), `commit_id` (the PR's head commit, so the
+/// review anchors to the exact diff the TUI showed), `body` (the fixed
+/// review summary), and one `comments` entry per [`RenderedComment`] —
+/// `start_line`/`start_side` are omitted when `start_line` is `None`
+/// (GitHub's API distinguishes a single-line comment by their absence,
+/// rather than by `start_line == line`). Extracted as its own pure
+/// function so the request shape is unit-testable without shelling out to
+/// `gh`, mirroring `pr_info::parse_pr_view_json`'s own "parse/build
+/// separately from the process call" split.
+fn review_request_json(
+    ctx: &PrContext,
+    verdict: Verdict,
+    summary: &str,
+    comments: &[RenderedComment],
+) -> serde_json::Value {
+    let comments_json: Vec<serde_json::Value> = comments
+        .iter()
+        .map(|comment| {
+            let mut entry = serde_json::json!({
+                "path": comment.path,
+                "line": comment.line,
+                "side": "RIGHT",
+                "body": comment.body,
+            });
+            if let Some(start_line) = comment.start_line {
+                entry["start_line"] = serde_json::json!(start_line);
+                entry["start_side"] = serde_json::json!("RIGHT");
+            }
+            entry
+        })
+        .collect();
+
+    serde_json::json!({
+        "commit_id": ctx.head_sha,
+        "event": verdict_event(verdict),
+        "body": summary,
+        "comments": comments_json,
+    })
+}
+
+/// GitHub review API's own `event` string per [`Verdict`].
+fn verdict_event(verdict: Verdict) -> &'static str {
+    match verdict {
+        Verdict::Approve => "APPROVE",
+        Verdict::RequestChanges => "REQUEST_CHANGES",
+        Verdict::Comment => "COMMENT",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn pr_context() -> PrContext {
+        PrContext {
+            owner: "octocat".to_string(),
+            repo: "hello-world".to_string(),
+            number: 42,
+            head_sha: "abc123".to_string(),
+        }
+    }
+
+    #[test]
+    fn should_build_request_json_with_single_line_comment() {
+        let comments = vec![RenderedComment {
+            path: "src/lib.rs".to_string(),
+            line: 10,
+            start_line: None,
+            body: "please rename this".to_string(),
+        }];
+
+        let actual = review_request_json(&pr_context(), Verdict::Approve, "Looks good.", &comments);
+
+        assert_eq!(
+            serde_json::json!({
+                "commit_id": "abc123",
+                "event": "APPROVE",
+                "body": "Looks good.",
+                "comments": [
+                    {
+                        "path": "src/lib.rs",
+                        "line": 10,
+                        "side": "RIGHT",
+                        "body": "please rename this",
+                    }
+                ],
+            }),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_build_request_json_with_multi_line_comment() {
+        let comments = vec![RenderedComment {
+            path: "src/lib.rs".to_string(),
+            line: 18,
+            start_line: Some(12),
+            body: "this whole block needs a test".to_string(),
+        }];
+
+        let actual = review_request_json(
+            &pr_context(),
+            Verdict::RequestChanges,
+            "Needs work.",
+            &comments,
+        );
+
+        assert_eq!(
+            serde_json::json!({
+                "commit_id": "abc123",
+                "event": "REQUEST_CHANGES",
+                "body": "Needs work.",
+                "comments": [
+                    {
+                        "path": "src/lib.rs",
+                        "line": 18,
+                        "side": "RIGHT",
+                        "start_line": 12,
+                        "start_side": "RIGHT",
+                        "body": "this whole block needs a test",
+                    }
+                ],
+            }),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_build_request_json_with_comment_verdict_and_no_comments() {
+        let actual = review_request_json(&pr_context(), Verdict::Comment, "Just a note.", &[]);
+
+        assert_eq!(
+            serde_json::json!({
+                "commit_id": "abc123",
+                "event": "COMMENT",
+                "body": "Just a note.",
+                "comments": [],
+            }),
+            actual
+        );
+    }
+}

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -40,6 +40,7 @@
 //!   may not line up with the actual file content.
 
 mod cli;
+mod clipboard;
 mod display;
 mod generated_paths;
 mod git;
@@ -57,6 +58,7 @@ mod test_util;
 
 use clap::Parser;
 use cli::{Cli, Command};
+use clipboard::Osc52Clipboard;
 use display::{DisplayMode, resolve_display_mode};
 use generated_paths::check_generated_paths_batch;
 use git::commands::{list_repo_files_for_outline, resolve_repo_root};
@@ -64,8 +66,10 @@ use git::file_read::read_working_tree_file;
 use github::base_sha::{
     fetch_branch_head, fetch_oid, fetch_pr_head, object_exists_locally, resolve_pr_base_sha,
 };
-use github::pr_arg::parse_pr_arg;
+use github::pr_arg::{PrArg, parse_pr_arg};
 use github::pr_info::fetch_pr_info;
+use github::remote::{git_remote_origin_url, parse_github_remote};
+use github::review::GhReviewSubmitter;
 use github::workdir::resolve_pr_workdir;
 use log_writer::DeferredLogSink;
 use notes::{
@@ -77,6 +81,7 @@ use pipeline::{
 use progress::AnalysisProgress;
 use rinkaku_core::render::{Report, render};
 use rinkaku_tui::TuiSession;
+use rinkaku_tui::review::PrContext;
 use spinner::{AnalysisPhase, Spinner};
 use splash_progress::SplashProgress;
 use std::io::IsTerminal;
@@ -169,10 +174,11 @@ fn main() -> anyhow::Result<()> {
                     analyzed.diff_text,
                     analyzed.resolved_workdir,
                     analyzed.pr_head_sha,
+                    analyzed.pr_context,
                 )
             });
             let (session, buffered_notes) = progress.into_session_and_notes();
-            let (report, diff_text, resolved_workdir, pr_head_sha) = match outcome {
+            let (report, diff_text, resolved_workdir, pr_head_sha, pr_context) = match outcome {
                 Ok(analyzed) => analyzed,
                 Err(err) => {
                     // `session` (and with it, `TuiSession`'s `Drop` impl)
@@ -213,6 +219,18 @@ fn main() -> anyhow::Result<()> {
                 Some(reader) => reader,
                 None => &rinkaku_tui::source::WorkingTreeSourceReader,
             };
+            // ADR 0048: sink A (GitHub PR review) is wired up only when
+            // `pr_context` resolved; sink B (clipboard) is always
+            // available. `GhReviewSubmitter`/`Osc52Clipboard` are the
+            // composition root's only concrete port implementations —
+            // `rinkaku-tui` depends on the `ReviewSubmitter`/`ClipboardSink`
+            // trait definitions alone.
+            let submitter = pr_context.is_some().then_some(&GhReviewSubmitter as _);
+            let review_ports = rinkaku_tui::ReviewPorts {
+                pr_context,
+                submitter,
+                clipboard: &Osc52Clipboard,
+            };
             let result = session
                 .run(
                     &report,
@@ -220,6 +238,7 @@ fn main() -> anyhow::Result<()> {
                     cli.entry.as_deref(),
                     &repo_root,
                     source_reader,
+                    review_ports,
                 )
                 .map_err(anyhow::Error::from);
             // Flushed after `TuiSession::run` has already restored the
@@ -312,6 +331,12 @@ struct AnalyzedReport {
     diff_text: String,
     resolved_workdir: Option<PathBuf>,
     pr_head_sha: Option<String>,
+    /// The PR's identity, for `--tui`'s review-notes sink A (ADR 0048) —
+    /// `Some` only in `--pr` mode, and only when owner/repo could be
+    /// resolved (see [`resolve_pr_context`]'s own doc comment on why that
+    /// resolution can fail even in `--pr` mode without failing the whole
+    /// run). `None` for every other input mode.
+    pr_context: Option<PrContext>,
 }
 
 /// Runs the same `--pr`/`--base`/stdin/whole-repo input-mode chain
@@ -340,7 +365,7 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
     // input mode, the same way `resolved_workdir` above already carries
     // out `--pr`'s resolved clone directory.
     let mut pr_head_sha: Option<String> = None;
-    let (report, diff_text) = if let Some(pr_arg) = &cli.pr {
+    let (report, diff_text, pr_context) = if let Some(pr_arg) = &cli.pr {
         // Validate the arg and derive the fetch refspec's PR number, but
         // pass the original (trimmed) value — not the parsed number — to
         // `gh pr view` (see that function's doc comment for why).
@@ -391,9 +416,17 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
                 base_branch = pr_info.base_ref_name,
             ));
         }
-        run_base_pipeline(cli, &base_sha, &head_sha, cwd, progress)?
+        let (report, diff_text) = run_base_pipeline(cli, &base_sha, &head_sha, cwd, progress)?;
+        // ADR 0048: `PrContext` for `--tui`'s review-notes sink A, `None`
+        // when owner/repo can't be resolved (`resolve_pr_context`'s own
+        // doc comment on why that is a soft failure, not a hard error —
+        // the analysis above has already succeeded by this point, and
+        // losing sink A is strictly less bad than losing the whole run).
+        let pr_context = resolve_pr_context(&parsed, cwd, number, head_sha);
+        (report, diff_text, pr_context)
     } else if let Some(base) = &cli.base {
-        run_base_pipeline(cli, base, &cli.head, None, progress)?
+        let (report, diff_text) = run_base_pipeline(cli, base, &cli.head, None, progress)?;
+        (report, diff_text, None)
     } else if std::io::stdin().is_terminal() {
         // ADR 0017: this is the third arm of an `if let Some(pr) ... else if
         // let Some(base) ... else if <here>` chain, so reaching it already
@@ -447,7 +480,7 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
         if let Some(note) = repo_outline_empty_note(&report) {
             progress.note(note.to_string());
         }
-        (report, String::new())
+        (report, String::new(), None)
     } else {
         let diff_text = read_stdin_diff()?;
         if diff_text.trim().is_empty() {
@@ -493,7 +526,7 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
         if let Some(note) = garbage_input_note(&diff_text, &report) {
             progress.note(note.to_string());
         }
-        (report, diff_text)
+        (report, diff_text, None)
     };
 
     Ok(AnalyzedReport {
@@ -501,6 +534,44 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
         diff_text,
         resolved_workdir,
         pr_head_sha,
+        pr_context,
+    })
+}
+
+/// Resolves a [`PrContext`] for `--tui`'s review-notes sink A (ADR 0048),
+/// given the already-validated `parsed` PR arg, the `cwd` `--pr` mode
+/// resolved (`resolve_pr_workdir`'s own doc comment), the PR `number`, and
+/// its `head_sha` (already fetched and verified against `gh`'s own report
+/// by this function's only caller). Owner/repo come straight off `parsed`
+/// for [`PrArg::Url`]; for [`PrArg::Number`] (no repository information of
+/// its own) they are resolved the same way `--pr` URL mode itself decides
+/// which clone to use — `git remote get-url origin` in `cwd`, parsed via
+/// [`parse_github_remote`].
+///
+/// `None` (rather than a hard error) when owner/repo cannot be resolved —
+/// a bare `--pr <number>` run inside a clone whose `origin` isn't a GitHub
+/// remote at all (or has none) can still analyze and render/render-TUI
+/// successfully; only sink A (posting a GitHub PR review) needs this, and
+/// losing just that sink is strictly better than failing the whole run
+/// over a feature the reviewer may not even reach.
+fn resolve_pr_context(
+    parsed: &PrArg,
+    cwd: Option<&std::path::Path>,
+    number: u64,
+    head_sha: String,
+) -> Option<PrContext> {
+    let (owner, repo) = match parsed {
+        PrArg::Url { owner, repo, .. } => (owner.clone(), repo.clone()),
+        PrArg::Number(_) => {
+            let origin = git_remote_origin_url(cwd).ok().flatten()?;
+            parse_github_remote(&origin)?
+        }
+    };
+    Some(PrContext {
+        owner,
+        repo,
+        number,
+        head_sha,
     })
 }
 

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -58,7 +58,7 @@ mod test_util;
 
 use clap::Parser;
 use cli::{Cli, Command};
-use clipboard::Osc52Clipboard;
+use clipboard::SystemClipboard;
 use display::{DisplayMode, resolve_display_mode};
 use generated_paths::check_generated_paths_batch;
 use git::commands::{list_repo_files_for_outline, resolve_repo_root};
@@ -221,15 +221,16 @@ fn main() -> anyhow::Result<()> {
             };
             // ADR 0048: sink A (GitHub PR review) is wired up only when
             // `pr_context` resolved; sink B (clipboard) is always
-            // available. `GhReviewSubmitter`/`Osc52Clipboard` are the
+            // available. `GhReviewSubmitter`/`SystemClipboard` are the
             // composition root's only concrete port implementations —
             // `rinkaku-tui` depends on the `ReviewSubmitter`/`ClipboardSink`
             // trait definitions alone.
             let submitter = pr_context.is_some().then_some(&GhReviewSubmitter as _);
+            let system_clipboard = SystemClipboard::detect();
             let review_ports = rinkaku_tui::ReviewPorts {
                 pr_context,
                 submitter,
-                clipboard: &Osc52Clipboard,
+                clipboard: &system_clipboard,
             };
             let result = session
                 .run(


### PR DESCRIPTION
## Summary

Implements ADR 0048 v1: location-anchored review notes in the TUI, exported to either a GitHub PR review (sink A) or a clipboard packet addressed to an AI agent (sink B, via OSC 52). Sink C (interactive agent session) is out of scope, deferred to a follow-up PR per the ADR.

Touch points, matching the ADR's own list:

1. **`InputKey`/`App::handle_key` routing** — new variants (`NoteCompose`, `NotesList`, `ComposeChar`, `ComposeBackspace`, `NoteDelete`); the review overlay takes the highest key-space priority in both `translate_key` and `handle_key`, ahead of the help overlay. The notes-list overlay's grammar was unified with the jump popup's own (`j`/`k` move, Enter proceed, Esc back, `d` delete) after review feedback — `NoteExport`/its dedicated `x` key were removed in favor of routing Enter through `open_export_menu`.
2. **Selection-snapshot derivation** — `derive_selection_snapshot`/`first_anchor_run`, now in `rinkaku-tui/src/review_flow.rs`, built from the cursor plus the already-parsed diff hunks; `run_app` special-cases `NoteCompose` (the one key needing this data) before dispatch, via `dispatch_note_compose_key`.
3. **`main.rs` composition root** — `resolve_pr_context` assembles a `PrContext` in `--pr` mode (owner/repo from the parsed `--pr` arg, or `git remote get-url origin` for a bare PR number); `GhReviewSubmitter` (`rinkaku::github::review`) posts via `gh api .../reviews --method POST --input -`; `Osc52Clipboard` (`rinkaku::clipboard`) writes the OSC 52 escape sequence with a hand-rolled base64 encoder, now with a size guard that warns (but still attempts the copy) when a packet risks exceeding a terminal's OSC 52 payload cap.
4. **Rendering** — a new `rinkaku-tui/src/review/` module (destination-neutral `Note`/`ReviewState`, per-sink renderers, port traits), a `note_markers` cache-on-change value threaded through `run_app` alongside `blast_radius_selection`/`diff_pane_content`, an `n:N` tree-row badge, a `*` diff-pane line marker, and `ui::review_overlay`'s compose/list/export-menu/verdict-menu draw functions. The export menu's rendering now shares `export_menu_entries`/`ExportMenuEntry::label` with the state machine's own gating (see QA below).
5. **Full-width key normalization** — `input_translate.rs`'s `normalize_fullwidth_key` folds full-width ASCII (a Japanese/CJK IME left on) down to half-width before matching any normal-mode/overlay gesture, except while composing a note (free text stays verbatim).

`rinkaku-core` is untouched, per the ADR's absolute condition.

## Notes

- Rebased onto `origin/main` twice: once mid-implementation (after #158/#159, both touching `ui::draw`'s own parameter list — resolved by hand), and again after the three-angle review round below (after #162/#163, resolved by hand; `rinkaku-tui/src/ui/source_screen.rs`'s conflict required care since the same conflict shape had already been resolved once before in this branch's own history — see `cd19d64`).
- `rinkaku-tui/src/lib.rs` was flagged as crossing into the file-size "warn" band in a previous revision of this PR. Fixed in this revision: split into `input_translate.rs` (raw `crossterm` → `InputKey` translation) and `review_flow.rs` (the ADR 0048 review-notes composing/exporting/caching glue), following ADR 0028's "split along responsibility, not line count". `lib.rs` is now 925 lines.

## QA: three-angle review (map-assisted, independent, dynamic)

Findings from a three-angle review round (map-assisted static pass, independent static pass, dynamic-verification pass) and how they were fixed are recorded in [experiment 0001 round 35](docs/experiments/0001-map-assisted-llm-review/rounds/035.md).

- **Blocker (map-assisted pass)**: `draw_export_menu_overlay` rendered `["GitHub PR review", "Clipboard (for an AI agent)"]` unconditionally, regardless of whether sink A was actually available, while `ReviewState::confirm_export` resolved the cursor against `export_menu_entries(sink_a_available)` (which omits the GitHub entry when sink A is absent) — the two disagreed about what cursor position 0 meant. A regression test written before the fix confirmed the *actual* pre-fix behavior: confirming position 0 with sink A unavailable already fell through correctly to `Clipboard` at the state-machine level (not a silent close, not a wrong GitHub export) — only the *rendering* was wrong. Fixed by sharing `export_menu_entries`/`ExportMenuEntry::label` between the state machine and the render path.
- **Major (independent pass)**: pressing `n` over a row with no derivable `SelectionSnapshot` (a directory row, or the source screen) left `App` untouched, skipping `App::handle_key`'s unconditional `pending_prefix` clear — the same regression class ADR 0022 already fixed once for `gd`/`gr`. Fixed by extracting `dispatch_note_compose_key`, which always calls `handle_key` first, mirroring `dispatch_non_source_key`'s existing precedent.
- **Minor**: added an OSC 52 packet size guard (advisory warning, not a blocker to the copy); added positive-case test coverage for the `n:N` tree badge and diff-pane `*` marker (every prior test only exercised an empty `NoteMarkers`); documented the external-constraint invariant behind `render_review_comments`'s `(1, 1)` anchor fallback.
- **Binding rework** (reviewer feedback during the same round): full-width IME key normalization, and unifying the notes-list overlay's `x`/Enter grammar with the jump popup's own.

## Test plan

- [x] `make test` — all workspace tests pass (rinkaku-tui 807, up from 778 in a previous revision)
- [x] `make lint` — `cargo fmt --check` + `cargo clippy -D warnings` clean
- [x] Dynamic verification: non-TTY stdin/stdout for `--base`/stdin modes (exit 0, correct output); `--tui` on non-TTY stdin fails gracefully (exit 1, clean error, no panic); ran the built `rinkaku` binary against this PR's own diff and confirmed the new symbols/file-size warning appear correctly in the map output
- [x] Interactive TUI walkthrough (compose → list → export menu → verdict menu → GitHub review / clipboard) — the review-notes flow was driven via `tmux` during the three-angle review's dynamic pass (reproducing both the export-menu blocker and the `pending_prefix` leak against the pre-fix build), and the GitHub PR review export path was confirmed manually against a real PR
