### PR TITLE
feat(tui): split shared diff-pane hunks into per-symbol sub-hunks

### DIFF
--- a/docs/adr/0053-split-shared-hunk-into-per-symbol-sub-hunks.md
+++ b/docs/adr/0053-split-shared-hunk-into-per-symbol-sub-hunks.md
@@ -1,0 +1,198 @@
+# 0053. Split a shared hunk into per-symbol sub-hunks at attribution time
+
+- Status: accepted
+- Date: 2026-07-15
+
+## Context
+
+ADR 0029 changed the diff pane's file-selection attribution rule from
+"first symbol only" to "every symbol whose range the hunk intersects",
+cloning the whole hunk into each owning section. That ADR's own
+Alternatives section already named and rejected the finer-grained
+option — "split a multi-symbol hunk into per-symbol sub-hunks at
+attribution time" — as "substantially more complex" for the problem it
+was solving (auto-scroll silently doing nothing), while flagging it
+could be "revisited if reviewers find the duplicated-hunk-body a real
+annoyance in practice."
+
+That revisit condition has now been met. Real review sessions confirm
+that walking the left-pane symbol list on a file where several
+adjacent symbols share a hunk (a brand-new file being the guaranteed
+case, per ADR 0029's own Context) shows the *same hunk body, verbatim,
+repeatedly* as the reviewer moves from symbol to symbol — the visible
+trade ADR 0029 accepted turns out to cost more reading effort than
+expected in practice. This ADR replaces whole-hunk duplication with
+per-symbol splitting, amending ADR 0029's attribution step (not its
+core "attribute to every intersecting symbol" rule, which stays).
+
+## Decision
+
+**Split only when a hunk intersects two or more symbol ranges.** A
+hunk touching zero or one symbol is attributed unchanged (the existing
+early-return path) — no new sub-hunk machinery runs for the common
+case.
+
+**Row ownership resolves in a single pass over the hunk's lines.**
+Added/Context lines carry a new-file line number (the same derivation
+`ui::diff_pane::new_side_line_numbers` already uses), so each is
+attributed to whichever symbol range contains that line number, or to
+"no symbol" when none does. Removed lines carry no new-file line
+number of their own — a removal is a *position*, not a range
+(`diff_view::Hunk::new_range`'s own zero-width convention for a pure
+deletion) — so a Removed line inherits the owner of the current run:
+the most recently resolved Added/Context line's owner, or, when a hunk
+opens with Removed lines before any Added/Context line has appeared,
+the owner of the *next* Added/Context line the scan reaches
+(retroactive attribution, resolved by buffering the leading Removed
+run until an owner is known).
+
+A maximal run of consecutive lines sharing the same owner (including
+the "no symbol" owner) becomes one sub-hunk; the owner changing —
+including transitions into or out of "no symbol" — starts a new
+sub-hunk.
+
+**An unowned run becomes its own sub-hunk, routed to the module-level
+bucket.** Import lines and the gaps between symbols are not
+absorbed into whichever symbol happens to be nearest; they keep the
+existing `MODULE_LEVEL_TITLE` treatment, just as a sub-hunk instead of
+a share of a larger hunk.
+
+**A line owned by more than one symbol still appears in every owning
+symbol's sub-hunk.** Symbol ranges are expected to be non-overlapping
+in practice (a real extractor's contract), so "one line, one owner"
+covers the common case and is what makes splitting eliminate
+duplication there. When ranges do overlap — pathological input, not a
+real extractor's output — ADR 0029's "attribute to every intersecting
+symbol" rule still governs: the line-ownership scan is repeated once
+per distinct owner rather than picking a single winner, so an
+overlapping pair of symbols still both receive that line, same as
+before this ADR. This is the one shape a split does not shrink the
+duplication for, because the duplication there reflects a genuine
+double ownership, not an artifact of whole-hunk attribution.
+
+**No context padding at sub-hunk boundaries.** A sub-hunk holds exactly
+the contiguous run of lines resolved to its owner — no extra lines are
+duplicated onto an adjacent sub-hunk for readability. Padding would
+reintroduce the cross-section duplication this ADR exists to remove,
+just at a smaller scale.
+
+**Every sub-hunk gets an exactly recomputed `@@` header,** not an
+approximation:
+
+- New-side start/count come directly from the sub-hunk's own resolved
+  line run (mirroring `diff_view::Hunk::new_range`'s existing
+  start/count convention).
+- Old-side start is the original hunk's old-side start plus the number
+  of old-side lines (Removed + Context) consumed by every sub-hunk that
+  precedes this one within the same original hunk — computed by
+  running total during the same single-pass scan, not derived
+  separately afterward.
+
+**New module `rinkaku-tui/src/hunk_split.rs`**, following the
+`split_pairing.rs` precedent (also split out of `diff_shape.rs` for an
+independent responsibility) rather than growing `diff_shape.rs`
+further. `build_file_content` calls into it and no longer performs
+attribution inline. Tests are large enough to warrant the same
+`#[cfg(test)] #[path = "hunk_split_tests/..."] mod tests;` split
+`diff_shape_tests`/`split_pairing_tests` already use.
+
+**Highlight lookup needs one new field, not a new lookup mechanism.**
+`highlight::highlight_hunk` still computes one `Vec<LineHighlight>` per
+*original* hunk, keyed by `source_index` exactly as before — re-running
+highlighting per sub-hunk would be both wasteful (highlighting is the
+expensive step per that module's own doc comment) and pointless (the
+highlight data is the same tokens, just sliced differently). Instead
+`AttributedHunk` gains `origin_offset: usize`, the sub-hunk's start
+index within the original hunk's `lines`. The render side
+(`ui::diff_pane::diff_pane_lines`/`diff_pane_split_rows`) already
+indexes a hunk's own `lines` positionally when looking up its
+highlight; it now offsets that index by `origin_offset` before
+indexing into the `source_index`-keyed highlight slice — the same
+"index-based indirection instead of a new lookup" shape
+`split_pairing::SplitRow::left_index`/`right_index` already
+established for exactly this kind of problem (rows that don't
+positionically line up with the original `lines` slice one-to-one).
+
+**`]c`/`[c` and auto-scroll need no code change.** `hunk_start_lines`,
+`walk_sections`, `section_start_line_for_symbol`, and
+`symbol_id_for_scroll_line` only count hunks that are actually present
+in a section's `hunks: Vec<AttributedHunk>` — they have no opinion on
+where those `AttributedHunk`s came from. Once `build_file_content`
+stops duplicating a shared hunk and instead emits one (smaller)
+sub-hunk per owning section, these functions' existing per-section walk
+produces exactly one jump stop per rendered sub-hunk automatically. Only
+their test fixtures' expected values change, not their implementation.
+
+## Alternatives
+
+- **Keep whole-hunk duplication (status quo, ADR 0029).** Rejected:
+  this is the exact problem prompting this ADR — dogfooding confirms
+  the duplicated hunk body is a real reading-effort cost, not a
+  theoretical one, and ADR 0029 itself named this as the condition
+  under which it should be revisited.
+- **Nearest-symbol attribution for unowned (module-level) runs**,
+  folding import/gap lines into whichever symbol section is closest
+  rather than a separate module-level bucket. Rejected: this would
+  misattribute lines to a symbol that never actually changed them,
+  undermining the diff pane's per-symbol "orient before reading"
+  purpose (ADR 0020) that this whole attribution system exists to
+  serve — an import line under a function's header looks like part of
+  that function's diff when it is not.
+- **Pad sub-hunk boundaries with a few lines of shared context** so a
+  reader jumping to one symbol's section sees a line or two of the
+  neighboring change for orientation. Rejected: this reintroduces the
+  duplication this ADR removes, just bounded to N lines instead of the
+  whole hunk — the annoyance driving this ADR was specifically about
+  repeated content, and a small amount of repeated content is still
+  repeated content.
+- **Approximate the old-side header** (e.g. reuse the original hunk's
+  old-side start for every sub-hunk, or split old-side count evenly).
+  Rejected: an inaccurate `@@` header is actively misleading if a
+  reviewer ever compares it against the real diff (e.g. copy-pasting it
+  into another tool, or cross-checking against `git diff` output side
+  by side) and the accurate value is no harder to compute — it is a
+  running total already available during the same single pass that
+  resolves line ownership.
+- **Implement splitting inline in `diff_shape.rs`.** Rejected on
+  CLAUDE.md's file-size discipline: `diff_shape.rs` is already 417
+  lines covering section-building and unified-view line counting;
+  adding a second, independent responsibility (line-level hunk
+  splitting) to the same file repeats the exact situation
+  `split_pairing.rs` was already extracted from once. A new
+  responsibility gets a new module, per `split_pairing.rs`'s own
+  precedent.
+
+## Consequences
+
+- The diff pane no longer shows a shared hunk's body verbatim under
+  every owning symbol's section — each section shows only the lines
+  that are actually "its own", so scrolling through a file's sections
+  no longer re-reads the same text repeatedly.
+- `hunk_start_lines`'s "`]c`/`[c` has one stop per rendered hunk
+  occurrence" behavior (ADR 0029's own framing) is preserved exactly,
+  just now against smaller, non-duplicated sub-hunks instead of
+  repeated whole hunks — a reviewer jumping hunk-to-hunk sees each
+  stop's content exactly once across the file rather than once per
+  owning section.
+- `AttributedHunk` gains an `origin_offset: usize` field — every
+  existing test fixture that constructs an `AttributedHunk` directly
+  (`diff_shape_tests`, `diff_pane_tests`, `source_screen_tests`, and
+  any other call site) needs that field threaded through. For a hunk
+  that was never split (the common case, single-owner hunks),
+  `origin_offset` is always `0`.
+- ADR 0029's own two regression tests
+  (`should_attribute_overlapping_hunk_to_every_symbol_it_intersects`,
+  `should_attribute_new_file_single_hunk_to_every_symbol_it_defines`)
+  change their expected output from "the same whole hunk cloned into
+  every owning section" to "each section receiving its own, smaller
+  sub-hunk" — this amends ADR 0029's attribution step; ADR 0029's core
+  decision (attribute to every intersecting symbol, not just the
+  first) is unchanged and still the reason a new-file symbol's
+  auto-scroll target resolves at all.
+- No change to `rinkaku-core` or to Markdown/JSON output —
+  `hunk_split.rs` lives entirely in `rinkaku-tui`'s presentation layer,
+  same scope boundary ADR 0029 already confirmed for this attribution
+  step.
+- No backward-compatibility concern: the TUI has not shipped a release
+  (ADR 0015/0016, restated by ADR 0020, ADR 0027, and ADR 0029), so
+  this amendment applies in place.

--- a/docs/adr/0053-split-shared-hunk-into-per-symbol-sub-hunks.md
+++ b/docs/adr/0053-split-shared-hunk-into-per-symbol-sub-hunks.md
@@ -88,6 +88,22 @@ approximation:
   running total during the same single-pass scan, not derived
   separately afterward.
 
+**A hunk with no Added/Context line at all falls back to the whole
+hunk's own zero-width position.** The single-pass row-ownership scan
+above assumes at least one Added/Context line exists to seed the
+Removed-run inheritance rule from. An ordinary deletion from the
+middle of an existing symbol — not just the brand-new-file or
+whole-symbol-removal cases already covered — can produce a hunk that
+is 100% Removed lines, leaving every row unresolved. For that case,
+ownership is resolved once for the whole hunk instead of per line: the
+hunk's own `new_range` zero-width position (`diff_view::Hunk::
+new_range`'s convention) is tested against each symbol range with
+`diff_view::hunk_intersects`' existing half-open rule — reused rather
+than reimplemented, so this fallback cannot drift from the rule
+`diff_view::hunks_for_range` already uses for the symbol-row view — and
+the resulting owner set (zero, one, or more symbols) is assigned to
+every line in the hunk.
+
 **New module `rinkaku-tui/src/hunk_split.rs`**, following the
 `split_pairing.rs` precedent (also split out of `diff_shape.rs` for an
 independent responsibility) rather than growing `diff_shape.rs`

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -44,9 +44,10 @@ pub struct ContractHeader {
     pub signature: String,
 }
 
-/// One [`Hunk`], cloned out of the original [`FileHunks`] into a shaped
-/// [`DiffSection`] (this module's own doc comment on why cloning, not
-/// borrowing), plus its `source_index` — its position in that original
+/// One [`Hunk`] (or, per ADR 0053, one per-symbol slice of a shared hunk —
+/// see `origin_offset` below), cloned out of the original [`FileHunks`] into
+/// a shaped [`DiffSection`] (this module's own doc comment on why cloning,
+/// not borrowing), plus its `source_index` — its position in that original
 /// `FileHunks::hunks` slice. `crate::highlight::lookup_hunk_highlight`
 /// looks up a hunk's precomputed highlight by `std::ptr::eq` against the
 /// *original* `Hunk` it was highlighted from; a clone breaks that pointer
@@ -58,6 +59,18 @@ pub struct ContractHeader {
 pub struct AttributedHunk {
     pub source_index: usize,
     pub hunk: Hunk,
+    /// This hunk's start index within the *original* hunk's `lines`
+    /// (`crate::diff_shape::AttributedHunk`), i.e. `hunk_split::SubHunk::origin_offset`
+    /// (ADR 0053) — `0` for a hunk that was never split (the common case,
+    /// including every hunk owned by only one symbol). `crate::ui::diff_pane`
+    /// offsets a line's position within `hunk.lines` by this before indexing
+    /// into `crate::highlight::lookup_hunk_highlight_by_index`'s
+    /// `source_index`-keyed, *original*-hunk-length highlight slice — the
+    /// highlight table is still computed once per original hunk (highlighting
+    /// is the expensive step; ADR 0053 does not want to re-run it once per
+    /// sub-hunk for the same tokens), so a sub-hunk's own `lines` no longer
+    /// line up positionally with that table without this offset.
+    pub origin_offset: usize,
 }
 
 /// One symbol's worth of shaped diff content: its own contract header
@@ -310,35 +323,36 @@ fn build_file_content(report: &Report, diff_files: &[FileHunks], path: &str) -> 
         .collect();
     let mut module_level_hunks: Vec<AttributedHunk> = Vec::new();
 
+    let symbol_ranges: Vec<(usize, rinkaku_core::diff::LineRange)> = symbols
+        .iter()
+        .enumerate()
+        .map(|(index, symbol)| (index, symbol.range))
+        .collect();
+
     for (source_index, hunk) in file_hunks.hunks.iter().enumerate() {
         // Every symbol (source order) whose range intersects this hunk —
         // ADR 0029 amends ADR 0020's original first-match-only rule: a
         // brand-new file's diff is always exactly one hunk spanning the
         // whole file, so first-match silently dropped every symbol but the
         // first from the diff pane and from auto-scroll (ADR 0027 decision
-        // 2). The hunk is cloned once per matching section — see ADR 0029
-        // for why the TUI departs from ADR 0020's "duplication misleads
-        // about total change size" reasoning (the TUI has no change-size
-        // total to mislead).
-        let owners: Vec<usize> = symbols
-            .iter()
-            .enumerate()
-            .filter(|(_, symbol)| {
-                crate::diff_view::hunk_intersects(hunk, symbol.range.start, symbol.range.end)
-            })
-            .map(|(index, _)| index)
-            .collect();
-        if owners.is_empty() {
-            module_level_hunks.push(AttributedHunk {
+        // 2). ADR 0053 further amends the attribution step itself: a hunk
+        // shared by more than one symbol is split into per-symbol
+        // sub-hunks (`crate::hunk_split::split_hunk`) rather than cloned
+        // whole into every owning section, so a reviewer no longer reads
+        // the same hunk body once per owning symbol.
+        for (owner, sub_hunk) in crate::hunk_split::split_hunk(hunk, &symbol_ranges) {
+            let attributed = AttributedHunk {
                 source_index,
-                hunk: hunk.clone(),
-            });
-        } else {
-            for index in owners {
-                sections[index].hunks.push(AttributedHunk {
-                    source_index,
-                    hunk: hunk.clone(),
-                });
+                hunk: Hunk {
+                    header: sub_hunk.header,
+                    new_range: sub_hunk.new_range,
+                    lines: sub_hunk.lines,
+                },
+                origin_offset: sub_hunk.origin_offset,
+            };
+            match owner {
+                Some(index) => sections[index].hunks.push(attributed),
+                None => module_level_hunks.push(attributed),
             }
         }
     }

--- a/rinkaku-tui/src/diff_shape_tests/build_diff_pane_content.rs
+++ b/rinkaku-tui/src/diff_shape_tests/build_diff_pane_content.rs
@@ -183,18 +183,18 @@ fn should_omit_module_level_section_when_every_hunk_is_attributed_to_a_symbol() 
 }
 
 #[test]
-fn should_attribute_overlapping_hunk_to_every_symbol_it_intersects() {
+fn should_split_overlapping_hunk_into_a_sub_hunk_per_symbol_it_intersects() {
     // Two symbols with adjacent, overlapping ranges (a pathological
     // input a real extractor would not normally produce, but the
     // shaping function's contract must still resolve deterministically).
-    // ADR 0029 amends ADR 0020's original first-match-only rule: a hunk
-    // intersecting more than one symbol's range is now attributed to
-    // every one of them, not just the first in source order — see ADR
-    // 0029 for why the TUI diff pane departs from ADR 0020's
-    // summary-view "duplication misleads about total change size"
-    // reasoning (the TUI has no change-size total to mislead, and a
-    // dropped section silently breaks that symbol's auto-scroll — ADR
-    // 0027 decision 2 — which is the worse failure mode here).
+    // ADR 0029 established "attribute to every intersecting symbol, not
+    // just the first"; ADR 0053 amends the attribution step itself to
+    // split the hunk into a per-symbol sub-hunk instead of cloning the
+    // whole hunk into every owning section. Here both symbols' ranges
+    // genuinely overlap at the one shared line, so both sub-hunks still
+    // carry that same line (ADR 0053's own doc comment on
+    // `hunk_split::split_hunk`) — this is the one case a split does not
+    // eliminate duplication, because the line truly belongs to both.
     let report = Report {
         files: vec![FileReport {
             path: "lib.rs".to_string(),
@@ -215,24 +215,23 @@ fn should_attribute_overlapping_hunk_to_every_symbol_it_intersects() {
 
     let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
 
+    let expected_hunk = AttributedHunk {
+        source_index: 0,
+        hunk: hunk("@@ -1,1 +3,1 @@", Some((3, 3)), vec!["shared line"]),
+        origin_offset: 0,
+    };
     let expected = DiffPaneContent::File(vec![
         DiffSection {
             title: "fn foo()".to_string(),
             symbol_id: Some("lib.rs::foo".to_string()),
             contract_header: None,
-            hunks: vec![attributed(
-                0,
-                hunk("@@ -1,1 +1,5 @@", Some((3, 4)), vec!["shared line"]),
-            )],
+            hunks: vec![expected_hunk.clone()],
         },
         DiffSection {
             title: "fn bar()".to_string(),
             symbol_id: Some("lib.rs::bar".to_string()),
             contract_header: None,
-            hunks: vec![attributed(
-                0,
-                hunk("@@ -1,1 +1,5 @@", Some((3, 4)), vec!["shared line"]),
-            )],
+            hunks: vec![expected_hunk],
         },
     ]);
     assert_eq!(expected, actual);
@@ -240,13 +239,17 @@ fn should_attribute_overlapping_hunk_to_every_symbol_it_intersects() {
 
 #[test]
 fn should_attribute_new_file_single_hunk_to_every_symbol_it_defines() {
-    // Regression test (PR #86 dogfooding, ADR 0029): a brand-new file's
-    // diff is always exactly one hunk spanning the whole file
-    // (`@@ -0,0 +1,N @@`), so every symbol the file defines has a
-    // range inside that one hunk. Before ADR 0029, only the first
+    // Regression test (PR #86 dogfooding, ADR 0029, amended by ADR 0053):
+    // a brand-new file's diff is always exactly one hunk spanning the
+    // whole file (`@@ -0,0 +1,N @@`), so every symbol the file defines
+    // has a range inside that one hunk. Before ADR 0029, only the first
     // symbol in source order (`foo`) ever got a section; `bar` and
     // `baz` were silently dropped, breaking their diff-pane auto-scroll
-    // (ADR 0027 decision 2) with no error or indicator.
+    // (ADR 0027 decision 2) with no error or indicator. ADR 0053 further
+    // amends the attribution step to split this one hunk into a sub-hunk
+    // per symbol (plus a module-level sub-hunk for the blank separator
+    // lines between them) instead of cloning the whole hunk into every
+    // section.
     let report = Report {
         files: vec![FileReport {
             path: "file_size.rs".to_string(),
@@ -263,7 +266,19 @@ fn should_attribute_new_file_single_hunk_to_every_symbol_it_defines() {
         hunks: vec![hunk(
             "@@ -0,0 +1,11 @@",
             Some((1, 11)),
-            vec!["whole new file"],
+            vec![
+                "fn foo() {",
+                "    body();",
+                "}",
+                "",
+                "fn bar() {",
+                "    body();",
+                "}",
+                "",
+                "fn baz() {",
+                "    body();",
+                "}",
+            ],
         )],
     }];
     let target = DiffTarget::File {
@@ -272,28 +287,65 @@ fn should_attribute_new_file_single_hunk_to_every_symbol_it_defines() {
 
     let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
 
-    let expected_hunk = attributed(
-        0,
-        hunk("@@ -0,0 +1,11 @@", Some((1, 11)), vec!["whole new file"]),
-    );
     let expected = DiffPaneContent::File(vec![
         DiffSection {
             title: "fn foo()".to_string(),
             symbol_id: Some("file_size.rs::foo".to_string()),
             contract_header: None,
-            hunks: vec![expected_hunk.clone()],
+            hunks: vec![AttributedHunk {
+                source_index: 0,
+                hunk: hunk(
+                    "@@ -0,3 +1,3 @@",
+                    Some((1, 3)),
+                    vec!["fn foo() {", "    body();", "}"],
+                ),
+                origin_offset: 0,
+            }],
         },
         DiffSection {
             title: "fn bar()".to_string(),
             symbol_id: Some("file_size.rs::bar".to_string()),
             contract_header: None,
-            hunks: vec![expected_hunk.clone()],
+            hunks: vec![AttributedHunk {
+                source_index: 0,
+                hunk: hunk(
+                    "@@ -4,3 +5,3 @@",
+                    Some((5, 7)),
+                    vec!["fn bar() {", "    body();", "}"],
+                ),
+                origin_offset: 4,
+            }],
         },
         DiffSection {
             title: "fn baz()".to_string(),
             symbol_id: Some("file_size.rs::baz".to_string()),
             contract_header: None,
-            hunks: vec![expected_hunk],
+            hunks: vec![AttributedHunk {
+                source_index: 0,
+                hunk: hunk(
+                    "@@ -8,3 +9,3 @@",
+                    Some((9, 11)),
+                    vec!["fn baz() {", "    body();", "}"],
+                ),
+                origin_offset: 8,
+            }],
+        },
+        DiffSection {
+            title: MODULE_LEVEL_TITLE.to_string(),
+            symbol_id: None,
+            contract_header: None,
+            hunks: vec![
+                AttributedHunk {
+                    source_index: 0,
+                    hunk: hunk("@@ -3,1 +4,1 @@", Some((4, 4)), vec![""]),
+                    origin_offset: 3,
+                },
+                AttributedHunk {
+                    source_index: 0,
+                    hunk: hunk("@@ -7,1 +8,1 @@", Some((8, 8)), vec![""]),
+                    origin_offset: 7,
+                },
+            ],
         },
     ]);
     assert_eq!(expected, actual);

--- a/rinkaku-tui/src/diff_shape_tests/build_diff_pane_content.rs
+++ b/rinkaku-tui/src/diff_shape_tests/build_diff_pane_content.rs
@@ -103,6 +103,51 @@ fn should_attribute_pure_deletion_hunk_to_owning_symbol_instead_of_module_level(
 }
 
 #[test]
+fn should_attribute_hunk_with_only_removed_lines_to_owning_symbol_not_module_level() {
+    // Blocker regression: a hunk whose lines are *all* `Removed` (an
+    // ordinary mid-function deletion, not a whole-symbol or brand-new-file
+    // edge case) has no Added/Context anchor line for
+    // `crate::hunk_split::line_owners` to seed from, so it used to fall
+    // through to the module-level bucket regardless of which symbol's body
+    // the deleted lines came from. The shared `hunk()` fixture helper
+    // always builds `Context` lines (`crate::diff_shape_tests::hunk`'s own
+    // doc comment), which cannot reproduce this shape, so this test builds
+    // the hunk directly with real `Removed` lines.
+    let report = Report {
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![symbol("lib.rs::foo", "foo", LineRange { start: 1, end: 3 })],
+        }],
+        ..empty_report()
+    };
+    let removed_hunk = Hunk {
+        header: "@@ -2,1 +1,0 @@".to_string(),
+        new_range: Some((2, 1)),
+        lines: vec![crate::diff_view::DiffLine {
+            kind: crate::diff_view::DiffLineKind::Removed,
+            content: "    old_body();".to_string(),
+        }],
+    };
+    let diff_files = vec![FileHunks {
+        path: "lib.rs".to_string(),
+        hunks: vec![removed_hunk.clone()],
+    }];
+    let target = DiffTarget::File {
+        path: "lib.rs".to_string(),
+    };
+
+    let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+    let expected = DiffPaneContent::File(vec![DiffSection {
+        title: "fn foo()".to_string(),
+        symbol_id: Some("lib.rs::foo".to_string()),
+        contract_header: None,
+        hunks: vec![attributed(0, removed_hunk)],
+    }]);
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn should_bucket_hunk_under_module_level_when_it_intersects_no_symbol() {
     let report = Report {
         files: vec![FileReport {

--- a/rinkaku-tui/src/diff_shape_tests/build_diff_pane_content.rs
+++ b/rinkaku-tui/src/diff_shape_tests/build_diff_pane_content.rs
@@ -1,6 +1,24 @@
 use super::*;
 use pretty_assertions::assert_eq;
 
+/// Builds a [`Hunk`] whose every line is `Added` (`crate::diff_shape_tests`'
+/// shared `hunk()` helper always builds `Context` lines instead, which
+/// cannot represent a brand-new file's diff: real `git diff` output for a
+/// new file has no old side at all).
+fn added_hunk(header: &str, new_range: Option<(usize, usize)>, lines: Vec<&str>) -> Hunk {
+    Hunk {
+        header: header.to_string(),
+        new_range,
+        lines: lines
+            .into_iter()
+            .map(|content| crate::diff_view::DiffLine {
+                kind: crate::diff_view::DiffLineKind::Added,
+                content: content.to_string(),
+            })
+            .collect(),
+    }
+}
+
 #[test]
 fn should_return_empty_when_target_is_none() {
     let report = empty_report();
@@ -295,6 +313,11 @@ fn should_attribute_new_file_single_hunk_to_every_symbol_it_defines() {
     // per symbol (plus a module-level sub-hunk for the blank separator
     // lines between them) instead of cloning the whole hunk into every
     // section.
+    //
+    // A real brand-new-file hunk has every line `Added` and an old-side
+    // count of 0 (there is no old side at all), unlike the shared `hunk()`
+    // fixture helper, which always builds `Context` lines — so this test
+    // builds its own hunk directly rather than via that helper.
     let report = Report {
         files: vec![FileReport {
             path: "file_size.rs".to_string(),
@@ -308,7 +331,7 @@ fn should_attribute_new_file_single_hunk_to_every_symbol_it_defines() {
     };
     let diff_files = vec![FileHunks {
         path: "file_size.rs".to_string(),
-        hunks: vec![hunk(
+        hunks: vec![added_hunk(
             "@@ -0,0 +1,11 @@",
             Some((1, 11)),
             vec![
@@ -339,8 +362,8 @@ fn should_attribute_new_file_single_hunk_to_every_symbol_it_defines() {
             contract_header: None,
             hunks: vec![AttributedHunk {
                 source_index: 0,
-                hunk: hunk(
-                    "@@ -0,3 +1,3 @@",
+                hunk: added_hunk(
+                    "@@ -0,0 +1,3 @@",
                     Some((1, 3)),
                     vec!["fn foo() {", "    body();", "}"],
                 ),
@@ -353,8 +376,8 @@ fn should_attribute_new_file_single_hunk_to_every_symbol_it_defines() {
             contract_header: None,
             hunks: vec![AttributedHunk {
                 source_index: 0,
-                hunk: hunk(
-                    "@@ -4,3 +5,3 @@",
+                hunk: added_hunk(
+                    "@@ -0,0 +5,3 @@",
                     Some((5, 7)),
                     vec!["fn bar() {", "    body();", "}"],
                 ),
@@ -367,8 +390,8 @@ fn should_attribute_new_file_single_hunk_to_every_symbol_it_defines() {
             contract_header: None,
             hunks: vec![AttributedHunk {
                 source_index: 0,
-                hunk: hunk(
-                    "@@ -8,3 +9,3 @@",
+                hunk: added_hunk(
+                    "@@ -0,0 +9,3 @@",
                     Some((9, 11)),
                     vec!["fn baz() {", "    body();", "}"],
                 ),
@@ -382,12 +405,12 @@ fn should_attribute_new_file_single_hunk_to_every_symbol_it_defines() {
             hunks: vec![
                 AttributedHunk {
                     source_index: 0,
-                    hunk: hunk("@@ -3,1 +4,1 @@", Some((4, 4)), vec![""]),
+                    hunk: added_hunk("@@ -0,0 +4,1 @@", Some((4, 4)), vec![""]),
                     origin_offset: 3,
                 },
                 AttributedHunk {
                     source_index: 0,
-                    hunk: hunk("@@ -7,1 +8,1 @@", Some((8, 8)), vec![""]),
+                    hunk: added_hunk("@@ -0,0 +8,1 @@", Some((8, 8)), vec![""]),
                     origin_offset: 7,
                 },
             ],

--- a/rinkaku-tui/src/diff_shape_tests/mod.rs
+++ b/rinkaku-tui/src/diff_shape_tests/mod.rs
@@ -82,7 +82,13 @@ pub(super) fn hunk(header: &str, new_range: Option<(usize, usize)>, lines: Vec<&
 /// Wraps `hunk` with the `source_index` it occupies in the fixture's
 /// `FileHunks::hunks` — every test below builds its `diff_files`
 /// fixture with hunks in a fixed order, so this index is just "which
-/// position in that `vec![...]` this hunk was written at".
+/// position in that `vec![...]` this hunk was written at". `origin_offset`
+/// is `0` (ADR 0053: this hunk was never split — the fixture's own
+/// `hunk(...)` always builds the whole hunk).
 pub(super) fn attributed(source_index: usize, hunk: Hunk) -> AttributedHunk {
-    AttributedHunk { source_index, hunk }
+    AttributedHunk {
+        source_index,
+        hunk,
+        origin_offset: 0,
+    }
 }

--- a/rinkaku-tui/src/event_loop/scroll_sync_tests.rs
+++ b/rinkaku-tui/src/event_loop/scroll_sync_tests.rs
@@ -266,6 +266,7 @@ fn diff_pane_content_with_two_symbol_sections() -> diff_shape::DiffPaneContent {
             hunks: vec![diff_shape::AttributedHunk {
                 source_index: 0,
                 hunk: hunk("@@ -1,1 +1,2 @@", (1, 2), "fn foo() {}"),
+                origin_offset: 0,
             }],
         },
         diff_shape::DiffSection {
@@ -275,6 +276,7 @@ fn diff_pane_content_with_two_symbol_sections() -> diff_shape::DiffPaneContent {
             hunks: vec![diff_shape::AttributedHunk {
                 source_index: 1,
                 hunk: hunk("@@ -10,1 +10,2 @@", (10, 11), "fn bar() {}"),
+                origin_offset: 0,
             }],
         },
     ])
@@ -386,6 +388,7 @@ fn should_return_none_when_scroll_moved_into_the_module_level_bucket() {
                         content: "fn foo() {}".to_string(),
                     }],
                 },
+                origin_offset: 0,
             }],
         },
         diff_shape::DiffSection {
@@ -402,6 +405,7 @@ fn should_return_none_when_scroll_moved_into_the_module_level_bucket() {
                         content: "use foo::bar;".to_string(),
                     }],
                 },
+                origin_offset: 0,
             }],
         },
     ]);
@@ -444,6 +448,7 @@ fn diff_pane_content_with_foo_signature_changed() -> diff_shape::DiffPaneContent
             hunks: vec![diff_shape::AttributedHunk {
                 source_index: 0,
                 hunk: hunk("@@ -1,1 +1,2 @@", (1, 2), "fn foo(a: i32) {}"),
+                origin_offset: 0,
             }],
         },
         diff_shape::DiffSection {
@@ -453,6 +458,7 @@ fn diff_pane_content_with_foo_signature_changed() -> diff_shape::DiffPaneContent
             hunks: vec![diff_shape::AttributedHunk {
                 source_index: 1,
                 hunk: hunk("@@ -10,1 +10,2 @@", (10, 11), "fn bar() {}"),
+                origin_offset: 0,
             }],
         },
     ])
@@ -756,6 +762,13 @@ fn report_with_two_adjacent_signature_changed_symbols() -> Report {
     }
 }
 
+/// The two symbols' new-side lines here must actually land inside
+/// `report_with_two_adjacent_signature_changed_symbols`'s own ranges
+/// (`foo`: 1-3, `bar`: 5-7) — `crate::hunk_split::split_hunk` derives each
+/// line's owner from its *real* new-file position (a running count over
+/// `lines`, the same derivation `crate::ui::diff_pane::new_side_line_numbers`
+/// uses), not from the hunk header's declared range alone, so each
+/// function needs a body line to occupy every line its own range claims.
 fn diff_hunks_with_two_signature_changed_sections() -> Vec<diff_view::FileHunks> {
     use diff_view::{DiffLine, DiffLineKind, Hunk};
 
@@ -767,11 +780,15 @@ fn diff_hunks_with_two_signature_changed_sections() -> Vec<diff_view::FileHunks>
             lines: vec![
                 DiffLine {
                     kind: DiffLineKind::Removed,
-                    content: "fn foo(a: i32) {}".to_string(),
+                    content: "fn foo(a: i32) {".to_string(),
                 },
                 DiffLine {
                     kind: DiffLineKind::Added,
-                    content: "fn foo(a: i32, extra: i32) {}".to_string(),
+                    content: "fn foo(a: i32, extra: i32) {".to_string(),
+                },
+                DiffLine {
+                    kind: DiffLineKind::Context,
+                    content: "}".to_string(),
                 },
                 DiffLine {
                     kind: DiffLineKind::Context,
@@ -779,11 +796,15 @@ fn diff_hunks_with_two_signature_changed_sections() -> Vec<diff_view::FileHunks>
                 },
                 DiffLine {
                     kind: DiffLineKind::Removed,
-                    content: "fn bar(a: i32) {}".to_string(),
+                    content: "fn bar(a: i32) {".to_string(),
                 },
                 DiffLine {
                     kind: DiffLineKind::Added,
-                    content: "fn bar(a: i32, extra: i32) {}".to_string(),
+                    content: "fn bar(a: i32, extra: i32) {".to_string(),
+                },
+                DiffLine {
+                    kind: DiffLineKind::Context,
+                    content: "}".to_string(),
                 },
             ],
         }],

--- a/rinkaku-tui/src/hunk_split.rs
+++ b/rinkaku-tui/src/hunk_split.rs
@@ -93,6 +93,15 @@ pub fn split_hunk(hunk: &Hunk, symbols: &[(usize, LineRange)]) -> Vec<(Option<us
 /// Removed lines (before any Added/Context line has appeared) takes the
 /// owner set of the *next* resolved line, and every other Removed line
 /// takes the owner set of the *previous* resolved line.
+///
+/// A hunk with **no** Added/Context line at all (an ordinary deletion from
+/// the middle of an existing symbol, not just the brand-new-file or
+/// whole-symbol-removal edge cases) has no anchor for that forward/back-fill
+/// to seed from, so every line stays unresolved through both passes. This
+/// case falls back to testing the whole hunk's own zero-width `new_range`
+/// position against `symbols` via [`crate::diff_view::hunk_intersects`]'
+/// half-open rule, and — if it lands inside one or more symbols — assigns
+/// that owner set to every line in the hunk.
 fn line_owners(hunk: &Hunk, symbols: &[(usize, LineRange)]) -> Vec<Vec<usize>> {
     let mut owners: Vec<Option<Vec<usize>>> = vec![None; hunk.lines.len()];
     let mut next_new_line = hunk.new_range.map(|(start, _)| start);
@@ -111,6 +120,11 @@ fn line_owners(hunk: &Hunk, symbols: &[(usize, LineRange)]) -> Vec<Vec<usize>> {
             .collect();
         owners[index] = Some(line_owners);
         next_new_line = Some(new_line + 1);
+    }
+
+    if owners.iter().all(Option::is_none) {
+        let anchor_owners = anchorless_deletion_owners(hunk, symbols);
+        return owners.iter().map(|_| anchor_owners.clone()).collect();
     }
 
     // Retroactive attribution for Removed runs (function doc comment):
@@ -134,6 +148,20 @@ fn line_owners(hunk: &Hunk, symbols: &[(usize, LineRange)]) -> Vec<Vec<usize>> {
     owners
         .into_iter()
         .map(|owner| owner.unwrap_or_default())
+        .collect()
+}
+
+/// Owner set for a hunk with no Added/Context anchor line, resolved from
+/// its zero-width `new_range` position via `hunk_intersects`' half-open
+/// rule (`line_owners`' own doc comment) instead of the per-line new-file
+/// position test used for anchored lines — reused rather than
+/// reimplemented so this fallback stays in sync with
+/// `crate::diff_view::hunks_for_range`'s symbol-row filtering.
+fn anchorless_deletion_owners(hunk: &Hunk, symbols: &[(usize, LineRange)]) -> Vec<usize> {
+    symbols
+        .iter()
+        .filter(|(_, range)| crate::diff_view::hunk_intersects(hunk, range.start, range.end))
+        .map(|(symbol_index, _)| *symbol_index)
         .collect()
 }
 

--- a/rinkaku-tui/src/hunk_split.rs
+++ b/rinkaku-tui/src/hunk_split.rs
@@ -1,0 +1,287 @@
+//! Splits one [`Hunk`] shared by multiple symbol ranges into per-symbol
+//! sub-hunks (ADR 0053), split out from `crate::diff_shape` (CLAUDE.md's
+//! file-size discipline: an independent responsibility — line-level hunk
+//! splitting — distinct from that module's section-building and
+//! unified-view line counting), following the `crate::split_pairing`
+//! precedent for the same kind of extraction.
+//!
+//! ADR 0029 attributed a hunk intersecting several symbol ranges to every
+//! one of them by cloning the whole hunk into each owning section — simple,
+//! but it meant a reviewer walking adjacent symbols saw the same hunk body
+//! repeated once per section. ADR 0053 replaces that whole-hunk duplication
+//! with splitting: each symbol's section gets only the lines that are
+//! actually "its own".
+
+use crate::diff_view::{DiffLine, DiffLineKind, Hunk};
+use rinkaku_core::diff::LineRange;
+
+/// One symbol's slice of a split hunk: a subset of the original hunk's
+/// `lines`, with its own recomputed `@@` header and new-side range (ADR
+/// 0053 decision "every sub-hunk gets an exactly recomputed header").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubHunk {
+    pub header: String,
+    pub new_range: Option<(usize, usize)>,
+    pub lines: Vec<DiffLine>,
+    /// This sub-hunk's start index within the original hunk's `lines` —
+    /// threaded through so a caller holding the original hunk's
+    /// `source_index` (`crate::diff_shape::AttributedHunk`) can still look
+    /// up per-line highlight data, which stays keyed by position in the
+    /// *original* hunk (`crate::highlight::highlight_hunk`'s own doc
+    /// comment on why it is computed once per original hunk, not per
+    /// sub-hunk).
+    pub origin_offset: usize,
+}
+
+/// Splits `hunk` into per-symbol [`SubHunk`]s against `symbols` (each
+/// entry's own index into the caller's symbol list, paired with its
+/// [`LineRange`], mirroring `crate::diff_shape::build_file_content`'s
+/// existing `symbols.iter().enumerate()` shape). Returns one
+/// `(Option<usize>, SubHunk)` per maximal contiguous run of lines sharing
+/// the same owner set — `Some(index)` for a symbol-owned run, `None` for a
+/// run that intersects no symbol at all (module-level bucket, ADR 0053
+/// decision). A line whose new-file position falls inside more than one
+/// symbol's range (only possible with pathologically overlapping symbol
+/// ranges — real extractors don't produce these, but ADR 0029's own
+/// "attribute to every intersecting symbol" contract still applies) appears
+/// in more than one returned entry, mirroring ADR 0029's pre-split behavior
+/// for that line rather than picking one owner arbitrarily.
+///
+/// When `hunk` intersects fewer than two symbol ranges, returns exactly one
+/// entry wrapping `hunk` unchanged (`origin_offset: 0`) — splitting only
+/// has a purpose once a hunk is actually shared, and single-owner hunks
+/// (the common case) skip the line-by-line scan entirely.
+pub fn split_hunk(hunk: &Hunk, symbols: &[(usize, LineRange)]) -> Vec<(Option<usize>, SubHunk)> {
+    let owners = line_owners(hunk, symbols);
+    let all_owners: std::collections::HashSet<usize> = owners.iter().flatten().copied().collect();
+    let every_line_unowned = owners.iter().all(Vec::is_empty);
+
+    // Nothing to split when at most one distinct symbol touches this hunk
+    // at all: either every line is unowned (module-level), or every owned
+    // line shares the same single symbol.
+    if all_owners.len() <= 1 {
+        let owner = if every_line_unowned {
+            None
+        } else {
+            all_owners.into_iter().next()
+        };
+        return vec![(
+            owner,
+            SubHunk {
+                header: hunk.header.clone(),
+                new_range: hunk.new_range,
+                lines: hunk.lines.clone(),
+                origin_offset: 0,
+            },
+        )];
+    }
+
+    build_sub_hunks(hunk, &owners)
+}
+
+/// Resolves the set of owners for each line in `hunk.lines` (same length,
+/// same order): every symbol index whose range contains that line's
+/// new-file position, empty when none does.
+///
+/// Added/Context lines carry their own new-file line number (the same
+/// derivation `crate::ui::diff_pane::new_side_line_numbers` uses) and are
+/// resolved directly against `symbols`. A Removed line has no new-file line
+/// number of its own — deletion is a *position*, not a range
+/// (`crate::diff_view::Hunk::new_range`'s own zero-width convention) — so it
+/// inherits the owner set of the current run, resolved in a second pass
+/// once every Added/Context line's owners are known: a leading run of
+/// Removed lines (before any Added/Context line has appeared) takes the
+/// owner set of the *next* resolved line, and every other Removed line
+/// takes the owner set of the *previous* resolved line.
+fn line_owners(hunk: &Hunk, symbols: &[(usize, LineRange)]) -> Vec<Vec<usize>> {
+    let mut owners: Vec<Option<Vec<usize>>> = vec![None; hunk.lines.len()];
+    let mut next_new_line = hunk.new_range.map(|(start, _)| start);
+
+    for (index, line) in hunk.lines.iter().enumerate() {
+        if line.kind == DiffLineKind::Removed {
+            continue;
+        }
+        let Some(new_line) = next_new_line else {
+            continue;
+        };
+        let line_owners: Vec<usize> = symbols
+            .iter()
+            .filter(|(_, range)| range.start <= new_line && new_line <= range.end)
+            .map(|(symbol_index, _)| *symbol_index)
+            .collect();
+        owners[index] = Some(line_owners);
+        next_new_line = Some(new_line + 1);
+    }
+
+    // Retroactive attribution for Removed runs (function doc comment):
+    // forward-fill from the previous resolved line, then back-fill any
+    // still-unresolved leading run from the next resolved line.
+    let mut last_owner: Option<Vec<usize>> = None;
+    for slot in owners.iter_mut() {
+        match slot {
+            Some(owner) => last_owner = Some(owner.clone()),
+            None => *slot = last_owner.clone(),
+        }
+    }
+    let mut next_owner: Option<Vec<usize>> = None;
+    for slot in owners.iter_mut().rev() {
+        match slot {
+            Some(owner) => next_owner = Some(owner.clone()),
+            None => *slot = next_owner.clone(),
+        }
+    }
+
+    owners
+        .into_iter()
+        .map(|owner| owner.unwrap_or_default())
+        .collect()
+}
+
+/// Groups `hunk.lines` into maximal contiguous runs, one per distinct
+/// symbol (plus one for the module-level "no symbol" bucket), turning each
+/// run into its own [`SubHunk`] with an exactly recomputed header
+/// (function's own doc comment on [`split_hunk`]). A symbol whose owned
+/// lines are all non-contiguous (interleaved with another symbol's lines)
+/// yields more than one run, and thus more than one `SubHunk`, for that
+/// same symbol — this is the exact shape splitting is meant to produce:
+/// `crate::diff_shape::build_file_content` pushes every returned entry onto
+/// that symbol's section in order, so its section still reads as one
+/// contiguous diff top-to-bottom even though this function emitted several
+/// pieces.
+fn build_sub_hunks(hunk: &Hunk, owners: &[Vec<usize>]) -> Vec<(Option<usize>, SubHunk)> {
+    // Every distinct owner that appears anywhere, each contributing its own
+    // independent run-scan over the whole line range — this is what lets a
+    // pathologically overlapping pair of symbol ranges (Context, ADR 0029)
+    // both claim the same line without one silently winning over the other.
+    let mut distinct_owners: Vec<Option<usize>> = Vec::new();
+    for line_owners in owners {
+        if line_owners.is_empty() && !distinct_owners.contains(&None) {
+            distinct_owners.push(None);
+        }
+        for &owner in line_owners {
+            if !distinct_owners.contains(&Some(owner)) {
+                distinct_owners.push(Some(owner));
+            }
+        }
+    }
+
+    let mut result: Vec<(usize, Option<usize>, SubHunk)> = Vec::new();
+    for owner in distinct_owners {
+        let owns = |index: usize| -> bool {
+            match owner {
+                Some(symbol_index) => owners[index].contains(&symbol_index),
+                None => owners[index].is_empty(),
+            }
+        };
+
+        let mut next_new_line = hunk.new_range.map(|(start, _)| start).unwrap_or(1);
+        let old_start = old_start_for_hunk(hunk).unwrap_or(0);
+        let mut old_line_offset = 0usize;
+
+        let mut index = 0;
+        while index < hunk.lines.len() {
+            if !owns(index) {
+                if hunk.lines[index].kind != DiffLineKind::Removed {
+                    next_new_line += 1;
+                }
+                if hunk.lines[index].kind != DiffLineKind::Added {
+                    old_line_offset += 1;
+                }
+                index += 1;
+                continue;
+            }
+
+            let start = index;
+            let mut end = index + 1;
+            while end < hunk.lines.len() && owns(end) {
+                end += 1;
+            }
+
+            let run = &hunk.lines[start..end];
+            let run_new_line_count = run
+                .iter()
+                .filter(|line| line.kind != DiffLineKind::Removed)
+                .count();
+            let run_old_line_count = run
+                .iter()
+                .filter(|line| line.kind != DiffLineKind::Added)
+                .count();
+
+            let new_range = if run_new_line_count == 0 {
+                // A pure-deletion run: same zero-width convention
+                // `crate::diff_view::Hunk::new_range` already uses for a
+                // pure-deletion hunk — the position content used to occupy,
+                // not a `start <= end` span.
+                (next_new_line > 0).then_some((next_new_line, next_new_line - 1))
+            } else {
+                Some((next_new_line, next_new_line + run_new_line_count - 1))
+            };
+            let header =
+                format_sub_hunk_header(old_start + old_line_offset, run_old_line_count, new_range);
+
+            result.push((
+                start,
+                owner,
+                SubHunk {
+                    header,
+                    new_range,
+                    lines: run.to_vec(),
+                    origin_offset: start,
+                },
+            ));
+
+            next_new_line += run_new_line_count;
+            old_line_offset += run_old_line_count;
+            index = end;
+        }
+    }
+
+    // Restore document order across owners: `distinct_owners`' own order
+    // (first-appearance) does not match line order once a later-appearing
+    // owner's first run actually starts earlier than an earlier-appearing
+    // owner's later run — sorting by each entry's own start index is the
+    // one ordering `crate::diff_shape::build_file_content` actually needs
+    // (it pushes each entry onto its owning section, order within a
+    // section coming from this sort, not from `distinct_owners`).
+    result.sort_by_key(|(start, _, _)| *start);
+    result
+        .into_iter()
+        .map(|(_, owner, sub_hunk)| (owner, sub_hunk))
+        .collect()
+}
+
+/// Parses the original hunk header's old-side start (`@@ -a,b +c,d @@`'s
+/// `a`), the base every sub-hunk's own old-side start is computed relative
+/// to (ADR 0053 decision: "old-side start is the original hunk's old-side
+/// start plus lines consumed by preceding sub-hunks"). `None` when the
+/// header doesn't match the expected shape — mirrors
+/// `crate::diff_view::parse_new_side_header`'s own defensive-parse
+/// contract, since a hunk whose header this module cannot read at all
+/// cannot have a meaningful old-side start recomputed for its sub-hunks
+/// either.
+fn old_start_for_hunk(hunk: &Hunk) -> Option<usize> {
+    let body = hunk.header.strip_prefix("@@ ")?.split(" @@").next()?;
+    let old_part = body.split(' ').next()?;
+    let old_part = old_part.strip_prefix('-')?;
+    let start_str = old_part.split(',').next()?;
+    start_str.parse().ok()
+}
+
+/// Formats a sub-hunk's own `@@ -old_start,old_count +new_start,new_count @@`
+/// header from its resolved old-side start/count and new-side range.
+fn format_sub_hunk_header(
+    old_start: usize,
+    old_count: usize,
+    new_range: Option<(usize, usize)>,
+) -> String {
+    let (new_start, new_count) = match new_range {
+        Some((start, end)) if start <= end => (start, end - start + 1),
+        Some((start, _)) => (start, 0),
+        None => (0, 0),
+    };
+    format!("@@ -{old_start},{old_count} +{new_start},{new_count} @@")
+}
+
+#[cfg(test)]
+#[path = "hunk_split_tests/mod.rs"]
+mod tests;

--- a/rinkaku-tui/src/hunk_split_tests/mod.rs
+++ b/rinkaku-tui/src/hunk_split_tests/mod.rs
@@ -1,0 +1,57 @@
+//! Tests for `crate::hunk_split`, split from the source file (ADR 0028)
+//! following the `crate::split_pairing_tests` precedent.
+
+use super::*;
+use crate::diff_view::{DiffLine, DiffLineKind};
+
+mod split_hunk;
+
+/// Builds a [`Hunk`] fixture with `new_range` derived from `new_start` and
+/// the added/context line count, mirroring
+/// `crate::diff_shape_tests::hunk`'s own convention (every non-`Removed`
+/// entry of `kinds_and_content` counts toward the new-side span). Lets each
+/// test spell out `[(DiffLineKind, &str), ...]` inline rather than building
+/// `DiffLine`s by hand.
+pub(super) fn hunk(header: &str, new_start: usize, lines: &[(DiffLineKind, &str)]) -> Hunk {
+    let diff_lines: Vec<DiffLine> = lines
+        .iter()
+        .map(|(kind, content)| DiffLine {
+            kind: *kind,
+            content: content.to_string(),
+        })
+        .collect();
+    let new_count = diff_lines
+        .iter()
+        .filter(|line| line.kind != DiffLineKind::Removed)
+        .count();
+    let new_range = if new_count == 0 {
+        (new_start > 0).then_some((new_start, new_start - 1))
+    } else {
+        Some((new_start, new_start + new_count - 1))
+    };
+    Hunk {
+        header: header.to_string(),
+        new_range,
+        lines: diff_lines,
+    }
+}
+
+pub(super) fn sub(
+    header: &str,
+    new_range: Option<(usize, usize)>,
+    lines: &[(DiffLineKind, &str)],
+    origin_offset: usize,
+) -> SubHunk {
+    SubHunk {
+        header: header.to_string(),
+        new_range,
+        lines: lines
+            .iter()
+            .map(|(kind, content)| DiffLine {
+                kind: *kind,
+                content: content.to_string(),
+            })
+            .collect(),
+        origin_offset,
+    }
+}

--- a/rinkaku-tui/src/hunk_split_tests/split_hunk.rs
+++ b/rinkaku-tui/src/hunk_split_tests/split_hunk.rs
@@ -382,3 +382,63 @@ fn should_emit_one_sub_hunk_per_symbol_when_symbol_ranges_overlap() {
     let expected = vec![(Some(0), expected_sub.clone()), (Some(1), expected_sub)];
     assert_eq!(expected, actual);
 }
+
+#[test]
+fn should_attribute_pure_deletion_hunk_to_the_symbol_its_zero_width_position_falls_inside() {
+    // A hunk with no Added/Context line at all (every line Removed) has no
+    // anchor line for `line_owners`' normal forward/back-fill passes to
+    // seed from — this is the everyday case of deleting a few lines out of
+    // the middle of an existing function, not just the brand-new-file or
+    // whole-symbol-removal edge cases. `foo` spans new-file lines 1-3; the
+    // deletion's zero-width position (new_start 2, `Hunk::new_range`'s own
+    // convention) falls inside it.
+    let original = hunk(
+        "@@ -2,1 +1,0 @@",
+        2,
+        &[(DiffLineKind::Removed, "    old_body();")],
+    );
+    let symbols = [(0, LineRange { start: 1, end: 3 })];
+
+    let actual = split_hunk(&original, &symbols);
+
+    assert_eq!(
+        vec![(
+            Some(0),
+            SubHunk {
+                header: original.header.clone(),
+                new_range: original.new_range,
+                lines: original.lines.clone(),
+                origin_offset: 0,
+            }
+        )],
+        actual
+    );
+}
+
+#[test]
+fn should_route_pure_deletion_hunk_to_module_level_bucket_when_position_intersects_no_symbol() {
+    // Same shape as the test above, but the deletion's zero-width position
+    // sits in the gap between two symbols rather than inside either one, so
+    // it must fall through to the module-level (`None`) bucket rather than
+    // being silently attributed to a neighboring symbol.
+    let original = hunk("@@ -4,1 +3,0 @@", 4, &[(DiffLineKind::Removed, "")]);
+    let symbols = [
+        (0, LineRange { start: 1, end: 3 }),
+        (1, LineRange { start: 5, end: 7 }),
+    ];
+
+    let actual = split_hunk(&original, &symbols);
+
+    assert_eq!(
+        vec![(
+            None,
+            SubHunk {
+                header: original.header.clone(),
+                new_range: original.new_range,
+                lines: original.lines.clone(),
+                origin_offset: 0,
+            }
+        )],
+        actual
+    );
+}

--- a/rinkaku-tui/src/hunk_split_tests/split_hunk.rs
+++ b/rinkaku-tui/src/hunk_split_tests/split_hunk.rs
@@ -1,0 +1,384 @@
+use super::*;
+use pretty_assertions::assert_eq;
+use rinkaku_core::diff::LineRange;
+
+#[test]
+fn should_return_unsplit_hunk_when_only_one_symbol_intersects() {
+    let original = hunk(
+        "@@ -1,2 +1,2 @@",
+        1,
+        &[
+            (DiffLineKind::Context, "fn foo() {"),
+            (DiffLineKind::Added, "    body();"),
+        ],
+    );
+    let symbols = [(0, LineRange { start: 1, end: 5 })];
+
+    let actual = split_hunk(&original, &symbols);
+
+    assert_eq!(
+        vec![(
+            Some(0),
+            SubHunk {
+                header: original.header.clone(),
+                new_range: original.new_range,
+                lines: original.lines.clone(),
+                origin_offset: 0,
+            }
+        )],
+        actual
+    );
+}
+
+#[test]
+fn should_return_unsplit_hunk_with_none_owner_when_no_symbol_intersects() {
+    let original = hunk(
+        "@@ -1,1 +1,1 @@",
+        1,
+        &[(DiffLineKind::Context, "use foo::bar;")],
+    );
+    let symbols = [(0, LineRange { start: 10, end: 20 })];
+
+    let actual = split_hunk(&original, &symbols);
+
+    assert_eq!(
+        vec![(
+            None,
+            SubHunk {
+                header: original.header.clone(),
+                new_range: original.new_range,
+                lines: original.lines.clone(),
+                origin_offset: 0,
+            }
+        )],
+        actual
+    );
+}
+
+#[test]
+fn should_split_added_and_context_lines_at_symbol_boundary() {
+    // Two adjacent symbols sharing one hunk, no Removed lines: `foo` owns
+    // new-file lines 1-2, `bar` owns line 3.
+    let original = hunk(
+        "@@ -1,3 +1,3 @@",
+        1,
+        &[
+            (DiffLineKind::Context, "fn foo() {}"),
+            (DiffLineKind::Added, "fn foo2() {}"),
+            (DiffLineKind::Context, "fn bar() {}"),
+        ],
+    );
+    let symbols = [
+        (0, LineRange { start: 1, end: 2 }),
+        (1, LineRange { start: 3, end: 3 }),
+    ];
+
+    let actual = split_hunk(&original, &symbols);
+
+    let expected = vec![
+        (
+            Some(0),
+            sub(
+                "@@ -1,1 +1,2 @@",
+                Some((1, 2)),
+                &[
+                    (DiffLineKind::Context, "fn foo() {}"),
+                    (DiffLineKind::Added, "fn foo2() {}"),
+                ],
+                0,
+            ),
+        ),
+        (
+            Some(1),
+            sub(
+                "@@ -2,1 +3,1 @@",
+                Some((3, 3)),
+                &[(DiffLineKind::Context, "fn bar() {}")],
+                2,
+            ),
+        ),
+    ];
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_route_gap_between_symbols_to_module_level_bucket() {
+    // `foo` owns line 1, an unowned import sits at line 2, `bar` owns line
+    // 3 — three sub-hunks, the middle one with a `None` owner.
+    let original = hunk(
+        "@@ -1,3 +1,3 @@",
+        1,
+        &[
+            (DiffLineKind::Context, "fn foo() {}"),
+            (DiffLineKind::Added, "use foo::bar;"),
+            (DiffLineKind::Context, "fn bar() {}"),
+        ],
+    );
+    let symbols = [
+        (0, LineRange { start: 1, end: 1 }),
+        (1, LineRange { start: 3, end: 3 }),
+    ];
+
+    let actual = split_hunk(&original, &symbols);
+
+    let expected = vec![
+        (
+            Some(0),
+            sub(
+                "@@ -1,1 +1,1 @@",
+                Some((1, 1)),
+                &[(DiffLineKind::Context, "fn foo() {}")],
+                0,
+            ),
+        ),
+        (
+            None,
+            sub(
+                "@@ -2,0 +2,1 @@",
+                Some((2, 2)),
+                &[(DiffLineKind::Added, "use foo::bar;")],
+                1,
+            ),
+        ),
+        (
+            Some(1),
+            sub(
+                "@@ -2,1 +3,1 @@",
+                Some((3, 3)),
+                &[(DiffLineKind::Context, "fn bar() {}")],
+                2,
+            ),
+        ),
+    ];
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_attribute_removed_only_run_to_the_previous_owner() {
+    // `foo` (lines 1-2) is followed by a Removed-only run (no new-file
+    // line of its own) before `bar` (line 3) resumes — the removed run
+    // must inherit `foo`'s ownership (the run immediately preceding it),
+    // not `bar`'s.
+    let original = hunk(
+        "@@ -1,4 +1,3 @@",
+        1,
+        &[
+            (DiffLineKind::Context, "fn foo() {}"),
+            (DiffLineKind::Added, "fn foo2() {}"),
+            (DiffLineKind::Removed, "fn old_helper() {}"),
+            (DiffLineKind::Context, "fn bar() {}"),
+        ],
+    );
+    let symbols = [
+        (0, LineRange { start: 1, end: 2 }),
+        (1, LineRange { start: 3, end: 3 }),
+    ];
+
+    let actual = split_hunk(&original, &symbols);
+
+    let expected = vec![
+        (
+            Some(0),
+            sub(
+                "@@ -1,2 +1,2 @@",
+                Some((1, 2)),
+                &[
+                    (DiffLineKind::Context, "fn foo() {}"),
+                    (DiffLineKind::Added, "fn foo2() {}"),
+                    (DiffLineKind::Removed, "fn old_helper() {}"),
+                ],
+                0,
+            ),
+        ),
+        (
+            Some(1),
+            sub(
+                "@@ -3,1 +3,1 @@",
+                Some((3, 3)),
+                &[(DiffLineKind::Context, "fn bar() {}")],
+                3,
+            ),
+        ),
+    ];
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_retroactively_attribute_leading_removed_run_to_the_next_owner() {
+    // The hunk opens with Removed lines before any Added/Context line has
+    // appeared — those lines have no "previous owner" yet, so they must
+    // take the owner of the next resolved (Added/Context) line, which is
+    // `bar`.
+    let original = hunk(
+        "@@ -1,3 +1,2 @@",
+        1,
+        &[
+            (DiffLineKind::Removed, "fn old_top_level() {}"),
+            (DiffLineKind::Context, "fn foo() {}"),
+            (DiffLineKind::Context, "fn bar() {}"),
+        ],
+    );
+    let symbols = [
+        (0, LineRange { start: 1, end: 1 }),
+        (1, LineRange { start: 2, end: 2 }),
+    ];
+
+    let actual = split_hunk(&original, &symbols);
+
+    let expected = vec![
+        (
+            Some(0),
+            sub(
+                "@@ -1,2 +1,1 @@",
+                Some((1, 1)),
+                &[
+                    (DiffLineKind::Removed, "fn old_top_level() {}"),
+                    (DiffLineKind::Context, "fn foo() {}"),
+                ],
+                0,
+            ),
+        ),
+        (
+            Some(1),
+            sub(
+                "@@ -3,1 +2,1 @@",
+                Some((2, 2)),
+                &[(DiffLineKind::Context, "fn bar() {}")],
+                2,
+            ),
+        ),
+    ];
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_split_brand_new_file_single_hunk_into_one_sub_hunk_per_symbol() {
+    // ADR 0029's own regression scenario: a brand-new file is always
+    // exactly one hunk spanning the whole file, so every symbol it
+    // defines shares that one hunk. ADR 0053 now splits it into one
+    // sub-hunk per symbol instead of cloning the whole hunk into every
+    // section.
+    let original = hunk(
+        "@@ -0,0 +1,3 @@",
+        1,
+        &[
+            (DiffLineKind::Added, "fn foo() {}"),
+            (DiffLineKind::Added, "fn bar() {}"),
+            (DiffLineKind::Added, "fn baz() {}"),
+        ],
+    );
+    let symbols = [
+        (0, LineRange { start: 1, end: 1 }),
+        (1, LineRange { start: 2, end: 2 }),
+        (2, LineRange { start: 3, end: 3 }),
+    ];
+
+    let actual = split_hunk(&original, &symbols);
+
+    let expected = vec![
+        (
+            Some(0),
+            sub(
+                "@@ -0,0 +1,1 @@",
+                Some((1, 1)),
+                &[(DiffLineKind::Added, "fn foo() {}")],
+                0,
+            ),
+        ),
+        (
+            Some(1),
+            sub(
+                "@@ -0,0 +2,1 @@",
+                Some((2, 2)),
+                &[(DiffLineKind::Added, "fn bar() {}")],
+                1,
+            ),
+        ),
+        (
+            Some(2),
+            sub(
+                "@@ -0,0 +3,1 @@",
+                Some((3, 3)),
+                &[(DiffLineKind::Added, "fn baz() {}")],
+                2,
+            ),
+        ),
+    ];
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_recompute_old_side_header_across_multiple_sub_hunks() {
+    // Old-side start must accumulate: the second sub-hunk's `-` start is
+    // the original hunk's old start (10) plus the first sub-hunk's own
+    // old-side line count (2: one context + one removed).
+    let original = hunk(
+        "@@ -10,3 +10,3 @@",
+        10,
+        &[
+            (DiffLineKind::Context, "fn foo() {}"),
+            (DiffLineKind::Removed, "fn old() {}"),
+            (DiffLineKind::Added, "fn bar() {}"),
+        ],
+    );
+    let symbols = [
+        (0, LineRange { start: 10, end: 10 }),
+        (1, LineRange { start: 11, end: 11 }),
+    ];
+
+    let actual = split_hunk(&original, &symbols);
+
+    let expected = vec![
+        (
+            Some(0),
+            sub(
+                "@@ -10,2 +10,1 @@",
+                Some((10, 10)),
+                &[
+                    (DiffLineKind::Context, "fn foo() {}"),
+                    (DiffLineKind::Removed, "fn old() {}"),
+                ],
+                0,
+            ),
+        ),
+        (
+            Some(1),
+            sub(
+                "@@ -12,0 +11,1 @@",
+                Some((11, 11)),
+                &[(DiffLineKind::Added, "fn bar() {}")],
+                2,
+            ),
+        ),
+    ];
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_emit_one_sub_hunk_per_symbol_when_symbol_ranges_overlap() {
+    // Pathological input (a real extractor would not normally produce
+    // overlapping symbol ranges), but ADR 0029's "attribute to every
+    // intersecting symbol" contract still applies: a line whose new-file
+    // position falls inside both `foo` (1-5) and `bar` (3-8) must appear
+    // in both symbols' sub-hunks rather than only the first one found.
+    let original = hunk(
+        "@@ -1,1 +1,5 @@",
+        3,
+        &[(DiffLineKind::Context, "shared line")],
+    );
+    let symbols = [
+        (0, LineRange { start: 1, end: 5 }),
+        (1, LineRange { start: 3, end: 8 }),
+    ];
+
+    let actual = split_hunk(&original, &symbols);
+
+    let expected_sub = sub(
+        "@@ -1,1 +3,1 @@",
+        Some((3, 3)),
+        &[(DiffLineKind::Context, "shared line")],
+        0,
+    );
+    let expected = vec![(Some(0), expected_sub.clone()), (Some(1), expected_sub)];
+    assert_eq!(expected, actual);
+}

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -41,6 +41,7 @@ pub mod diff_view;
 mod event_loop;
 pub mod help;
 pub mod highlight;
+mod hunk_split;
 mod input_translate;
 pub mod nav;
 pub mod note_markers;

--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -357,9 +357,12 @@ pub(crate) fn diff_pane_lines(
                 // — `flatten` collapses "no highlight data at all for this
                 // hunk" and "this specific line had no highlight" into the
                 // same `None` `diff_line` already treats as its fallback
-                // signal.
+                // signal. `origin_offset` (ADR 0053) rebases `line_index`
+                // back into the *original* hunk's line positions, since
+                // `hunk_highlight` stays keyed by that original length even
+                // when `attributed.hunk` is a smaller split sub-hunk.
                 let token_spans = hunk_highlight
-                    .and_then(|lines| lines.get(line_index).cloned())
+                    .and_then(|lines| lines.get(attributed.origin_offset + line_index).cloned())
                     .flatten();
                 let has_note = new_side_lines[line_index].is_some_and(|line_no| {
                     crate::note_markers::line_has_note(note_markers, path, line_no)
@@ -507,6 +510,7 @@ pub(crate) fn diff_pane_split_rows(
                 left.push(split_side_line(
                     split_row.left.as_ref(),
                     split_row.left_index,
+                    attributed.origin_offset,
                     hunk_highlight,
                     None,
                 ));
@@ -519,6 +523,7 @@ pub(crate) fn diff_pane_split_rows(
                 right.push(split_side_line(
                     split_row.right.as_ref(),
                     split_row.right_index,
+                    attributed.origin_offset,
                     hunk_highlight,
                     Some(right_has_note),
                 ));
@@ -573,13 +578,17 @@ fn section_anchor_split_row(section: &DiffSection) -> (Line<'static>, Line<'stat
 fn split_side_line(
     line: Option<&DiffLine>,
     index: Option<usize>,
+    origin_offset: usize,
     hunk_highlight: Option<&[Option<Vec<TokenSpan>>]>,
     has_note: Option<bool>,
 ) -> Line<'static> {
     let rendered = match (line, index) {
         (Some(line), Some(index)) => {
+            // `origin_offset` (ADR 0053) rebases `index` back into the
+            // *original* hunk's line positions — `diff_pane_lines`'s own
+            // sibling offset has the full explanation.
             let token_spans = hunk_highlight
-                .and_then(|lines| lines.get(index).cloned())
+                .and_then(|lines| lines.get(origin_offset + index).cloned())
                 .flatten();
             diff_line(line, token_spans)
         }

--- a/rinkaku-tui/src/ui/diff_pane_tests/note_markers.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/note_markers.rs
@@ -28,6 +28,7 @@ fn section_for(diff_text: &str) -> DiffSection {
         hunks: vec![AttributedHunk {
             source_index: 0,
             hunk,
+            origin_offset: 0,
         }],
     }
 }

--- a/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
@@ -293,3 +293,65 @@ index e69de29..4b825dc 100644
         .unwrap_or_else(|| panic!("expected a row with the removed line, got:\n{text}"));
     assert!(!removed_row.contains("+fn foo() {}"));
 }
+
+#[test]
+fn should_offset_highlight_lookup_by_origin_offset_in_split_view_when_hunk_was_split() {
+    // Split-view sibling of `styling::should_offset_highlight_lookup_by_origin_offset_when_hunk_was_split`
+    // (ADR 0053): `split_side_line` looks up `hunk_highlight` by
+    // `split_row.left_index`/`right_index`, which — like unified view's
+    // `line_index` — is a position within the *sub*-hunk's own `lines`,
+    // not the original hunk's. `origin_offset` must be added before that
+    // lookup here too.
+    let section = DiffSection {
+        title: "fn bar()".to_string(),
+        symbol_id: Some("lib.rs::bar".to_string()),
+        contract_header: None,
+        hunks: vec![crate::diff_shape::AttributedHunk {
+            source_index: 0,
+            hunk: crate::diff_view::Hunk {
+                header: "@@ -2,1 +2,1 @@".to_string(),
+                new_range: Some((2, 2)),
+                lines: vec![DiffLine {
+                    kind: DiffLineKind::Added,
+                    content: "bar_body".to_string(),
+                }],
+            },
+            origin_offset: 1,
+        }],
+    };
+    let highlighted_file = HighlightedFile {
+        path: "lib.rs".to_string(),
+        hunks: vec![vec![
+            Some(vec![TokenSpan {
+                start: 0,
+                end: 8,
+                palette_index: 0,
+            }]),
+            Some(vec![TokenSpan {
+                start: 0,
+                end: 8,
+                palette_index: 1,
+            }]),
+        ]],
+    };
+
+    let (_, right) = diff_pane_split_rows(
+        &[&section],
+        true,
+        Some(&highlighted_file),
+        &crate::note_markers::NoteMarkers::default(),
+        "lib.rs",
+    );
+
+    let body_line = right
+        .iter()
+        .find(|line| line.spans.iter().any(|span| span.content == "bar_body"))
+        .expect("body line present");
+    let token_style = body_line
+        .spans
+        .iter()
+        .find(|span| span.content == "bar_body")
+        .expect("bar_body span present")
+        .style;
+    assert_eq!(crate::ui::style::palette_style(1).fg, token_style.fg);
+}

--- a/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
@@ -183,6 +183,74 @@ index e69de29..4b825dc 100644
 }
 
 #[test]
+fn should_offset_highlight_lookup_by_origin_offset_when_hunk_was_split() {
+    // ADR 0053: a hunk shared by two symbols is split into per-symbol
+    // sub-hunks, each keeping `origin_offset` — its start index within
+    // the *original* hunk's `lines` — needed to look up the right slice
+    // of `crate::highlight::highlight_hunk`'s output, which stays keyed
+    // by position in the original, unsplit hunk (that highlight table is
+    // computed once per original hunk, not re-split alongside it). This
+    // section's sub-hunk starts at `origin_offset` 1 (after the first
+    // section's own 1 line); `hunk_highlight[0]` and `hunk_highlight[1]`
+    // are deliberately set to different, distinguishable spans so an
+    // unoffset lookup (`line_index` 0 instead of `origin_offset +
+    // line_index` = 1) is caught by asserting the exact `TokenSpan`
+    // used, not just "some" highlight was applied.
+    let section = DiffSection {
+        title: "fn bar()".to_string(),
+        symbol_id: Some("lib.rs::bar".to_string()),
+        contract_header: None,
+        hunks: vec![crate::diff_shape::AttributedHunk {
+            source_index: 0,
+            hunk: crate::diff_view::Hunk {
+                header: "@@ -2,1 +2,1 @@".to_string(),
+                new_range: Some((2, 2)),
+                lines: vec![DiffLine {
+                    kind: DiffLineKind::Added,
+                    content: "bar_body".to_string(),
+                }],
+            },
+            origin_offset: 1,
+        }],
+    };
+    let highlighted_file = HighlightedFile {
+        path: "lib.rs".to_string(),
+        hunks: vec![vec![
+            Some(vec![TokenSpan {
+                start: 0,
+                end: 8,
+                palette_index: 0,
+            }]),
+            Some(vec![TokenSpan {
+                start: 0,
+                end: 8,
+                palette_index: 1,
+            }]),
+        ]],
+    };
+
+    let actual = diff_pane_lines(
+        &[&section],
+        true,
+        Some(&highlighted_file),
+        &crate::note_markers::NoteMarkers::default(),
+        "lib.rs",
+    );
+
+    let body_line = actual
+        .iter()
+        .find(|line| line.spans.iter().any(|span| span.content == "bar_body"))
+        .expect("body line present");
+    let token_style = body_line
+        .spans
+        .iter()
+        .find(|span| span.content == "bar_body")
+        .expect("bar_body span present")
+        .style;
+    assert_eq!(crate::ui::style::palette_style(1).fg, token_style.fg);
+}
+
+#[test]
 fn should_fall_back_to_plain_diff_style_when_file_extension_is_unrecognized() {
     // A symbol whose path has no known extension (mirrors an unbuilt
     // language, e.g. YAML): `App::selected_diff_target` reads the path


### PR DESCRIPTION
## Summary

Walking symbols in the left pane no longer shows the same hunk body repeated under every section that shares it. A hunk intersecting more than one symbol's range is now **split into per-symbol sub-hunks at attribution time** instead of being cloned whole into each owning section.

This adopts the alternative ADR 0029 explicitly rejected-for-later ("can be revisited if reviewers find the duplicated-hunk-body a real annoyance in practice") — that condition was met during real review use. Design is recorded in **ADR 0053**, which amends ADR 0029.

## Key decisions (see ADR 0053)

- Split activates only when a hunk intersects two or more symbol ranges; the common single-owner case is passed through unchanged.
- Added/Context lines are owned by the symbol range containing their new-file line number; Removed lines inherit the current run's owner (retroactively for hunk-leading removals).
- A hunk with **no** Added/Context anchor at all (pure deletion) falls back to testing its zero-width `new_range` position via the existing `diff_view::hunk_intersects` half-open rule.
- Unowned runs (imports, gaps between symbols) become their own sub-hunks under the module-level bucket.
- Sub-hunk `@@` headers are recomputed exactly on both sides; no extra context padding at cut boundaries.
- Overlapping symbol ranges (a line owned by several symbols) still render in every owning section — deliberate, preserves ADR 0029's contract.
- New sibling module `hunk_split.rs` (+ `hunk_split_tests/`), following `split_pairing.rs`'s precedent, keeps `diff_shape.rs` under the file-size watch threshold.
- `AttributedHunk` gains `origin_offset` so highlight lookups (computed per original hunk) slice correctly into sub-hunks; `]c`/`[c` and auto-scroll needed no code change — deduplicated stops fall out of the attribution change.

## Review & verification

- **Static (map-assisted) pass**: found one blocker — pure-deletion hunks dropped to module level (fixed in b31292c with a regression test that failed before the fix) — plus a fixture-realism should-fix (fixed in b85fac1). All other angles (split completeness, highlight offsets, jump stops, conventions) confirmed clean.
- **Dynamic pass (ratatui TestBackend, headless)**: original symptom verified gone on a real diff — this branch's own `hunk_split.rs` (one `@@ -0,0 +1,287 @@` hunk, 6 symbols) renders as 7 sections with zero cross-section line duplication and working auto-scroll for every symbol. Module-level gaps, leading-removal attribution, overlaps, empty diff, and non-TTY binary invocations all pass.
- `make test` (853) and `make lint` (fmt + clippy `-D warnings`) pass.

## Notes

- Parallel PR `fix/diff-pane-scroll-wrap-unit` (ADR 0052, scroll-unit contract) touches adjacent test files; whichever lands second may need a trivial rebase.