### PR TITLE
feat(tui): open the PR in a web browser with w (ADR 0050)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ whichever sinks apply to how you launched the TUI:
   packet (one section per note, with the note's own symbol signature)
   via an OSC 52 terminal escape sequence, so it works over SSH too.
 
+Press `w` from anywhere to open the PR's page in your web browser
+(only when you started with `rinkaku --pr <url or number>`).
+
 ## Install
 
 | Method | Command |

--- a/docs/adr/0049-tui-open-pr-in-browser.md
+++ b/docs/adr/0049-tui-open-pr-in-browser.md
@@ -1,0 +1,117 @@
+# 0049. TUI: open the PR in a web browser
+
+- Status: Accepted
+- Date: 2026-07-15
+
+## Context
+
+`--pr` mode already resolves everything needed to identify the PR being
+reviewed (`PrContext { owner, repo, number, head_sha }`, introduced by
+ADR 0048 for sink A's `gh api` calls). A reviewer working through the
+TUI who wants to jump to the PR's page on github.com — to check CI
+status, read an existing comment thread, or hand the URL to someone
+else — currently has to reconstruct the URL by hand or shell out
+separately; there is no in-TUI action for it, unlike `gh pr view -w`'s
+familiar one-flag shortcut.
+
+## Decision
+
+**A new global key, `w`/`W`, opens the current PR's page in the
+reviewer's default web browser.** `w` is chosen to match `gh` CLI's own
+`-w`/`--web` convention for "open in a browser"; `o`/`O` (`ToggleOrder`)
+and `s`/`S` (`Source`) are already bound, and `g` is reserved as the
+`gd`/`gr`/`gg` two-key prefix, so none of those are available.
+
+**Scope is the PR page URL only**: `https://github.com/{owner}/{repo}/pull/{number}`.
+No cursor-relative URL (a file/line-anchored link into the diff) is
+built — see Alternatives.
+
+**Port**: a new `BrowserOpener` trait, one method, defined in
+`rinkaku-tui` (the consumer side) alongside `ReviewSubmitter`/
+`ClipboardSink`:
+
+```rust
+pub trait BrowserOpener {
+    fn open_url(&self, url: &str) -> Result<(), String>;
+}
+```
+
+The `rinkaku` binary crate implements it by spawning the platform's
+"open a URL" command directly (`open` on macOS, `xdg-open` on Linux),
+mirroring `clipboard.rs`'s existing direct-spawn shape (ADR 0048's own
+clipboard sink) rather than adding a crate dependency for a single OS
+command invocation. `main.rs`'s composition root constructs the
+implementation and wires it in, the same way `SystemClipboard`/
+`GhReviewSubmitter` are wired today.
+
+**Availability**: `w` is a global key (translated regardless of
+screen/focus, like `d`/`r`/`s`), but the action it performs needs a
+`PrContext` — unavailable outside `--pr` mode (stdin input, `--base`
+mode). Rather than hiding the key (impossible for a single global
+binding the way an overlay's own menu can omit an entry, ADR 0048's
+sink A precedent) or silently no-op'ing, pressing `w` without a
+`PrContext` sets a status-line message explaining why, mirroring the
+existing "note: jumplist has no earlier location"-style status-line
+feedback `App::handle_key`'s `JumpBack`/`JumpForward` arms already give
+for an unavailable action. A spawn failure (no `open`/`xdg-open` on
+`PATH`, or the browser command itself erroring) is reported the same
+way — best-effort, never a crash.
+
+**Wiring**: `PrContext` is already threaded from `main.rs` through
+`ReviewPorts` down to `run_app` (ADR 0048); this feature adds one more
+field to that same struct (`browser: &dyn BrowserOpener`) rather than a
+second parallel plumbing path. Because `App` itself does not hold
+`PrContext` (only `review_sink_a_available: bool`, ADR 0048's own
+"App doesn't need the whole context, just whether sink A is on the
+menu" decision), `w` is special-cased in `run_app` before dispatch —
+the same pattern `InputKey::NoteCompose`/`InputKey::Source` already
+follow for "needs data `App::handle_key` doesn't have."
+
+## Alternatives
+
+- **Build a cursor-relative URL** (a link into the diff anchored at the
+  row/line under the cursor, using GitHub's `#diff-<hash>` file-anchor
+  or line-range fragment). Rejected for v1: the TUI's own data
+  structures have no notion of "a GitHub URL for this location" today
+  (`review::NoteLocation`'s anchor is a 1-based line range, not a
+  file-content hash GitHub's own `#diff-` fragments require), and
+  computing that hash correctly would add a new dependency (a SHA-256
+  implementation, unlike ADR 0048's base64, which this project already
+  hand-rolls) for a feature this ADR's scope does not need. The PR page
+  itself is one click away from any file's diff via GitHub's own UI, so
+  the marginal benefit of a deep link is small relative to the added
+  surface. A future ADR can revisit this once a concrete reviewer need
+  is identified.
+- **Silently no-op when `PrContext` is unavailable**, instead of a
+  status-line message. Rejected: indistinguishable from the key simply
+  not being bound, which is worse for discoverability than the
+  existing jumplist-empty precedent this ADR follows — a reviewer who
+  presses `w` outside `--pr` mode should learn why nothing happened,
+  not wonder if they mistyped.
+- **Add a crate dependency (e.g. `open`) for cross-platform URL
+  opening** instead of spawning `open`/`xdg-open` directly. Rejected on
+  the same grounds ADR 0048 rejected `arboard` for clipboard access:
+  this project already has a working direct-spawn precedent
+  (`clipboard.rs`) for exactly this class of "shell out to a
+  platform-specific helper program" problem, and a one-method port
+  needs no crate to satisfy it.
+
+## Consequences
+
+- `ReviewPorts` gains one field (`browser: &dyn BrowserOpener`),
+  always present (unlike `submitter`, which is `Option`) since the key
+  itself is global — the port always exists, only the `PrContext` it
+  needs may be absent.
+- `InputKey` gains one variant (`OpenPrInBrowser`), translated
+  unconditionally by `input_translate::translate_key` like every other
+  global key, and special-cased in `run_app` before dispatch (mirrors
+  `NoteCompose`/`Source`'s existing precedent) rather than routed
+  through `App::handle_key`.
+- `rinkaku`'s composition root gains one more concrete port
+  implementation (`SystemBrowserOpener` or equivalent), tested the same
+  way `clipboard.rs`'s `copy_via_command` is — a nonexistent-command
+  spawn-failure case, not a real browser launch.
+- `docs/tui.md`'s Global key-bindings table and the `?` help overlay's
+  Global group both gain a `w` row; `README.md`'s "How to read the
+  TUI" section gains one line describing the action (no ADR reference
+  in that file, per this project's convention).

--- a/docs/adr/0050-tui-open-pr-in-browser.md
+++ b/docs/adr/0050-tui-open-pr-in-browser.md
@@ -1,4 +1,4 @@
-# 0049. TUI: open the PR in a web browser
+# 0050. TUI: open the PR in a web browser
 
 - Status: Accepted
 - Date: 2026-07-15

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -105,6 +105,8 @@ Press `?` in the TUI for the always-up-to-date table.
 | `s` / `S` | Open the source view for the symbol under the cursor |
 | `gd` / `gr` | Jump to a callee / caller ([ADR 0022](adr/0022-jump-navigation-and-jumplist.md)) |
 | `ctrl-o` / `ctrl-i` | Jump back / forward through the jumplist |
+| `n` / `N` | Compose a review note / open the notes list ([ADR 0048](adr/0048-tui-review-actions.md)) |
+| `w` / `W` | Open the current PR's page in a web browser, `--pr` mode only ([ADR 0049](adr/0049-tui-open-pr-in-browser.md)) |
 | `?` | Toggle the help overlay |
 | `q` / `ctrl-c` | Quit (from the entry view); `esc`/`q` also returns from the source view |
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -106,7 +106,7 @@ Press `?` in the TUI for the always-up-to-date table.
 | `gd` / `gr` | Jump to a callee / caller ([ADR 0022](adr/0022-jump-navigation-and-jumplist.md)) |
 | `ctrl-o` / `ctrl-i` | Jump back / forward through the jumplist |
 | `n` / `N` | Compose a review note / open the notes list ([ADR 0048](adr/0048-tui-review-actions.md)) |
-| `w` / `W` | Open the current PR's page in a web browser, `--pr` mode only ([ADR 0049](adr/0049-tui-open-pr-in-browser.md)) |
+| `w` / `W` | Open the current PR's page in a web browser, `--pr` mode only ([ADR 0050](adr/0050-tui-open-pr-in-browser.md)) |
 | `?` | Toggle the help overlay |
 | `q` / `ctrl-c` | Quit (from the entry view); `esc`/`q` also returns from the source view |
 

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -603,7 +603,7 @@ impl App {
                 | InputKey::ComposeBackspace
                 | InputKey::NoteDelete,
             ) => {}
-            // `w` (ADR 0049) needs the session's `PrContext`, which `App`
+            // `w` (ADR 0050) needs the session's `PrContext`, which `App`
             // does not hold — `crate::lib::run_app` special-cases this
             // variant before dispatch (mirroring `NoteCompose`'s own
             // precedent just above), so this arm is a no-op stub kept only

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -603,6 +603,12 @@ impl App {
                 | InputKey::ComposeBackspace
                 | InputKey::NoteDelete,
             ) => {}
+            // `w` (ADR 0049) needs the session's `PrContext`, which `App`
+            // does not hold — `crate::lib::run_app` special-cases this
+            // variant before dispatch (mirroring `NoteCompose`'s own
+            // precedent just above), so this arm is a no-op stub kept only
+            // for match exhaustiveness.
+            (Screen::Entry, _, InputKey::OpenPrInBrowser) => {}
         }
 
         if !preserve_scroll && !preserve_scroll_after_jump {

--- a/rinkaku-tui/src/app/input_key.rs
+++ b/rinkaku-tui/src/app/input_key.rs
@@ -219,7 +219,7 @@ pub enum InputKey {
     /// `d` while the notes list overlay is open: deletes the note under
     /// the list cursor.
     NoteDelete,
-    /// `w`/`W` (ADR 0049): opens the current PR's page in the reviewer's
+    /// `w`/`W` (ADR 0050): opens the current PR's page in the reviewer's
     /// default web browser. Global, like `d`/`r`/`s` — translated
     /// regardless of screen/focus. Needs the session's `PrContext`, which
     /// `App` does not hold (mirroring [`Self::NoteCompose`]'s own "IO/

--- a/rinkaku-tui/src/app/input_key.rs
+++ b/rinkaku-tui/src/app/input_key.rs
@@ -219,4 +219,12 @@ pub enum InputKey {
     /// `d` while the notes list overlay is open: deletes the note under
     /// the list cursor.
     NoteDelete,
+    /// `w`/`W` (ADR 0049): opens the current PR's page in the reviewer's
+    /// default web browser. Global, like `d`/`r`/`s` — translated
+    /// regardless of screen/focus. Needs the session's `PrContext`, which
+    /// `App` does not hold (mirroring [`Self::NoteCompose`]'s own "IO/
+    /// derivation stays outside `App`" precedent) — `crate::lib::run_app`
+    /// special-cases this variant before dispatch rather than routing it
+    /// through `App::handle_key`.
+    OpenPrInBrowser,
 }

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -178,6 +178,10 @@ const GLOBAL_BINDINGS: &[KeyBinding] = &[
         description: "Jump forward to the next location in the jumplist",
     },
     KeyBinding {
+        keys: "w / W",
+        description: "Open the current PR's page in a web browser (--pr mode only)",
+    },
+    KeyBinding {
         keys: "?",
         description: "Toggle this help overlay",
     },
@@ -491,6 +495,19 @@ mod tests {
         assert!(keys.contains(&"n"));
         assert!(keys.contains(&"N"));
         assert!(keys.contains(&"j/k, Enter, Esc, d"));
+    }
+
+    #[test]
+    fn should_document_open_pr_in_browser_binding_in_the_global_group() {
+        let global = HELP_CONTENT
+            .keymap_groups
+            .iter()
+            .find(|group| group.title == "Global")
+            .expect("Global group present");
+
+        let keys: Vec<&str> = global.bindings.iter().map(|binding| binding.keys).collect();
+
+        assert!(keys.contains(&"w / W"));
     }
 
     #[test]

--- a/rinkaku-tui/src/input_translate.rs
+++ b/rinkaku-tui/src/input_translate.rs
@@ -216,7 +216,7 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         // already no-ops every non-scroll key there.
         KeyCode::Char('n') => Some(InputKey::NoteCompose),
         KeyCode::Char('N') => Some(InputKey::NotesList),
-        // `w`/`W` (ADR 0049): opens the current PR's page in a web browser —
+        // `w`/`W` (ADR 0050): opens the current PR's page in a web browser —
         // matches `gh` CLI's own `-w`/`--web` convention. Global regardless
         // of screen/focus, like `d`/`r`/`s`; `crate::lib::run_app`
         // special-cases the actual dispatch (it needs the session's

--- a/rinkaku-tui/src/input_translate.rs
+++ b/rinkaku-tui/src/input_translate.rs
@@ -216,6 +216,12 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         // already no-ops every non-scroll key there.
         KeyCode::Char('n') => Some(InputKey::NoteCompose),
         KeyCode::Char('N') => Some(InputKey::NotesList),
+        // `w`/`W` (ADR 0049): opens the current PR's page in a web browser —
+        // matches `gh` CLI's own `-w`/`--web` convention. Global regardless
+        // of screen/focus, like `d`/`r`/`s`; `crate::lib::run_app`
+        // special-cases the actual dispatch (it needs the session's
+        // `PrContext`, which `App` doesn't hold).
+        KeyCode::Char('w') | KeyCode::Char('W') => Some(InputKey::OpenPrInBrowser),
         // `g` (ADR 0022): the first half of the `gd`/`gr` two-key sequence.
         // Checked after the `pending_prefix` resolution above so a second
         // `g` press (`gg`, not a bound sequence today) simply restarts the

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -61,9 +61,9 @@ use app::{App, BlastRadiusSelection, InputKey, Screen};
 use input_translate::{translate_key, translate_mouse_event};
 use ratatui::crossterm::event::{self, Event, KeyEventKind};
 use review::PrContext;
-use review::ports::{ClipboardSink, ReviewSubmitter};
+use review::ports::{BrowserOpener, ClipboardSink, ReviewSubmitter};
 use review_flow::{
-    derive_selection_snapshot, dispatch_note_compose_key, perform_export,
+    derive_selection_snapshot, dispatch_note_compose_key, open_pr_in_browser, perform_export,
     should_recompute_note_markers,
 };
 use rinkaku_core::render::Report;
@@ -81,11 +81,14 @@ pub(crate) use review_flow::first_anchor_run;
 /// `submitter` are both `Some`/`None` together (sink A's own "absent when
 /// no PR context" rule — [`crate::app::App::with_review_sink_a_available`]'s
 /// own doc comment), `clipboard` is always present since sink B never
-/// depends on a PR.
+/// depends on a PR. `browser` (ADR 0049) is likewise always present — `w` is
+/// a global key regardless of `pr_context`, so the port itself always
+/// exists; only the `PrContext` it needs to build a URL may be absent.
 pub struct ReviewPorts<'a> {
     pub pr_context: Option<PrContext>,
     pub submitter: Option<&'a dyn ReviewSubmitter>,
     pub clipboard: &'a dyn ClipboardSink,
+    pub browser: &'a dyn BrowserOpener,
 }
 
 /// The event loop [`TuiSession::run`] (`crate::session`) drives once it has
@@ -302,6 +305,16 @@ pub(crate) fn run_app(
                 // documents did).
                 let snapshot = derive_selection_snapshot(&app, report, &diff_hunks);
                 app = dispatch_note_compose_key(app, snapshot);
+            } else if let InputKey::OpenPrInBrowser = input_key {
+                // ADR 0049: needs `review_ports.pr_context`/`.browser`,
+                // neither of which `App::handle_key` has access to (mirrors
+                // `InputKey::NoteCompose`'s own precedent just above).
+                // `app.handle_key(input_key)` still runs first for the
+                // blanket `status`/`pending_prefix` reset every key needs
+                // (`App::handle_key`'s own doc comment) — its own arm for
+                // this variant is a no-op stub, same as `NoteCompose`'s.
+                app = app.handle_key(input_key);
+                app = open_pr_in_browser(app, &review_ports);
             } else if let InputKey::Source = input_key {
                 app = app.handle_key(input_key);
                 if let Screen::Source { symbol_id, .. } = app.screen().clone()

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -81,7 +81,7 @@ pub(crate) use review_flow::first_anchor_run;
 /// `submitter` are both `Some`/`None` together (sink A's own "absent when
 /// no PR context" rule — [`crate::app::App::with_review_sink_a_available`]'s
 /// own doc comment), `clipboard` is always present since sink B never
-/// depends on a PR. `browser` (ADR 0049) is likewise always present — `w` is
+/// depends on a PR. `browser` (ADR 0050) is likewise always present — `w` is
 /// a global key regardless of `pr_context`, so the port itself always
 /// exists; only the `PrContext` it needs to build a URL may be absent.
 pub struct ReviewPorts<'a> {
@@ -306,7 +306,7 @@ pub(crate) fn run_app(
                 let snapshot = derive_selection_snapshot(&app, report, &diff_hunks);
                 app = dispatch_note_compose_key(app, snapshot);
             } else if let InputKey::OpenPrInBrowser = input_key {
-                // ADR 0049: needs `review_ports.pr_context`/`.browser`,
+                // ADR 0050: needs `review_ports.pr_context`/`.browser`,
                 // neither of which `App::handle_key` has access to (mirrors
                 // `InputKey::NoteCompose`'s own precedent just above).
                 // `app.handle_key(input_key)` still runs first for the

--- a/rinkaku-tui/src/lib_tests/mod.rs
+++ b/rinkaku-tui/src/lib_tests/mod.rs
@@ -20,8 +20,11 @@
 //!   auto-sync in the reverse direction of ADR 0027's tree → diff scroll
 //! - `perform_export` — `clipboard_export_status`'s OSC 52 size-guard
 //!   warning and error-message passthrough (ADR 0048)
+//! - `open_pr_in_browser` — the no-`PrContext`/spawn-failure status-line
+//!   messages and the URL built from a `PrContext` (ADR 0049)
 
 use crate::app::JumpCandidate;
+use crate::review::ports::BrowserOpener;
 use crate::source;
 use rinkaku_core::graph::SymbolGraph;
 use rinkaku_core::render::Report;
@@ -30,11 +33,39 @@ mod diff_scroll_sync;
 mod goto_dispatch;
 mod hunk_jump;
 mod note_snapshot;
+mod open_pr_in_browser;
 mod perform_export;
 mod recompute_and_reload;
 mod scroll_clamp;
 mod translate_key;
 mod translate_mouse;
+
+/// A [`BrowserOpener`] fake shared by [`perform_export`]/[`open_pr_in_browser`]'s
+/// tests — `ReviewPorts::browser` is always present (ADR 0049), so every
+/// `ReviewPorts` fixture needs one even when the test itself is not
+/// exercising `w`. `opened_url` records the last URL passed to
+/// [`BrowserOpener::open_url`] so a test can assert the exact URL built from
+/// a [`crate::review::PrContext`], not just the resulting status message.
+pub(super) struct FakeBrowserOpener {
+    pub(super) result: Result<(), String>,
+    pub(super) opened_url: std::cell::RefCell<Option<String>>,
+}
+
+impl FakeBrowserOpener {
+    pub(super) fn new(result: Result<(), String>) -> Self {
+        Self {
+            result,
+            opened_url: std::cell::RefCell::new(None),
+        }
+    }
+}
+
+impl BrowserOpener for FakeBrowserOpener {
+    fn open_url(&self, url: &str) -> Result<(), String> {
+        *self.opened_url.borrow_mut() = Some(url.to_string());
+        self.result.clone()
+    }
+}
 
 pub(super) fn empty_report() -> Report {
     Report {

--- a/rinkaku-tui/src/lib_tests/mod.rs
+++ b/rinkaku-tui/src/lib_tests/mod.rs
@@ -21,7 +21,7 @@
 //! - `perform_export` — `clipboard_export_status`'s OSC 52 size-guard
 //!   warning and error-message passthrough (ADR 0048)
 //! - `open_pr_in_browser` — the no-`PrContext`/spawn-failure status-line
-//!   messages and the URL built from a `PrContext` (ADR 0049)
+//!   messages and the URL built from a `PrContext` (ADR 0050)
 
 use crate::app::JumpCandidate;
 use crate::review::ports::BrowserOpener;
@@ -41,7 +41,7 @@ mod translate_key;
 mod translate_mouse;
 
 /// A [`BrowserOpener`] fake shared by [`perform_export`]/[`open_pr_in_browser`]'s
-/// tests — `ReviewPorts::browser` is always present (ADR 0049), so every
+/// tests — `ReviewPorts::browser` is always present (ADR 0050), so every
 /// `ReviewPorts` fixture needs one even when the test itself is not
 /// exercising `w`. `opened_url` records the last URL passed to
 /// [`BrowserOpener::open_url`] so a test can assert the exact URL built from

--- a/rinkaku-tui/src/lib_tests/open_pr_in_browser.rs
+++ b/rinkaku-tui/src/lib_tests/open_pr_in_browser.rs
@@ -1,4 +1,4 @@
-//! `open_pr_in_browser` tests (ADR 0049): the no-`PrContext` and
+//! `open_pr_in_browser` tests (ADR 0050): the no-`PrContext` and
 //! spawn-failure status-line messages, and the URL actually passed to
 //! [`crate::review::ports::BrowserOpener`] when a `PrContext` is present.
 

--- a/rinkaku-tui/src/lib_tests/open_pr_in_browser.rs
+++ b/rinkaku-tui/src/lib_tests/open_pr_in_browser.rs
@@ -1,0 +1,89 @@
+//! `open_pr_in_browser` tests (ADR 0049): the no-`PrContext` and
+//! spawn-failure status-line messages, and the URL actually passed to
+//! [`crate::review::ports::BrowserOpener`] when a `PrContext` is present.
+
+use super::FakeBrowserOpener;
+use super::empty_report;
+use crate::ReviewPorts;
+use crate::app::App;
+use crate::review::PrContext;
+use crate::review::ports::ClipboardSink;
+use crate::review_flow::open_pr_in_browser;
+use pretty_assertions::assert_eq;
+
+struct NoopClipboard;
+
+impl ClipboardSink for NoopClipboard {
+    fn copy(&self, _text: &str) -> Result<String, String> {
+        Ok(String::new())
+    }
+}
+
+fn ports_with<'a>(
+    pr_context: Option<PrContext>,
+    clipboard: &'a NoopClipboard,
+    browser: &'a FakeBrowserOpener,
+) -> ReviewPorts<'a> {
+    ReviewPorts {
+        pr_context,
+        submitter: None,
+        clipboard,
+        browser,
+    }
+}
+
+fn pr_context() -> PrContext {
+    PrContext {
+        owner: "hiro-o918".to_string(),
+        repo: "rinkaku".to_string(),
+        number: 42,
+        head_sha: "deadbeef".to_string(),
+    }
+}
+
+#[test]
+fn should_set_a_status_message_when_no_pr_context_is_available() {
+    let report = empty_report();
+    let app = App::new(&report);
+    let clipboard = NoopClipboard;
+    let browser = FakeBrowserOpener::new(Ok(()));
+    let ports = ports_with(None, &clipboard, &browser);
+
+    let actual = open_pr_in_browser(app, &ports);
+
+    assert_eq!(
+        Some("note: no PR context available to open a browser (not running in --pr mode)"),
+        actual.status()
+    );
+    assert_eq!(None, *browser.opened_url.borrow());
+}
+
+#[test]
+fn should_open_the_pr_page_url_when_a_pr_context_is_available() {
+    let report = empty_report();
+    let app = App::new(&report);
+    let clipboard = NoopClipboard;
+    let browser = FakeBrowserOpener::new(Ok(()));
+    let ports = ports_with(Some(pr_context()), &clipboard, &browser);
+
+    let actual = open_pr_in_browser(app, &ports);
+
+    assert_eq!(None, actual.status());
+    assert_eq!(
+        Some("https://github.com/hiro-o918/rinkaku/pull/42".to_string()),
+        *browser.opened_url.borrow()
+    );
+}
+
+#[test]
+fn should_set_an_error_status_message_when_the_browser_port_fails() {
+    let report = empty_report();
+    let app = App::new(&report);
+    let clipboard = NoopClipboard;
+    let browser = FakeBrowserOpener::new(Err("no display".to_string()));
+    let ports = ports_with(Some(pr_context()), &clipboard, &browser);
+
+    let actual = open_pr_in_browser(app, &ports);
+
+    assert_eq!(Some("error opening browser: no display"), actual.status());
+}

--- a/rinkaku-tui/src/lib_tests/perform_export.rs
+++ b/rinkaku-tui/src/lib_tests/perform_export.rs
@@ -18,11 +18,15 @@ impl ClipboardSink for FakeClipboard {
     }
 }
 
-fn ports_with(clipboard: &FakeClipboard) -> ReviewPorts<'_> {
+fn ports_with<'a>(
+    clipboard: &'a FakeClipboard,
+    browser: &'a super::FakeBrowserOpener,
+) -> ReviewPorts<'a> {
     ReviewPorts {
         pr_context: None,
         submitter: None,
         clipboard,
+        browser,
     }
 }
 
@@ -31,10 +35,11 @@ fn should_surface_the_ports_status_line_when_copy_succeeds() {
     let clipboard = FakeClipboard {
         result: Ok("copied review notes to clipboard via pbcopy".to_string()),
     };
+    let browser = super::FakeBrowserOpener::new(Ok(()));
 
     let actual = perform_export(
         ReviewState::default(),
-        &ports_with(&clipboard),
+        &ports_with(&clipboard, &browser),
         ExportRequest::Clipboard,
     );
 
@@ -49,10 +54,11 @@ fn should_wrap_the_ports_error_in_the_error_prefix_when_copy_fails() {
     let clipboard = FakeClipboard {
         result: Err("no tty".to_string()),
     };
+    let browser = super::FakeBrowserOpener::new(Ok(()));
 
     let actual = perform_export(
         ReviewState::default(),
-        &ports_with(&clipboard),
+        &ports_with(&clipboard, &browser),
         ExportRequest::Clipboard,
     );
 

--- a/rinkaku-tui/src/lib_tests/translate_key.rs
+++ b/rinkaku-tui/src/lib_tests/translate_key.rs
@@ -541,6 +541,26 @@ fn should_translate_fullwidth_question_mark_to_toggle_help() {
 }
 
 #[test]
+fn should_translate_lowercase_w_to_open_pr_in_browser() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('w'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::OpenPrInBrowser), actual);
+}
+
+#[test]
+fn should_translate_uppercase_w_to_open_pr_in_browser() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('W'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::OpenPrInBrowser), actual);
+}
+
+#[test]
 fn should_not_normalize_fullwidth_characters_while_composing_a_note() {
     // The compose buffer is free text (ADR 0048) — a full-width character
     // typed there must land in the note body verbatim, not get folded to

--- a/rinkaku-tui/src/review/mod.rs
+++ b/rinkaku-tui/src/review/mod.rs
@@ -84,6 +84,18 @@ pub struct PrContext {
     pub head_sha: String,
 }
 
+/// The PR's own page on github.com (ADR 0049) — the URL `w` opens in the
+/// reviewer's default browser. Scoped to the PR page itself, not a
+/// cursor-relative deep link into the diff (ADR 0049's Alternatives).
+pub fn pr_url(ctx: &PrContext) -> String {
+    format!(
+        "https://github.com/{owner}/{repo}/pull/{number}",
+        owner = ctx.owner,
+        repo = ctx.repo,
+        number = ctx.number,
+    )
+}
+
 /// The verdict a reviewer picks when exporting to sink A (GitHub PR
 /// review), mirroring GitHub's own pending-review submit dialog.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rinkaku-tui/src/review/mod.rs
+++ b/rinkaku-tui/src/review/mod.rs
@@ -84,9 +84,9 @@ pub struct PrContext {
     pub head_sha: String,
 }
 
-/// The PR's own page on github.com (ADR 0049) — the URL `w` opens in the
+/// The PR's own page on github.com (ADR 0050) — the URL `w` opens in the
 /// reviewer's default browser. Scoped to the PR page itself, not a
-/// cursor-relative deep link into the diff (ADR 0049's Alternatives).
+/// cursor-relative deep link into the diff (ADR 0050's Alternatives).
 pub fn pr_url(ctx: &PrContext) -> String {
     format!(
         "https://github.com/{owner}/{repo}/pull/{number}",

--- a/rinkaku-tui/src/review/ports.rs
+++ b/rinkaku-tui/src/review/ports.rs
@@ -30,3 +30,11 @@ pub trait ReviewSubmitter {
 pub trait ClipboardSink {
     fn copy(&self, text: &str) -> Result<String, String>;
 }
+
+/// Opens `url` in the reviewer's default web browser (ADR 0049), best-effort
+/// — implemented by spawning the platform's own "open a URL" command
+/// (`open`/`xdg-open`), mirroring [`ClipboardSink`]'s direct-spawn shape
+/// rather than adding a crate dependency for one OS command invocation.
+pub trait BrowserOpener {
+    fn open_url(&self, url: &str) -> Result<(), String>;
+}

--- a/rinkaku-tui/src/review/ports.rs
+++ b/rinkaku-tui/src/review/ports.rs
@@ -31,7 +31,7 @@ pub trait ClipboardSink {
     fn copy(&self, text: &str) -> Result<String, String>;
 }
 
-/// Opens `url` in the reviewer's default web browser (ADR 0049), best-effort
+/// Opens `url` in the reviewer's default web browser (ADR 0050), best-effort
 /// — implemented by spawning the platform's own "open a URL" command
 /// (`open`/`xdg-open`), mirroring [`ClipboardSink`]'s direct-spawn shape
 /// rather than adding a crate dependency for one OS command invocation.

--- a/rinkaku-tui/src/review/tests.rs
+++ b/rinkaku-tui/src/review/tests.rs
@@ -391,3 +391,22 @@ mod revision_tests {
         assert_eq!(0, state.revision());
     }
 }
+
+mod pr_url_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_build_the_pr_page_url_from_owner_repo_and_number() {
+        let ctx = PrContext {
+            owner: "hiro-o918".to_string(),
+            repo: "rinkaku".to_string(),
+            number: 42,
+            head_sha: "deadbeef".to_string(),
+        };
+
+        let actual = pr_url(&ctx);
+
+        assert_eq!("https://github.com/hiro-o918/rinkaku/pull/42", actual);
+    }
+}

--- a/rinkaku-tui/src/review_flow.rs
+++ b/rinkaku-tui/src/review_flow.rs
@@ -13,7 +13,7 @@ use crate::app::{App, InputKey, Screen};
 use crate::{ReviewPorts, diff_view, review};
 use rinkaku_core::render::Report;
 
-/// Applies [`InputKey::OpenPrInBrowser`] (ADR 0049): opens `ports.pr_context`'s
+/// Applies [`InputKey::OpenPrInBrowser`] (ADR 0050): opens `ports.pr_context`'s
 /// PR page via `ports.browser`, given `App` has no `PrContext` of its own
 /// (mirroring [`dispatch_note_compose_key`]'s own "needs data `handle_key`
 /// doesn't have" precedent). Sets a status-line message either way — success

--- a/rinkaku-tui/src/review_flow.rs
+++ b/rinkaku-tui/src/review_flow.rs
@@ -16,10 +16,11 @@ use rinkaku_core::render::Report;
 /// Applies [`InputKey::OpenPrInBrowser`] (ADR 0050): opens `ports.pr_context`'s
 /// PR page via `ports.browser`, given `App` has no `PrContext` of its own
 /// (mirroring [`dispatch_note_compose_key`]'s own "needs data `handle_key`
-/// doesn't have" precedent). Sets a status-line message either way — success
-/// is silent otherwise (the browser opening is the reviewer's own
-/// confirmation), a missing `PrContext` or a spawn failure is reported so `w`
-/// pressed outside `--pr` mode is distinguishable from an unbound key.
+/// doesn't have" precedent). Only the two failure paths (no `PrContext`, or
+/// `ports.browser` erroring) set a status-line message — a successful open
+/// leaves it untouched, since the browser actually opening is itself the
+/// reviewer's confirmation — so `w` pressed outside `--pr` mode is
+/// distinguishable from an unbound key.
 pub(crate) fn open_pr_in_browser(mut app: App, ports: &ReviewPorts<'_>) -> App {
     let Some(pr_context) = &ports.pr_context else {
         app.set_status(

--- a/rinkaku-tui/src/review_flow.rs
+++ b/rinkaku-tui/src/review_flow.rs
@@ -13,6 +13,27 @@ use crate::app::{App, InputKey, Screen};
 use crate::{ReviewPorts, diff_view, review};
 use rinkaku_core::render::Report;
 
+/// Applies [`InputKey::OpenPrInBrowser`] (ADR 0049): opens `ports.pr_context`'s
+/// PR page via `ports.browser`, given `App` has no `PrContext` of its own
+/// (mirroring [`dispatch_note_compose_key`]'s own "needs data `handle_key`
+/// doesn't have" precedent). Sets a status-line message either way — success
+/// is silent otherwise (the browser opening is the reviewer's own
+/// confirmation), a missing `PrContext` or a spawn failure is reported so `w`
+/// pressed outside `--pr` mode is distinguishable from an unbound key.
+pub(crate) fn open_pr_in_browser(mut app: App, ports: &ReviewPorts<'_>) -> App {
+    let Some(pr_context) = &ports.pr_context else {
+        app.set_status(
+            "note: no PR context available to open a browser (not running in --pr mode)",
+        );
+        return app;
+    };
+    let url = review::pr_url(pr_context);
+    if let Err(message) = ports.browser.open_url(&url) {
+        app.set_status(format!("error opening browser: {message}"));
+    }
+    app
+}
+
 /// Applies [`InputKey::NoteCompose`] given the [`review::SelectionSnapshot`]
 /// `crate::run_app` already derived from the cursor (that derivation needs
 /// `report`/the parsed diff hunks, which `App::handle_key` has no access

--- a/rinkaku/src/browser.rs
+++ b/rinkaku/src/browser.rs
@@ -1,4 +1,4 @@
-//! Opens a URL in the reviewer's default web browser (ADR 0049) by spawning
+//! Opens a URL in the reviewer's default web browser (ADR 0050) by spawning
 //! the platform's own "open a URL" command (`open` on macOS, `xdg-open` on
 //! Linux) — mirroring `clipboard.rs`'s direct-spawn shape rather than adding
 //! a crate dependency for one OS command invocation.

--- a/rinkaku/src/browser.rs
+++ b/rinkaku/src/browser.rs
@@ -1,0 +1,93 @@
+//! Opens a URL in the reviewer's default web browser (ADR 0049) by spawning
+//! the platform's own "open a URL" command (`open` on macOS, `xdg-open` on
+//! Linux) — mirroring `clipboard.rs`'s direct-spawn shape rather than adding
+//! a crate dependency for one OS command invocation.
+
+use rinkaku_tui::review::ports::BrowserOpener;
+
+pub(crate) struct SystemBrowserOpener;
+
+/// The command used to open a URL, by target OS — `cfg!(target_os = ...)`
+/// rather than `#[cfg(...)]` items, so [`command_for_os`] stays a plain,
+/// unit-testable function instead of three mutually-exclusive compiled
+/// variants (matching this crate's existing "extract the pure choice,
+/// spawn separately" shape, `clipboard.rs`'s `choose_clipboard_backend`).
+fn command_for_os(target_os: &str) -> Option<&'static str> {
+    match target_os {
+        "macos" => Some("open"),
+        "linux" => Some("xdg-open"),
+        _ => None,
+    }
+}
+
+/// Spawns `program url` and waits for it to exit — split out of
+/// [`BrowserOpener::open_url`] so a test can exercise the spawn-failure path
+/// against a nonexistent program name without depending on which command
+/// [`command_for_os`] would have chosen on the host platform (mirroring
+/// `clipboard.rs`'s own `copy_via_command` extraction).
+fn open_via_command(program: &str, url: &str) -> Result<(), String> {
+    let status = std::process::Command::new(program)
+        .arg(url)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|err| format!("failed to spawn {program}: {err}"))?
+        .wait()
+        .map_err(|err| format!("failed to wait for {program}: {err}"))?;
+    if !status.success() {
+        return Err(format!("{program} exited with {status}"));
+    }
+    Ok(())
+}
+
+impl BrowserOpener for SystemBrowserOpener {
+    fn open_url(&self, url: &str) -> Result<(), String> {
+        let Some(program) = command_for_os(std::env::consts::OS) else {
+            return Err(format!(
+                "no known browser-open command for platform {}",
+                std::env::consts::OS
+            ));
+        };
+        open_via_command(program, url)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_choose_open_on_macos() {
+        let actual = command_for_os("macos");
+
+        assert_eq!(Some("open"), actual);
+    }
+
+    #[test]
+    fn should_choose_xdg_open_on_linux() {
+        let actual = command_for_os("linux");
+
+        assert_eq!(Some("xdg-open"), actual);
+    }
+
+    #[test]
+    fn should_return_none_for_an_unsupported_platform() {
+        let actual = command_for_os("windows");
+
+        assert_eq!(None, actual);
+    }
+
+    #[test]
+    fn should_report_spawn_failure_when_command_does_not_exist() {
+        let actual = open_via_command("rinkaku-nonexistent-browser-cmd", "https://example.com");
+
+        assert_eq!(
+            true,
+            actual
+                .unwrap_err()
+                .starts_with("failed to spawn rinkaku-nonexistent-browser-cmd")
+        );
+    }
+}

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -39,6 +39,7 @@
 //!   that assumption doesn't hold, line numbers in the extracted symbols
 //!   may not line up with the actual file content.
 
+mod browser;
 mod cli;
 mod clipboard;
 mod display;
@@ -56,6 +57,7 @@ mod splash_progress;
 #[cfg(test)]
 mod test_util;
 
+use browser::SystemBrowserOpener;
 use clap::Parser;
 use cli::{Cli, Command};
 use clipboard::SystemClipboard;
@@ -227,10 +229,12 @@ fn main() -> anyhow::Result<()> {
             // trait definitions alone.
             let submitter = pr_context.is_some().then_some(&GhReviewSubmitter as _);
             let system_clipboard = SystemClipboard::detect();
+            let system_browser = SystemBrowserOpener;
             let review_ports = rinkaku_tui::ReviewPorts {
                 pr_context,
                 submitter,
                 clipboard: &system_clipboard,
+                browser: &system_browser,
             };
             let result = session
                 .run(


### PR DESCRIPTION
## Summary

Adds a global `w`/`W` keybind that opens the currently displayed PR's
page on github.com in the reviewer's default web browser — a TUI
equivalent of `gh pr view -w`, available from any focus/screen while a
`--pr` session is open.

## Design

- **Key choice**: `o` and `s` are already bound (`ToggleOrder`,
  `Source`), and `g` is reserved as the `gd`/`gr`/`gg` two-key prefix,
  so none of those are available. `w` matches `gh` CLI's own `-w`/
  `--web` convention for "open in a browser", making the mapping
  discoverable to anyone who already knows `gh`.
- **Port shape (ADR 0050)**: `BrowserOpener` is defined in
  `rinkaku-tui/src/review/ports.rs` alongside `ReviewSubmitter` /
  `ClipboardSink` (ADR 0048), keeping the same consumer-side trait
  convention — one method, `fn open_url(&self, url: &str) ->
  Result<(), String>`. The `rinkaku` binary crate implements it in a
  new `browser.rs` module that spawns the platform's own command
  (`open` on macOS, `xdg-open` on Linux) directly, mirroring
  `clipboard.rs`'s direct-spawn shape rather than adding a crate
  dependency for one OS invocation. `main.rs`'s composition root
  constructs and wires it in through `ReviewPorts.browser`.
- **Scope**: PR page URL only
  (`https://github.com/{owner}/{repo}/pull/{number}`). A
  cursor-relative deep link into the diff is deliberately out of scope
  — see ADR 0050's Alternatives for the rejection reasoning (would
  require a new sha256 dep for GitHub's `#diff-` fragment, and the map
  has no notion of "URL for this location" today).
- **Best-effort + status line feedback**: `w` is a global key (always
  translated), so it can be pressed outside `--pr` mode where no
  `PrContext` exists. Rather than hiding the key or silently no-op'ing,
  a missing `PrContext` sets a status-line message (`"note: no PR
  context available to open a browser (not running in --pr mode)"`),
  mirroring the existing `JumpBack`/`JumpForward` "jumplist has no
  earlier location" precedent. A spawn/exec failure is reported the
  same way. A successful open leaves the status untouched — the
  browser actually opening is the reviewer's own confirmation.
- **Dispatch**: `App` only holds `review_sink_a_available: bool`, not
  the full `PrContext` (ADR 0048's decision), so `run_app`
  special-cases `InputKey::OpenPrInBrowser` before dispatch — the same
  pattern `InputKey::NoteCompose`/`InputKey::Source` already follow
  for "needs data `App::handle_key` doesn't have."

## QA

- `make test` — 1405 tests green (195 rinkaku-core + 399 rinkaku +
  811 rinkaku-tui, 0 failed).
- `make lint` — clean (`cargo fmt --all --check` +
  `cargo clippy --all-targets --all-features -- -D warnings`).
- Dynamic verification:
  - `w`/`W` translates to `OpenPrInBrowser` regardless of focus/screen
    outside overlays (unit tests) and is intercepted as
    `ComposeChar('w')` while the review compose overlay is open (same
    early-return branch that already handles `?` as a literal — pinned
    by the pre-existing compose-overlay `translate_key` contract; no
    change to that branch means `w` inherits it for free).
  - `--pr 164 --tui` launched against a real open PR: pressing `w`
    left no error status, and running the identical shell command
    `SystemBrowserOpener` would spawn (`open
    https://github.com/hiro-o918/rinkaku/pull/164`) also exits 0,
    confirming the end-to-end path on macOS.
  - `--base main --tui < /dev/null` (non-TTY): exits 1 with a clean
    `anyhow::Error` ("Device not configured"), no panic — the
    existing non-TTY guard is untouched.
  - `--base main < /dev/null` (non-TUI, non-TTY): exits 0, produces
    the map — no regression in the non-TUI paths.

## Docs

- New `docs/adr/0050-tui-open-pr-in-browser.md` (MADR-style,
  Accepted).
- `docs/tui.md` Global key-bindings table: added `w`/`W` row, and
  backfilled the previously-missing `n`/`N` row for ADR 0048 (review
  notes) as a `docs:` commit in the same PR.
- `README.md` "How to read the TUI" section: one line describing `w`
  (no inline ADR reference, per this repo's convention for README).
- `?` help overlay's Global group (`rinkaku-tui/src/help.rs`).