### PR TITLE
feat(tui): render changed signatures as the diff pane anchor line

### DIFF
--- a/docs/adr/0044-tui-split-view-diff-pane.md
+++ b/docs/adr/0044-tui-split-view-diff-pane.md
@@ -83,7 +83,13 @@ the unified view's. Concretely:
 **4. The shared line-index space is preserved by making `SplitRow`
 itself the thing both views render per logical line — including a
 `None`/`None` filler row for a unified line `walk_sections`
-already counted but a merged split pair consumed.** Concretely,
+already counted but a merged split pair consumed.** (Amended below:
+"mode-aware row counts for the section anchor" — a changed-signature
+section anchor now legitimately renders a different row count in
+unified vs. split, so `walk_sections` and its three consumers take a
+`DiffViewMode` parameter; every other line in a section, including
+every hunk body line, is still governed by this decision unchanged.)
+Concretely,
 `pair_hunk_lines` returns exactly `hunk.lines.len()` `SplitRow`s, one
 per original `DiffLine`, not `max(removed, added)`: when a paired-off
 `Removed`/`Added` pair merges onto one *rendered* split row, the
@@ -98,7 +104,13 @@ replaced run in split mode, in exchange for zero changes to
 desyncing ADR 0027's tree→diff auto-scroll or ADR 0030's diff→tree
 sync when the view mode is toggled mid-session.
 
-**5. Rendering.** `crate::ui::diff_pane::draw_diff_pane` branches on
+**5. Rendering.** (Amended below: "mode-aware row counts for the
+section anchor" replaces this decision's contract-header/filler-row
+layout — the section title and the contract header are no longer
+separate scaffold elements, so there is no filler row to keep a
+2-line budget intact. The rest of this decision, the plain
+title/hunk-header scaffold and the highlighting lookup, is unchanged.)
+`crate::ui::diff_pane::draw_diff_pane` branches on
 `app.diff_view_mode()`: unified keeps calling `diff_pane_lines` exactly
 as today; split calls a new `diff_pane_split_rows`, which produces the
 same section/header/hunk-header scaffolding as `diff_pane_lines` and
@@ -313,3 +325,63 @@ reindentation or a single changed argument does not swamp the score,
 and order-insensitive token-set overlap (not a positional token
 comparison) so a reordered clause still scores high — both suit
 comparing source lines, whose meaningful unit of change is the token.
+
+## Amendment: mode-aware row counts for the section anchor
+
+Decision 4's shared line-index space assumed every rendered element —
+including the section title and, separately, a changed symbol's
+2-line contract header below it — has the same row count in unified
+and split. A follow-up dogfooding pass found the contract header's own
+styling (plain foreground-only red/green text, no background) didn't
+read as a diff at a glance, unlike every other `+`/`-` line in the
+pane (ADR 0018's background-tint convention). Fixing that surfaced a
+better layout: the section anchor a reviewer lands on when jumping to
+a symbol should show the diff itself, not a plain title with a diff
+summary bolted on below it. So a changed signature's contract header
+now *replaces* the section title outright, and unified/split render
+that replacement differently:
+
+- **Unified** shows a 2-line `- {old}` / `+ {new}` pair standing in
+  for the title, each carrying the same `ADDED_BG`/`REMOVED_BG` tint
+  ordinary diff lines use.
+- **Split** pairs `{old}` (left) and `{new}` (right) onto the title's
+  own single row — split view already had no use for the extra filler
+  row decision 5's old contract-header layout budgeted for, since old
+  and new sit side by side rather than stacked.
+
+An unchanged section's title is unaffected in both modes (still one
+plain bold row). So a changed-signature section's anchor is 2 rows in
+unified but 1 row in split — the first case in this ADR where the two
+modes legitimately disagree on a row count for the same section,
+something decision 4 did not anticipate and could not, by
+construction, absorb: there is no unified-side line for split's single
+paired row to correspond to.
+
+**`crate::diff_shape::walk_sections` and its three public consumers
+(`hunk_start_lines`, `section_start_line_for_symbol`,
+`symbol_id_for_scroll_line`) now take a `DiffViewMode` parameter.**
+Each computes the section-anchor row count as 2 (unified, changed
+signature), 1 (unified, unchanged title), or 1 (split, either case),
+before continuing with decision 3/4's unchanged per-hunk counting.
+Callers pass `App::diff_view_mode()` — the *requested* mode, i.e. what
+`v`/`V` last toggled — not the pane's possibly-narrower *effective*
+mode after decision 7's `MIN_SPLIT_VIEW_WIDTH` fallback silently
+renders unified anyway. Threading the effective mode through instead
+would require plumbing the diff pane's `Rect` width into
+`crate::run_app`'s key-dispatch layer, which today has no notion of
+pane geometry at all — a materially larger change for a narrow-terminal
+edge case.
+
+**Accepted trade-off:** when the pane is narrower than
+`MIN_SPLIT_VIEW_WIDTH` and the reviewer has toggled to split, a
+hunk-jump (`]`/`[`) or symbol-scroll target computed from the
+requested (`Split`) row count can be off by one row per
+changed-signature section actually rendered as unified. This does not
+desync the diff pane from the tree cursor and does not corrupt
+rendering — `crate::ui::clamp_scroll` already absorbs any resulting
+overscroll the same way it absorbs any other requested-vs-actual
+mismatch, next frame. This is strictly narrower than decision 4's
+original invariant, not a full supersession of it: every other
+element a section renders (hunk headers, hunk body lines, blank
+separators) still has one shared row count across both modes,
+unchanged.

--- a/docs/adr/0044-tui-split-view-diff-pane.md
+++ b/docs/adr/0044-tui-split-view-diff-pane.md
@@ -363,25 +363,18 @@ paired row to correspond to.
 Each computes the section-anchor row count as 2 (unified, changed
 signature), 1 (unified, unchanged title), or 1 (split, either case),
 before continuing with decision 3/4's unchanged per-hunk counting.
-Callers pass `App::diff_view_mode()` — the *requested* mode, i.e. what
-`v`/`V` last toggled — not the pane's possibly-narrower *effective*
-mode after decision 7's `MIN_SPLIT_VIEW_WIDTH` fallback silently
-renders unified anyway. Threading the effective mode through instead
-would require plumbing the diff pane's `Rect` width into
-`crate::run_app`'s key-dispatch layer, which today has no notion of
-pane geometry at all — a materially larger change for a narrow-terminal
-edge case.
+Callers pass the *effective* mode last drawn (the pane's actually-rendered
+mode this frame, threaded through
+[`crate::ui::DrawOutcome::effective_diff_view_mode`] and folded back into
+`crate::run_app`'s loop between frames), not the requested
+`App::diff_view_mode()` — so decision 7's `MIN_SPLIT_VIEW_WIDTH` narrow-
+terminal fallback (`Split` requested but `Unified` rendered) still keeps
+the scroll math aligned with what the reviewer actually sees. The startup
+init and any frame that did not draw the diff pane (source screen, a
+different right pane) fall back to the requested mode — the effective
+mode simply is the requested mode there.
 
-**Accepted trade-off:** when the pane is narrower than
-`MIN_SPLIT_VIEW_WIDTH` and the reviewer has toggled to split, a
-hunk-jump (`]`/`[`) or symbol-scroll target computed from the
-requested (`Split`) row count can be off by one row per
-changed-signature section actually rendered as unified. This does not
-desync the diff pane from the tree cursor and does not corrupt
-rendering — `crate::ui::clamp_scroll` already absorbs any resulting
-overscroll the same way it absorbs any other requested-vs-actual
-mismatch, next frame. This is strictly narrower than decision 4's
-original invariant, not a full supersession of it: every other
-element a section renders (hunk headers, hunk body lines, blank
-separators) still has one shared row count across both modes,
-unchanged.
+Decision 4's shared line-index invariant is narrowed, not fully
+superseded: every element a section renders other than its anchor row
+(hunk headers, hunk body lines, blank separators) still has one shared
+row count across both modes, unchanged.

--- a/docs/adr/0044-tui-split-view-diff-pane.md
+++ b/docs/adr/0044-tui-split-view-diff-pane.md
@@ -378,3 +378,8 @@ Decision 4's shared line-index invariant is narrowed, not fully
 superseded: every element a section renders other than its anchor row
 (hunk headers, hunk body lines, blank separators) still has one shared
 row count across both modes, unchanged.
+
+This supersedes an earlier "accepted trade-off" phrasing (now removed)
+that acknowledged a narrow-terminal wrong-symbol sync hazard as
+unavoidable — threading the effective mode into the scroll math closes
+that hazard, it is not merely documented.

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -117,11 +117,12 @@ pub const MODULE_LEVEL_TITLE: &str = "(module level)";
 /// handling to jump the scroll offset to a hunk boundary. `view_mode` picks
 /// which of the two anchor-row shapes [`walk_sections`] counts (unified's
 /// title-or-2-line-signature-pair vs. split's always-one-row anchor —
-/// [`walk_sections`]'s own doc comment); callers pass `App::diff_view_mode`,
-/// the *requested* mode, not the pane's possibly-narrower effective one
-/// (`crate::ui::diff_pane::MIN_SPLIT_VIEW_WIDTH`'s fallback) — the resulting
-/// off-by-a-few-line target in that narrow-pane case is no worse than any
-/// other overscroll `crate::ui::clamp_scroll` already absorbs next frame.
+/// [`walk_sections`]'s own doc comment); callers pass the *effective* mode
+/// last drawn ([`crate::ui::DrawOutcome::effective_diff_view_mode`], folded
+/// back into `crate::run_app`'s loop between frames), not the requested
+/// `App::diff_view_mode()`, so the count matches what a reviewer actually
+/// sees when ADR 0044 decision 7's [`crate::ui::diff_pane::MIN_SPLIT_VIEW_WIDTH`]
+/// fallback silently renders `Split` as `Unified`.
 /// Mirrors `diff_pane_lines`/`diff_pane_split_rows`'s own line-counting
 /// exactly rather than reusing either function directly, since this module
 /// must stay free of `ratatui` types (module doc comment) — a change to

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -12,8 +12,10 @@
 //! the symbol whose section it falls inside, so `crate::run_app` can sync
 //! the tree cursor when the reviewer scrolls the pane manually.
 //!
-//! Each section whose symbol's contract changed gets a 2-line old/new
-//! signature header up front.
+//! Each section whose symbol's contract changed carries a
+//! [`ContractHeader`], rendered by `crate::ui::diff_pane` in place of the
+//! section's own title line (the anchor row(s) a reviewer lands on when
+//! jumping to that symbol) rather than as a separate header.
 //!
 //! Pure and free of `ratatui` types, mirroring every other view-model in
 //! this crate (`crate::tree`/`crate::nav`/`crate::detail`/`crate::blast_radius`):
@@ -25,7 +27,7 @@
 //! `crate::ui::draw` must not call it, for the identical reason
 //! `ui::draw` must not call `App::selected_blast_radius_view` either.
 
-use crate::app::DiffTarget;
+use crate::app::{DiffTarget, DiffViewMode};
 use crate::diff_view::{FileHunks, Hunk, file_hunks};
 pub use crate::split_pairing::{SplitRow, pair_hunk_lines};
 use rinkaku_core::extract::Classification;
@@ -112,18 +114,23 @@ pub const MODULE_LEVEL_TITLE: &str = "(module level)";
 /// already operates in) where each hunk in `content` starts, in the exact
 /// order `crate::ui::draw_diff_pane`/`diff_pane_lines` renders them — used
 /// by `crate::run_app`'s `]c`/`[c` (`InputKey::NextHunk`/`PrevHunk`)
-/// handling to jump the scroll offset to a hunk boundary. Mirrors
-/// `diff_pane_lines`'s own line-counting exactly (section separator blank
-/// lines, an optional bold section header, an optional 2-line contract
-/// header, a blank line before each hunk's own header when anything
-/// precedes it) rather than reusing that function directly, since this
-/// module must stay free of `ratatui` types (module doc comment) — a
-/// change to `diff_pane_lines`'s layout must be mirrored here by hand, the
-/// same trade `crate::order`'s own doc comment already accepts for its
-/// deliberately duplicated Tarjan SCC implementation.
-pub fn hunk_start_lines(content: &DiffPaneContent) -> Vec<usize> {
+/// handling to jump the scroll offset to a hunk boundary. `view_mode` picks
+/// which of the two anchor-row shapes [`walk_sections`] counts (unified's
+/// title-or-2-line-signature-pair vs. split's always-one-row anchor —
+/// [`walk_sections`]'s own doc comment); callers pass `App::diff_view_mode`,
+/// the *requested* mode, not the pane's possibly-narrower effective one
+/// (`crate::ui::diff_pane::MIN_SPLIT_VIEW_WIDTH`'s fallback) — the resulting
+/// off-by-a-few-line target in that narrow-pane case is no worse than any
+/// other overscroll `crate::ui::clamp_scroll` already absorbs next frame.
+/// Mirrors `diff_pane_lines`/`diff_pane_split_rows`'s own line-counting
+/// exactly rather than reusing either function directly, since this module
+/// must stay free of `ratatui` types (module doc comment) — a change to
+/// either function's layout must be mirrored here by hand, the same trade
+/// `crate::order`'s own doc comment already accepts for its deliberately
+/// duplicated Tarjan SCC implementation.
+pub fn hunk_start_lines(content: &DiffPaneContent, view_mode: DiffViewMode) -> Vec<usize> {
     let mut starts = Vec::new();
-    for (_, _, _, hunk_starts) in walk_sections(content) {
+    for (_, _, _, hunk_starts) in walk_sections(content, view_mode) {
         starts.extend(hunk_starts);
     }
     starts
@@ -138,16 +145,21 @@ pub fn hunk_start_lines(content: &DiffPaneContent) -> Vec<usize> {
 /// diff lines all fell inside another symbol's range — same rule as
 /// [`build_diff_pane_content`]'s "drop empty sections" step).
 ///
-/// Points at the *start of the section*, including its title line — not at
-/// the first hunk's `@@` header (ADR 0027 decision 3): a reviewer moving
-/// between symbols wants to see the section title (and its contract header,
-/// when present) first, before the hunks that follow.
+/// Points at the *start of the section*, including its anchor row(s) — not
+/// at the first hunk's `@@` header (ADR 0027 decision 3): a reviewer moving
+/// between symbols wants to see the section's title or changed-signature
+/// pair first, before the hunks that follow. `view_mode` has the same
+/// meaning as [`hunk_start_lines`]'s own parameter.
 ///
 /// Used by `crate::run_app` to write the auto-scroll target into
 /// `App::right_pane_scroll` right after `build_diff_pane_content` rebuilds
 /// the shaped content for a new selection.
-pub fn section_start_line_for_symbol(content: &DiffPaneContent, symbol_id: &str) -> Option<usize> {
-    walk_sections(content)
+pub fn section_start_line_for_symbol(
+    content: &DiffPaneContent,
+    symbol_id: &str,
+    view_mode: DiffViewMode,
+) -> Option<usize> {
+    walk_sections(content, view_mode)
         .find(|(_, section, _, _)| section.symbol_id.as_deref() == Some(symbol_id))
         .map(|(_, _, section_start, _)| section_start)
 }
@@ -159,8 +171,9 @@ pub fn section_start_line_for_symbol(content: &DiffPaneContent, symbol_id: &str)
 /// and returns that section's `symbol_id`. A section's span runs from its
 /// own start line (inclusive) up to the next section's start line
 /// (exclusive), or through the end of the content for the last section —
-/// so scrolling anywhere within a symbol's title/contract-header/hunks
-/// resolves to that symbol, not just its exact first line.
+/// so scrolling anywhere within a symbol's anchor row(s)/hunks resolves to
+/// that symbol, not just its exact first line. `view_mode` has the same
+/// meaning as [`hunk_start_lines`]'s own parameter.
 ///
 /// Returns `None` in two cases `crate::run_app`'s caller treats
 /// identically (ADR 0030 decision 3 — leave the tree cursor untouched
@@ -170,8 +183,13 @@ pub fn section_start_line_for_symbol(content: &DiffPaneContent, symbol_id: &str)
 /// module-level exclusion), or `scroll_line` is past the end of every
 /// section (an overscroll about to be clamped by `crate::ui::clamp_scroll`
 /// next frame) — also `None` on [`DiffPaneContent::Empty`].
-pub fn symbol_id_for_scroll_line(content: &DiffPaneContent, scroll_line: usize) -> Option<&str> {
-    let sections: Vec<(usize, &DiffSection, usize, Vec<usize>)> = walk_sections(content).collect();
+pub fn symbol_id_for_scroll_line(
+    content: &DiffPaneContent,
+    scroll_line: usize,
+    view_mode: DiffViewMode,
+) -> Option<&str> {
+    let sections: Vec<(usize, &DiffSection, usize, Vec<usize>)> =
+        walk_sections(content, view_mode).collect();
     let (_, (_, section, _, _)) =
         sections
             .iter()
@@ -191,14 +209,22 @@ pub fn symbol_id_for_scroll_line(content: &DiffPaneContent, scroll_line: usize) 
 /// One entry per section for line-counting consumers ([`hunk_start_lines`]
 /// and [`section_start_line_for_symbol`] both need the exact same layout
 /// walk, kept in one place so a change to
-/// [`crate::ui::diff_pane_lines`]'s rendered layout only has to be mirrored
-/// once here — the same trade [`hunk_start_lines`]'s own doc comment already
-/// accepts for the mirroring itself). Yields `(section_index, &section,
-/// section_start_line, hunk_start_lines)` — `section_start_line` is where
-/// the section's title (or its very first line, when nothing precedes it)
-/// begins.
+/// [`crate::ui::diff_pane_lines`]/[`crate::ui::diff_pane_split_rows`]'s
+/// rendered layout only has to be mirrored once here — the same trade
+/// [`hunk_start_lines`]'s own doc comment already accepts for the
+/// mirroring itself). Yields `(section_index, &section, section_start_line,
+/// hunk_start_lines)` — `section_start_line` is where the section's anchor
+/// row (or its very first line, when nothing precedes it) begins.
+///
+/// `view_mode` picks the anchor's row count: unified
+/// ([`DiffViewMode::Unified`]) renders a changed signature as 2 stacked
+/// rows but an unchanged title as 1; split ([`DiffViewMode::Split`]) always
+/// pairs the anchor onto exactly 1 row since old/new sit side by side
+/// rather than stacked — the two modes' row counts only diverge on a
+/// section whose signature changed, and only there.
 fn walk_sections(
     content: &DiffPaneContent,
+    view_mode: DiffViewMode,
 ) -> impl Iterator<Item = (usize, &DiffSection, usize, Vec<usize>)> {
     let sections: &[DiffSection] = match content {
         DiffPaneContent::Empty => &[],
@@ -212,14 +238,15 @@ fn walk_sections(
             line += 1; // blank line between sections
         }
         let section_start = line;
-        line += 1; // section title line (always shown now — ADR 0027)
-        if section.contract_header.is_some() {
-            line += 2; // "- previous" / "+ current" lines
-        }
+        line += match (view_mode, section.contract_header.is_some()) {
+            (DiffViewMode::Split, _) => 1,
+            (DiffViewMode::Unified, true) => 2,
+            (DiffViewMode::Unified, false) => 1,
+        };
 
         let mut hunk_starts = Vec::with_capacity(section.hunks.len());
         for attributed in &section.hunks {
-            // Blank line before every hunk header: the section title is
+            // Blank line before every hunk header: the section anchor is
             // always shown (ADR 0027 collapsed the two former
             // `show_section_headers` cases into one), so every hunk —
             // including a section's first — has *something* on the line

--- a/rinkaku-tui/src/diff_shape_tests/build_diff_pane_content.rs
+++ b/rinkaku-tui/src/diff_shape_tests/build_diff_pane_content.rs
@@ -302,10 +302,16 @@ fn should_attribute_new_file_single_hunk_to_every_symbol_it_defines() {
     // decision 2 / decision 4) — not just the first.
     assert_eq!(
         Some(0),
-        section_start_line_for_symbol(&actual, "file_size.rs::foo")
+        section_start_line_for_symbol(&actual, "file_size.rs::foo", DiffViewMode::Unified)
     );
-    assert!(section_start_line_for_symbol(&actual, "file_size.rs::bar").is_some());
-    assert!(section_start_line_for_symbol(&actual, "file_size.rs::baz").is_some());
+    assert!(
+        section_start_line_for_symbol(&actual, "file_size.rs::bar", DiffViewMode::Unified)
+            .is_some()
+    );
+    assert!(
+        section_start_line_for_symbol(&actual, "file_size.rs::baz", DiffViewMode::Unified)
+            .is_some()
+    );
 }
 
 #[test]

--- a/rinkaku-tui/src/diff_shape_tests/hunk_start_lines.rs
+++ b/rinkaku-tui/src/diff_shape_tests/hunk_start_lines.rs
@@ -3,7 +3,7 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn should_return_empty_hunk_starts_when_content_is_empty() {
-    let actual = hunk_start_lines(&DiffPaneContent::Empty);
+    let actual = hunk_start_lines(&DiffPaneContent::Empty, DiffViewMode::Unified);
 
     assert_eq!(Vec::<usize>::new(), actual);
 }
@@ -29,15 +29,16 @@ fn should_offset_first_hunk_start_by_title_and_blank_when_file_has_a_single_sect
         )],
     }]);
 
-    let actual = hunk_start_lines(&content);
+    let actual = hunk_start_lines(&content, DiffViewMode::Unified);
 
     assert_eq!(vec![2], actual);
 }
 
 #[test]
-fn should_offset_hunk_start_by_contract_header_lines_when_section_has_one() {
-    // Title(0), 2 contract-header lines (1, 2), blank before the hunk (3),
-    // hunk header (4) — hunk starts at line 4.
+fn should_offset_hunk_start_by_contract_header_lines_in_unified_view_when_section_has_one() {
+    // The contract header replaces the section's plain title (not an
+    // addition to it): 2 signature lines (0, 1), blank before the hunk
+    // (2), hunk header (3) — hunk starts at line 3.
     let content = DiffPaneContent::File(vec![DiffSection {
         title: "fn foo(a, b)".to_string(),
         symbol_id: Some("lib.rs::foo".to_string()),
@@ -51,9 +52,34 @@ fn should_offset_hunk_start_by_contract_header_lines_when_section_has_one() {
         )],
     }]);
 
-    let actual = hunk_start_lines(&content);
+    let actual = hunk_start_lines(&content, DiffViewMode::Unified);
 
-    assert_eq!(vec![4], actual);
+    assert_eq!(vec![3], actual);
+}
+
+#[test]
+fn should_offset_hunk_start_by_a_single_anchor_row_in_split_view_when_section_has_a_contract_header()
+ {
+    // Split view always pairs the anchor onto exactly 1 row regardless of
+    // whether the signature changed: signature row(0), blank before the
+    // hunk(1), hunk header(2) — hunk starts at line 2 (one line earlier
+    // than the unified-view case above).
+    let content = DiffPaneContent::File(vec![DiffSection {
+        title: "fn foo(a, b)".to_string(),
+        symbol_id: Some("lib.rs::foo".to_string()),
+        contract_header: Some(ContractHeader {
+            previous_signature: "fn foo(a)".to_string(),
+            signature: "fn foo(a, b)".to_string(),
+        }),
+        hunks: vec![attributed(
+            0,
+            hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo(a, b) {}"]),
+        )],
+    }]);
+
+    let actual = hunk_start_lines(&content, DiffViewMode::Split);
+
+    assert_eq!(vec![2], actual);
 }
 
 #[test]
@@ -80,7 +106,7 @@ fn should_offset_second_hunk_start_by_first_hunk_header_and_body_length() {
         ],
     }]);
 
-    let actual = hunk_start_lines(&content);
+    let actual = hunk_start_lines(&content, DiffViewMode::Unified);
 
     assert_eq!(vec![2, 6], actual);
 }
@@ -111,7 +137,7 @@ fn should_offset_hunk_start_by_section_header_and_separator_lines_for_a_file_sel
         },
     ]);
 
-    let actual = hunk_start_lines(&content);
+    let actual = hunk_start_lines(&content, DiffViewMode::Unified);
 
     assert_eq!(vec![2, 7], actual);
 }
@@ -145,7 +171,7 @@ fn should_emit_one_hunk_jump_stop_per_section_when_a_hunk_is_shared_by_two_symbo
     };
     let content = build_diff_pane_content(&report, &diff_files, Some(&target));
 
-    let actual = hunk_start_lines(&content);
+    let actual = hunk_start_lines(&content, DiffViewMode::Unified);
 
     // Section 0 (`foo`): title(0), blank(1), hunk header(2), 1 body
     // line(3) — 4 lines. Blank separator(4), section 1 (`bar`)

--- a/rinkaku-tui/src/diff_shape_tests/section_start_line.rs
+++ b/rinkaku-tui/src/diff_shape_tests/section_start_line.rs
@@ -3,7 +3,11 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn should_return_none_for_symbol_start_when_content_is_empty() {
-    let actual = section_start_line_for_symbol(&DiffPaneContent::Empty, "lib.rs::foo");
+    let actual = section_start_line_for_symbol(
+        &DiffPaneContent::Empty,
+        "lib.rs::foo",
+        DiffViewMode::Unified,
+    );
 
     assert_eq!(None, actual);
 }
@@ -21,7 +25,7 @@ fn should_return_zero_for_symbol_start_when_content_has_a_single_matching_sectio
         )],
     }]);
 
-    let actual = section_start_line_for_symbol(&content, "lib.rs::foo");
+    let actual = section_start_line_for_symbol(&content, "lib.rs::foo", DiffViewMode::Unified);
 
     assert_eq!(Some(0), actual);
 }
@@ -51,19 +55,20 @@ fn should_return_second_section_start_when_symbol_id_matches_the_second_section(
         },
     ]);
 
-    let actual = section_start_line_for_symbol(&content, "lib.rs::bar");
+    let actual = section_start_line_for_symbol(&content, "lib.rs::bar", DiffViewMode::Unified);
 
     assert_eq!(Some(5), actual);
 }
 
 #[test]
-fn should_point_at_section_title_line_when_section_has_a_contract_header() {
-    // The section start is the title line, *before* the contract header —
-    // ADR 0027 decision 3: the reviewer wants the section title and its
-    // contract change first, not the hunks below them.
-    // Section 0: title(0), body(1), 2 contract-header lines(2,3), blank
-    // before hunk(4), hunk header(5) — 6 lines. Blank between sections at
-    // line 6, section 1 title at line 7.
+fn should_point_at_section_anchor_line_in_unified_view_when_section_has_a_contract_header() {
+    // The section start is the anchor row(s) — the 2-line old/new
+    // signature pair standing in for the title, *before* the hunks (ADR
+    // 0027 decision 3: the reviewer wants the section's changed signature
+    // first, not the hunks below it).
+    // Section 0: 2 signature lines(0,1), blank before hunk(2), hunk
+    // header(3), 1 body line(4) — 5 lines. Blank between sections at line
+    // 5, section 1 title at line 6.
     let content = DiffPaneContent::File(vec![
         DiffSection {
             title: "fn foo(a, b)".to_string(),
@@ -88,9 +93,44 @@ fn should_point_at_section_title_line_when_section_has_a_contract_header() {
         },
     ]);
 
-    let actual = section_start_line_for_symbol(&content, "lib.rs::bar");
+    let actual = section_start_line_for_symbol(&content, "lib.rs::bar", DiffViewMode::Unified);
 
-    assert_eq!(Some(7), actual);
+    assert_eq!(Some(6), actual);
+}
+
+#[test]
+fn should_point_at_single_anchor_row_in_split_view_when_section_has_a_contract_header() {
+    // Split view always pairs the anchor onto exactly 1 row: signature
+    // row(0), blank before hunk(1), hunk header(2), 1 body line(3) — 4
+    // lines. Blank between sections at line 4, section 1 title at line 5
+    // (one line earlier than the unified-view case above).
+    let content = DiffPaneContent::File(vec![
+        DiffSection {
+            title: "fn foo(a, b)".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
+            contract_header: Some(ContractHeader {
+                previous_signature: "fn foo(a)".to_string(),
+                signature: "fn foo(a, b)".to_string(),
+            }),
+            hunks: vec![attributed(
+                0,
+                hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo(a, b) {}"]),
+            )],
+        },
+        DiffSection {
+            title: "fn bar()".to_string(),
+            symbol_id: Some("lib.rs::bar".to_string()),
+            contract_header: None,
+            hunks: vec![attributed(
+                1,
+                hunk("@@ -10,1 +10,2 @@", Some((10, 11)), vec!["fn bar() {}"]),
+            )],
+        },
+    ]);
+
+    let actual = section_start_line_for_symbol(&content, "lib.rs::bar", DiffViewMode::Split);
+
+    assert_eq!(Some(5), actual);
 }
 
 #[test]
@@ -110,7 +150,7 @@ fn should_return_none_for_module_level_bucket_when_asked_by_any_symbol_id() {
         )],
     }]);
 
-    let actual = section_start_line_for_symbol(&content, MODULE_LEVEL_TITLE);
+    let actual = section_start_line_for_symbol(&content, MODULE_LEVEL_TITLE, DiffViewMode::Unified);
 
     assert_eq!(None, actual);
 }
@@ -127,7 +167,8 @@ fn should_return_none_when_symbol_id_matches_no_section() {
         )],
     }]);
 
-    let actual = section_start_line_for_symbol(&content, "lib.rs::nonexistent");
+    let actual =
+        section_start_line_for_symbol(&content, "lib.rs::nonexistent", DiffViewMode::Unified);
 
     assert_eq!(None, actual);
 }

--- a/rinkaku-tui/src/diff_shape_tests/symbol_id_for_scroll_line.rs
+++ b/rinkaku-tui/src/diff_shape_tests/symbol_id_for_scroll_line.rs
@@ -7,7 +7,7 @@ use super::*;
 
 #[test]
 fn should_return_none_for_scroll_line_when_content_is_empty() {
-    let actual = symbol_id_for_scroll_line(&DiffPaneContent::Empty, 0);
+    let actual = symbol_id_for_scroll_line(&DiffPaneContent::Empty, 0, DiffViewMode::Unified);
 
     assert_eq!(None, actual);
 }
@@ -25,7 +25,7 @@ fn should_return_the_only_symbol_when_scroll_line_is_its_title_line() {
         )],
     }]);
 
-    let actual = symbol_id_for_scroll_line(&content, 0);
+    let actual = symbol_id_for_scroll_line(&content, 0, DiffViewMode::Unified);
 
     assert_eq!(Some("lib.rs::foo"), actual);
 }
@@ -45,7 +45,7 @@ fn should_return_the_only_symbol_when_scroll_line_is_inside_its_hunk_body_not_ju
         )],
     }]);
 
-    let actual = symbol_id_for_scroll_line(&content, 3);
+    let actual = symbol_id_for_scroll_line(&content, 3, DiffViewMode::Unified);
 
     assert_eq!(Some("lib.rs::foo"), actual);
 }
@@ -77,11 +77,20 @@ fn should_return_the_second_symbol_when_scroll_line_falls_inside_its_section() {
         },
     ]);
 
-    assert_eq!(Some("lib.rs::bar"), symbol_id_for_scroll_line(&content, 5));
-    assert_eq!(Some("lib.rs::bar"), symbol_id_for_scroll_line(&content, 7));
+    assert_eq!(
+        Some("lib.rs::bar"),
+        symbol_id_for_scroll_line(&content, 5, DiffViewMode::Unified)
+    );
+    assert_eq!(
+        Some("lib.rs::bar"),
+        symbol_id_for_scroll_line(&content, 7, DiffViewMode::Unified)
+    );
     // The boundary immediately before section 1 still belongs to
     // section 0.
-    assert_eq!(Some("lib.rs::foo"), symbol_id_for_scroll_line(&content, 4));
+    assert_eq!(
+        Some("lib.rs::foo"),
+        symbol_id_for_scroll_line(&content, 4, DiffViewMode::Unified)
+    );
 }
 
 #[test]
@@ -112,7 +121,7 @@ fn should_return_none_when_scroll_line_falls_inside_the_module_level_bucket() {
 
     // Module-level section starts at line 5 (same layout math as the
     // two-symbol test above).
-    let actual = symbol_id_for_scroll_line(&content, 5);
+    let actual = symbol_id_for_scroll_line(&content, 5, DiffViewMode::Unified);
 
     assert_eq!(None, actual);
 }
@@ -135,7 +144,7 @@ fn should_return_the_last_symbol_when_scroll_line_is_past_every_section_start_bu
     // section's span is open-ended, matching an overscroll that is
     // about to be clamped by `crate::ui::clamp_scroll` next frame
     // rather than a position inside some other symbol.
-    let actual = symbol_id_for_scroll_line(&content, 100);
+    let actual = symbol_id_for_scroll_line(&content, 100, DiffViewMode::Unified);
 
     assert_eq!(Some("lib.rs::foo"), actual);
 }

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -169,7 +169,9 @@ pub(crate) fn run_app(
     // when the first row happens to be a symbol) already opens with the
     // correct scroll offset rather than an unrelated 0.
     let mut last_diff_focus: Option<app::DiffFocus> = app.selected_diff_focus(report);
-    if let Some(target_scroll) = auto_scroll_for_diff_focus(&app, report, &diff_pane_content) {
+    if let Some(target_scroll) =
+        auto_scroll_for_diff_focus(&app, report, &diff_pane_content, app.diff_view_mode())
+    {
         app = app.with_right_pane_scroll(target_scroll);
     }
     // The source screen's (`s` key) file read + syntax highlight, computed
@@ -208,6 +210,16 @@ pub(crate) fn run_app(
     // would produce a step that does not match what the reviewer is
     // actually looking at.
     let mut last_help_scroll_viewport_height: Option<usize> = None;
+    // The diff pane's *effective* view mode as of the last drawn frame
+    // (`ui::DrawOutcome::effective_diff_view_mode`) — the ADR 0044
+    // decision 7 fallback (`MIN_SPLIT_VIEW_WIDTH`) means a requested
+    // `Split` can render as `Unified` on a narrow pane, and the ADR
+    // 0044 decision 4 amendment's mode-aware `walk_sections` needs the
+    // effective mode (not the requested one) for its scroll math to
+    // match what is on screen. Initialized to the requested mode so
+    // the very first key press before any frame has drawn (a rare edge
+    // case at startup) still has a sensible value to feed in.
+    let mut last_effective_diff_view_mode: app::DiffViewMode = app.diff_view_mode();
     // ADR 0048's `NoteMarkers` cache-on-change, mirroring
     // `blast_radius_selection`/`diff_pane_content`'s own up-front-then-
     // gated-recompute shape: built once from `App::new`'s initial (empty)
@@ -247,6 +259,9 @@ pub(crate) fn run_app(
         app = clamp_help_scroll_after_draw(app, outcome.clamped_help_scroll);
         if outcome.help_scroll_viewport_height.is_some() {
             last_help_scroll_viewport_height = outcome.help_scroll_viewport_height;
+        }
+        if let Some(mode) = outcome.effective_diff_view_mode {
+            last_effective_diff_view_mode = mode;
         }
 
         if app.should_quit() {
@@ -396,7 +411,13 @@ pub(crate) fn run_app(
                 // lives in its own function rather than inline here — see
                 // `dispatch_non_source_key`'s own doc comment for why this
                 // split exists (ADR 0022's `pending_prefix` regression).
-                app = dispatch_non_source_key(app, report, &diff_pane_content, input_key);
+                app = dispatch_non_source_key(
+                    app,
+                    report,
+                    &diff_pane_content,
+                    input_key,
+                    last_effective_diff_view_mode,
+                );
             }
 
             // ADR 0048: performs the export this key requested, if any —
@@ -427,6 +448,7 @@ pub(crate) fn run_app(
                     &diff_hunks,
                     last_diff_focus,
                     scroll_before_dispatch,
+                    last_effective_diff_view_mode,
                 );
                 app = effects.app;
                 diff_pane_content = effects.diff_pane_content;
@@ -488,6 +510,7 @@ fn apply_diff_pane_selection_effects(
     diff_hunks: &[diff_view::FileHunks],
     last_diff_focus: Option<app::DiffFocus>,
     scroll_before_dispatch: usize,
+    effective_diff_view_mode: app::DiffViewMode,
 ) -> DiffPaneSelectionEffects {
     let diff_pane_content = diff_shape::build_diff_pane_content(
         report,
@@ -507,13 +530,18 @@ fn apply_diff_pane_selection_effects(
     // a different symbol do we retarget the pane.
     let next_focus = app.selected_diff_focus(report);
     let last_diff_focus = if next_focus != last_diff_focus {
-        if let Some(target_scroll) = auto_scroll_for_diff_focus(&app, report, &diff_pane_content) {
+        if let Some(target_scroll) =
+            auto_scroll_for_diff_focus(&app, report, &diff_pane_content, effective_diff_view_mode)
+        {
             app = app.with_right_pane_scroll(target_scroll);
         }
         next_focus
-    } else if let Some(target_symbol_id) =
-        sync_target_for_scroll(&app, &diff_pane_content, scroll_before_dispatch)
-    {
+    } else if let Some(target_symbol_id) = sync_target_for_scroll(
+        &app,
+        &diff_pane_content,
+        scroll_before_dispatch,
+        effective_diff_view_mode,
+    ) {
         // ADR 0030: the mirror-image sync — this key's dispatch did not
         // itself move the cursor (`next_focus == last_diff_focus`, the `if`
         // branch above), but it did move `right_pane_scroll` onto a
@@ -564,6 +592,7 @@ fn sync_target_for_scroll(
     app: &App,
     diff_pane_content: &diff_shape::DiffPaneContent,
     scroll_before_dispatch: usize,
+    effective_diff_view_mode: app::DiffViewMode,
 ) -> Option<String> {
     if !should_apply_hunk_jump(app) {
         return None;
@@ -574,7 +603,7 @@ fn sync_target_for_scroll(
     let target_symbol_id = diff_shape::symbol_id_for_scroll_line(
         diff_pane_content,
         app.right_pane_scroll(),
-        app.diff_view_mode(),
+        effective_diff_view_mode,
     )?;
     if Some(target_symbol_id) == app.selected_symbol_id() {
         return None;
@@ -693,6 +722,7 @@ fn dispatch_non_source_key(
     report: &Report,
     diff_pane_content: &diff_shape::DiffPaneContent,
     input_key: InputKey,
+    effective_diff_view_mode: app::DiffViewMode,
 ) -> App {
     if let InputKey::NextHunk | InputKey::PrevHunk = input_key
         && should_apply_hunk_jump(&app)
@@ -701,7 +731,7 @@ fn dispatch_non_source_key(
         // caller (to know where each hunk starts — `App::handle_key` itself
         // has no notion of that content), so the jump target is computed
         // here rather than inside `App`.
-        let scroll = diff_shape::hunk_start_lines(diff_pane_content, app.diff_view_mode());
+        let scroll = diff_shape::hunk_start_lines(diff_pane_content, effective_diff_view_mode);
         let next = jump_scroll_target(&scroll, app.right_pane_scroll(), input_key);
         if let Some(target) = next {
             return app.handle_key(input_key).with_right_pane_scroll(target);
@@ -776,12 +806,13 @@ fn auto_scroll_for_diff_focus(
     app: &App,
     report: &Report,
     diff_pane_content: &diff_shape::DiffPaneContent,
+    effective_diff_view_mode: app::DiffViewMode,
 ) -> Option<usize> {
     let focus = app.selected_diff_focus(report)?;
     diff_shape::section_start_line_for_symbol(
         diff_pane_content,
         &focus.symbol_id,
-        app.diff_view_mode(),
+        effective_diff_view_mode,
     )
 }
 

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -571,8 +571,11 @@ fn sync_target_for_scroll(
     if app.right_pane_scroll() == scroll_before_dispatch {
         return None;
     }
-    let target_symbol_id =
-        diff_shape::symbol_id_for_scroll_line(diff_pane_content, app.right_pane_scroll())?;
+    let target_symbol_id = diff_shape::symbol_id_for_scroll_line(
+        diff_pane_content,
+        app.right_pane_scroll(),
+        app.diff_view_mode(),
+    )?;
     if Some(target_symbol_id) == app.selected_symbol_id() {
         return None;
     }
@@ -698,7 +701,7 @@ fn dispatch_non_source_key(
         // caller (to know where each hunk starts — `App::handle_key` itself
         // has no notion of that content), so the jump target is computed
         // here rather than inside `App`.
-        let scroll = diff_shape::hunk_start_lines(diff_pane_content);
+        let scroll = diff_shape::hunk_start_lines(diff_pane_content, app.diff_view_mode());
         let next = jump_scroll_target(&scroll, app.right_pane_scroll(), input_key);
         if let Some(target) = next {
             return app.handle_key(input_key).with_right_pane_scroll(target);
@@ -775,7 +778,11 @@ fn auto_scroll_for_diff_focus(
     diff_pane_content: &diff_shape::DiffPaneContent,
 ) -> Option<usize> {
     let focus = app.selected_diff_focus(report)?;
-    diff_shape::section_start_line_for_symbol(diff_pane_content, &focus.symbol_id)
+    diff_shape::section_start_line_for_symbol(
+        diff_pane_content,
+        &focus.symbol_id,
+        app.diff_view_mode(),
+    )
 }
 
 /// Whether `crate::run_app`'s [`InputKey::Source`] arm should re-run

--- a/rinkaku-tui/src/lib_tests/diff_scroll_sync.rs
+++ b/rinkaku-tui/src/lib_tests/diff_scroll_sync.rs
@@ -219,6 +219,98 @@ fn should_return_none_when_scroll_moved_into_the_module_level_bucket() {
     assert_eq!(None, actual);
 }
 
+/// Two-section fixture where `foo`'s signature changed and `bar`'s did
+/// not — the only shape whose section boundaries diverge between
+/// `Split` (anchor is always 1 row) and `Unified` (a changed-signature
+/// anchor is 2 rows). `bar` therefore starts one row later in
+/// `Unified` than in `Split`.
+fn diff_pane_content_with_foo_signature_changed() -> diff_shape::DiffPaneContent {
+    use diff_view::{DiffLine, DiffLineKind, Hunk};
+
+    fn hunk(header: &str, new_range: (usize, usize), line: &str) -> Hunk {
+        Hunk {
+            header: header.to_string(),
+            new_range: Some(new_range),
+            lines: vec![DiffLine {
+                kind: DiffLineKind::Context,
+                content: line.to_string(),
+            }],
+        }
+    }
+
+    diff_shape::DiffPaneContent::File(vec![
+        diff_shape::DiffSection {
+            title: "fn foo(a: i32)".to_string(),
+            symbol_id: Some("lib.rs::foo".to_string()),
+            contract_header: Some(diff_shape::ContractHeader {
+                previous_signature: "fn foo()".to_string(),
+                signature: "fn foo(a: i32)".to_string(),
+            }),
+            hunks: vec![diff_shape::AttributedHunk {
+                source_index: 0,
+                hunk: hunk("@@ -1,1 +1,2 @@", (1, 2), "fn foo(a: i32) {}"),
+            }],
+        },
+        diff_shape::DiffSection {
+            title: "fn bar()".to_string(),
+            symbol_id: Some("lib.rs::bar".to_string()),
+            contract_header: None,
+            hunks: vec![diff_shape::AttributedHunk {
+                source_index: 1,
+                hunk: hunk("@@ -10,1 +10,2 @@", (10, 11), "fn bar() {}"),
+            }],
+        },
+    ])
+}
+
+/// Regression pin for `a1e71d6`'s narrow-terminal fix: the same scroll
+/// offset must resolve to different symbols under `Split` vs `Unified`
+/// when a preceding section has a changed signature. Reverting
+/// `a1e71d6` (feeding the *requested* mode instead of the *effective*
+/// mode into `symbol_id_for_scroll_line`) collapses the two branches
+/// onto the same answer and this test starts failing.
+#[test]
+fn should_resolve_a_different_symbol_at_the_boundary_when_effective_view_mode_differs() {
+    let content = diff_pane_content_with_foo_signature_changed();
+    let boundary = diff_shape::section_start_line_for_symbol(
+        &content,
+        "lib.rs::bar",
+        app::DiffViewMode::Split,
+    )
+    .expect("bar's start under Split must resolve");
+
+    let split = diff_shape::symbol_id_for_scroll_line(&content, boundary, app::DiffViewMode::Split);
+    let unified =
+        diff_shape::symbol_id_for_scroll_line(&content, boundary, app::DiffViewMode::Unified);
+
+    assert_eq!(Some("lib.rs::bar"), split);
+    assert_eq!(Some("lib.rs::foo"), unified);
+}
+
+/// End-to-end companion to
+/// `should_resolve_a_different_symbol_at_the_boundary_when_effective_view_mode_differs`:
+/// `sync_target_for_scroll` (the caller that actually feeds
+/// `symbol_id_for_scroll_line`) must produce the answer matching the
+/// *effective* view mode passed in, not the requested one.
+#[test]
+fn should_sync_to_the_symbol_matching_the_effective_view_mode_at_the_boundary() {
+    let report = report_with_two_symbols();
+    let content = diff_pane_content_with_foo_signature_changed();
+    let boundary = diff_shape::section_start_line_for_symbol(
+        &content,
+        "lib.rs::bar",
+        app::DiffViewMode::Split,
+    )
+    .expect("bar's start under Split must resolve");
+    let app = app_focused_on_diff_pane_with_scroll(&report, boundary);
+
+    let split = sync_target_for_scroll(&app, &content, 0, app::DiffViewMode::Split);
+    let unified = sync_target_for_scroll(&app, &content, 0, app::DiffViewMode::Unified);
+
+    assert_eq!(Some("lib.rs::bar".to_string()), split);
+    assert_eq!(None, unified);
+}
+
 #[test]
 fn should_move_the_tree_cursor_to_bar_when_synced() {
     let report = report_with_two_symbols();

--- a/rinkaku-tui/src/lib_tests/diff_scroll_sync.rs
+++ b/rinkaku-tui/src/lib_tests/diff_scroll_sync.rs
@@ -401,3 +401,213 @@ fn should_resync_scroll_to_current_symbols_section_when_diff_pane_is_reentered_w
     assert_eq!(5, effects.app.right_pane_scroll());
     assert_eq!(Some("lib.rs::bar"), effects.app.selected_symbol_id());
 }
+
+// --- apply_diff_pane_selection_effects with adjacent signature-changed
+// symbols sharing one hunk (ADR 0029), driven end-to-end through the
+// draw+clamp pipeline: the fixtures above use `contract_header: None` and
+// two separate hunks, and their tests observe `apply_diff_pane_selection_effects`
+// output in isolation. This block covers the interaction between the
+// mode-aware anchor rows added by the amendment on ADR 0044 decision 4
+// and the actual post-frame scroll — the target computation and the
+// clamp-against-`wrap_lines` output are both correct only when the two
+// agree on how many rows the anchor occupies in the currently-rendered mode.
+
+/// Two `SignatureChanged` symbols so close that git's line-level diff
+/// produces one hunk spanning both — ADR 0029 duplicates it into both
+/// sections.
+fn report_with_two_adjacent_signature_changed_symbols() -> Report {
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::{Classification, ExtractedSymbol, SymbolKind};
+    use rinkaku_core::render::FileReport;
+
+    fn changed_symbol(id: &str, name: &str, range: LineRange, previous: &str) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature: format!("fn {name}(a: i32, extra: i32)"),
+            range,
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: Some(Classification::SignatureChanged),
+            previous_signature: Some(previous.to_string()),
+        }
+    }
+
+    Report {
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![
+                changed_symbol(
+                    "lib.rs::foo",
+                    "foo",
+                    LineRange { start: 1, end: 3 },
+                    "fn foo(a: i32)",
+                ),
+                changed_symbol(
+                    "lib.rs::bar",
+                    "bar",
+                    LineRange { start: 5, end: 7 },
+                    "fn bar(a: i32)",
+                ),
+            ],
+        }],
+        ..empty_report()
+    }
+}
+
+fn diff_hunks_with_two_signature_changed_sections() -> Vec<diff_view::FileHunks> {
+    use diff_view::{DiffLine, DiffLineKind, Hunk};
+
+    vec![diff_view::FileHunks {
+        path: "lib.rs".to_string(),
+        hunks: vec![Hunk {
+            header: "@@ -1,7 +1,7 @@".to_string(),
+            new_range: Some((1, 7)),
+            lines: vec![
+                DiffLine {
+                    kind: DiffLineKind::Removed,
+                    content: "fn foo(a: i32) {}".to_string(),
+                },
+                DiffLine {
+                    kind: DiffLineKind::Added,
+                    content: "fn foo(a: i32, extra: i32) {}".to_string(),
+                },
+                DiffLine {
+                    kind: DiffLineKind::Context,
+                    content: "".to_string(),
+                },
+                DiffLine {
+                    kind: DiffLineKind::Removed,
+                    content: "fn bar(a: i32) {}".to_string(),
+                },
+                DiffLine {
+                    kind: DiffLineKind::Added,
+                    content: "fn bar(a: i32, extra: i32) {}".to_string(),
+                },
+            ],
+        }],
+    }]
+}
+
+/// Mirrors one iteration of `crate::run_app`'s loop: dispatch + sync +
+/// draw + post-draw fold-back. Caller must size the viewport smaller than
+/// the pane's content — if it fits, `crate::ui::clamp_scroll` pins scroll
+/// to 0 regardless of the requested target and any regression in
+/// `apply_diff_pane_selection_effects`'s target computation is invisible.
+fn dispatch_draw_and_fold(
+    mut app: App,
+    report: &Report,
+    diff_hunks: &[diff_view::FileHunks],
+    last_diff_focus: Option<app::DiffFocus>,
+    input_key: InputKey,
+    width: u16,
+    height: u16,
+) -> App {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let scroll_before_dispatch = app.right_pane_scroll();
+    app = app.handle_key(input_key);
+    let effects = apply_diff_pane_selection_effects(
+        app,
+        report,
+        diff_hunks,
+        last_diff_focus,
+        scroll_before_dispatch,
+    );
+    let app = effects.app;
+    let diff_pane_content = effects.diff_pane_content;
+
+    let diff_highlights = crate::highlight::highlight_diff_files(diff_hunks);
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+    let mut outcome = crate::ui::DrawOutcome::default();
+    terminal
+        .draw(|frame| {
+            outcome = crate::ui::draw(
+                frame,
+                &app,
+                report,
+                &diff_pane_content,
+                &diff_highlights,
+                &app::BlastRadiusSelection::NotApplicable,
+                None,
+                diff_hunks,
+                &crate::note_markers::NoteMarkers::default(),
+            );
+        })
+        .expect("draw");
+    crate::clamp_right_pane_scroll_after_draw(app, outcome.clamped_right_pane_scroll)
+}
+
+#[test]
+fn should_scroll_into_the_second_signature_changed_section_in_unified_view() {
+    // `App::new` defaults to `DiffViewMode::Split` (ADR 0044 amendment);
+    // `ToggleSplitView` is what reaches unified rendering here.
+    let report = report_with_two_adjacent_signature_changed_symbols();
+    let diff_hunks = diff_hunks_with_two_signature_changed_sections();
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::ToggleSplitView);
+    assert_eq!(Some("lib.rs::foo"), app.selected_symbol_id());
+    let last_diff_focus = app.selected_diff_focus(&report);
+
+    let app = dispatch_draw_and_fold(
+        app,
+        &report,
+        &diff_hunks,
+        last_diff_focus,
+        InputKey::Down,
+        160,
+        10,
+    );
+
+    assert_eq!(Some("lib.rs::bar"), app.selected_symbol_id());
+    let expected_scroll = diff_shape::section_start_line_for_symbol(
+        &diff_shape::build_diff_pane_content(
+            &report,
+            &diff_hunks,
+            app.selected_diff_target(&report).as_ref(),
+        ),
+        "lib.rs::bar",
+        app.diff_view_mode(),
+    )
+    .expect("bar's section start must resolve");
+    assert_eq!(expected_scroll, app.right_pane_scroll());
+}
+
+#[test]
+fn should_scroll_into_the_second_signature_changed_section_in_split_view() {
+    // `App::new` already defaults to `DiffViewMode::Split`.
+    let report = report_with_two_adjacent_signature_changed_symbols();
+    let diff_hunks = diff_hunks_with_two_signature_changed_sections();
+    let app = App::new(&report).handle_key(InputKey::Down);
+    assert_eq!(Some("lib.rs::foo"), app.selected_symbol_id());
+    let last_diff_focus = app.selected_diff_focus(&report);
+
+    let app = dispatch_draw_and_fold(
+        app,
+        &report,
+        &diff_hunks,
+        last_diff_focus,
+        InputKey::Down,
+        160,
+        10,
+    );
+
+    assert_eq!(Some("lib.rs::bar"), app.selected_symbol_id());
+    let expected_scroll = diff_shape::section_start_line_for_symbol(
+        &diff_shape::build_diff_pane_content(
+            &report,
+            &diff_hunks,
+            app.selected_diff_target(&report).as_ref(),
+        ),
+        "lib.rs::bar",
+        app.diff_view_mode(),
+    )
+    .expect("bar's section start must resolve");
+    assert_eq!(expected_scroll, app.right_pane_scroll());
+}

--- a/rinkaku-tui/src/lib_tests/diff_scroll_sync.rs
+++ b/rinkaku-tui/src/lib_tests/diff_scroll_sync.rs
@@ -113,7 +113,7 @@ fn should_return_none_when_scroll_did_not_change_this_key() {
     // which symbol the unchanged offset happens to point at.
     let app = app_focused_on_diff_pane_with_scroll(&report, 5);
 
-    let actual = sync_target_for_scroll(&app, &content, 5);
+    let actual = sync_target_for_scroll(&app, &content, 5, app::DiffViewMode::Split);
 
     assert_eq!(None, actual);
 }
@@ -125,7 +125,7 @@ fn should_return_none_when_tree_is_focused_even_if_scroll_changed() {
     let app = App::new(&report).with_right_pane_scroll(5);
     assert_eq!(app::Focus::Tree, app.focus());
 
-    let actual = sync_target_for_scroll(&app, &content, 0);
+    let actual = sync_target_for_scroll(&app, &content, 0, app::DiffViewMode::Split);
 
     assert_eq!(None, actual);
 }
@@ -140,7 +140,7 @@ fn should_return_none_when_right_pane_is_not_diff_even_if_focus_is_right() {
         .with_right_pane_scroll(5);
     assert_eq!(app::RightPane::Detail, app.right_pane());
 
-    let actual = sync_target_for_scroll(&app, &content, 0);
+    let actual = sync_target_for_scroll(&app, &content, 0, app::DiffViewMode::Split);
 
     assert_eq!(None, actual);
 }
@@ -153,7 +153,7 @@ fn should_return_bar_when_scroll_moved_into_bars_section() {
     // (line 2) down into bar's section (line 5, its title line).
     let app = app_focused_on_diff_pane_with_scroll(&report, 5);
 
-    let actual = sync_target_for_scroll(&app, &content, 2);
+    let actual = sync_target_for_scroll(&app, &content, 2, app::DiffViewMode::Split);
 
     assert_eq!(Some("lib.rs::bar".to_string()), actual);
 }
@@ -166,7 +166,7 @@ fn should_return_none_when_scroll_moved_but_stayed_within_the_current_symbols_se
     // inside foo's own section (0-4) — nothing to sync.
     let app = app_focused_on_diff_pane_with_scroll(&report, 2);
 
-    let actual = sync_target_for_scroll(&app, &content, 0);
+    let actual = sync_target_for_scroll(&app, &content, 0, app::DiffViewMode::Split);
 
     assert_eq!(None, actual);
 }
@@ -214,7 +214,7 @@ fn should_return_none_when_scroll_moved_into_the_module_level_bucket() {
     // two-symbol fixture).
     let app = app_focused_on_diff_pane_with_scroll(&report, 5);
 
-    let actual = sync_target_for_scroll(&app, &content, 2);
+    let actual = sync_target_for_scroll(&app, &content, 2, app::DiffViewMode::Split);
 
     assert_eq!(None, actual);
 }
@@ -312,6 +312,7 @@ fn should_sync_tree_cursor_when_scroll_moves_into_a_different_symbols_section() 
         &diff_hunks,
         last_diff_focus,
         scroll_before_dispatch,
+        app::DiffViewMode::Split,
     );
 
     assert_eq!(Some("lib.rs::bar"), effects.app.selected_symbol_id());
@@ -345,6 +346,7 @@ fn should_not_bounce_scroll_back_on_the_next_key_after_a_sync() {
         &diff_hunks,
         last_diff_focus,
         scroll_before_first_key,
+        app::DiffViewMode::Split,
     );
     assert_eq!(Some("lib.rs::bar"), first.app.selected_symbol_id());
     assert_eq!(5, first.app.right_pane_scroll());
@@ -364,6 +366,7 @@ fn should_not_bounce_scroll_back_on_the_next_key_after_a_sync() {
         &diff_hunks,
         first.last_diff_focus,
         scroll_before_second_key,
+        app::DiffViewMode::Split,
     );
 
     assert_eq!(6, second.app.right_pane_scroll());
@@ -392,7 +395,14 @@ fn should_resync_scroll_to_current_symbols_section_when_diff_pane_is_reentered_w
     // `run_app`'s loop passes in after a Diff -> Detail -> Diff toggle
     // with the cursor untouched, per the fix.
     let app = app.with_right_pane_scroll(0);
-    let effects = apply_diff_pane_selection_effects(app, &report, &diff_hunks, None, 0);
+    let effects = apply_diff_pane_selection_effects(
+        app,
+        &report,
+        &diff_hunks,
+        None,
+        0,
+        app::DiffViewMode::Split,
+    );
 
     // bar's section starts at line 5 (same layout as every other test in
     // this file); landing at 0 would show foo's section under a pinned
@@ -510,6 +520,11 @@ fn dispatch_draw_and_fold(
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
 
+    // Mirrors `run_app`'s startup init: before any frame has drawn there
+    // is no `last_effective_diff_view_mode` yet, so the requested mode is
+    // used until the first `DrawOutcome::effective_diff_view_mode` folds
+    // back.
+    let effective_mode = app.diff_view_mode();
     let scroll_before_dispatch = app.right_pane_scroll();
     app = app.handle_key(input_key);
     let effects = apply_diff_pane_selection_effects(
@@ -518,6 +533,7 @@ fn dispatch_draw_and_fold(
         diff_hunks,
         last_diff_focus,
         scroll_before_dispatch,
+        effective_mode,
     );
     let app = effects.app;
     let diff_pane_content = effects.diff_pane_content;

--- a/rinkaku-tui/src/lib_tests/goto_dispatch.rs
+++ b/rinkaku-tui/src/lib_tests/goto_dispatch.rs
@@ -113,9 +113,21 @@ fn should_clear_pending_prefix_so_next_d_toggles_diff_after_a_one_candidate_gd_j
     // now set) `GotoDefinition` for the following `d` — both routed
     // through `dispatch_non_source_key`, the same function `run_app`
     // itself calls, rather than `App::handle_key` directly.
-    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
+    let app = dispatch_non_source_key(
+        app,
+        &report,
+        &diff_content,
+        InputKey::PendingGoto,
+        app::DiffViewMode::Split,
+    );
     assert_eq!(Some(app::PendingPrefix::G), app.pending_prefix());
-    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoDefinition);
+    let app = dispatch_non_source_key(
+        app,
+        &report,
+        &diff_content,
+        InputKey::GotoDefinition,
+        app::DiffViewMode::Split,
+    );
     assert_eq!(None, app.pending_prefix(), "gd must clear pending_prefix");
 
     // The regression itself: a *plain* `d` right after the jump must
@@ -126,7 +138,13 @@ fn should_clear_pending_prefix_so_next_d_toggles_diff_after_a_one_candidate_gd_j
     // this assertion on `right_pane()` is an indirect but faithful proxy
     // for "the next `d` meant ToggleDiff, not gd".
     let right_pane_before = app.right_pane();
-    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::ToggleDiff);
+    let app = dispatch_non_source_key(
+        app,
+        &report,
+        &diff_content,
+        InputKey::ToggleDiff,
+        app::DiffViewMode::Split,
+    );
     assert_ne!(
         right_pane_before,
         app.right_pane(),
@@ -151,8 +169,20 @@ fn should_clear_pending_prefix_so_next_d_toggles_diff_after_a_multi_candidate_gr
         .handle_key(InputKey::Down);
     let diff_content = diff_shape::DiffPaneContent::Empty;
 
-    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
-    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoReferences);
+    let app = dispatch_non_source_key(
+        app,
+        &report,
+        &diff_content,
+        InputKey::PendingGoto,
+        app::DiffViewMode::Split,
+    );
+    let app = dispatch_non_source_key(
+        app,
+        &report,
+        &diff_content,
+        InputKey::GotoReferences,
+        app::DiffViewMode::Split,
+    );
     assert!(
         app.jump_popup().is_some(),
         "gr with 2 candidates must open the popup"
@@ -167,7 +197,13 @@ fn should_clear_pending_prefix_so_next_d_toggles_diff_after_a_multi_candidate_gr
     // return is the second path the #61-review finding flagged: it used
     // to return before the (then-later-positioned) `pending_prefix`
     // clear, so a stale prefix could survive an entire popup session.
-    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PopupCancel);
+    let app = dispatch_non_source_key(
+        app,
+        &report,
+        &diff_content,
+        InputKey::PopupCancel,
+        app::DiffViewMode::Split,
+    );
     assert_eq!(None, app.jump_popup());
     assert_eq!(None, app.pending_prefix());
 
@@ -175,7 +211,13 @@ fn should_clear_pending_prefix_so_next_d_toggles_diff_after_a_multi_candidate_gr
     // `d` after the cancelled popup must toggle the right pane, not
     // silently re-resolve as another `gr`.
     let right_pane_before = app.right_pane();
-    let app = dispatch_non_source_key(app, &report, &diff_content, InputKey::ToggleDiff);
+    let app = dispatch_non_source_key(
+        app,
+        &report,
+        &diff_content,
+        InputKey::ToggleDiff,
+        app::DiffViewMode::Split,
+    );
     assert_ne!(
         right_pane_before,
         app.right_pane(),
@@ -214,22 +256,46 @@ fn should_restore_the_scroll_offset_the_reviewer_was_at_when_jumping_back_after_
 
     // Cursor on "foo" (row 1), scrolled 5 lines into its Diff pane.
     let mut app = App::new(&report).handle_key(InputKey::Down);
-    app = dispatch_non_source_key(app, &report, &diff_content, InputKey::Open); // focus -> Right, RightPane::Diff
+    app = dispatch_non_source_key(
+        app,
+        &report,
+        &diff_content,
+        InputKey::Open,
+        app::DiffViewMode::Split,
+    ); // focus -> Right, RightPane::Diff
     for _ in 0..5 {
-        app = dispatch_non_source_key(app, &report, &diff_content, InputKey::Down);
+        app = dispatch_non_source_key(
+            app,
+            &report,
+            &diff_content,
+            InputKey::Down,
+            app::DiffViewMode::Split,
+        );
     }
     assert_eq!(5, app.right_pane_scroll());
 
     // The real `gd` key sequence: `g` (PendingGoto) then `d`
     // (GotoDefinition) — "bar" is "foo"'s one callee, so this jumps
     // immediately (`GotoOutcome::One`) rather than opening the popup.
-    app = dispatch_non_source_key(app, &report, &diff_content, InputKey::PendingGoto);
+    app = dispatch_non_source_key(
+        app,
+        &report,
+        &diff_content,
+        InputKey::PendingGoto,
+        app::DiffViewMode::Split,
+    );
     assert_eq!(
         5,
         app.right_pane_scroll(),
         "the leading g of gd must not disturb scroll either"
     );
-    app = dispatch_non_source_key(app, &report, &diff_content, InputKey::GotoDefinition);
+    app = dispatch_non_source_key(
+        app,
+        &report,
+        &diff_content,
+        InputKey::GotoDefinition,
+        app::DiffViewMode::Split,
+    );
     assert_eq!(Some("lib.rs::bar"), app.selected_symbol_id());
     assert_eq!(
         0,
@@ -238,7 +304,13 @@ fn should_restore_the_scroll_offset_the_reviewer_was_at_when_jumping_back_after_
     );
 
     // Ctrl-o: jump back to "foo" — the regression this test guards.
-    app = dispatch_non_source_key(app, &report, &diff_content, InputKey::JumpBack);
+    app = dispatch_non_source_key(
+        app,
+        &report,
+        &diff_content,
+        InputKey::JumpBack,
+        app::DiffViewMode::Split,
+    );
 
     assert_eq!(Some("lib.rs::foo"), app.selected_symbol_id());
     assert_eq!(

--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -303,16 +303,13 @@ fn selected_row_badges(app: &App) -> Badges {
 }
 
 /// Formats every [`DiffSection`] in `sections` into styled lines (ADR
-/// 0020): a section header (a symbol's own signature, styled bold, or the
-/// fixed "(module level)" label) only when `show_section_headers` is set —
-/// a single-section symbol selection has nothing to disambiguate a header
-/// would add value to, so it is omitted there and the pane opens straight
-/// on the (optional) contract header/hunks, matching this pane's pre-ADR-
-/// 0020 layout for a symbol row. A file selection (multiple sections, or
-/// one section that still benefits from being named) always shows headers.
-/// Each section's own `contract_header` (when present) renders as a 2-line
-/// red/green old/new pair before that section's hunks — the outline-before-
-/// implementation disclosure order ADR 0020 asks for.
+/// 0020): a section anchor (via [`section_anchor_lines`]) only when
+/// `show_section_headers` is set — a single-section symbol selection has
+/// nothing to disambiguate a header would add value to, so it is omitted
+/// there and the pane opens straight on the hunks, matching this pane's
+/// pre-ADR-0020 layout for a symbol row. A file selection (multiple
+/// sections, or one section that still benefits from being named) always
+/// shows headers.
 ///
 /// Within each section, hunk headers stay dim, `+`/`-` marker glyphs keep
 /// their existing bold green/red foreground, and each line's own code
@@ -335,24 +332,11 @@ pub(crate) fn diff_pane_lines(
             lines.push(Line::raw(""));
         }
         if show_section_headers {
-            lines.push(Line::styled(
-                section.title.clone(),
-                Style::default().add_modifier(Modifier::BOLD),
-            ));
-        }
-        if let Some(contract) = &section.contract_header {
-            lines.push(Line::styled(
-                format!("- {}", contract.previous_signature),
-                Style::default().fg(Color::Red),
-            ));
-            lines.push(Line::styled(
-                format!("+ {}", contract.signature),
-                Style::default().fg(Color::Green),
-            ));
+            lines.extend(section_anchor_lines(section));
         }
 
         for (hunk_index, attributed) in section.hunks.iter().enumerate() {
-            if hunk_index > 0 || show_section_headers || section.contract_header.is_some() {
+            if hunk_index > 0 || show_section_headers {
                 lines.push(Line::raw(""));
             }
             lines.push(Line::styled(
@@ -385,6 +369,31 @@ pub(crate) fn diff_pane_lines(
         }
     }
     lines
+}
+
+/// A section's anchor line(s) in unified view: the plain bold title when
+/// [`DiffSection::contract_header`] is `None`, or a bold 2-line `- {old}` /
+/// `+ {new}` pair carrying the same `ADDED_BG`/`REMOVED_BG` background tint
+/// as a hunk body line when it is `Some` — the changed-signature case
+/// replaces the title outright rather than showing both, since the title
+/// *is* the old signature's replacement.
+fn section_anchor_lines(section: &DiffSection) -> Vec<Line<'static>> {
+    match &section.contract_header {
+        None => vec![Line::styled(
+            section.title.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        )],
+        Some(contract) => vec![
+            Line::styled(
+                format!("- {}", contract.previous_signature),
+                added_removed_style(DiffLineKind::Removed).add_modifier(Modifier::BOLD),
+            ),
+            Line::styled(
+                format!("+ {}", contract.signature),
+                added_removed_style(DiffLineKind::Added).add_modifier(Modifier::BOLD),
+            ),
+        ],
+    }
 }
 
 /// This hunk's own new-side line number for each of `hunk.lines`, `None`
@@ -439,19 +448,19 @@ fn prefix_note_marker(line: Line<'static>, has_note: bool) -> Line<'static> {
 }
 
 /// Split-view (ADR 0044) counterpart of [`diff_pane_lines`]: the same
-/// section/contract-header/hunk-header scaffold, but each hunk's body is
-/// paired via [`crate::diff_shape::pair_hunk_lines`] into old-side/new-side
-/// columns instead of one interleaved column. A title/hunk-header line
-/// renders identically on both sides (`left`/`right` share it); the
-/// contract header's old/new signatures render side by side on one row
-/// instead — the whole point of a split view is comparing them without
-/// scanning past an interleaved line in between. Returns `(left, right)`,
-/// each the same length — [`crate::diff_shape::SplitRow`]'s own invariant
-/// (one row per source [`DiffLine`]) means every hunk contributes the same
-/// row count here as it does to [`diff_pane_lines`], and the contract
-/// header's own filler row below the paired signatures keeps its 2-line
-/// scaffold budget intact — so this function's total line count always
-/// matches `diff_pane_lines`'s for the same `sections`/`show_section_headers`,
+/// section/hunk-header scaffold, but each hunk's body is paired via
+/// [`crate::diff_shape::pair_hunk_lines`] into old-side/new-side columns
+/// instead of one interleaved column. A plain title renders identically on
+/// both sides (`left`/`right` share it); a changed signature instead pairs
+/// its old/new [`DiffSection::contract_header`] on that same one row
+/// (`left` = previous, `right` = current) — the whole point of a split view
+/// is comparing them without scanning past an interleaved row in between.
+/// Returns `(left, right)`, each the same length — [`crate::diff_shape::SplitRow`]'s
+/// own invariant (one row per source [`DiffLine`]) means every hunk
+/// contributes the same row count here as it does to [`diff_pane_lines`],
+/// and the anchor is always exactly one row regardless of which of the two
+/// arms below fires — so this function's total line count always matches
+/// `diff_pane_lines`'s for the same `sections`/`show_section_headers`,
 /// required for `walk_sections`' shared line-counting (ADR 0044 decision 4)
 /// to stay correct regardless of which of the two this pane actually
 /// renders.
@@ -470,28 +479,13 @@ pub(crate) fn diff_pane_split_rows(
             right.push(Line::raw(""));
         }
         if show_section_headers {
-            let title = Line::styled(
-                section.title.clone(),
-                Style::default().add_modifier(Modifier::BOLD),
-            );
-            left.push(title.clone());
-            right.push(title);
-        }
-        if let Some(contract) = &section.contract_header {
-            left.push(Line::styled(
-                format!("- {}", contract.previous_signature),
-                Style::default().fg(Color::Red),
-            ));
-            right.push(Line::styled(
-                format!("+ {}", contract.signature),
-                Style::default().fg(Color::Green),
-            ));
-            left.push(Line::raw(""));
-            right.push(Line::raw(""));
+            let (anchor_left, anchor_right) = section_anchor_split_row(section);
+            left.push(anchor_left);
+            right.push(anchor_right);
         }
 
         for (hunk_index, attributed) in section.hunks.iter().enumerate() {
-            if hunk_index > 0 || show_section_headers || section.contract_header.is_some() {
+            if hunk_index > 0 || show_section_headers {
                 left.push(Line::raw(""));
                 right.push(Line::raw(""));
             }
@@ -532,6 +526,35 @@ pub(crate) fn diff_pane_split_rows(
         }
     }
     (left, right)
+}
+
+/// A section's anchor row in split view, paired as `(left, right)`: the
+/// same bold plain title on both sides when [`DiffSection::contract_header`]
+/// is `None`, or the old/new signatures side by side (left = previous,
+/// right = current) with the matching `ADDED_BG`/`REMOVED_BG` tint when it
+/// is `Some` — mirrors [`section_anchor_lines`]'s unified-view choice
+/// between the two, but as one paired row instead of two stacked lines
+/// since split view compares old/new positionally rather than sequentially.
+fn section_anchor_split_row(section: &DiffSection) -> (Line<'static>, Line<'static>) {
+    match &section.contract_header {
+        None => {
+            let title = Line::styled(
+                section.title.clone(),
+                Style::default().add_modifier(Modifier::BOLD),
+            );
+            (title.clone(), title)
+        }
+        Some(contract) => (
+            Line::styled(
+                format!("- {}", contract.previous_signature),
+                added_removed_style(DiffLineKind::Removed).add_modifier(Modifier::BOLD),
+            ),
+            Line::styled(
+                format!("+ {}", contract.signature),
+                added_removed_style(DiffLineKind::Added).add_modifier(Modifier::BOLD),
+            ),
+        ),
+    }
 }
 
 /// One [`SplitRow`](crate::diff_shape::SplitRow) side's rendered [`Line`] —
@@ -601,13 +624,31 @@ pub(crate) fn plain_diff_line(line: &DiffLine) -> Line<'static> {
     match line.kind {
         DiffLineKind::Added => Line::styled(
             format!("+{}", line.content),
-            Style::default().fg(Color::Green).bg(ADDED_BG),
+            added_removed_style(DiffLineKind::Added),
         ),
         DiffLineKind::Removed => Line::styled(
             format!("-{}", line.content),
-            Style::default().fg(Color::Red).bg(REMOVED_BG),
+            added_removed_style(DiffLineKind::Removed),
         ),
         DiffLineKind::Context => Line::raw(format!(" {}", line.content)),
+    }
+}
+
+/// The fg/bg pair for an `Added`/`Removed` line (ADR 0018: diff signal lives
+/// in the background, not just the foreground), shared by [`plain_diff_line`]
+/// and a section's changed-signature anchor row(s) — the anchor is a
+/// synthetic old/new pair rather than an actual hunk body line, but it
+/// still needs to read as a diff at a glance.
+///
+/// Panics on `DiffLineKind::Context`: no caller here ever has a
+/// context-kind line to style.
+fn added_removed_style(kind: DiffLineKind) -> Style {
+    match kind {
+        DiffLineKind::Added => Style::default().fg(Color::Green).bg(ADDED_BG),
+        DiffLineKind::Removed => Style::default().fg(Color::Red).bg(REMOVED_BG),
+        DiffLineKind::Context => {
+            unreachable!("contract headers and plain diff lines are never Context-kind")
+        }
     }
 }
 

--- a/rinkaku-tui/src/ui/diff_pane_tests/row_kinds.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/row_kinds.rs
@@ -306,8 +306,9 @@ index e69de29..4b825dc 100644
         .expect("draw");
 
     let text = buffer_text(&terminal);
-    // The 2-line old/new contract header precedes the hunk body itself
-    // (ADR 0020's outline-before-implementation disclosure order).
+    // The 2-line old/new signature pair stands in for the section title and
+    // precedes the hunk body itself (ADR 0020's outline-before-
+    // implementation disclosure order).
     assert!(text.contains("- fn foo(a: i32)"));
     assert!(text.contains("+ fn foo(a: i32, b: i32)"));
     assert!(text.contains("-fn foo(a: i32) {}"));

--- a/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
@@ -101,12 +101,11 @@ index e69de29..4b825dc 100644
 }
 
 #[test]
-fn should_pair_old_and_new_signature_on_one_row_when_section_has_a_contract_header() {
-    // Regression coverage for the diagonal-placement bug a static review
-    // caught: the contract header's old/new signatures must land on the
-    // *same* row (left = old, right = new), not on two separate rows with
-    // one side blank each — the whole point of a split view is comparing
-    // them without scanning past an interleaved row in between.
+fn should_pair_old_and_new_signature_on_the_anchor_row_when_section_has_a_contract_header() {
+    // The changed signature replaces the section's title outright rather
+    // than adding a header below it: old/new land on the *same* one row
+    // (left = old, right = new) — the whole point of a split view is
+    // comparing them without scanning past an interleaved row in between.
     let section = DiffSection {
         title: "fn foo(a: i32, b: i32)".to_string(),
         symbol_id: Some("lib.rs::foo".to_string()),
@@ -126,31 +125,23 @@ fn should_pair_old_and_new_signature_on_one_row_when_section_has_a_contract_head
     );
 
     assert_eq!(
-        vec![
-            Line::styled(
-                "fn foo(a: i32, b: i32)".to_string(),
-                Style::default().add_modifier(Modifier::BOLD),
-            ),
-            Line::styled(
-                "- fn foo(a: i32)".to_string(),
-                Style::default().fg(Color::Red),
-            ),
-            Line::raw(""),
-        ],
+        vec![Line::styled(
+            "- fn foo(a: i32)".to_string(),
+            Style::default()
+                .fg(Color::Red)
+                .bg(REMOVED_BG)
+                .add_modifier(Modifier::BOLD),
+        )],
         left
     );
     assert_eq!(
-        vec![
-            Line::styled(
-                "fn foo(a: i32, b: i32)".to_string(),
-                Style::default().add_modifier(Modifier::BOLD),
-            ),
-            Line::styled(
-                "+ fn foo(a: i32, b: i32)".to_string(),
-                Style::default().fg(Color::Green),
-            ),
-            Line::raw(""),
-        ],
+        vec![Line::styled(
+            "+ fn foo(a: i32, b: i32)".to_string(),
+            Style::default()
+                .fg(Color::Green)
+                .bg(ADDED_BG)
+                .add_modifier(Modifier::BOLD),
+        )],
         right
     );
     // ADR 0044 decision 4's shared line-counting invariant: both sides

--- a/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
@@ -150,6 +150,31 @@ fn should_pair_old_and_new_signature_on_the_anchor_row_when_section_has_a_contra
 }
 
 #[test]
+fn should_mirror_the_plain_bold_title_on_both_sides_in_split_view_when_signature_is_unchanged() {
+    let section = DiffSection {
+        title: "fn foo()".to_string(),
+        symbol_id: Some("lib.rs::foo".to_string()),
+        contract_header: None,
+        hunks: vec![],
+    };
+
+    let (left, right) = diff_pane_split_rows(
+        &[&section],
+        true,
+        None,
+        &crate::note_markers::NoteMarkers::default(),
+        "lib.rs",
+    );
+
+    let expected = vec![Line::styled(
+        "fn foo()".to_string(),
+        Style::default().add_modifier(Modifier::BOLD),
+    )];
+    assert_eq!(expected, left);
+    assert_eq!(expected, right);
+}
+
+#[test]
 fn should_draw_old_and_new_signature_side_by_side_when_symbol_signature_changed() {
     let report = Report {
         origin: rinkaku_core::render::ReportOrigin::Diff,

--- a/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
@@ -298,3 +298,71 @@ fn should_keep_context_line_unstyled_in_plain_diff_line_when_no_token_spans() {
 
     assert_eq!(Line::raw(" fn foo() {}".to_string()), actual);
 }
+
+#[test]
+fn should_replace_the_section_title_with_a_tinted_old_new_pair_in_unified_view_when_signature_changed()
+ {
+    let section = crate::diff_shape::DiffSection {
+        title: "fn foo(a: i32, b: i32)".to_string(),
+        symbol_id: Some("lib.rs::foo".to_string()),
+        contract_header: Some(crate::diff_shape::ContractHeader {
+            previous_signature: "fn foo(a: i32)".to_string(),
+            signature: "fn foo(a: i32, b: i32)".to_string(),
+        }),
+        hunks: vec![],
+    };
+
+    let actual = diff_pane_lines(
+        &[&section],
+        true,
+        None,
+        &crate::note_markers::NoteMarkers::default(),
+        "lib.rs",
+    );
+
+    assert_eq!(
+        vec![
+            Line::styled(
+                "- fn foo(a: i32)".to_string(),
+                Style::default()
+                    .fg(Color::Red)
+                    .bg(REMOVED_BG)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Line::styled(
+                "+ fn foo(a: i32, b: i32)".to_string(),
+                Style::default()
+                    .fg(Color::Green)
+                    .bg(ADDED_BG)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ],
+        actual
+    );
+}
+
+#[test]
+fn should_keep_the_plain_bold_title_in_unified_view_when_signature_is_unchanged() {
+    let section = crate::diff_shape::DiffSection {
+        title: "fn foo()".to_string(),
+        symbol_id: Some("lib.rs::foo".to_string()),
+        contract_header: None,
+        hunks: vec![],
+    };
+
+    let actual = diff_pane_lines(
+        &[&section],
+        true,
+        None,
+        &crate::note_markers::NoteMarkers::default(),
+        "lib.rs",
+    );
+
+    assert_eq!(
+        vec![Line::styled(
+            "fn foo()".to_string(),
+            Style::default().add_modifier(Modifier::BOLD),
+        )],
+        actual
+    );
+}

--- a/rinkaku-tui/src/ui/mod.rs
+++ b/rinkaku-tui/src/ui/mod.rs
@@ -88,6 +88,19 @@ pub struct DrawOutcome {
     /// half-page press while the overlay is open sizes its step against the
     /// overlay's own box, not whatever pane happens to be underneath it.
     pub help_scroll_viewport_height: Option<usize>,
+    /// The diff pane's *effective* view mode as actually rendered this
+    /// frame — [`crate::app::DiffViewMode::Split`] only when the pane is
+    /// wide enough to honor a `Split` request (ADR 0044 decision 7's
+    /// [`crate::ui::diff_pane::MIN_SPLIT_VIEW_WIDTH`] threshold), else
+    /// [`crate::app::DiffViewMode::Unified`]. `None` when the diff pane
+    /// did not render at all this frame (source screen, or a different
+    /// right pane). `crate::run_app` remembers this between frames and
+    /// passes it into `diff_shape::hunk_start_lines`/
+    /// `section_start_line_for_symbol`/`symbol_id_for_scroll_line`, so
+    /// their scroll math matches the mode actually on screen rather than
+    /// the requested one — decision 4 amendment's "narrow-terminal
+    /// fallback wrong-symbol sync" hazard, closed.
+    pub effective_diff_view_mode: Option<crate::app::DiffViewMode>,
 }
 
 /// Draws one full frame: the entry view (tree + right pane split) or the
@@ -175,11 +188,20 @@ pub fn draw(
             } else {
                 None
             };
+            let effective_diff_view_mode = if app.right_pane() == crate::app::RightPane::Diff {
+                Some(effective_diff_view_mode_for_body(
+                    body,
+                    app.diff_view_mode(),
+                ))
+            } else {
+                None
+            };
             DrawOutcome {
                 clamped_right_pane_scroll: clamped,
                 scroll_viewport_height,
                 clamped_help_scroll: None,
                 help_scroll_viewport_height: None,
+                effective_diff_view_mode,
             }
         }
         Screen::Source {
@@ -201,6 +223,7 @@ pub fn draw(
                 scroll_viewport_height: Some(inner_height),
                 clamped_help_scroll: None,
                 help_scroll_viewport_height: None,
+                effective_diff_view_mode: None,
             }
         }
     };
@@ -241,6 +264,32 @@ fn right_pane_viewport_height(body: Rect) -> usize {
     ])
     .areas(body);
     right.height.saturating_sub(2) as usize
+}
+
+/// The diff pane's effective view mode given `body` and the requested
+/// mode — mirrors [`crate::ui::diff_pane::draw_diff_pane`]'s own
+/// `split_requested && split_fits` gate so `DrawOutcome` can report the
+/// mode a reviewer actually saw without depending on `draw_diff_pane`'s
+/// return value (kept `Option<usize>` for the clamp fold-back, shared
+/// with the other right-pane variants).
+fn effective_diff_view_mode_for_body(
+    body: Rect,
+    requested: crate::app::DiffViewMode,
+) -> crate::app::DiffViewMode {
+    let [_, right] = Layout::horizontal([
+        Constraint::Percentage(ENTRY_TREE_WIDTH_PERCENT),
+        Constraint::Percentage(ENTRY_RIGHT_WIDTH_PERCENT),
+    ])
+    .areas(body);
+    match requested {
+        crate::app::DiffViewMode::Split
+            if right.width >= crate::ui::diff_pane::MIN_SPLIT_VIEW_WIDTH =>
+        {
+            crate::app::DiffViewMode::Split
+        }
+        crate::app::DiffViewMode::Split => crate::app::DiffViewMode::Unified,
+        crate::app::DiffViewMode::Unified => crate::app::DiffViewMode::Unified,
+    }
 }
 
 /// Tree-pane / right-pane horizontal split percentages for [`Screen::Entry`],

--- a/rinkaku-tui/src/ui/source_screen_tests/error_handling.rs
+++ b/rinkaku-tui/src/ui/source_screen_tests/error_handling.rs
@@ -107,6 +107,7 @@ fn should_report_none_clamped_scroll_but_source_viewport_height_when_source_scre
         scroll_viewport_height: None,
         clamped_help_scroll: None,
         help_scroll_viewport_height: None,
+        effective_diff_view_mode: None,
     };
     terminal
         .draw(|frame| {


### PR DESCRIPTION
## Summary

- Contract-header diff lines were drawn with red/green foreground only (no background tint), so a changed signature did not read as a diff at a glance the way every other +/- line in the pane does (ADR 0018).
- Fix: make the section anchor itself the diff. Unified shows a 2-line `- {old}` / `+ {new}` pair with the usual `ADDED_BG`/`REMOVED_BG` tint in place of the plain title; split pairs `{old}` (left) and `{new}` (right) onto the anchor's own single row. Unchanged signatures still render as a plain bold title in both modes.
- Side effect: a changed-signature anchor is 2 rows in unified but 1 row in split — the first case where the two modes legitimately disagree on a row count. `diff_shape::walk_sections` and its three consumers (`hunk_start_lines`, `section_start_line_for_symbol`, `symbol_id_for_scroll_line`) now take a `DiffViewMode`; `DrawOutcome::effective_diff_view_mode` folds the pane's actually-rendered mode back into `run_app`'s loop so a narrow-terminal `MIN_SPLIT_VIEW_WIDTH` fallback (requested Split, effective Unified) still keeps the scroll math aligned with what the reviewer sees.
- ADR 0044 amended twice: once to record the row-count invariant narrowing, once to note the narrow-terminal wrong-symbol sync hazard is closed by the effective-mode threading rather than merely accepted.

## Test plan

- [x] `make test` — 813 tests pass (unified/split styling for the new anchor, adjacent signature-changed scroll target end-to-end, boundary regression pins that fail if the effective-mode threading is reverted, split unchanged-title mirror)
- [x] `make lint` — clean (fmt + clippy `-D warnings`)
- [x] Revert-simulation: temporarily reverting `sync_target_for_scroll` back to `App::diff_view_mode()` makes the new boundary sync test fail; restoring makes it pass again