### PR TITLE
feat(tui): read --pr mode's source view from the PR head snapshot

### DIFF
--- a/docs/adr/0046-source-view-diff-overlay.md
+++ b/docs/adr/0046-source-view-diff-overlay.md
@@ -193,3 +193,19 @@ position ADR 0026 already centers on the symbol.
   — `--base` mode is unaffected, since there the working tree already
   *is* the new side by construction. Left as a follow-up rather than
   folded into this ADR's decision.
+
+## Amendment: `--pr` mode now reads the source view from the head snapshot (ADR 0047)
+
+The `--pr` follow-up above is now fixed. `rinkaku-tui/src/source.rs`
+gained a `SourceReader` port (one method,
+`read(repo_root, relative_path) -> Result<String, String>`) that
+`load_symbol_source`/`load_highlighted_symbol_source` read through
+instead of calling `std::fs::read_to_string` directly.
+`WorkingTreeSourceReader` is the default, used by every input mode
+exactly as before. `main.rs` (the composition root) wires in a
+`git show <head SHA>:<path>`-backed reader
+(`rinkaku::git::file_read::PrHeadSourceReader`) only for `--pr` mode,
+using the PR head SHA and resolved workdir it already has in hand
+from `fetch_pr_head`/`resolve_pr_workdir`. See ADR 0047 for the
+rationale behind introducing the port itself (why this is a shared
+abstraction rather than a one-off branch).

--- a/docs/adr/0047-source-reader-port-for-pr-head-snapshot.md
+++ b/docs/adr/0047-source-reader-port-for-pr-head-snapshot.md
@@ -1,0 +1,107 @@
+# 0047. Inject a `SourceReader` port so `--pr` mode reads the source view from the head snapshot
+
+- Status: accepted
+- Date: 2026-07-15
+- Related: [ADR 0046](0046-source-view-diff-overlay.md) (its
+  Consequences section flags this exact gap as a follow-up), [ADR
+  0016](0016-tui-crate-and-stack.md) (`rinkaku-tui` may perform the
+  source view's file read, but must not shell out to `git` itself)
+
+## Context
+
+ADR 0046's diff overlay disables itself (falls back to plain
+rendering, with a pane-title note) whenever the source view's file
+content doesn't match the diff's recorded context lines. For `--pr`
+mode this fires on essentially every file the PR actually changes:
+`--pr` fetches the PR's head ref (`refs/pull/N/head`) into the
+resolved workdir but never checks it out (`main.rs`'s own module doc
+comment on its `--pr` read strategy), so
+`rinkaku_tui::source::load_symbol_source` keeps reading whatever the
+working tree happened to hold before `rinkaku` ran — unrelated to the
+PR's new side. The overlay's drift check correctly detects this and
+disables itself, but the result is that `--pr` mode — the input mode a
+reviewer reaches for most often — is exactly where the diff overlay is
+least available.
+
+`rinkaku-tui` must not run `git` itself (ADR 0016 decision 3: only
+`main.rs`/adapters own IO beyond the one source-file read the source
+view already makes). Fixing the gap therefore means `main.rs` handing
+`rinkaku-tui` a different way to read a file's content for `--pr`
+mode specifically — `git show <head SHA>:<path>`, the same read
+strategy `rinkaku/src/git/file_read.rs::read_git_show_file` already
+uses for `--base`/`--pr`'s own diff-analysis pipeline (`pipeline.rs`).
+
+## Decision
+
+**1. `rinkaku-tui/src/source.rs` gains a `SourceReader` trait**, one
+method: `fn read(&self, repo_root: &Path, relative_path: &str) ->
+Result<String, String>`. Defined in `source.rs` (the consumer), not in
+`rinkaku`'s adapter layer — same "port defined where it's used" rule
+this project's architecture conventions already apply everywhere
+else. `load_symbol_source`/`load_highlighted_symbol_source` take
+`reader: &dyn SourceReader` and call `reader.read(...)` instead of
+`std::fs::read_to_string` directly.
+
+**2. `WorkingTreeSourceReader` (in the same module) is the default
+implementation**, wrapping exactly the `resolve_source_path` +
+`std::fs::read_to_string` logic the source view always used before
+this ADR. Every input mode except `--pr` (stdin, `--base`, and `--pr`
+before this ADR) keeps this reader — no behavior change for them.
+
+**3. `rinkaku`'s adapter layer gains `PrHeadSourceReader`**
+(`rinkaku/src/git/file_read.rs`), implementing `SourceReader` by
+calling the existing `read_git_show_file(cwd, head, path)` — the same
+function `pipeline.rs` already uses for `--base`/`--pr`'s own file
+reads, so this is a new caller of existing IO, not new IO.
+
+**4. `main.rs` (composition root) wires the reader per input mode.**
+`run_analysis`'s `--pr` branch already resolves both the values this
+reader needs — the workdir (`resolve_pr_workdir`) and the head SHA
+(`fetch_pr_head`) — so `AnalyzedReport` grows a `pr_head_sha: Option<String>`
+field (`None` for every mode but `--pr`, mirroring how
+`resolved_workdir` already carries the workdir out). The
+`DisplayMode::Tui` branch constructs `PrHeadSourceReader { head,
+cwd: resolved_workdir }` when `pr_head_sha` is `Some`, else uses
+`WorkingTreeSourceReader`, and passes `&dyn SourceReader` into
+`TuiSession::run` (itself threading it through to `run_app`).
+
+## Alternatives
+
+- **Plumb the head SHA into `rinkaku-tui` and let it call `git show`
+  itself.** Rejected: ADR 0016 draws the line at "one source-file
+  read" precisely to keep `rinkaku-tui` free of process-spawning IO;
+  adding a `git show` invocation inside the TUI crate would cross that
+  line for a capability `rinkaku`'s adapter layer already has.
+- **Branch inside `load_symbol_source` on an `Option<PrContext>`
+  parameter instead of a trait.** Rejected as a worse shape for the
+  same job: a trait keeps `source.rs` ignorant of what `--pr` even is
+  (it only knows "a way to read a file"), whereas a context struct
+  would leak `--pr`-specific concepts into a module every input mode
+  shares, and every future read strategy (a hypothetical LSP-backed
+  read, a remote content API) would need another branch instead of
+  another impl.
+- **Do nothing, keep the ADR 0046 Consequences note as accepted
+  scope.** Rejected because the gap lands on the input mode used most
+  during real PR review (see this project's own dogfooding workflow,
+  which runs `--pr` for the map-assisted review pass) — the very
+  scenario the diff overlay was built for.
+
+## Consequences
+
+- `--pr` mode's source view (`s`) now shows the diff overlay for
+  files the PR changes, matching `--base` mode's behavior — no more
+  "overlay unavailable" note for the common case.
+- `--base` and stdin modes are unaffected: `WorkingTreeSourceReader`
+  preserves their exact prior behavior (including the *existing*,
+  documented drift risk when the working tree has been edited since
+  the diff was produced or diffed against a different revision).
+- `rinkaku-tui` gains one new public trait plus one new public struct
+  in `source.rs`; no new file, no new module — the module stays under
+  the file-size discipline's watch threshold.
+- `rinkaku`'s adapter layer gains one new small struct
+  (`PrHeadSourceReader`) reusing existing `read_git_show_file`
+  plumbing; no new subprocess call shape.
+- A future read strategy (e.g. an LSP-backed reader) has a clear
+  extension point: implement `SourceReader`, wire it in at
+  `main.rs`'s composition root — no changes needed inside `source.rs`
+  itself.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -125,9 +125,12 @@ entries — same behavior as neovim's jumplist.
 ## Source view
 
 `s` on a symbol row opens the file scrolled to and highlighting its
-line range. Reads the working tree (not the historical commit
-`--base`/`--pr` compared against), so the highlighted range can drift
-if you edit the file after opening the TUI. `esc`/`q` returns.
+line range. In `--base` and stdin mode, this reads the working tree
+(not the historical commit compared against), so the highlighted
+range can drift if you edit the file after opening the TUI. In `--pr`
+mode, this reads the PR's head snapshot instead (`git show <head
+SHA>:<path>`), so it stays consistent with the diff regardless of
+what's checked out locally. `esc`/`q` returns.
 
 When the open file has diff hunks, they're overlaid directly onto the
 full file: added lines get a green background and a `+` gutter,
@@ -135,12 +138,10 @@ removed lines appear as extra red-background rows with a `-` gutter
 inserted at the position they used to occupy — the diff pane's
 signal, but in the context of the whole file rather than clipped to
 the changed lines alone. The overlay is always on; there's no key to
-toggle it off. If the file on disk no longer matches the diff (edited
-since it was produced, or diffed against a different revision), the
-pane falls back to its plain, unhighlighted rendering and says so in
-its title. In particular, `--pr` shows your local checkout here, not
-a snapshot of the PR's branch, so files the PR changes typically fall
-back to plain rendering too.
+toggle it off. If the file's content doesn't match the diff (in
+`--base`/stdin mode, edited since the diff was produced or diffed
+against a different revision), the pane falls back to its plain,
+unhighlighted rendering and says so in its title.
 
 ## Combining with `--entry`
 

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -56,15 +56,16 @@ use std::time::Duration;
 /// taken over the terminal — see [`run`]'s doc comment (re-exported from
 /// `crate::session`, which retains the full terminal-lifecycle rationale
 /// that used to live here) for what `report`, `diff_text`, `entry_path`,
-/// and `repo_root` mean. `pub(crate)` rather than private: `crate::session`
-/// is a sibling module, not a submodule, so it needs this visibility to
-/// call in.
+/// `repo_root`, and `source_reader` mean. `pub(crate)` rather than private:
+/// `crate::session` is a sibling module, not a submodule, so it needs this
+/// visibility to call in.
 pub(crate) fn run_app(
     terminal: &mut ratatui::DefaultTerminal,
     report: &Report,
     diff_text: &str,
     entry_path: Option<&str>,
     repo_root: &std::path::Path,
+    source_reader: &dyn source::SourceReader,
 ) -> std::io::Result<()> {
     let mut app = App::new(report);
     if let Some(path) = entry_path {
@@ -245,8 +246,12 @@ pub(crate) fn run_app(
                         &symbol_id,
                     )
                 {
-                    let loaded =
-                        source::load_highlighted_symbol_source(report, &symbol_id, repo_root);
+                    let loaded = source::load_highlighted_symbol_source(
+                        report,
+                        &symbol_id,
+                        repo_root,
+                        source_reader,
+                    );
                     // A failure is surfaced on the status line right away
                     // (rather than only discovered on the next redraw)
                     // *and* cached into `source_content` below so

--- a/rinkaku-tui/src/session.rs
+++ b/rinkaku-tui/src/session.rs
@@ -9,6 +9,7 @@
 //! only the terminal-lifecycle wrapper around that loop moves here.
 
 use crate::run_app;
+use crate::source::{SourceReader, WorkingTreeSourceReader};
 use crate::splash;
 use ratatui::crossterm::event;
 use ratatui::crossterm::execute;
@@ -79,6 +80,11 @@ use rinkaku_core::render::Report;
 /// (ADR 0016). Without it, the source view would only work when `rinkaku`
 /// happens to be invoked from the repository root.
 ///
+/// Uses [`WorkingTreeSourceReader`] for the source drill-down's file reads
+/// (ADR 0047's default) — callers that need `--pr` mode's head-snapshot
+/// reader go through [`TuiSession::run`] directly instead, passing their
+/// own [`SourceReader`].
+///
 /// A thin convenience wrapper around [`TuiSession::init`] +
 /// [`TuiSession::run`] for callers that have no splash screen to draw
 /// in between (ADR 0033) — every terminal-lifecycle detail this doc
@@ -90,7 +96,13 @@ pub fn run(
     entry_path: Option<&str>,
     repo_root: &std::path::Path,
 ) -> std::io::Result<()> {
-    TuiSession::init()?.run(report, diff_text, entry_path, repo_root)
+    TuiSession::init()?.run(
+        report,
+        diff_text,
+        entry_path,
+        repo_root,
+        &WorkingTreeSourceReader,
+    )
 }
 
 /// Owns the terminal's raw-mode/alternate-screen/mouse-capture lifecycle
@@ -171,14 +183,28 @@ impl TuiSession {
     /// matching the postamble the pre-ADR-0033 [`run`] function always ran.
     /// See [`run`]'s own doc comment (preserved there) for what `report`,
     /// `diff_text`, `entry_path`, and `repo_root` mean.
+    ///
+    /// `source_reader` is the source drill-down's file-content port (ADR
+    /// 0047): [`WorkingTreeSourceReader`] for every input mode except
+    /// `--pr`, for which `main.rs` wires in a `git show`-backed reader so
+    /// the source view reflects the PR's head snapshot rather than
+    /// whatever happens to be checked out locally.
     pub fn run(
         mut self,
         report: &Report,
         diff_text: &str,
         entry_path: Option<&str>,
         repo_root: &std::path::Path,
+        source_reader: &dyn SourceReader,
     ) -> std::io::Result<()> {
-        let result = run_app(&mut self.terminal, report, diff_text, entry_path, repo_root);
+        let result = run_app(
+            &mut self.terminal,
+            report,
+            diff_text,
+            entry_path,
+            repo_root,
+            source_reader,
+        );
         let _ = execute!(std::io::stdout(), event::DisableMouseCapture);
         ratatui::restore();
         result

--- a/rinkaku-tui/src/source.rs
+++ b/rinkaku-tui/src/source.rs
@@ -16,6 +16,14 @@
 //! reading them off disk needs the repository root joined in first rather
 //! than treating them as relative to wherever `rinkaku` happens to be
 //! invoked from (e.g. a subdirectory) — see [`resolve_source_path`].
+//!
+//! **File content itself comes from a [`SourceReader`] (ADR 0047), not a
+//! hardcoded `std::fs::read_to_string` call.** `rinkaku-tui` never shells
+//! out to `git` (ADR 0016), so `--pr` mode's IO — reading a file as it
+//! existed at the PR's head commit, via `git show <sha>:<path>` — is
+//! implemented in `rinkaku`'s own adapter layer and injected in through
+//! this trait; [`WorkingTreeSourceReader`] is the default every other
+//! input mode uses.
 
 /// A symbol's location in `Report`, resolved from its id — enough for
 /// [`load_symbol_source`] to know which file to read and
@@ -53,52 +61,69 @@ pub struct HighlightedSourceView {
     pub token_highlights: Vec<crate::highlight::LineHighlight>,
 }
 
-/// Reads `id`'s file off the working tree and builds a [`SourceView`] for
-/// it, or an error message suitable for the status line on failure (no
-/// such symbol in `report`, or the file read itself failing — a moved/
-/// deleted file since the diff was analyzed, a permissions error, etc.).
-///
-/// Always reads from the working tree, regardless of which input mode
-/// (`--base`, `--pr`, stdin) produced `report` — unlike `main.rs`'s
-/// `--base`/`--pr` pipelines, which read historical content via
-/// `git show <rev>:<path>` to stay pinned to the exact diffed commit, the
-/// TUI's source view is a live "look at the file now" drill-down, so
-/// reading the working tree is the right behavior even when `report` was
-/// built from a historical diff (the alternative — plumbing the resolved
-/// head SHA all the way from `main.rs` into `rinkaku_tui::run` just for
-/// this one view — is deferred until a real user need for it shows up).
+/// A source of file content for the source drill-down (ADR 0047),
+/// injected so this crate's only IO stays behind a small port rather than
+/// a hardcoded `std::fs` call — `rinkaku-tui` never shells out to `git`
+/// itself (ADR 0016), so a reader backed by `git show` lives in `rinkaku`'s
+/// adapter layer and is wired in from there.
+pub trait SourceReader {
+    /// Reads `relative_path` (repository-root-relative, see this module's
+    /// doc comment) and returns its content, or an error message suitable
+    /// for the status line on failure.
+    fn read(&self, repo_root: &std::path::Path, relative_path: &str) -> Result<String, String>;
+}
+
+/// The default [`SourceReader`]: reads `relative_path` off the working
+/// tree, joined onto `repo_root` via [`resolve_source_path`]. Used by
+/// every input mode except `--pr` (ADR 0047), for which `main.rs` wires in
+/// a `git show <head SHA>:<path>`-backed reader instead so the source view
+/// reflects the PR's actual head snapshot rather than whatever happens to
+/// be checked out locally.
+pub struct WorkingTreeSourceReader;
+
+impl SourceReader for WorkingTreeSourceReader {
+    fn read(&self, repo_root: &std::path::Path, relative_path: &str) -> Result<String, String> {
+        let full_path = resolve_source_path(repo_root, relative_path);
+        std::fs::read_to_string(&full_path).map_err(|source| {
+            format!(
+                "failed to read {}: {source} (not present in the working tree — expected for a \
+                 file diffed from a PR or historical commit not checked out locally)",
+                full_path.display()
+            )
+        })
+    }
+}
+
+/// Reads `id`'s file via `reader` and builds a [`SourceView`] for it, or an
+/// error message suitable for the status line on failure (no such symbol
+/// in `report`, or the file read itself failing).
 ///
 /// `repo_root` anchors `location.path` (always repository-root-relative,
-/// see this module's doc comment) via [`resolve_source_path`] — callers
-/// pass the repository root `main.rs` resolves once at startup
-/// (`rinkaku_tui::run`'s own `repo_root` parameter), not the process's
-/// current directory, so this still works when `rinkaku` is invoked from a
-/// subdirectory of the repository.
+/// see this module's doc comment) — callers pass the repository root
+/// `main.rs` resolves once at startup (`rinkaku_tui::run`'s own
+/// `repo_root` parameter), not the process's current directory, so this
+/// still works when `rinkaku` is invoked from a subdirectory of the
+/// repository.
 ///
-/// A consequence of reading live: a symbol's `range` in `report` reflects
-/// the file's content *at analysis time*. If the file is edited on disk
-/// afterward (including between opening the TUI and pressing `s` on a
-/// given row), the highlighted lines can drift from the symbol's actual
-/// current location, or — if the file shrank — extend past its current
-/// end entirely. [`visible_window`] clamps to the file's current length
-/// either way rather than producing an out-of-bounds window, but it makes
-/// no attempt to re-locate the symbol in the changed content.
+/// With [`WorkingTreeSourceReader`] (every input mode except `--pr`), a
+/// symbol's `range` in `report` reflects the file's content *at analysis
+/// time*. If the file is edited on disk afterward (including between
+/// opening the TUI and pressing `s` on a given row), the highlighted lines
+/// can drift from the symbol's actual current location, or — if the file
+/// shrank — extend past its current end entirely. [`visible_window`]
+/// clamps to the file's current length either way rather than producing
+/// an out-of-bounds window, but it makes no attempt to re-locate the
+/// symbol in the changed content.
 pub fn load_symbol_source(
     report: &rinkaku_core::render::Report,
     id: &str,
     repo_root: &std::path::Path,
+    reader: &dyn SourceReader,
 ) -> Result<SourceView, String> {
     let location = find_symbol_location(report, id)
         .ok_or_else(|| format!("symbol not found in report: {id}"))?;
 
-    let full_path = resolve_source_path(repo_root, &location.path);
-    let content = std::fs::read_to_string(&full_path).map_err(|source| {
-        format!(
-            "failed to read {}: {source} (not present in the working tree — expected for a \
-             file diffed from a PR or historical commit not checked out locally)",
-            full_path.display()
-        )
-    })?;
+    let content = reader.read(repo_root, &location.path)?;
 
     Ok(SourceView {
         path: location.path,
@@ -127,8 +152,9 @@ pub fn load_highlighted_symbol_source(
     report: &rinkaku_core::render::Report,
     id: &str,
     repo_root: &std::path::Path,
+    reader: &dyn SourceReader,
 ) -> Result<HighlightedSourceView, String> {
-    let view = load_symbol_source(report, id, repo_root)?;
+    let view = load_symbol_source(report, id, repo_root, reader)?;
     let token_highlights = crate::highlight::highlight_source_lines(&view.path, &view.lines);
     Ok(HighlightedSourceView {
         view,
@@ -369,7 +395,12 @@ mod tests {
     fn should_return_error_message_when_load_symbol_source_finds_no_such_symbol() {
         let report = empty_report();
 
-        let actual = load_symbol_source(&report, "missing::id", std::path::Path::new("/repo"));
+        let actual = load_symbol_source(
+            &report,
+            "missing::id",
+            std::path::Path::new("/repo"),
+            &WorkingTreeSourceReader,
+        );
 
         assert_eq!(
             Err("symbol not found in report: missing::id".to_string()),
@@ -428,7 +459,12 @@ mod tests {
             highlight_start: 1,
             highlight_end: 1,
         });
-        let actual = load_symbol_source(&report, "src/lib.rs::foo", dir.path());
+        let actual = load_symbol_source(
+            &report,
+            "src/lib.rs::foo",
+            dir.path(),
+            &WorkingTreeSourceReader,
+        );
 
         assert_eq!(expected, actual);
     }
@@ -450,12 +486,102 @@ mod tests {
             ..empty_report()
         };
 
-        let actual = load_symbol_source(&report, "src/missing.rs::foo", dir.path());
+        let actual = load_symbol_source(
+            &report,
+            "src/missing.rs::foo",
+            dir.path(),
+            &WorkingTreeSourceReader,
+        );
 
         let error = actual.expect_err("a missing file must fail rather than silently succeed");
         assert!(
             error.contains("not present in the working tree"),
             "error message should explain the file may not be checked out locally, got: {error}"
+        );
+    }
+
+    /// A [`SourceReader`] that always returns fixed content, ignoring both
+    /// arguments — used to prove [`load_symbol_source`] actually reads
+    /// through the injected reader rather than reaching for the working
+    /// tree directly.
+    struct FakeSourceReader {
+        content: Result<String, String>,
+    }
+
+    impl SourceReader for FakeSourceReader {
+        fn read(
+            &self,
+            _repo_root: &std::path::Path,
+            _relative_path: &str,
+        ) -> Result<String, String> {
+            self.content.clone()
+        }
+    }
+
+    #[test]
+    fn should_read_via_injected_reader_when_loading_symbol_source() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    LineRange { start: 1, end: 1 },
+                )],
+            }],
+            ..empty_report()
+        };
+        let reader = FakeSourceReader {
+            content: Ok("fn foo() { /* head snapshot */ }".to_string()),
+        };
+
+        let actual = load_symbol_source(
+            &report,
+            "src/lib.rs::foo",
+            std::path::Path::new("/unused"),
+            &reader,
+        );
+
+        assert_eq!(
+            Ok(SourceView {
+                path: "src/lib.rs".to_string(),
+                lines: vec!["fn foo() { /* head snapshot */ }".to_string()],
+                highlight_start: 1,
+                highlight_end: 1,
+            }),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_propagate_reader_error_when_loading_symbol_source() {
+        let report = Report {
+            origin: rinkaku_core::render::ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    LineRange { start: 1, end: 1 },
+                )],
+            }],
+            ..empty_report()
+        };
+        let reader = FakeSourceReader {
+            content: Err("git show origin/pr-head:src/lib.rs failed".to_string()),
+        };
+
+        let actual = load_symbol_source(
+            &report,
+            "src/lib.rs::foo",
+            std::path::Path::new("/unused"),
+            &reader,
+        );
+
+        assert_eq!(
+            Err("git show origin/pr-head:src/lib.rs failed".to_string()),
+            actual
         );
     }
 
@@ -480,8 +606,13 @@ mod tests {
             ..empty_report()
         };
 
-        let actual = load_highlighted_symbol_source(&report, "src/lib.rs::foo", dir.path())
-            .expect("expected a successful load for an existing .rs file");
+        let actual = load_highlighted_symbol_source(
+            &report,
+            "src/lib.rs::foo",
+            dir.path(),
+            &WorkingTreeSourceReader,
+        )
+        .expect("expected a successful load for an existing .rs file");
 
         assert_eq!(
             SourceView {
@@ -525,8 +656,13 @@ mod tests {
             ..empty_report()
         };
 
-        let actual = load_highlighted_symbol_source(&report, "config.yaml::root", dir.path())
-            .expect("expected a successful load for an existing file");
+        let actual = load_highlighted_symbol_source(
+            &report,
+            "config.yaml::root",
+            dir.path(),
+            &WorkingTreeSourceReader,
+        )
+        .expect("expected a successful load for an existing file");
 
         assert_eq!(vec![None], actual.token_highlights);
     }
@@ -548,7 +684,12 @@ mod tests {
             ..empty_report()
         };
 
-        let actual = load_highlighted_symbol_source(&report, "src/missing.rs::foo", dir.path());
+        let actual = load_highlighted_symbol_source(
+            &report,
+            "src/missing.rs::foo",
+            dir.path(),
+            &WorkingTreeSourceReader,
+        );
 
         let error = actual.expect_err("a missing file must fail rather than silently succeed");
         assert!(

--- a/rinkaku-tui/src/ui/source_screen/tests.rs
+++ b/rinkaku-tui/src/ui/source_screen/tests.rs
@@ -94,6 +94,7 @@ fn missing_file_source_content(
         report,
         symbol_id,
         std::path::Path::new("/repo"),
+        &crate::source::WorkingTreeSourceReader,
     ))
 }
 
@@ -214,6 +215,7 @@ fn should_apply_keyword_foreground_and_symbol_range_background_in_source_screen(
         &report,
         "lib.rs::foo",
         dir.path(),
+        &crate::source::WorkingTreeSourceReader,
     ));
     let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
@@ -285,6 +287,7 @@ fn should_fall_back_to_plain_source_style_when_file_extension_is_unrecognized() 
         &report,
         "config.yaml::foo",
         dir.path(),
+        &crate::source::WorkingTreeSourceReader,
     ));
     let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
@@ -389,6 +392,7 @@ fn draw_source_screen_for_test(
         report,
         "lib.rs::foo",
         repo_root,
+        &crate::source::WorkingTreeSourceReader,
     ));
     let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 

--- a/rinkaku/src/git/file_read.rs
+++ b/rinkaku/src/git/file_read.rs
@@ -7,6 +7,28 @@ pub(crate) fn read_working_tree_file(path: &str) -> std::io::Result<String> {
     std::fs::read_to_string(path)
 }
 
+/// [`rinkaku_tui::source::SourceReader`] backed by `git show <head>:<path>`
+/// (ADR 0047) — `main.rs` wires this into the TUI's source view for `--pr`
+/// mode, in place of [`rinkaku_tui::source::WorkingTreeSourceReader`]'s
+/// working-tree read, since `--pr` mode never checks the PR's head ref out
+/// (this module's own doc comment, and `main.rs`'s module doc comment on
+/// its `--pr` read strategy) — the working tree can be anything.
+///
+/// `head` is the resolved PR head SHA and `cwd` is the resolved `--pr`
+/// workdir, exactly the values `main.rs` already has in hand from
+/// `fetch_pr_head`/`resolve_pr_workdir` by the time the TUI starts.
+pub(crate) struct PrHeadSourceReader {
+    pub(crate) head: String,
+    pub(crate) cwd: Option<std::path::PathBuf>,
+}
+
+impl rinkaku_tui::source::SourceReader for PrHeadSourceReader {
+    fn read(&self, _repo_root: &std::path::Path, relative_path: &str) -> Result<String, String> {
+        read_git_show_file(self.cwd.as_deref(), &self.head, relative_path)
+            .map_err(|source| format!("failed to read {relative_path} at {}: {source}", self.head))
+    }
+}
+
 /// Reads a changed file's content as committed at `head`, via
 /// `git show <head>:<path>`. Used in `--base` mode so the content read
 /// always matches the commit the diff was generated against, independent
@@ -65,5 +87,68 @@ mod tests {
             .expect("git show should succeed for a committed file");
 
         assert_eq!(committed, actual);
+    }
+
+    mod pr_head_source_reader_tests {
+        use super::*;
+        use pretty_assertions::assert_eq;
+        use rinkaku_tui::source::SourceReader;
+
+        // Integration test for ADR 0047: the source view's `--pr` reader
+        // must read the resolved head commit, not the working tree — a
+        // working-tree edit made after the head was fetched (analogous to
+        // `--pr` never checking the fetched ref out) must not affect what
+        // this reader returns.
+        #[test]
+        fn should_read_head_commit_content_when_working_tree_is_dirty() {
+            let dir = tempfile::TempDir::new().expect("create tempdir");
+            let committed = "fn foo(a: i32) -> i32 {\n    a\n}\n";
+            init_repo_with_committed_file(dir.path(), committed);
+            let head = String::from_utf8(
+                std::process::Command::new("git")
+                    .args(["rev-parse", "HEAD"])
+                    .current_dir(dir.path())
+                    .output()
+                    .expect("run git rev-parse")
+                    .stdout,
+            )
+            .expect("git rev-parse output is UTF-8")
+            .trim()
+            .to_string();
+
+            std::fs::write(
+                dir.path().join("src/lib.rs"),
+                "fn foo(a: i32) -> i32 {\n    a + 999\n}\n",
+            )
+            .expect("dirty the working tree");
+
+            let reader = PrHeadSourceReader {
+                head,
+                cwd: Some(dir.path().to_path_buf()),
+            };
+
+            let actual = reader.read(std::path::Path::new("/unused"), "src/lib.rs");
+
+            assert_eq!(Ok(committed.to_string()), actual);
+        }
+
+        #[test]
+        fn should_return_error_message_when_head_commit_has_no_such_path() {
+            let dir = tempfile::TempDir::new().expect("create tempdir");
+            init_repo_with_committed_file(dir.path(), "fn foo() {}\n");
+
+            let reader = PrHeadSourceReader {
+                head: "HEAD".to_string(),
+                cwd: Some(dir.path().to_path_buf()),
+            };
+
+            let actual = reader.read(std::path::Path::new("/unused"), "src/missing.rs");
+
+            let error = actual.expect_err("a missing path must fail rather than silently succeed");
+            assert!(
+                error.contains("src/missing.rs"),
+                "error message should name the missing path, got: {error}"
+            );
+        }
     }
 }

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -164,10 +164,15 @@ fn main() -> anyhow::Result<()> {
                 // reintroduce exactly the raw-bytes-mid-redraw bug this ADR
                 // amendment fixes, just for one more call site.
                 let report = finish_report(&cli, &progress, analyzed.report);
-                (report, analyzed.diff_text, analyzed.resolved_workdir)
+                (
+                    report,
+                    analyzed.diff_text,
+                    analyzed.resolved_workdir,
+                    analyzed.pr_head_sha,
+                )
             });
             let (session, buffered_notes) = progress.into_session_and_notes();
-            let (report, diff_text, resolved_workdir) = match outcome {
+            let (report, diff_text, resolved_workdir, pr_head_sha) = match outcome {
                 Ok(analyzed) => analyzed,
                 Err(err) => {
                     // `session` (and with it, `TuiSession`'s `Drop` impl)
@@ -193,8 +198,29 @@ fn main() -> anyhow::Result<()> {
                 }
             };
             let repo_root = resolve_repo_root(resolved_workdir.as_deref());
+            // `--pr` mode never checks the fetched head ref out (this
+            // module's own doc comment on the `--pr` read strategy), so the
+            // working tree is not a reliable source for the source view's
+            // file content there — a `git show <head>:<path>` reader keeps
+            // it pinned to the PR's actual head snapshot instead (ADR
+            // 0047). Every other input mode keeps reading the working tree,
+            // unchanged.
+            let pr_source_reader = pr_head_sha.map(|head| git::file_read::PrHeadSourceReader {
+                head,
+                cwd: resolved_workdir.clone(),
+            });
+            let source_reader: &dyn rinkaku_tui::source::SourceReader = match &pr_source_reader {
+                Some(reader) => reader,
+                None => &rinkaku_tui::source::WorkingTreeSourceReader,
+            };
             let result = session
-                .run(&report, &diff_text, cli.entry.as_deref(), &repo_root)
+                .run(
+                    &report,
+                    &diff_text,
+                    cli.entry.as_deref(),
+                    &repo_root,
+                    source_reader,
+                )
                 .map_err(anyhow::Error::from);
             // Flushed after `TuiSession::run` has already restored the
             // terminal (its own postamble, unconditional on both the `Ok`
@@ -273,17 +299,19 @@ fn release_log_sink(sink: &DeferredLogSink<std::io::Stderr>) {
 }
 
 /// The result of [`run_analysis`]: a built [`Report`], the raw diff text
-/// (empty for the whole-repo-outline branch, ADR 0017), and the resolved
+/// (empty for the whole-repo-outline branch, ADR 0017), the resolved
 /// working directory (`--pr`'s own clone/cache directory, `None` for every
-/// other input mode) — grouped into a named struct rather than a tuple so
-/// each field keeps its name at the one call site that destructures all
-/// three (a positional tuple invites a field-order mix-up the first time
-/// this return shape is touched, the same reasoning
+/// other input mode), and the resolved PR head SHA (`--pr` only, `None`
+/// otherwise) — grouped into a named struct rather than a tuple so each
+/// field keeps its name at the one call site that destructures all four (a
+/// positional tuple invites a field-order mix-up the first time this
+/// return shape is touched, the same reasoning
 /// `rinkaku_tui::DiffPaneSelectionEffects` documents for itself).
 struct AnalyzedReport {
     report: Report,
     diff_text: String,
     resolved_workdir: Option<PathBuf>,
+    pr_head_sha: Option<String>,
 }
 
 /// Runs the same `--pr`/`--base`/stdin/whole-repo input-mode chain
@@ -306,6 +334,12 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
     // instead, showing an unrelated file if one happens to exist at the
     // same relative path there.
     let mut resolved_workdir: Option<std::path::PathBuf> = None;
+    // Populated only in the `--pr` branch below; carried out to
+    // `AnalyzedReport::pr_head_sha` so `main`'s `DisplayMode::Tui` arm can
+    // wire a `git show`-backed `SourceReader` (ADR 0047) for exactly this
+    // input mode, the same way `resolved_workdir` above already carries
+    // out `--pr`'s resolved clone directory.
+    let mut pr_head_sha: Option<String> = None;
     let (report, diff_text) = if let Some(pr_arg) = &cli.pr {
         // Validate the arg and derive the fetch refspec's PR number, but
         // pass the original (trimmed) value — not the parsed number — to
@@ -325,6 +359,7 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
         let cwd = workdir.as_deref();
         log::debug!("fetching PR #{number} head");
         let head_sha = fetch_pr_head(number, cwd)?;
+        pr_head_sha = Some(head_sha.clone());
         if head_sha != pr_info.head_ref_oid {
             anyhow::bail!(
                 "fetched PR #{number} head ({head_sha}) does not match `gh`'s reported head \
@@ -465,6 +500,7 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
         report,
         diff_text,
         resolved_workdir,
+        pr_head_sha,
     })
 }
 


### PR DESCRIPTION
## Summary

- `--pr` mode fetches the PR's head ref but never checks it out, so
  the source view's diff overlay (ADR 0046) fell back to plain
  rendering for essentially every file the PR actually changes — the
  ADR's own Consequences section flagged this as a follow-up.
- Injects a `SourceReader` port in `rinkaku-tui/src/source.rs`
  (`WorkingTreeSourceReader` default, unchanged behavior for
  `--base`/stdin) and wires in a `git show <head SHA>:<path>`-backed
  reader (`rinkaku::git::file_read::PrHeadSourceReader`) for `--pr`
  mode specifically, from `main.rs`'s composition root.
- New ADR 0047 records the port's design rationale; ADR 0046 gets a
  short amendment noting the follow-up is resolved. `docs/tui.md`
  updated to describe the new `--pr` behavior.

## QA

Before/after verification per the QA policy, using PR #159 (which
changed `rinkaku-tui/src/lib.rs`) as the test PR, with the working
tree pinned to the commit before #159 merged (reproducing "head ref
fetched but not checked out"):

- **Before (main, unfixed)**: `rinkaku --pr <...>/pull/159 --tui`,
  opened source view on `run_app` — title bar showed
  `(diff overlay unavailable — file on disk doesn't match the diff)`.
- **After (this branch)**: same steps — no drift note, and the
  actually-added line renders with the green `+` overlay
  (`43+| pub mod source_diff;`).
- **Regression check**: `--base` mode with a dirtied working tree
  (fixed binary) still shows the drift note — `--base`/stdin are
  unaffected, confirming the fix is `--pr`-specific.

All three scenarios captured via tmux screen captures. `make test`
(715 rinkaku-tui + 178 rinkaku tests) and `make lint` pass.

## Test plan

- [x] `make test` passes (rinkaku-tui: 715, rinkaku: 178, incl. 4 new
      tests: reader injection + error propagation in `source.rs`,
      `PrHeadSourceReader` integration tests in `git/file_read.rs`)
- [x] `make lint` passes
- [x] Before/after manual verification against a real merged PR
      (see QA section above)
- [x] `--base` mode regression check (dirty working tree still shows
      drift note)