### PR TITLE
feat(tui): align split-view run pairs by line similarity

### DIFF
--- a/docs/adr/0044-tui-split-view-diff-pane.md
+++ b/docs/adr/0044-tui-split-view-diff-pane.md
@@ -250,3 +250,66 @@ whenever the pane is too narrow for split, independent of
 `diff_view_mode` — so this default change carries no new risk for
 narrow terminals, only for wide ones where split was already available
 a keypress away.
+
+## Amendment: similarity-based alignment within a run
+
+Decision 3's positional pairing (row `i` of a replace run gets the
+run's `i`-th removed/added line) and the Alternatives section's
+rejection of "a real Myers-diff-style token/line alignment" both
+assumed a replace run's removed and added lines correspond 1:1 by
+position — reasonable when git's own line-level diff already resolved
+which old line corresponds to which new line, as Alternatives argued.
+Dogfooding surfaced a run shape where that assumption breaks: lines
+inserted *ahead* of an otherwise-unchanged line (e.g. a doc comment
+added above an unchanged function signature) shift every position
+after the insertion, so positional pairing puts the unchanged
+signature's `Removed` row next to the *comment's* `Added` row instead
+of the signature's own — the exact "scan past unrelated content to
+find the real counterpart" problem this whole ADR exists to fix,
+reintroduced inside the pane meant to fix it.
+
+The Alternatives section's rejection was about *re-diffing git's
+output* (finding correspondence git's line-level diff didn't already
+resolve) — that reasoning does not cover this case, where the
+correspondence *is* resolvable (the signature line is still
+recognizably the same line) but positional pairing discards the
+signal by only ever comparing same-offset lines.
+
+**`crate::split_pairing::pair_hunk_lines`'s per-run pairing
+(`crate::diff_shape::pair_hunk_lines` before this amendment split the
+module) is now a similarity-based alignment**, not pure position:
+
+- Each removed/added run pair is scored with a Needleman-Wunsch-style
+  alignment DP (gap cost 0) over per-line similarity — the Jaccard
+  index of each line's whitespace-split token set, `0.0..=1.0`.
+- Only pairs scoring at or above `SIMILARITY_THRESHOLD` (`0.5`) are
+  matched; an unmatched line becomes its own row against `None` on the
+  other side, preserving order.
+- **Two fallbacks reproduce the pre-amendment behavior exactly**,
+  rather than degrading alignment quality below what positional
+  pairing already offered: a run pair with zero matches above
+  threshold (no similarity signal to exploit) and a run longer than
+  `SIMILARITY_ALIGNMENT_MAX_RUN_LEN` (`200`, avoiding the DP's
+  quadratic cost on a rare, very large replace) both call the extracted
+  `positional_pairing` helper directly.
+- The total-row invariant (decision 4) is preserved by construction:
+  one filler row per *matched pair* (generalizing the old "one filler
+  row per positionally-paired row" count), so
+  `crate::diff_shape::walk_sections`/`hunk_start_lines`/
+  `section_start_line_for_symbol`/`symbol_id_for_scroll_line` still
+  need no changes — this amendment only changes *which* lines end up
+  paired on a row, never how many rows a run produces.
+
+This grew the pairing logic past what fits comfortably alongside
+`crate::diff_shape`'s section-building and unified-view line counting
+(CLAUDE.md's file-size discipline), so `SplitRow`/`pair_hunk_lines`
+and their helpers moved to a new sibling module,
+`crate::split_pairing`, re-exported from `crate::diff_shape` so every
+existing `crate::diff_shape::{SplitRow, pair_hunk_lines}` call site is
+unchanged.
+
+Token-based similarity (not a character diff) was chosen so
+reindentation or a single changed argument does not swamp the score,
+and order-insensitive token-set overlap (not a positional token
+comparison) so a reordered clause still scores high — both suit
+comparing source lines, whose meaningful unit of change is the token.

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -26,7 +26,8 @@
 //! `ui::draw` must not call `App::selected_blast_radius_view` either.
 
 use crate::app::DiffTarget;
-use crate::diff_view::{DiffLine, DiffLineKind, FileHunks, Hunk, file_hunks};
+use crate::diff_view::{FileHunks, Hunk, file_hunks};
+pub use crate::split_pairing::{SplitRow, pair_hunk_lines};
 use rinkaku_core::extract::Classification;
 use rinkaku_core::render::Report;
 
@@ -381,118 +382,6 @@ pub fn changed_line_ranges(sections: &[&DiffSection]) -> Vec<(usize, usize)> {
     ranges.sort_unstable();
     ranges.dedup();
     ranges
-}
-
-/// One rendered row of a split (side-by-side) diff view (ADR 0044): the
-/// old-side and new-side [`DiffLine`] shown on that row, either of which
-/// can be `None` — a filler cell with nothing on that side. `left_index`/
-/// `right_index` is that side's line's position in the hunk's original
-/// `lines` slice (`None` alongside a `None` line) — `crate::ui::diff_pane`
-/// needs this to look up [`crate::highlight::lookup_hunk_highlight_by_index`]'s
-/// per-line highlight table, which is indexed by that original interleaved
-/// position, not by `SplitRow` position (the two diverge as soon as any run
-/// merges two source lines onto one row).
-///
-/// [`pair_hunk_lines`] always returns one `SplitRow` per input
-/// [`DiffLine`], never fewer, so a hunk's split-mode row count matches its
-/// unified-mode row count exactly (ADR 0044 decision 4) — this is what lets
-/// [`walk_sections`]/[`hunk_start_lines`]/[`section_start_line_for_symbol`]/
-/// [`symbol_id_for_scroll_line`] stay unchanged regardless of
-/// [`crate::app::DiffViewMode`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SplitRow {
-    pub left: Option<DiffLine>,
-    pub left_index: Option<usize>,
-    pub right: Option<DiffLine>,
-    pub right_index: Option<usize>,
-}
-
-/// Pairs a hunk's interleaved `lines` into old-side/new-side [`SplitRow`]s
-/// for the split diff view (ADR 0044 decision 3). A `Context` line mirrors
-/// onto both sides. A maximal run of consecutive `Removed` lines
-/// immediately followed by a maximal run of consecutive `Added` lines pairs
-/// positionally (row `i` of the run gets the run's `i`-th removed/added
-/// line); when the two runs differ in length, the longer run's excess lines
-/// pair against `None` on the shorter side, one row per excess line. A
-/// `Removed` run with no following `Added` run (or vice versa) pairs every
-/// line against `None` on the other side.
-///
-/// Always returns exactly `lines.len()` rows (ADR 0044 decision 4): when a
-/// positional pairing merges two source lines onto one rendered row, a
-/// trailing `SplitRow { left: None, right: None }` filler row is appended
-/// for each merge, so the total row count never drops below the unified
-/// view's own line count — see [`SplitRow`]'s own doc comment for why this
-/// invariant matters.
-pub fn pair_hunk_lines(lines: &[DiffLine]) -> Vec<SplitRow> {
-    let mut rows = Vec::with_capacity(lines.len());
-    let mut i = 0;
-    while i < lines.len() {
-        match lines[i].kind {
-            DiffLineKind::Context => {
-                rows.push(SplitRow {
-                    left: Some(lines[i].clone()),
-                    left_index: Some(i),
-                    right: Some(lines[i].clone()),
-                    right_index: Some(i),
-                });
-                i += 1;
-            }
-            DiffLineKind::Removed => {
-                let removed_start = i;
-                let mut removed_end = i;
-                while removed_end < lines.len() && lines[removed_end].kind == DiffLineKind::Removed
-                {
-                    removed_end += 1;
-                }
-                let added_start = removed_end;
-                let mut added_end = removed_start.max(added_start);
-                while added_end < lines.len() && lines[added_end].kind == DiffLineKind::Added {
-                    added_end += 1;
-                }
-
-                let removed_run = &lines[removed_start..removed_end];
-                let added_run = &lines[added_start..added_end];
-                let paired = removed_run.len().max(added_run.len());
-                for offset in 0..paired {
-                    rows.push(SplitRow {
-                        left: removed_run.get(offset).cloned(),
-                        left_index: (offset < removed_run.len()).then_some(removed_start + offset),
-                        right: added_run.get(offset).cloned(),
-                        right_index: (offset < added_run.len()).then_some(added_start + offset),
-                    });
-                }
-                // Decision 4's filler rows: the run consumed
-                // `removed_run.len() + added_run.len()` source lines but
-                // only emitted `paired` rows so far — pad back up to the
-                // source count with blank filler rows.
-                let consumed = removed_run.len() + added_run.len();
-                for _ in paired..consumed {
-                    rows.push(SplitRow {
-                        left: None,
-                        left_index: None,
-                        right: None,
-                        right_index: None,
-                    });
-                }
-
-                i = added_end;
-            }
-            DiffLineKind::Added => {
-                // An `Added` run with no preceding `Removed` run (a pure
-                // insertion) — the `Removed` arm above already consumes any
-                // `Added` run that immediately follows a `Removed` run, so
-                // reaching this arm means there was none.
-                rows.push(SplitRow {
-                    left: None,
-                    left_index: None,
-                    right: Some(lines[i].clone()),
-                    right_index: Some(i),
-                });
-                i += 1;
-            }
-        }
-    }
-    rows
 }
 
 #[cfg(test)]

--- a/rinkaku-tui/src/diff_shape_tests/mod.rs
+++ b/rinkaku-tui/src/diff_shape_tests/mod.rs
@@ -14,6 +14,9 @@
 //! - `changed_line_ranges` — the Diff pane header's `range:` line data
 //!   (distinct new-side line spans, sorted and deduped across sections
 //!   so ADR 0029's cloned hunks produce one entry per span)
+//!
+//! `pair_hunk_lines`'s own tests moved to `crate::split_pairing_tests`
+//! alongside the rest of that module's split-out implementation.
 
 use super::*;
 use rinkaku_core::diff::LineRange;
@@ -24,7 +27,6 @@ use rinkaku_core::render::{FileReport, ReportOrigin};
 mod build_diff_pane_content;
 mod changed_line_ranges;
 mod hunk_start_lines;
-mod pair_hunk_lines;
 mod section_start_line;
 mod symbol_id_for_scroll_line;
 

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -42,6 +42,7 @@ mod session;
 pub mod source;
 pub mod source_diff;
 pub mod splash;
+mod split_pairing;
 pub mod tree;
 pub mod ui;
 

--- a/rinkaku-tui/src/split_pairing.rs
+++ b/rinkaku-tui/src/split_pairing.rs
@@ -1,0 +1,332 @@
+//! Split (side-by-side) diff view row pairing (ADR 0044 decisions 3-4,
+//! amended), split out from `crate::diff_shape` (CLAUDE.md's file-size
+//! discipline: an independent responsibility — pairing removed/added lines
+//! into rendered rows — distinct from that module's section-building and
+//! unified-view line counting) once this amendment's alignment algorithm
+//! grew the pairing logic past a single function. Re-exported from
+//! `crate::diff_shape` so every external call site keeps using
+//! `crate::diff_shape::{SplitRow, pair_hunk_lines}` unchanged.
+
+use crate::diff_view::{DiffLine, DiffLineKind};
+
+/// One rendered row of a split (side-by-side) diff view (ADR 0044): the
+/// old-side and new-side [`DiffLine`] shown on that row, either of which
+/// can be `None` — a filler cell with nothing on that side. `left_index`/
+/// `right_index` is that side's line's position in the hunk's original
+/// `lines` slice (`None` alongside a `None` line) — `crate::ui::diff_pane`
+/// needs this to look up [`crate::highlight::lookup_hunk_highlight_by_index`]'s
+/// per-line highlight table, which is indexed by that original interleaved
+/// position, not by `SplitRow` position (the two diverge as soon as any run
+/// merges two source lines onto one row).
+///
+/// [`pair_hunk_lines`] always returns one `SplitRow` per input
+/// [`DiffLine`], never fewer, so a hunk's split-mode row count matches its
+/// unified-mode row count exactly (ADR 0044 decision 4) — this is what lets
+/// `crate::diff_shape`'s `walk_sections`/`hunk_start_lines`/
+/// `section_start_line_for_symbol`/`symbol_id_for_scroll_line` stay
+/// unchanged regardless of [`crate::app::DiffViewMode`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SplitRow {
+    pub left: Option<DiffLine>,
+    pub left_index: Option<usize>,
+    pub right: Option<DiffLine>,
+    pub right_index: Option<usize>,
+}
+
+/// Pairs a hunk's interleaved `lines` into old-side/new-side [`SplitRow`]s
+/// for the split diff view (ADR 0044 decision 3, amended). A `Context` line
+/// mirrors onto both sides. A maximal run of consecutive `Removed` lines
+/// immediately followed by a maximal run of consecutive `Added` lines is
+/// aligned by [`align_run`] — see its own doc comment for the pairing rule.
+/// A `Removed` run with no following `Added` run (or vice versa) pairs every
+/// line against `None` on the other side.
+///
+/// Always returns exactly `lines.len()` rows (ADR 0044 decision 4): when a
+/// pairing merges two source lines onto one rendered row, a trailing
+/// `SplitRow { left: None, right: None }` filler row is appended for each
+/// merge, so the total row count never drops below the unified view's own
+/// line count — see [`SplitRow`]'s own doc comment for why this invariant
+/// matters.
+pub fn pair_hunk_lines(lines: &[DiffLine]) -> Vec<SplitRow> {
+    let mut rows = Vec::with_capacity(lines.len());
+    let mut i = 0;
+    while i < lines.len() {
+        match lines[i].kind {
+            DiffLineKind::Context => {
+                rows.push(SplitRow {
+                    left: Some(lines[i].clone()),
+                    left_index: Some(i),
+                    right: Some(lines[i].clone()),
+                    right_index: Some(i),
+                });
+                i += 1;
+            }
+            DiffLineKind::Removed => {
+                let removed_start = i;
+                let mut removed_end = i;
+                while removed_end < lines.len() && lines[removed_end].kind == DiffLineKind::Removed
+                {
+                    removed_end += 1;
+                }
+                let added_start = removed_end;
+                let mut added_end = removed_start.max(added_start);
+                while added_end < lines.len() && lines[added_end].kind == DiffLineKind::Added {
+                    added_end += 1;
+                }
+
+                let removed_run = &lines[removed_start..removed_end];
+                let added_run = &lines[added_start..added_end];
+                rows.extend(align_run(
+                    removed_run,
+                    removed_start,
+                    added_run,
+                    added_start,
+                ));
+
+                i = added_end;
+            }
+            DiffLineKind::Added => {
+                // An `Added` run with no preceding `Removed` run (a pure
+                // insertion) — the `Removed` arm above already consumes any
+                // `Added` run that immediately follows a `Removed` run, so
+                // reaching this arm means there was none.
+                rows.push(SplitRow {
+                    left: None,
+                    left_index: None,
+                    right: Some(lines[i].clone()),
+                    right_index: Some(i),
+                });
+                i += 1;
+            }
+        }
+    }
+    rows
+}
+
+/// A run pair longer than this on either side skips [`align_run`]'s O(n*m)
+/// similarity DP and falls back straight to [`positional_pairing`] — the
+/// DP cost is quadratic in run length, and a replace of this size is rare
+/// enough in practice that avoiding the cost matters more than the alignment
+/// quality gain for it.
+const SIMILARITY_ALIGNMENT_MAX_RUN_LEN: usize = 200;
+
+/// The minimum per-line similarity score (from [`line_similarity`], a
+/// `0.0..=1.0` normalized token overlap) for two lines to be considered the
+/// "same" line during alignment. Below this, [`align_run`] treats the pair
+/// as unrelated rather than forcing a low-confidence match.
+const SIMILARITY_THRESHOLD: f64 = 0.5;
+
+/// Aligns one removed/added run pair into [`SplitRow`]s (ADR 0044 amendment
+/// to decision 3). Positional pairing (row `i` gets the run's `i`-th
+/// removed/added line) reads well when a replace changes the *content* of
+/// each line in place, but reads badly when the two runs are shifted
+/// relative to each other — e.g. lines inserted ahead of an otherwise
+/// unchanged line pushes that line's row to line up against unrelated
+/// content instead of its near-identical counterpart (the motivating case
+/// for this change: a leading doc comment inserted ahead of an unchanged
+/// signature).
+///
+/// Instead, this finds the order-preserving matching between `removed_run`
+/// and `added_run` that maximizes total [`line_similarity`], keeping only
+/// matches at or above [`SIMILARITY_THRESHOLD`] (a Needleman-Wunsch-style
+/// alignment DP, gap cost 0 since an unmatched line just becomes its own
+/// `None`-paired row rather than being penalized). An unmatched line on
+/// either side becomes its own row paired with `None`; a run longer than
+/// [`SIMILARITY_ALIGNMENT_MAX_RUN_LEN`] skips the DP and falls back to
+/// [`positional_pairing`], and so does a run pair with zero matches above
+/// threshold — the latter reproduces the pre-amendment behavior exactly
+/// rather than emitting every line as unmatched, since positional pairing is
+/// already the best available guess once similarity has no signal to offer.
+///
+/// Preserves [`pair_hunk_lines`]'s total-row invariant: one filler row per
+/// matched pair, mirroring [`positional_pairing`]'s own filler-row count for
+/// the fully-positional case.
+fn align_run(
+    removed_run: &[DiffLine],
+    removed_start: usize,
+    added_run: &[DiffLine],
+    added_start: usize,
+) -> Vec<SplitRow> {
+    if removed_run.len() > SIMILARITY_ALIGNMENT_MAX_RUN_LEN
+        || added_run.len() > SIMILARITY_ALIGNMENT_MAX_RUN_LEN
+    {
+        return positional_pairing(removed_run, removed_start, added_run, added_start);
+    }
+
+    let pairs = best_alignment(removed_run, added_run);
+    if pairs.is_empty() {
+        return positional_pairing(removed_run, removed_start, added_run, added_start);
+    }
+
+    let mut rows = Vec::with_capacity(removed_run.len() + added_run.len());
+    let mut removed_cursor = 0;
+    let mut added_cursor = 0;
+    for (removed_offset, added_offset) in &pairs {
+        while removed_cursor < *removed_offset {
+            rows.push(SplitRow {
+                left: Some(removed_run[removed_cursor].clone()),
+                left_index: Some(removed_start + removed_cursor),
+                right: None,
+                right_index: None,
+            });
+            removed_cursor += 1;
+        }
+        while added_cursor < *added_offset {
+            rows.push(SplitRow {
+                left: None,
+                left_index: None,
+                right: Some(added_run[added_cursor].clone()),
+                right_index: Some(added_start + added_cursor),
+            });
+            added_cursor += 1;
+        }
+        rows.push(SplitRow {
+            left: Some(removed_run[removed_cursor].clone()),
+            left_index: Some(removed_start + removed_cursor),
+            right: Some(added_run[added_cursor].clone()),
+            right_index: Some(added_start + added_cursor),
+        });
+        removed_cursor += 1;
+        added_cursor += 1;
+    }
+    while removed_cursor < removed_run.len() {
+        rows.push(SplitRow {
+            left: Some(removed_run[removed_cursor].clone()),
+            left_index: Some(removed_start + removed_cursor),
+            right: None,
+            right_index: None,
+        });
+        removed_cursor += 1;
+    }
+    while added_cursor < added_run.len() {
+        rows.push(SplitRow {
+            left: None,
+            left_index: None,
+            right: Some(added_run[added_cursor].clone()),
+            right_index: Some(added_start + added_cursor),
+        });
+        added_cursor += 1;
+    }
+
+    // One filler row per matched pair, so the total row count stays at
+    // `removed_run.len() + added_run.len()` regardless of how many lines
+    // matched — the same invariant `positional_pairing` maintains for its
+    // own (fully-positional) matching.
+    for _ in 0..pairs.len() {
+        rows.push(SplitRow {
+            left: None,
+            left_index: None,
+            right: None,
+            right_index: None,
+        });
+    }
+    rows
+}
+
+/// The order-preserving, maximum-total-similarity matching between
+/// `removed_run` and `added_run`, keeping only pairs at or above
+/// [`SIMILARITY_THRESHOLD`]. Returns `(removed_offset, added_offset)` pairs
+/// in increasing order on both sides — a standard Needleman-Wunsch
+/// alignment DP with zero gap cost, where the "substitution score" is
+/// [`line_similarity`] when it clears the threshold and `f64::MIN` (never
+/// worth taking) otherwise.
+fn best_alignment(removed_run: &[DiffLine], added_run: &[DiffLine]) -> Vec<(usize, usize)> {
+    let rows = removed_run.len();
+    let cols = added_run.len();
+    let mut score = vec![vec![0.0_f64; cols + 1]; rows + 1];
+    for r in 1..=rows {
+        for c in 1..=cols {
+            let similarity =
+                line_similarity(&removed_run[r - 1].content, &added_run[c - 1].content);
+            let match_score = if similarity >= SIMILARITY_THRESHOLD {
+                score[r - 1][c - 1] + similarity
+            } else {
+                f64::MIN
+            };
+            score[r][c] = match_score.max(score[r - 1][c]).max(score[r][c - 1]);
+        }
+    }
+
+    let mut pairs = Vec::new();
+    let mut r = rows;
+    let mut c = cols;
+    while r > 0 && c > 0 {
+        if score[r][c] == score[r - 1][c] {
+            r -= 1;
+        } else if score[r][c] == score[r][c - 1] {
+            c -= 1;
+        } else {
+            pairs.push((r - 1, c - 1));
+            r -= 1;
+            c -= 1;
+        }
+    }
+    pairs.reverse();
+    pairs
+}
+
+/// Normalized token-overlap similarity between two lines, in `0.0..=1.0` —
+/// the Jaccard index of their whitespace-split token sets. Token-based
+/// (rather than character-based) so reindentation or a single changed
+/// argument does not swamp the score the way a character diff would, and
+/// order-insensitive so a reordered clause still scores high — both traits
+/// suit comparing source lines, whose meaningful unit is the token, not the
+/// character.
+fn line_similarity(a: &str, b: &str) -> f64 {
+    use std::collections::HashSet;
+
+    let tokens_a: HashSet<&str> = a.split_whitespace().collect();
+    let tokens_b: HashSet<&str> = b.split_whitespace().collect();
+    if tokens_a.is_empty() && tokens_b.is_empty() {
+        return 1.0;
+    }
+    let intersection = tokens_a.intersection(&tokens_b).count();
+    let union = tokens_a.union(&tokens_b).count();
+    if union == 0 {
+        0.0
+    } else {
+        intersection as f64 / union as f64
+    }
+}
+
+/// The pre-amendment pairing rule (ADR 0044 decision 3): row `i` of the run
+/// gets the run's `i`-th removed/added line; when the two runs differ in
+/// length, the longer run's excess lines pair against `None` on the shorter
+/// side, one row per excess line, followed by one filler row per paired
+/// row (decision 4). Used directly by [`align_run`] as its fallback when
+/// similarity alignment has no signal to offer or the run is too large to
+/// align cheaply.
+fn positional_pairing(
+    removed_run: &[DiffLine],
+    removed_start: usize,
+    added_run: &[DiffLine],
+    added_start: usize,
+) -> Vec<SplitRow> {
+    let mut rows = Vec::with_capacity(removed_run.len() + added_run.len());
+    let paired = removed_run.len().max(added_run.len());
+    for offset in 0..paired {
+        rows.push(SplitRow {
+            left: removed_run.get(offset).cloned(),
+            left_index: (offset < removed_run.len()).then_some(removed_start + offset),
+            right: added_run.get(offset).cloned(),
+            right_index: (offset < added_run.len()).then_some(added_start + offset),
+        });
+    }
+    // Decision 4's filler rows: the run consumed `removed_run.len() +
+    // added_run.len()` source lines but only emitted `paired` rows so far —
+    // pad back up to the source count with blank filler rows.
+    let consumed = removed_run.len() + added_run.len();
+    for _ in paired..consumed {
+        rows.push(SplitRow {
+            left: None,
+            left_index: None,
+            right: None,
+            right_index: None,
+        });
+    }
+    rows
+}
+
+#[cfg(test)]
+#[path = "split_pairing_tests/mod.rs"]
+mod tests;

--- a/rinkaku-tui/src/split_pairing_tests/mod.rs
+++ b/rinkaku-tui/src/split_pairing_tests/mod.rs
@@ -1,0 +1,9 @@
+//! Tests for `crate::split_pairing`, split from the source file (ADR 0028).
+//! One test module today (`pair_hunk_lines`, `crate::diff_shape::pair_hunk_lines`'s
+//! own re-exported entry point) — kept as a `mod.rs` rather than a single
+//! flat test file so a future second pub function here follows the same
+//! per-function grouping `diff_shape_tests/mod.rs` already established.
+
+use super::*;
+
+mod pair_hunk_lines;

--- a/rinkaku-tui/src/split_pairing_tests/pair_hunk_lines.rs
+++ b/rinkaku-tui/src/split_pairing_tests/pair_hunk_lines.rs
@@ -211,3 +211,162 @@ fn should_return_hunk_lines_len_rows_regardless_of_run_shape() {
 
     assert_eq!(lines.len(), actual.len());
 }
+
+#[test]
+fn should_align_matching_signature_past_inserted_leading_comment_lines() {
+    // ADR 0044 amendment: positional pairing put the old signature
+    // (removed row 0) next to the new side's first added line, which is
+    // now a doc comment rather than the shifted signature — the reader's
+    // original report. Similarity alignment must still match the two
+    // near-identical signature lines to each other and place the two
+    // unmatched leading comment lines as their own rows.
+    let lines = vec![
+        removed("fn compute(a: i32, b: i32) -> i32 {"),
+        added("/// Computes the sum of two numbers."),
+        added("/// Both arguments must be non-negative."),
+        added("fn compute(a: i32, b: i32) -> i64 {"),
+    ];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![
+            row(
+                None,
+                Some((added("/// Computes the sum of two numbers."), 1)),
+            ),
+            row(
+                None,
+                Some((added("/// Both arguments must be non-negative."), 2)),
+            ),
+            row(
+                Some((removed("fn compute(a: i32, b: i32) -> i32 {"), 0)),
+                Some((added("fn compute(a: i32, b: i32) -> i64 {"), 3)),
+            ),
+            row(None, None),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_align_matching_line_when_it_is_not_the_first_removed_line() {
+    // Mirrors the previous case with the match on the removed side instead
+    // of the added side: two removed lines no longer needed, followed by a
+    // line that is still present (near-identical) on the added side.
+    let lines = vec![
+        removed("// stale explanation, no longer accurate"),
+        removed("// second stale line"),
+        removed("fn compute(a: i32, b: i32) -> i32 {"),
+        added("fn compute(a: i32, b: i32) -> i64 {"),
+    ];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![
+            row(
+                Some((removed("// stale explanation, no longer accurate"), 0)),
+                None,
+            ),
+            row(Some((removed("// second stale line"), 1)), None),
+            row(
+                Some((removed("fn compute(a: i32, b: i32) -> i32 {"), 2)),
+                Some((added("fn compute(a: i32, b: i32) -> i64 {"), 3)),
+            ),
+            row(None, None),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_fall_back_to_positional_pairing_when_no_lines_are_similar() {
+    // No line on either side shares enough tokens with any line on the
+    // other side (every word differs) — similarity alignment degrades to
+    // exactly the old positional behavior rather than declining to pair
+    // anything.
+    let lines = vec![removed("alpha beta gamma"), added("delta epsilon zeta")];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![
+            row(
+                Some((removed("alpha beta gamma"), 0)),
+                Some((added("delta epsilon zeta"), 1)),
+            ),
+            row(None, None),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_align_every_line_when_removed_and_added_runs_are_identical_text() {
+    // Every line has an exact match on the other side — similarity
+    // alignment must recover the fully positional pairing. Two matched
+    // pairs still carry two filler rows, mirroring
+    // `should_pair_equal_length_removed_and_added_runs_positionally`'s
+    // existing 1-matched-pair/1-filler-row shape (ADR 0044 decision 4's
+    // total-row invariant scales the same way with more matches).
+    let lines = vec![
+        removed("fn a() {}"),
+        removed("fn b() {}"),
+        added("fn a() {}"),
+        added("fn b() {}"),
+    ];
+
+    let actual = pair_hunk_lines(&lines);
+
+    assert_eq!(
+        vec![
+            row(
+                Some((removed("fn a() {}"), 0)),
+                Some((added("fn a() {}"), 2)),
+            ),
+            row(
+                Some((removed("fn b() {}"), 1)),
+                Some((added("fn b() {}"), 3)),
+            ),
+            row(None, None),
+            row(None, None),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_fall_back_to_positional_pairing_when_run_exceeds_similarity_alignment_cap() {
+    // A run longer than `SIMILARITY_ALIGNMENT_MAX_RUN_LEN` skips the O(n*m)
+    // DP entirely and uses the old positional algorithm — every line is
+    // identical text on both sides (so similarity alignment, if it ran,
+    // would produce the same pairing anyway), which isolates this test to
+    // pinning the size cap itself rather than an alignment-quality
+    // difference.
+    let run_len = SIMILARITY_ALIGNMENT_MAX_RUN_LEN + 1;
+    let removed_lines: Vec<DiffLine> = (0..run_len)
+        .map(|index| removed(&format!("unique line {index}")))
+        .collect();
+    let added_lines: Vec<DiffLine> = (0..run_len)
+        .map(|index| added(&format!("unique line {index}")))
+        .collect();
+    let lines: Vec<DiffLine> = removed_lines
+        .iter()
+        .cloned()
+        .chain(added_lines.iter().cloned())
+        .collect();
+
+    let actual = pair_hunk_lines(&lines);
+
+    let mut expected: Vec<SplitRow> = (0..run_len)
+        .map(|index| {
+            row(
+                Some((removed_lines[index].clone(), index)),
+                Some((added_lines[index].clone(), run_len + index)),
+            )
+        })
+        .collect();
+    expected.extend((0..run_len).map(|_| row(None, None)));
+    assert_eq!(expected, actual);
+}


### PR DESCRIPTION
## Summary

- `pair_hunk_lines`'s per-run pairing (split diff view, ADR 0044) was purely positional: row `i` of a removed/added run always got the run's `i`-th line on each side. Lines inserted ahead of an otherwise-unchanged line (e.g. a doc comment added above a function signature) shifted every position after the insertion, so the unchanged signature's row lined up against the comment instead of its own near-identical counterpart on the other side — the exact "scan past unrelated content" problem ADR 0044 exists to fix, reintroduced inside it.
- Replaces per-run pairing with a similarity-based alignment: a Needleman-Wunsch-style DP over Jaccard token-overlap similarity (threshold 0.5), falling back to the original positional algorithm verbatim when no pair clears the threshold or a run exceeds a 200-line cap (avoids the DP's quadratic cost on rare, very large replaces).
- The total-row invariant (ADR 0044 decision 4 — split-mode row count always equals the unified view's) is preserved by construction: one filler row per *matched pair* instead of one per positionally-paired row.
- `SplitRow`/`pair_hunk_lines` and their helpers moved out of `diff_shape.rs` into a new sibling module `split_pairing.rs` (re-exported so all existing `diff_shape::{SplitRow, pair_hunk_lines}` call sites are unchanged) — the alignment algorithm is an independent responsibility from `diff_shape`'s section-building/line-counting, and kept the file under the file-size thresholds.
- Amends ADR 0044 (`docs/adr/0044-tui-split-view-diff-pane.md`) explaining the reversal of that ADR's original "positional pairing is sufficient" Alternatives-section reasoning.

**Not ready to merge** — held in draft pending explicit go-ahead.

## Test plan

- [x] `make test` (718 tests, including 9 pre-existing `pair_hunk_lines` regression tests unchanged + 6 new similarity-alignment tests)
- [x] `make lint`
- [x] `rinkaku --base main` (trusted main build) shows no new file-size warnings for touched files
- [x] Dynamic verification, fixture 1 (doc comment inserted above an unchanged-but-widened signature): built a two-commit fixture repo, ran `rinkaku --tui` in tmux — old/new signature lines land on the same split-view row despite two inserted comment lines ahead of the new signature; the two comment lines render as their own independent rows on the right only
- [x] Dynamic verification, fixture 2 (three scenarios in one diff, same tmux session):
  - Comment lines inserted ahead of an unchanged-but-widened signature (added-side match) — signature rows align, comment lines get their own right-only rows
  - Comment lines removed ahead of an unchanged body line (removed-side match) — comment lines get their own left-only rows, the unchanged body line renders as a plain context row (not part of the replace run)
  - A replace with zero token overlap on either side (fallback case) — pairs positionally, exactly matching `should_fall_back_to_positional_pairing_when_no_lines_are_similar`
- [x] Toggled `v` to unified view on the same fixture — unaffected (plain interleaved `-`/`+` lines), confirming `pair_hunk_lines` is only consumed by the split renderer
- [x] Scroll-sync regression: focused the diff pane, jumped to the bottom (`G`) — pinned header correctly resolved to `totally_unrelated` (the last section, past all three run-pairing cases), confirming `symbol_id_for_scroll_line`'s row-count-dependent lookup still works with the new alignment