### PR TITLE
fix(tui): unify right_pane_scroll on pre-wrap logical lines

### DIFF
--- a/docs/adr/0052-scroll-unit-is-logical-lines-wrap-confined-to-renderer.md
+++ b/docs/adr/0052-scroll-unit-is-logical-lines-wrap-confined-to-renderer.md
@@ -141,3 +141,33 @@ computes positions against the same field.
   and multi-row-wrapping signatures specifically to exercise the
   logical/display-row gap `926876e`'s wide-pane fixtures could not
   reach.
+
+## Amendment: fold-back must not undo the request (dynamic verification follow-up)
+
+Dynamic verification of the fix above found a second-order regression it
+introduced: `display_row_to_logical_line` alone is not a safe fold-back once
+a *single* logical line is long enough to occupy the whole viewport. When
+`clamp_scroll`'s display-row clamp lands inside that line's own wrapped
+span (rather than exactly at its first row), the fold-back reports that
+line's own index — silently undoing a request for a *later* logical line.
+The next `Down` re-requests the same target, resolves to the same clamped
+display row, and folds back to the same value: a stable fixed point well
+short of the content's end (reproduced with a huge wrapped leading line
+followed by short lines; `right_pane_scroll` never advanced past it).
+
+`render_scrollable_pane`'s write-back now goes through
+`resolve_folded_back_logical_line(origins, display_row, requested_scroll)`
+instead of calling `display_row_to_logical_line` directly: it floors the
+folded-back value at `requested_scroll` itself (capped at the last
+available logical line, so an overscrolled request cannot be reported as
+unclamped). The on-screen `display_row` passed to `Paragraph::scroll` is
+unchanged — this only corrects the logical-line value written back into
+`App`.
+
+Regression coverage:
+`rinkaku-tui/src/event_loop/scroll_sync_wrap_tests.rs`'s
+`should_advance_scroll_monotonically_past_a_huge_wrapped_leading_line_*`
+and `should_not_oscillate_when_alternating_down_and_up_past_a_huge_wrapped_leading_line`
+drive repeated `Down`/`Up` against a huge-then-short fixture at several
+viewport heights; `rinkaku-tui/src/ui/scroll_tests/wrap_origins.rs` covers
+`resolve_folded_back_logical_line` directly.

--- a/docs/adr/0052-scroll-unit-is-logical-lines-wrap-confined-to-renderer.md
+++ b/docs/adr/0052-scroll-unit-is-logical-lines-wrap-confined-to-renderer.md
@@ -1,0 +1,143 @@
+# 0052. `App::right_pane_scroll` is always a pre-wrap logical-line offset; wrap conversion is confined to the renderer
+
+- Status: Accepted
+- Date: 2026-07-15
+
+## Context
+
+`crate::diff_shape::walk_sections` (and its derivatives
+`section_start_line_for_symbol`, ADR 0027 decision 2, and
+`symbol_id_for_scroll_line`, ADR 0030 decision 2) compute a symbol
+section's scroll position by counting *logical* lines of the diff
+pane's shaped content — one count per rendered line before any
+width-based wrapping. `crate::ui::scroll::render_scrollable_pane`
+consumed that same `App::right_pane_scroll` value as a *display-row*
+index into `wrap_lines`/`pair_wrap`'s wrapped output, passed straight
+into `clamp_scroll` and `Paragraph::scroll` with no conversion between
+the two. Both sides shared one `usize` field, but the writer
+(`crate::diff_shape`) and the reader (`crate::ui::scroll`) disagreed on
+its unit whenever a signature line was long enough to wrap — which
+`render_scrollable_pane`'s own doc comment had already flagged as a
+hazard in the abstract ("any logical line long enough to wrap desyncs
+the scroll unit from the rendered unit") without anyone having
+actually violated it until this contract was in place on both sides at
+once.
+
+The mismatch produced two symptoms:
+
+1. Selecting a symbol in the entry tree wrote the correct *logical*
+   section-start line into `right_pane_scroll`, but the renderer
+   applied that number as a *display-row* offset — in a narrow pane
+   where an earlier section's signature wrapped, this landed short of
+   the target section, leaving the previous symbol's wrapped
+   continuation on screen instead.
+2. `crate::ui`'s post-draw fold-back
+   (`clamp_right_pane_scroll_after_draw`) writes the *clamped
+   display-row* value straight back into `App::right_pane_scroll`
+   unchanged whenever it was already in bounds (`clamp_scroll` only
+   ever lowers an overshooting value, never raises one) — so the
+   diff → tree reverse sync (`symbol_id_for_scroll_line`) went on to
+   compare that (accidentally valid-looking, but display-row-shaped)
+   number against `crate::diff_shape`'s logical-line section
+   boundaries. A scroll position sitting inside an earlier symbol's
+   wrapped display rows was misread as if it were several logical
+   lines further along, so the reverse lookup reported a different
+   (further-along) symbol than what the pane was actually showing.
+
+The existing regression test for this scroll path (`926876e`,
+`scroll_sync_tests.rs`) always used a 160-column pane against short
+single-line signatures, so no wrapping ever occurred and neither
+symptom had coverage.
+
+## Decision
+
+**`App::right_pane_scroll` is always a logical-line offset — an index
+into the diff pane's shaped content *before* any width-based
+wrapping.** This was already `crate::diff_shape`'s unit; the fix makes
+`crate::ui::scroll` honor it instead of silently reinterpreting it.
+
+**All wrap-width knowledge stays confined to
+`crate::ui::scroll::render_scrollable_pane`.** `crate::diff_shape`
+gains no notion of pane width, and `App` gains no notion of wrapping —
+exactly the module boundaries both already claimed in their doc
+comments; this decision is enforcing an existing (but violated)
+contract, not inventing a new one.
+
+**Wrap functions now also report each output row's originating logical
+line.** `wrap_lines_with_origins`/`pair_wrap_with_origins` replace
+`wrap_lines`/`pair_wrap` at `render_scrollable_pane`'s two call sites,
+returning `(wrapped_rows, origins)` where `origins[i]` is the logical
+line display row `i` was wrapped from. Two new pure functions convert
+between the two coordinate spaces using that mapping:
+
+- `logical_line_to_display_row(origins, logical_line)` — the first
+  display row of a given logical line (used going *in*: converting
+  `requested_scroll` before `clamp_scroll`/`Paragraph::scroll` run).
+- `display_row_to_logical_line(origins, display_row)` — the logical
+  line a given display row belongs to (used going *out*: converting
+  the clamped display-row value back to logical lines before
+  `render_scrollable_pane` returns it).
+
+`render_scrollable_pane`'s contract is now: callers pass and receive
+logical lines; `clamp_scroll`/`scroll_indicator`/`Paragraph::scroll`
+internally still operate on display rows, but that unit never crosses
+the function boundary.
+
+**`Focus::Right` `Up`/`Down` now move by one logical line, not one
+display row.** When a logical line wraps into several display rows,
+`j`/`k` jumps the whole logical line at once instead of stepping
+through its wrapped rows one at a time — an accepted granularity
+change (`app/handle_key.rs`'s `(Screen::Entry, Focus::Right, ...)`
+arms needed no code change; only their unit changed).
+
+**Detail/BlastRadius panes are unaffected in practice.** They share
+`render_scrollable_pane` but pass plain unwrapped `Vec<Line>` with no
+per-symbol section concept of their own, so "logical line" there is
+just "index into that `Vec<Line>`" — the same thing it already was.
+The unit distinction only matters where a second party (`crate::diff_shape`)
+computes positions against the same field.
+
+## Alternatives
+
+- **Make `crate::diff_shape` wrap-aware** (pass pane width down into
+  `walk_sections` and compute display-row positions directly).
+  Rejected: `crate::diff_shape` is deliberately free of `ratatui`
+  types and pane-layout knowledge (its own module doc comment); this
+  would leak a rendering concern into a pure view-model module and
+  couple every `diff_shape` call site to a concrete pane width even
+  where wrapping is not the caller's concern (e.g. `hunk_start_lines`'
+  `]`/`[` jump math).
+- **Store both units on `App`** (a display-row field alongside the
+  logical-line one, kept in sync by the renderer). Rejected: doubles
+  the state `App::handle_key`'s reset rules must track and reintroduces
+  exactly the two-source-of-truth risk this fix removes; a single
+  field with one unconditional unit is simpler to reason about.
+- **Give `wrap_lines`/`pair_wrap` an output-only breaking change**
+  (return `(Vec<Line>, Vec<usize>)` directly, dropping the old
+  signature). Rejected in favor of keeping the two-tuple functions as
+  thin wrappers initially, then removed once nothing outside tests
+  still called them (`cargo clippy --all-targets` flagged them as dead
+  code once `render_scrollable_pane` moved to the `_with_origins`
+  variants) — the `_with_origins` functions are now the only public
+  surface, and existing tests were updated to call them and discard
+  the origins tuple element where they don't need it.
+
+## Consequences
+
+- `crate::ui::scroll::render_scrollable_pane` converts `requested_scroll`
+  to a display row before `clamp_scroll`, and converts the clamped
+  display row back to a logical line before returning — every caller
+  outside this one function (`crate::app`, `crate::diff_shape`,
+  `crate::event_loop::scroll_sync`) continues to read and write
+  `right_pane_scroll` purely in logical-line terms, matching what their
+  own doc comments already claimed.
+- `wrap_lines`/`pair_wrap` (the old two-tuple/two-value signatures) are
+  removed; `wrap_lines_with_origins`/`pair_wrap_with_origins` are the
+  only wrap entry points, used both by `render_scrollable_pane` and by
+  tests that need the plain wrapped output (discarding the origins
+  return value).
+- New regression tests (`rinkaku-tui/src/event_loop/scroll_sync_wrap_tests.rs`,
+  `rinkaku-tui/src/ui/scroll_tests/wrap_origins.rs`) use narrow panes
+  and multi-row-wrapping signatures specifically to exercise the
+  logical/display-row gap `926876e`'s wide-pane fixtures could not
+  reach.

--- a/rinkaku-tui/src/event_loop/scroll_sync.rs
+++ b/rinkaku-tui/src/event_loop/scroll_sync.rs
@@ -296,3 +296,14 @@ pub(crate) fn jump_scroll_target(
 #[cfg(test)]
 #[path = "scroll_sync_tests.rs"]
 mod tests;
+
+// Split out (ADR 0028) rather than appended to `scroll_sync_tests.rs`
+// (already near this crate's file-size watch threshold on its own): this
+// scroll-unit fix's own regression coverage needs a *narrow* pane fixture
+// (wrapping actually occurs) distinct from every existing test in that file,
+// which deliberately uses a wide one (`scroll_sync_tests.rs`'s own
+// `dispatch_draw_and_fold` doc comment) — grouping by that fixture
+// difference keeps each file's tests self-consistent about what they pin.
+#[cfg(test)]
+#[path = "scroll_sync_wrap_tests.rs"]
+mod wrap_tests;

--- a/rinkaku-tui/src/event_loop/scroll_sync_wrap_tests.rs
+++ b/rinkaku-tui/src/event_loop/scroll_sync_wrap_tests.rs
@@ -17,6 +17,11 @@
 //!   screen, not silently resolve past it because a wrapped section
 //!   inflated the display-row count relative to the logical-line count the
 //!   lookup itself uses.
+//! - `should_advance_scroll_monotonically_past_a_huge_wrapped_leading_line_*`:
+//!   a follow-up regression in the symptom-1/2 fix itself — a display-row
+//!   clamp that lands *inside* a preceding wrapped span folded back to that
+//!   span's own logical line, undoing the request and stalling `Down` at a
+//!   fixed point before reaching the last symbol.
 
 use super::{apply_diff_pane_selection_effects, clamp_right_pane_scroll_after_draw};
 use crate::app::{self, App, InputKey};
@@ -492,4 +497,331 @@ fn should_resolve_the_correct_symbol_when_scroll_position_lands_inside_a_precedi
         resolved,
         "the reverse lookup fed the folded-back scroll must agree with what the pane actually shows"
     );
+}
+
+/// A huge symbol (an 80-parameter signature, wrapping into dozens of
+/// display rows at this file's narrow test widths) followed by three short
+/// one-line symbols — the fixture symptom-1/2's own giant-then-small
+/// fixture generalizes: a single wrapped leading section long enough that
+/// `clamp_scroll`'s display-row clamp can land *inside* its own wrapped
+/// span for several consecutive `Down` presses in a row, not just one.
+fn report_with_giant_then_three_short_symbols() -> Report {
+    fn symbol(id: &str, name: &str, range: LineRange, signature: String) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature,
+            range,
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        }
+    }
+
+    let giant_params = (0..80)
+        .map(|index| format!("p{index}: Type{index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let giant_signature = format!("fn giant({giant_params}) -> Result<Output, Error>");
+
+    Report {
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![
+                symbol(
+                    "lib.rs::giant",
+                    "giant",
+                    LineRange { start: 1, end: 2 },
+                    giant_signature,
+                ),
+                symbol(
+                    "lib.rs::first",
+                    "first",
+                    LineRange { start: 10, end: 11 },
+                    "fn first()".to_string(),
+                ),
+                symbol(
+                    "lib.rs::second",
+                    "second",
+                    LineRange { start: 20, end: 21 },
+                    "fn second()".to_string(),
+                ),
+                symbol(
+                    "lib.rs::third",
+                    "third",
+                    LineRange { start: 30, end: 31 },
+                    "fn third()".to_string(),
+                ),
+            ],
+        }],
+        ..empty_report()
+    }
+}
+
+fn diff_hunks_with_giant_then_three_short_sections() -> Vec<diff_view::FileHunks> {
+    use diff_view::{DiffLine, DiffLineKind, Hunk};
+
+    fn hunk(header: &str, new_range: (usize, usize), line: &str) -> Hunk {
+        Hunk {
+            header: header.to_string(),
+            new_range: Some(new_range),
+            lines: vec![DiffLine {
+                kind: DiffLineKind::Context,
+                content: line.to_string(),
+            }],
+        }
+    }
+
+    vec![diff_view::FileHunks {
+        path: "lib.rs".to_string(),
+        hunks: vec![
+            hunk("@@ -1,1 +1,2 @@", (1, 2), "fn giant(..) {}"),
+            hunk("@@ -10,1 +10,2 @@", (10, 11), "fn first() {}"),
+            hunk("@@ -20,1 +20,2 @@", (20, 21), "fn second() {}"),
+            hunk("@@ -30,1 +30,2 @@", (30, 31), "fn third() {}"),
+        ],
+    }]
+}
+
+/// Repeatedly presses `Down` while `Focus::Right` on the diff pane (bypassing
+/// `apply_diff_pane_selection_effects`'s tree-cursor gating, mirroring
+/// `should_resolve_the_correct_symbol_when_scroll_position_lands_inside_a_preceding_wrapped_section`'s
+/// own direct-request style) and returns `right_pane_scroll` after each
+/// press-draw-fold cycle — the sequence a regression test needs to assert
+/// monotonic progress against, not just the final value.
+fn scroll_positions_after_repeated_down(
+    report: &Report,
+    diff_hunks: &[diff_view::FileHunks],
+    view_mode_toggle: bool,
+    width: u16,
+    height: u16,
+    presses: usize,
+) -> Vec<usize> {
+    let mut app = App::new(report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Open);
+    if view_mode_toggle {
+        app = app.handle_key(InputKey::ToggleSplitView);
+    }
+    let content = diff_shape::build_diff_pane_content(
+        report,
+        diff_hunks,
+        app.selected_diff_target(report).as_ref(),
+    );
+    let diff_highlights = crate::highlight::highlight_diff_files(diff_hunks);
+
+    let mut positions = Vec::new();
+    for _ in 0..presses {
+        app = app.handle_key(InputKey::Down);
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, height))
+                .expect("terminal");
+        let mut outcome = crate::ui::DrawOutcome::default();
+        terminal
+            .draw(|frame| {
+                outcome = crate::ui::draw(
+                    frame,
+                    &app,
+                    report,
+                    &content,
+                    &diff_highlights,
+                    &app::BlastRadiusSelection::NotApplicable,
+                    None,
+                    diff_hunks,
+                    &crate::note_markers::NoteMarkers::default(),
+                );
+            })
+            .expect("draw");
+        app = clamp_right_pane_scroll_after_draw(app, outcome.clamped_right_pane_scroll);
+        positions.push(app.right_pane_scroll());
+    }
+    positions
+}
+
+/// Asserts `positions` never decreases step to step and eventually reaches
+/// at least `minimum_final` — the monotonic-progress-and-reaches-the-end
+/// contract this regression test exists to pin, shared by every
+/// `viewport_height`/view-mode case below. "At least" rather than "exactly"
+/// because `minimum_final` is the target symbol's own section-start line,
+/// while the settled scroll position can land anywhere from there through
+/// that symbol's own trailing hunk content — `symbol_id_for_scroll_line`'s
+/// reverse lookup, asserted separately by each caller, is what actually
+/// pins which symbol the settled position belongs to.
+fn assert_monotonic_and_reaches(positions: &[usize], minimum_final: usize) {
+    for window in positions.windows(2) {
+        assert!(
+            window[1] >= window[0],
+            "scroll must never regress: {positions:?}"
+        );
+    }
+    let final_position = *positions.last().expect("at least one position recorded");
+    assert!(
+        final_position >= minimum_final,
+        "scroll must reach at least the last symbol's section start ({minimum_final}): {positions:?}"
+    );
+}
+
+#[test]
+fn should_advance_scroll_monotonically_past_a_huge_wrapped_leading_line_in_unified_view() {
+    let report = report_with_giant_then_three_short_symbols();
+    let diff_hunks = diff_hunks_with_giant_then_three_short_sections();
+    let content = diff_shape::build_diff_pane_content(
+        &report,
+        &diff_hunks,
+        Some(&app::DiffTarget::File {
+            path: "lib.rs".to_string(),
+        }),
+    );
+    let last_line = diff_shape::section_start_line_for_symbol(
+        &content,
+        "lib.rs::third",
+        app::DiffViewMode::Unified,
+    )
+    .expect("third's section start must resolve");
+
+    for viewport_height in [2u16, 3, 4] {
+        let positions = scroll_positions_after_repeated_down(
+            &report,
+            &diff_hunks,
+            false,
+            40,
+            viewport_height + 6,
+            60,
+        );
+        assert_monotonic_and_reaches(&positions, last_line);
+
+        let resolved = diff_shape::symbol_id_for_scroll_line(
+            &content,
+            *positions.last().expect("at least one press recorded"),
+            app::DiffViewMode::Unified,
+        );
+        assert_eq!(
+            Some("lib.rs::third"),
+            resolved,
+            "reverse sync must resolve to the last symbol once scroll reaches the end (viewport_height={viewport_height})"
+        );
+    }
+}
+
+#[test]
+fn should_advance_scroll_monotonically_past_a_huge_wrapped_leading_line_in_split_view() {
+    let report = report_with_giant_then_three_short_symbols();
+    let diff_hunks = diff_hunks_with_giant_then_three_short_sections();
+    let content = diff_shape::build_diff_pane_content(
+        &report,
+        &diff_hunks,
+        Some(&app::DiffTarget::File {
+            path: "lib.rs".to_string(),
+        }),
+    );
+    let last_line = diff_shape::section_start_line_for_symbol(
+        &content,
+        "lib.rs::third",
+        app::DiffViewMode::Split,
+    )
+    .expect("third's section start must resolve");
+
+    for viewport_height in [2u16, 3, 4] {
+        let positions = scroll_positions_after_repeated_down(
+            &report,
+            &diff_hunks,
+            true,
+            170,
+            viewport_height + 6,
+            60,
+        );
+        assert_monotonic_and_reaches(&positions, last_line);
+
+        let resolved = diff_shape::symbol_id_for_scroll_line(
+            &content,
+            *positions.last().expect("at least one press recorded"),
+            app::DiffViewMode::Split,
+        );
+        assert_eq!(
+            Some("lib.rs::third"),
+            resolved,
+            "reverse sync must resolve to the last symbol once scroll reaches the end (viewport_height={viewport_height})"
+        );
+    }
+}
+
+#[test]
+fn should_not_oscillate_when_alternating_down_and_up_past_a_huge_wrapped_leading_line() {
+    let report = report_with_giant_then_three_short_symbols();
+    let diff_hunks = diff_hunks_with_giant_then_three_short_sections();
+    let content = diff_shape::build_diff_pane_content(
+        &report,
+        &diff_hunks,
+        Some(&app::DiffTarget::File {
+            path: "lib.rs".to_string(),
+        }),
+    );
+    let last_line = diff_shape::section_start_line_for_symbol(
+        &content,
+        "lib.rs::third",
+        app::DiffViewMode::Unified,
+    )
+    .expect("third's section start must resolve");
+    let diff_highlights = crate::highlight::highlight_diff_files(&diff_hunks);
+    let width = 40;
+    let height = 10;
+
+    let mut app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Open);
+    let draw_and_fold = |app: App, key: InputKey| -> App {
+        let app = app.handle_key(key);
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, height))
+                .expect("terminal");
+        let mut outcome = crate::ui::DrawOutcome::default();
+        terminal
+            .draw(|frame| {
+                outcome = crate::ui::draw(
+                    frame,
+                    &app,
+                    &report,
+                    &content,
+                    &diff_highlights,
+                    &app::BlastRadiusSelection::NotApplicable,
+                    None,
+                    &diff_hunks,
+                    &crate::note_markers::NoteMarkers::default(),
+                );
+            })
+            .expect("draw");
+        clamp_right_pane_scroll_after_draw(app, outcome.clamped_right_pane_scroll)
+    };
+
+    // Drive all the way down first, recording each step.
+    let mut down_positions = Vec::new();
+    for _ in 0..60 {
+        app = draw_and_fold(app, InputKey::Down);
+        down_positions.push(app.right_pane_scroll());
+    }
+    assert_monotonic_and_reaches(&down_positions, last_line);
+
+    // Then alternate Down/Up from the end: net movement per pair must be
+    // zero, and the value must never overshoot past what a single `Down`
+    // from the settled end position would produce.
+    for _ in 0..5 {
+        let before = app.right_pane_scroll();
+        app = draw_and_fold(app, InputKey::Down);
+        let after_down = app.right_pane_scroll();
+        app = draw_and_fold(app, InputKey::Up);
+        let after_up = app.right_pane_scroll();
+        assert!(
+            after_down >= before,
+            "Down must not regress scroll: before={before} after_down={after_down}"
+        );
+        assert!(
+            after_up <= after_down,
+            "Up must not leave scroll higher than the preceding Down: after_down={after_down} after_up={after_up}"
+        );
+    }
 }

--- a/rinkaku-tui/src/event_loop/scroll_sync_wrap_tests.rs
+++ b/rinkaku-tui/src/event_loop/scroll_sync_wrap_tests.rs
@@ -1,0 +1,495 @@
+//! Regression coverage for the scroll-unit fix (docs/adr/0052): every test
+//! in `scroll_sync_tests.rs` uses a pane 160 columns wide, where none of
+//! these fixtures' signatures ever wrap — so a bug that only manifests once
+//! `crate::ui::scroll::wrap_lines_with_origins`/`pair_wrap_with_origins`
+//! actually split a logical line into multiple display rows was invisible
+//! there. These tests use a narrow pane and signatures long enough to wrap,
+//! driven through the same `dispatch_draw_and_fold` pipeline
+//! `scroll_sync_tests.rs` uses for its own end-to-end coverage.
+//!
+//! - `should_land_symbol_selection_anchor_at_viewport_top_*`: symptom 1
+//!   (selecting a symbol did not scroll the diff pane to the corresponding
+//!   position) — the anchor row must be the first visible row after
+//!   auto-scroll, in both view modes.
+//! - `should_resolve_the_correct_symbol_when_scroll_position_lands_inside_a_preceding_wrapped_section`:
+//!   symptom 2 (scrolling stuck the tree-cursor sync on the wrong symbol) —
+//!   the reverse lookup must agree with what the pane actually has on
+//!   screen, not silently resolve past it because a wrapped section
+//!   inflated the display-row count relative to the logical-line count the
+//!   lookup itself uses.
+
+use super::{apply_diff_pane_selection_effects, clamp_right_pane_scroll_after_draw};
+use crate::app::{self, App, InputKey};
+use crate::event_loop::tests::empty_report;
+use crate::{diff_shape, diff_view};
+use pretty_assertions::assert_eq;
+use rinkaku_core::diff::LineRange;
+use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+use rinkaku_core::render::{FileReport, Report};
+
+/// Four symbols whose signatures are long enough to wrap at this file's
+/// narrow test widths (50-100 columns) — long parameter lists rather than
+/// artificially padded names, so the fixture still reads as a plausible
+/// signature.
+fn report_with_four_long_signature_symbols() -> Report {
+    fn symbol(id: &str, name: &str, range: LineRange, params: &str) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature: format!("fn {name}({params}) -> Result<ProcessedOutput, ProcessingError>"),
+            range,
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        }
+    }
+
+    Report {
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![
+                symbol(
+                    "lib.rs::first",
+                    "first",
+                    LineRange { start: 1, end: 2 },
+                    "input: RawInput, config: &ProcessingConfig",
+                ),
+                symbol(
+                    "lib.rs::second",
+                    "second",
+                    LineRange { start: 10, end: 11 },
+                    "input: RawInput, config: &ProcessingConfig, cache: &mut Cache",
+                ),
+                symbol(
+                    "lib.rs::third",
+                    "third",
+                    LineRange { start: 20, end: 21 },
+                    "input: RawInput, config: &ProcessingConfig, cache: &mut Cache, extra: bool",
+                ),
+                symbol(
+                    "lib.rs::fourth",
+                    "fourth",
+                    LineRange { start: 30, end: 31 },
+                    "input: RawInput, config: &ProcessingConfig, cache: &mut Cache, extra: bool, more: u64",
+                ),
+            ],
+        }],
+        ..empty_report()
+    }
+}
+
+fn diff_hunks_with_four_symbol_sections() -> Vec<diff_view::FileHunks> {
+    use diff_view::{DiffLine, DiffLineKind, Hunk};
+
+    fn hunk(header: &str, new_range: (usize, usize), line: &str) -> Hunk {
+        Hunk {
+            header: header.to_string(),
+            new_range: Some(new_range),
+            lines: vec![DiffLine {
+                kind: DiffLineKind::Context,
+                content: line.to_string(),
+            }],
+        }
+    }
+
+    vec![diff_view::FileHunks {
+        path: "lib.rs".to_string(),
+        hunks: vec![
+            hunk("@@ -1,1 +1,2 @@", (1, 2), "fn first(..) {}"),
+            hunk("@@ -10,1 +10,2 @@", (10, 11), "fn second(..) {}"),
+            hunk("@@ -20,1 +20,2 @@", (20, 21), "fn third(..) {}"),
+            hunk("@@ -30,1 +30,2 @@", (30, 31), "fn fourth(..) {}"),
+        ],
+    }]
+}
+
+/// Mirrors `scroll_sync_tests.rs`'s own `dispatch_draw_and_fold` exactly
+/// (one iteration of `crate::run_app`'s loop: dispatch + sync + draw +
+/// post-draw fold-back) — duplicated rather than shared because that
+/// function is private to its own file and this split (this file's own doc
+/// comment) is specifically about keeping the two fixtures apart.
+fn dispatch_draw_and_fold(
+    mut app: App,
+    report: &Report,
+    diff_hunks: &[diff_view::FileHunks],
+    last_diff_focus: Option<app::DiffFocus>,
+    input_key: InputKey,
+    width: u16,
+    height: u16,
+) -> App {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let effective_mode = app.diff_view_mode();
+    let scroll_before_dispatch = app.right_pane_scroll();
+    app = app.handle_key(input_key);
+    let effects = apply_diff_pane_selection_effects(
+        app,
+        report,
+        diff_hunks,
+        last_diff_focus,
+        scroll_before_dispatch,
+        effective_mode,
+    );
+    let app = effects.app;
+    let diff_pane_content = effects.diff_pane_content;
+
+    let diff_highlights = crate::highlight::highlight_diff_files(diff_hunks);
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+    let mut outcome = crate::ui::DrawOutcome::default();
+    terminal
+        .draw(|frame| {
+            outcome = crate::ui::draw(
+                frame,
+                &app,
+                report,
+                &diff_pane_content,
+                &diff_highlights,
+                &app::BlastRadiusSelection::NotApplicable,
+                None,
+                diff_hunks,
+                &crate::note_markers::NoteMarkers::default(),
+            );
+        })
+        .expect("draw");
+    clamp_right_pane_scroll_after_draw(app, outcome.clamped_right_pane_scroll)
+}
+
+/// The diff pane's rendered text, row by row, so a test can assert which
+/// row a given fragment first appears on (`render_scrollable_pane`'s header
+/// occupies fixed rows above the scrollable body, so text position within
+/// the pane — not just presence anywhere in the buffer — is what pins "at
+/// the top of the viewport").
+fn diff_pane_rows(terminal: &ratatui::Terminal<ratatui::backend::TestBackend>) -> Vec<String> {
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    // The right pane starts at 60% of the terminal width (`ENTRY_TREE_WIDTH_PERCENT`
+    // /`ENTRY_RIGHT_WIDTH_PERCENT`) — only that half is relevant to what the
+    // diff pane itself shows.
+    let right_start = area.width * 40 / 100;
+    (0..area.height)
+        .map(|y| {
+            (right_start..area.width)
+                .map(|x| buffer[(x, y)].symbol().to_string())
+                .collect::<String>()
+        })
+        .collect()
+}
+
+/// The first row index (0-based, within the diff pane's own rendered rows)
+/// containing `needle`, or `None` if it never appears — used to check that
+/// a symbol's anchor line lands inside the pane's scrollable body, not
+/// scrolled past the top edge into invisibility.
+fn first_row_containing(rows: &[String], needle: &str) -> Option<usize> {
+    rows.iter().position(|row| row.contains(needle))
+}
+
+/// Renders `app`/`diff_hunks` at `width`x`height` and returns the diff
+/// pane's rendered rows (`diff_pane_rows`), rebuilding the same
+/// `diff_pane_content` `dispatch_draw_and_fold` would have produced for
+/// `app`'s current selection — used after the fold-back loop to inspect
+/// the final frame without re-running the dispatch/sync step.
+fn render_diff_pane_rows(
+    app: &App,
+    report: &Report,
+    diff_hunks: &[diff_view::FileHunks],
+    width: u16,
+    height: u16,
+) -> Vec<String> {
+    let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, height))
+        .expect("terminal");
+    let diff_pane_content = diff_shape::build_diff_pane_content(
+        report,
+        diff_hunks,
+        app.selected_diff_target(report).as_ref(),
+    );
+    let diff_highlights = crate::highlight::highlight_diff_files(diff_hunks);
+    terminal
+        .draw(|frame| {
+            crate::ui::draw(
+                frame,
+                app,
+                report,
+                &diff_pane_content,
+                &diff_highlights,
+                &app::BlastRadiusSelection::NotApplicable,
+                None,
+                diff_hunks,
+                &crate::note_markers::NoteMarkers::default(),
+            );
+        })
+        .expect("draw");
+    diff_pane_rows(&terminal)
+}
+
+#[test]
+fn should_land_symbol_selection_anchor_at_viewport_top_in_unified_view() {
+    // Width 80: right pane inner width ~46 columns, well under `third`'s
+    // ~85-column signature — wrapping actually occurs (`ENTRY_RIGHT_WIDTH_PERCENT`'s
+    // 60% split plus `Block::bordered`'s 2-column border deduction).
+    let report = report_with_four_long_signature_symbols();
+    let diff_hunks = diff_hunks_with_four_symbol_sections();
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::ToggleSplitView); // App::new defaults to Split.
+    assert_eq!(Some("lib.rs::first"), app.selected_symbol_id());
+    let last_diff_focus = app.selected_diff_focus(&report);
+
+    // Two tree-cursor `Down`s land on `third`, past one whole wrapped
+    // section (`second`) — ADR 0027's auto-scroll should land the diff
+    // pane exactly on `third`'s own anchor row regardless.
+    let app = dispatch_draw_and_fold(
+        app,
+        &report,
+        &diff_hunks,
+        last_diff_focus,
+        InputKey::Down,
+        80,
+        20,
+    );
+    let last_diff_focus = app.selected_diff_focus(&report);
+    let app = dispatch_draw_and_fold(
+        app,
+        &report,
+        &diff_hunks,
+        last_diff_focus,
+        InputKey::Down,
+        80,
+        20,
+    );
+    assert_eq!(Some("lib.rs::third"), app.selected_symbol_id());
+
+    let rows = render_diff_pane_rows(&app, &report, &diff_hunks, 80, 20);
+    // `third`'s anchor line must be the first line of the pane's
+    // scrollable body — the header lines (identification/stats,
+    // `diff_pane_header_lines`) occupy fixed rows above it, so this checks
+    // it appears before `fourth`'s own anchor, not that it is at row 0
+    // literally.
+    let third_row = first_row_containing(&rows, "fn third(")
+        .expect("third's anchor line must be visible in the diff pane");
+    let fourth_row = first_row_containing(&rows, "fn fourth(");
+    if let Some(fourth_row) = fourth_row {
+        assert!(
+            third_row < fourth_row,
+            "third's anchor ({third_row}) must render above fourth's ({fourth_row})"
+        );
+    }
+    // Regression check for the pre-fix bug: `first`/`second`'s own anchor
+    // lines must have scrolled out of view once `third` is selected —
+    // before this fix, the logical-line scroll target was applied to the
+    // wrapped display-row viewport, so an offset short of the true wrapped
+    // position could leave earlier sections still on screen instead of
+    // scrolling to `third`.
+    assert_eq!(None, first_row_containing(&rows, "fn first("));
+    assert_eq!(None, first_row_containing(&rows, "fn second("));
+}
+
+#[test]
+fn should_land_symbol_selection_anchor_at_viewport_top_in_split_view() {
+    // Width 170: right pane inner width ~100, split into two ~49-wide
+    // columns (`MIN_SPLIT_VIEW_WIDTH` is 100) — `third`'s ~85-column
+    // signature still wraps on each side.
+    let report = report_with_four_long_signature_symbols();
+    let diff_hunks = diff_hunks_with_four_symbol_sections();
+    let app = App::new(&report).handle_key(InputKey::Down);
+    assert_eq!(app::DiffViewMode::Split, app.diff_view_mode());
+    assert_eq!(Some("lib.rs::first"), app.selected_symbol_id());
+    let last_diff_focus = app.selected_diff_focus(&report);
+
+    let app = dispatch_draw_and_fold(
+        app,
+        &report,
+        &diff_hunks,
+        last_diff_focus,
+        InputKey::Down,
+        170,
+        20,
+    );
+    let last_diff_focus = app.selected_diff_focus(&report);
+    let app = dispatch_draw_and_fold(
+        app,
+        &report,
+        &diff_hunks,
+        last_diff_focus,
+        InputKey::Down,
+        170,
+        20,
+    );
+    assert_eq!(Some("lib.rs::third"), app.selected_symbol_id());
+
+    let rows = render_diff_pane_rows(&app, &report, &diff_hunks, 170, 20);
+    let third_row = first_row_containing(&rows, "fn third(")
+        .expect("third's anchor line must be visible in the diff pane");
+    let fourth_row = first_row_containing(&rows, "fn fourth(");
+    if let Some(fourth_row) = fourth_row {
+        assert!(
+            third_row < fourth_row,
+            "third's anchor ({third_row}) must render above fourth's ({fourth_row})"
+        );
+    }
+    assert_eq!(None, first_row_containing(&rows, "fn first("));
+    assert_eq!(None, first_row_containing(&rows, "fn second("));
+}
+
+/// A giant symbol (a 20-parameter signature) followed by a one-line symbol
+/// — `giant`'s signature alone wraps into many display rows at this file's
+/// narrow test widths, so `small`'s logical section-start offset (a small
+/// number, e.g. 5) sits many display rows short of where `small` actually
+/// renders once `giant` has wrapped.
+fn report_with_giant_then_small_symbol() -> Report {
+    fn symbol(id: &str, name: &str, range: LineRange, signature: String) -> ExtractedSymbol {
+        ExtractedSymbol {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            signature,
+            range,
+            container: None,
+            referenced_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        }
+    }
+
+    let giant_params = (0..20)
+        .map(|index| format!("p{index}: Type{index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let giant_signature = format!("fn giant({giant_params}) -> Result<Output, Error>");
+
+    Report {
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![
+                symbol(
+                    "lib.rs::giant",
+                    "giant",
+                    LineRange { start: 1, end: 2 },
+                    giant_signature,
+                ),
+                symbol(
+                    "lib.rs::small",
+                    "small",
+                    LineRange { start: 10, end: 11 },
+                    "fn small()".to_string(),
+                ),
+            ],
+        }],
+        ..empty_report()
+    }
+}
+
+fn diff_hunks_with_giant_then_small_sections() -> Vec<diff_view::FileHunks> {
+    use diff_view::{DiffLine, DiffLineKind, Hunk};
+
+    vec![diff_view::FileHunks {
+        path: "lib.rs".to_string(),
+        hunks: vec![
+            Hunk {
+                header: "@@ -1,1 +1,2 @@".to_string(),
+                new_range: Some((1, 2)),
+                lines: vec![DiffLine {
+                    kind: DiffLineKind::Context,
+                    content: "fn giant(..) {}".to_string(),
+                }],
+            },
+            Hunk {
+                header: "@@ -10,1 +10,2 @@".to_string(),
+                new_range: Some((10, 11)),
+                lines: vec![DiffLine {
+                    kind: DiffLineKind::Context,
+                    content: "fn small() {}".to_string(),
+                }],
+            },
+        ],
+    }]
+}
+
+#[test]
+fn should_resolve_the_correct_symbol_when_scroll_position_lands_inside_a_preceding_wrapped_section()
+{
+    // Symptom 2's regression pin: before the fix, `render_scrollable_pane`
+    // clamped/consumed `requested_scroll` directly as a *display-row* index
+    // into the wrapped content, with no conversion from the *logical-line*
+    // unit `crate::diff_shape::section_start_line_for_symbol` produces it
+    // in. Requesting `small`'s logical section-start (a small number) left
+    // the rendered viewport still showing `giant`'s own wrapped
+    // continuation — `small`'s anchor line was nowhere on screen — while
+    // the fold-back nonetheless wrote that same small number back into
+    // `App::right_pane_scroll` unchanged (`clamp_scroll` never *increases*
+    // an in-bounds value), so the very next `symbol_id_for_scroll_line`
+    // reverse lookup reported `small` as selected despite the pane still
+    // showing `giant`: the tree cursor and the diff pane's own content
+    // silently disagreed about which symbol was "current".
+    let report = report_with_giant_then_small_symbol();
+    let diff_hunks = diff_hunks_with_giant_then_small_sections();
+    let content = diff_shape::build_diff_pane_content(
+        &report,
+        &diff_hunks,
+        Some(&app::DiffTarget::File {
+            path: "lib.rs".to_string(),
+        }),
+    );
+    let small_start = diff_shape::section_start_line_for_symbol(
+        &content,
+        "lib.rs::small",
+        app::DiffViewMode::Unified,
+    )
+    .expect("small's section start must resolve");
+
+    // Request `small`'s logical section-start directly (bypassing
+    // `apply_diff_pane_selection_effects`'s own gating, since this test
+    // targets `render_scrollable_pane`'s own unit contract in isolation)
+    // and render at a narrow width where `giant`'s signature wraps.
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::ToggleSplitView)
+        .handle_key(InputKey::Open)
+        .with_right_pane_scroll(small_start);
+    let diff_highlights = crate::highlight::highlight_diff_files(&diff_hunks);
+    let mut terminal =
+        ratatui::Terminal::new(ratatui::backend::TestBackend::new(40, 10)).expect("terminal");
+    let mut outcome = crate::ui::DrawOutcome::default();
+    terminal
+        .draw(|frame| {
+            outcome = crate::ui::draw(
+                frame,
+                &app,
+                &report,
+                &content,
+                &diff_highlights,
+                &app::BlastRadiusSelection::NotApplicable,
+                None,
+                &diff_hunks,
+                &crate::note_markers::NoteMarkers::default(),
+            );
+        })
+        .expect("draw");
+    let rows = diff_pane_rows(&terminal);
+    let folded_back_scroll = outcome
+        .clamped_right_pane_scroll
+        .expect("diff pane must report a clamped scroll");
+
+    assert!(
+        first_row_containing(&rows, "fn small(").is_some(),
+        "small's anchor line must be visible once requested at its own logical start; rows: {rows:?}"
+    );
+    let resolved = diff_shape::symbol_id_for_scroll_line(
+        &content,
+        folded_back_scroll,
+        app::DiffViewMode::Unified,
+    );
+    assert_eq!(
+        Some("lib.rs::small"),
+        resolved,
+        "the reverse lookup fed the folded-back scroll must agree with what the pane actually shows"
+    );
+}

--- a/rinkaku-tui/src/ui/scroll.rs
+++ b/rinkaku-tui/src/ui/scroll.rs
@@ -116,7 +116,8 @@ pub(crate) fn render_scrollable_pane(
             let display_row = clamp_scroll(wrapped.len(), viewport_height, requested_display_row);
             let paragraph = Paragraph::new(wrapped.clone()).scroll((display_row as u16, 0));
             frame.render_widget(paragraph, body_area);
-            let logical_scroll = display_row_to_logical_line(&origins, display_row);
+            let logical_scroll =
+                resolve_folded_back_logical_line(&origins, display_row, requested_scroll);
             (wrapped.len(), display_row, logical_scroll)
         }
         Body::Split(left, right) => {
@@ -151,7 +152,8 @@ pub(crate) fn render_scrollable_pane(
                 Paragraph::new(right_rows.clone()).scroll((display_row as u16, 0)),
                 right_area,
             );
-            let logical_scroll = display_row_to_logical_line(&origins, display_row);
+            let logical_scroll =
+                resolve_folded_back_logical_line(&origins, display_row, requested_scroll);
             (left_rows.len(), display_row, logical_scroll)
         }
     };
@@ -309,6 +311,35 @@ pub(crate) fn display_row_to_logical_line(origins: &[usize], display_row: usize)
         .or_else(|| origins.last())
         .copied()
         .unwrap_or(0)
+}
+
+/// The logical-line value [`render_scrollable_pane`] should write back to
+/// its caller, given `origins`, the just-clamped `display_row`, and the
+/// `requested_logical_line` that produced it before clamping.
+///
+/// Plain [`display_row_to_logical_line`] is not enough here: when
+/// `display_row` lands *inside* a preceding logical line's wrapped span
+/// (rather than exactly at its first row) — which happens whenever
+/// `clamp_scroll` pulls the display row back into a span that started
+/// before the requested logical line — folding back reports that earlier
+/// line's own index, silently undoing the request. The next `Down` then
+/// asks for `requested_logical_line + 1` again, [`logical_line_to_display_row`]
+/// resolves it to the same clamped `display_row`, and the value never
+/// advances. Flooring the fold-back at `requested_logical_line` (itself
+/// capped to the last available logical line, so an overscrolled request
+/// cannot be reported as unclamped) keeps every request's floor intact
+/// without touching the display-row clamp `Paragraph::scroll` actually
+/// consumes.
+pub(crate) fn resolve_folded_back_logical_line(
+    origins: &[usize],
+    display_row: usize,
+    requested_logical_line: usize,
+) -> usize {
+    let Some(&last_logical_line) = origins.last() else {
+        return 0;
+    };
+    let capped_request = requested_logical_line.min(last_logical_line);
+    display_row_to_logical_line(origins, display_row).max(capped_request)
 }
 
 /// Wraps a single logical [`Line`] into one or more output lines, per

--- a/rinkaku-tui/src/ui/scroll.rs
+++ b/rinkaku-tui/src/ui/scroll.rs
@@ -1,10 +1,18 @@
 //! Pure scroll/wrap helpers shared by the panes in this module — extracted so
 //! `clamp_scroll`, `scroll_indicator`, `visible_index_window`,
 //! `window_overflow_indicators`, `windowed_rows_with_indicators`,
-//! `wrap_lines`/`wrap_one_line`, and `truncate_to_width` stay unit-testable
-//! without a live `ratatui::backend::TestBackend`, and so
+//! `wrap_lines_with_origins`/`wrap_one_line`, and `truncate_to_width` stay
+//! unit-testable without a live `ratatui::backend::TestBackend`, and so
 //! [`render_scrollable_pane`] itself (the one non-pure helper here) has a
 //! single home shared by every pane that scrolls.
+//!
+//! `App::right_pane_scroll` is a logical-line offset (an index into the
+//! unwrapped content), the same unit `crate::diff_shape` computes symbol
+//! section positions in — [`logical_line_to_display_row`]/
+//! [`display_row_to_logical_line`] are the only place that unit is ever
+//! converted to/from the wrapped display-row index `ratatui::widgets::Paragraph::scroll`
+//! actually consumes, confining wrap-width knowledge to this module rather
+//! than leaking it into `App`/`crate::diff_shape`.
 
 use super::style::pane_border_style;
 use ratatui::Frame;
@@ -15,7 +23,9 @@ use ratatui::widgets::{Block, Paragraph};
 use unicode_width::UnicodeWidthChar;
 
 /// Renders `lines` into a bordered pane titled `title`, scrolled to
-/// `requested_scroll` lines down and clamped to what actually fits
+/// `requested_scroll` *logical* lines down (an index into the unwrapped
+/// `body`, the same unit `crate::diff_shape::walk_sections` and its
+/// derivatives compute against) and clamped to what actually fits
 /// (`clamp_scroll`'s own doc comment on why clamping only happens here,
 /// not in `crate::app`). When the content overflows the pane's inner
 /// height, the title grows a `(first-last/total)` suffix so the reviewer
@@ -28,26 +38,28 @@ use unicode_width::UnicodeWidthChar;
 /// duplicating the clamp-then-scroll-then-indicator sequence, since the two
 /// panes' only difference is which `Vec<Line>` and title they pass in.
 ///
-/// `lines` is wrapped (via [`wrap_lines`]) to the pane's inner width
-/// *before* `clamp_scroll`/`scroll_indicator` run and *before* handing it to
-/// `Paragraph`, and `Paragraph::wrap` is deliberately not used here: that
-/// widget's own line-wrapping happens after `Paragraph::scroll` has already
-/// consumed `scroll.y` as an offset into the *unwrapped* logical lines, so
-/// any logical line long enough to wrap desyncs the scroll unit from the
-/// rendered unit — content past the first wrapped line of such a line
-/// becomes unreachable at any scroll offset, and the overflow indicator
-/// (computed from logical line count) undercounts and falsely claims
-/// everything is visible. Wrapping first makes every one of
-/// `clamp_scroll`/`scroll_indicator`/`Paragraph::scroll` operate on the same
-/// "one rendered terminal row" unit.
+/// `lines` is wrapped (via [`wrap_lines_with_origins`]) to the pane's inner
+/// width *before* handing it to `Paragraph`, and `Paragraph::wrap` is
+/// deliberately not used here: that widget's own line-wrapping happens
+/// after `Paragraph::scroll` has already consumed `scroll.y`, which would
+/// force the scroll unit back onto rendered rows. Confining wrap knowledge
+/// to this function (rather than the logical-line unit `App::right_pane_scroll`
+/// and `crate::diff_shape` share) is this fix's whole point: converting
+/// `requested_scroll` to its first display row via [`logical_line_to_display_row`]
+/// happens *after* wrapping, `clamp_scroll`/`scroll_indicator`/
+/// `Paragraph::scroll` all operate on the wrapped (display-row) unit as
+/// before, and the clamped result is converted back to a logical line via
+/// [`display_row_to_logical_line`] before being returned — so every
+/// consumer outside this function only ever sees logical lines.
 ///
-/// Returns the actually-applied (clamped) scroll offset — dogfooding
-/// finding: `App::right_pane_scroll` is deliberately an *unclamped*
-/// "requested" value (its own doc comment), so repeated `j` past the
-/// content's end kept incrementing that request with no visible effect,
-/// and winding it back down again took as many `k` presses as it took to
-/// overshoot — the scrollbar-less pane gave no feedback that this had
-/// happened. `crate::run_app` feeds this return value back into `App` via
+/// Returns the actually-applied (clamped) scroll offset, in the same
+/// logical-line unit as `requested_scroll` — dogfooding finding:
+/// `App::right_pane_scroll` is deliberately an *unclamped* "requested"
+/// value (its own doc comment), so repeated `j` past the content's end
+/// kept incrementing that request with no visible effect, and winding it
+/// back down again took as many `k` presses as it took to overshoot — the
+/// scrollbar-less pane gave no feedback that this had happened.
+/// `crate::run_app` feeds this return value back into `App` via
 /// `App::with_right_pane_scroll` after every draw, so the *next* `k` moves
 /// the visible content immediately instead of first re-tracing the
 /// overshoot.
@@ -96,14 +108,16 @@ pub(crate) fn render_scrollable_pane(
         Layout::vertical([Constraint::Length(header_rows), Constraint::Min(0)]).areas(inner_area);
 
     let viewport_height = body_area.height as usize;
-    let (content_len, scroll) = match body {
+    let (content_len, display_row, logical_scroll) = match body {
         Body::Single(lines) => {
             let viewport_width = body_area.width as usize;
-            let wrapped = wrap_lines(lines, viewport_width);
-            let scroll = clamp_scroll(wrapped.len(), viewport_height, requested_scroll);
-            let paragraph = Paragraph::new(wrapped.clone()).scroll((scroll as u16, 0));
+            let (wrapped, origins) = wrap_lines_with_origins(lines, viewport_width);
+            let requested_display_row = logical_line_to_display_row(&origins, requested_scroll);
+            let display_row = clamp_scroll(wrapped.len(), viewport_height, requested_display_row);
+            let paragraph = Paragraph::new(wrapped.clone()).scroll((display_row as u16, 0));
             frame.render_widget(paragraph, body_area);
-            (wrapped.len(), scroll)
+            let logical_scroll = display_row_to_logical_line(&origins, display_row);
+            (wrapped.len(), display_row, logical_scroll)
         }
         Body::Split(left, right) => {
             // A 1-column gutter between the two sides, mirroring a border's
@@ -115,27 +129,30 @@ pub(crate) fn render_scrollable_pane(
                 Constraint::Min(0),
             ])
             .areas(body_area);
-            let (left_rows, right_rows) = pair_wrap(
+            let (left_rows, right_rows, origins) = pair_wrap_with_origins(
                 left,
                 right,
                 left_area.width as usize,
                 right_area.width as usize,
             );
-            let scroll = clamp_scroll(left_rows.len(), viewport_height, requested_scroll);
+            let requested_display_row = logical_line_to_display_row(&origins, requested_scroll);
+            let display_row = clamp_scroll(left_rows.len(), viewport_height, requested_display_row);
 
             frame.render_widget(
-                Paragraph::new(left_rows.clone()).scroll((scroll as u16, 0)),
+                Paragraph::new(left_rows.clone()).scroll((display_row as u16, 0)),
                 left_area,
             );
             frame.render_widget(
-                Paragraph::new(vec![Line::raw("│"); left_rows.len()]).scroll((scroll as u16, 0)),
+                Paragraph::new(vec![Line::raw("│"); left_rows.len()])
+                    .scroll((display_row as u16, 0)),
                 gutter_area,
             );
             frame.render_widget(
-                Paragraph::new(right_rows.clone()).scroll((scroll as u16, 0)),
+                Paragraph::new(right_rows.clone()).scroll((display_row as u16, 0)),
                 right_area,
             );
-            (left_rows.len(), scroll)
+            let logical_scroll = display_row_to_logical_line(&origins, display_row);
+            (left_rows.len(), display_row, logical_scroll)
         }
     };
 
@@ -143,7 +160,10 @@ pub(crate) fn render_scrollable_pane(
     // (e.g. `" Detail "`, matching every other `Block` title in this
     // module) — trim the trailing one before appending the indicator so
     // the two don't produce a double space (`"Detail  (1-17/43)"`).
-    let title = match scroll_indicator(content_len, viewport_height, scroll) {
+    // The indicator is measured in display rows (`content_len` is the
+    // wrapped row count), not logical lines, so it uses `display_row`
+    // rather than the logical-line `logical_scroll` this function returns.
+    let title = match scroll_indicator(content_len, viewport_height, display_row) {
         Some(indicator) => format!("{}{indicator} ", title.trim_end()),
         None => title.to_string(),
     };
@@ -156,7 +176,7 @@ pub(crate) fn render_scrollable_pane(
         let header = Paragraph::new(header_lines[..header_rows as usize].to_vec());
         frame.render_widget(header, header_area);
     }
-    scroll
+    logical_scroll
 }
 
 /// [`render_scrollable_pane`]'s scrollable content, either a single column
@@ -177,14 +197,22 @@ pub(crate) enum Body<'a> {
 /// its counterpart on the other side at a narrow column width — this
 /// function pads per logical row so the two columns never drift out of
 /// alignment after wrapping.
-pub(crate) fn pair_wrap(
+///
+/// Also returns, for each output display row, the logical row index (the
+/// shared `left`/`right` index) it was wrapped from — the split-view input
+/// to [`logical_line_to_display_row`]/[`display_row_to_logical_line`], so
+/// [`render_scrollable_pane`] can convert between `App::right_pane_scroll`'s
+/// logical-line unit and the wrapped rows `Paragraph::scroll` actually
+/// consumes.
+pub(crate) fn pair_wrap_with_origins(
     left: &[Line<'static>],
     right: &[Line<'static>],
     left_width: usize,
     right_width: usize,
-) -> (Vec<Line<'static>>, Vec<Line<'static>>) {
+) -> (Vec<Line<'static>>, Vec<Line<'static>>, Vec<usize>) {
     let mut left_out = Vec::new();
     let mut right_out = Vec::new();
+    let mut origins = Vec::new();
     let row_count = left.len().max(right.len());
     for index in 0..row_count {
         let left_wrapped = left
@@ -199,9 +227,10 @@ pub(crate) fn pair_wrap(
         for row in 0..rows {
             left_out.push(left_wrapped.get(row).cloned().unwrap_or(Line::raw("")));
             right_out.push(right_wrapped.get(row).cloned().unwrap_or(Line::raw("")));
+            origins.push(index);
         }
     }
-    (left_out, right_out)
+    (left_out, right_out, origins)
 }
 
 /// Wraps each of `lines` to `width` display columns, splitting a logical
@@ -229,20 +258,61 @@ pub(crate) fn pair_wrap(
 /// into — an actual zero-width pane cannot render any column anyway, and
 /// looping without ever advancing would otherwise be a defensive infinite-
 /// loop risk).
-pub(crate) fn wrap_lines(lines: &[Line<'static>], width: usize) -> Vec<Line<'static>> {
+///
+/// Also returns, for each output display row, the index into `lines` (the
+/// logical line, `App::right_pane_scroll`'s unit) it was wrapped from — the
+/// single-column input to [`logical_line_to_display_row`]/
+/// [`display_row_to_logical_line`], mirroring [`pair_wrap_with_origins`] for
+/// the split-view body.
+pub(crate) fn wrap_lines_with_origins(
+    lines: &[Line<'static>],
+    width: usize,
+) -> (Vec<Line<'static>>, Vec<usize>) {
     if width == 0 {
-        return lines.to_vec();
+        return (lines.to_vec(), (0..lines.len()).collect());
     }
 
     let mut output = Vec::new();
-    for line in lines {
-        output.extend(wrap_one_line(line, width));
+    let mut origins = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        let wrapped = wrap_one_line(line, width);
+        origins.extend(std::iter::repeat_n(index, wrapped.len()));
+        output.extend(wrapped);
     }
-    output
+    (output, origins)
+}
+
+/// Converts a logical-line offset (`App::right_pane_scroll`'s unit, and
+/// [`crate::diff_shape::walk_sections`]'s) to the display-row index of that
+/// logical line's *first* wrapped row, given `origins` (either
+/// [`wrap_lines_with_origins`]'s or [`pair_wrap_with_origins`]'s per-row
+/// logical-line index). A `logical_line` past every origin (an overscroll
+/// about to be clamped by [`clamp_scroll`] anyway, or empty content) maps to
+/// `origins.len()` — one past the last display row, which `clamp_scroll`
+/// then pulls back into range exactly like any other overscrolled request.
+pub(crate) fn logical_line_to_display_row(origins: &[usize], logical_line: usize) -> usize {
+    origins
+        .iter()
+        .position(|&origin| origin >= logical_line)
+        .unwrap_or(origins.len())
+}
+
+/// The inverse of [`logical_line_to_display_row`]: the logical-line index
+/// that display row `display_row` was wrapped from, given the same
+/// `origins`. `display_row` past the end of `origins` (defensively — a
+/// caller passes in a value [`clamp_scroll`] already bounded to
+/// `origins.len() - 1` in practice) falls back to the last origin, or `0`
+/// when `origins` itself is empty (nothing to scroll to).
+pub(crate) fn display_row_to_logical_line(origins: &[usize], display_row: usize) -> usize {
+    origins
+        .get(display_row)
+        .or_else(|| origins.last())
+        .copied()
+        .unwrap_or(0)
 }
 
 /// Wraps a single logical [`Line`] into one or more output lines, per
-/// [`wrap_lines`]'s doc comment. A line with no spans at all (a blank line)
+/// [`wrap_lines_with_origins`]'s doc comment. A line with no spans at all (a blank line)
 /// produces exactly one empty output line, matching `ratatui::widgets::Wrap`
 /// rendering a blank logical line as one blank row rather than zero rows.
 pub(crate) fn wrap_one_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
@@ -288,7 +358,7 @@ pub(crate) fn wrap_one_line(line: &Line<'static>, width: usize) -> Vec<Line<'sta
 
 /// Truncates `text` to fit within `width` display columns, replacing the
 /// tail with a single `…` (1 column) when it does not fit — unlike
-/// [`wrap_lines`], which turns overflow into *more rows*, this turns
+/// [`wrap_lines_with_origins`], which turns overflow into *more rows*, this turns
 /// overflow into a shorter *single* row, for callers whose windowing math
 /// (e.g. [`windowed_rows_with_indicators`]) has already committed to
 /// "one logical item = one rendered row" and would desync if a row were

--- a/rinkaku-tui/src/ui/scroll_tests/mod.rs
+++ b/rinkaku-tui/src/ui/scroll_tests/mod.rs
@@ -4,11 +4,14 @@
 //! - `clamp_and_indicator` — `clamp_scroll`/`scroll_indicator`
 //! - `windowing` — `visible_index_window`/`window_overflow_indicators`/
 //!   `windowed_rows_with_indicators` (the #61-review cursor-follow fix)
-//! - `wrap_lines` — `wrap_lines`/`wrap_one_line`
+//! - `wrap_lines` — `wrap_lines_with_origins`/`wrap_one_line`
 //! - `truncation` — `truncate_to_width`/`truncate_to_width_keeping_tail`/
 //!   `truncate_line_to_width`
 //! - `pair_wrap` — ADR 0044's per-side wrap-then-pad helper for the Diff
 //!   pane's split view
+//! - `wrap_origins` — the logical-line <-> display-row conversion
+//!   (`logical_line_to_display_row`/`display_row_to_logical_line`) this
+//!   scroll-unit fix adds
 
 use super::*;
 
@@ -17,3 +20,4 @@ mod pair_wrap;
 mod truncation;
 mod windowing;
 mod wrap_lines;
+mod wrap_origins;

--- a/rinkaku-tui/src/ui/scroll_tests/pair_wrap.rs
+++ b/rinkaku-tui/src/ui/scroll_tests/pair_wrap.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+fn pair_wrap(
+    left: &[Line<'static>],
+    right: &[Line<'static>],
+    left_width: usize,
+    right_width: usize,
+) -> (Vec<Line<'static>>, Vec<Line<'static>>) {
+    let (left_out, right_out, _origins) =
+        pair_wrap_with_origins(left, right, left_width, right_width);
+    (left_out, right_out)
+}
+
 #[test]
 fn should_return_empty_columns_when_both_sides_are_empty() {
     let actual = pair_wrap(&[], &[], 10, 10);

--- a/rinkaku-tui/src/ui/scroll_tests/wrap_lines.rs
+++ b/rinkaku-tui/src/ui/scroll_tests/wrap_lines.rs
@@ -1,13 +1,13 @@
 use super::*;
 use ratatui::style::{Color, Style};
 
-// --- wrap_lines (pure helper) ---
+// --- wrap_lines_with_origins (pure helper) ---
 
 #[test]
 fn should_return_lines_unchanged_when_width_is_zero() {
     let lines = vec![Line::raw("hello world")];
 
-    let actual = wrap_lines(&lines, 0);
+    let actual = wrap_lines_with_origins(&lines, 0).0;
 
     assert_eq!(lines, actual);
 }
@@ -16,7 +16,7 @@ fn should_return_lines_unchanged_when_width_is_zero() {
 fn should_return_one_empty_line_when_input_line_is_blank() {
     let lines = vec![Line::raw("")];
 
-    let actual = wrap_lines(&lines, 10);
+    let actual = wrap_lines_with_origins(&lines, 10).0;
 
     assert_eq!(vec![Line::raw("")], actual);
 }
@@ -25,7 +25,7 @@ fn should_return_one_empty_line_when_input_line_is_blank() {
 fn should_not_wrap_when_line_fits_exactly_within_width() {
     let lines = vec![Line::raw("abcde")];
 
-    let actual = wrap_lines(&lines, 5);
+    let actual = wrap_lines_with_origins(&lines, 5).0;
 
     assert_eq!(vec![Line::raw("abcde")], actual);
 }
@@ -34,7 +34,7 @@ fn should_not_wrap_when_line_fits_exactly_within_width() {
 fn should_split_long_ascii_line_into_multiple_lines_at_the_width_boundary() {
     let lines = vec![Line::raw("abcdefghij")];
 
-    let actual = wrap_lines(&lines, 4);
+    let actual = wrap_lines_with_origins(&lines, 4).0;
 
     assert_eq!(
         vec![Line::raw("abcd"), Line::raw("efgh"), Line::raw("ij"),],
@@ -49,7 +49,7 @@ fn should_wrap_full_width_characters_without_splitting_a_double_width_char_acros
     // so it wraps onto the next line rather than being sliced in half.
     let lines = vec![Line::raw("ああa")];
 
-    let actual = wrap_lines(&lines, 3);
+    let actual = wrap_lines_with_origins(&lines, 3).0;
 
     assert_eq!(vec![Line::raw("あ"), Line::raw("あa")], actual);
 }
@@ -59,7 +59,7 @@ fn should_preserve_span_style_on_both_fragments_when_a_styled_span_is_split_by_w
     let style = Style::default().fg(Color::Red);
     let lines = vec![Line::from(vec![Span::styled("abcdef", style)])];
 
-    let actual = wrap_lines(&lines, 4);
+    let actual = wrap_lines_with_origins(&lines, 4).0;
 
     assert_eq!(
         vec![
@@ -78,7 +78,7 @@ fn should_preserve_distinct_span_styles_when_a_multi_span_line_wraps_across_span
     let red = Style::default().fg(Color::Red);
     let lines = vec![Line::from(vec![Span::raw("ab"), Span::styled("cdef", red)])];
 
-    let actual = wrap_lines(&lines, 3);
+    let actual = wrap_lines_with_origins(&lines, 3).0;
 
     assert_eq!(
         vec![
@@ -93,7 +93,7 @@ fn should_preserve_distinct_span_styles_when_a_multi_span_line_wraps_across_span
 fn should_wrap_each_logical_line_independently_when_multiple_lines_are_passed() {
     let lines = vec![Line::raw("abcdef"), Line::raw("xy")];
 
-    let actual = wrap_lines(&lines, 4);
+    let actual = wrap_lines_with_origins(&lines, 4).0;
 
     assert_eq!(
         vec![Line::raw("abcd"), Line::raw("ef"), Line::raw("xy")],

--- a/rinkaku-tui/src/ui/scroll_tests/wrap_origins.rs
+++ b/rinkaku-tui/src/ui/scroll_tests/wrap_origins.rs
@@ -125,3 +125,60 @@ fn should_round_trip_a_logical_line_through_display_row_conversion_when_it_wraps
 
     assert_eq!(2, actual);
 }
+
+// --- resolve_folded_back_logical_line: fold-back that never undoes a
+// request that landed inside a preceding wrapped span ---
+
+// 48 display rows of logical line 0 (a huge wrapped signature), followed
+// by three unwrapped short lines.
+fn origins_with_one_huge_wrapped_line_then_three_short_lines() -> Vec<usize> {
+    let mut origins = vec![0; 48];
+    origins.extend([1, 2, 3]);
+    origins
+}
+
+#[test]
+fn should_return_the_requested_logical_line_when_the_clamped_display_row_lands_inside_its_own_wrapped_span()
+ {
+    let origins = origins_with_one_huge_wrapped_line_then_three_short_lines();
+
+    let actual = resolve_folded_back_logical_line(&origins, 0, 0);
+
+    assert_eq!(0, actual);
+}
+
+#[test]
+fn should_return_the_requested_logical_line_when_it_resolves_past_the_wrapped_span_into_a_short_line()
+ {
+    let origins = origins_with_one_huge_wrapped_line_then_three_short_lines();
+
+    let actual = resolve_folded_back_logical_line(&origins, 0, 1);
+
+    assert_eq!(1, actual);
+}
+
+#[test]
+fn should_return_the_last_logical_line_when_the_clamped_display_row_lands_on_its_last_wrapped_row()
+{
+    let origins = origins_with_one_huge_wrapped_line_then_three_short_lines();
+
+    let actual = resolve_folded_back_logical_line(&origins, 47, 3);
+
+    assert_eq!(3, actual);
+}
+
+#[test]
+fn should_cap_an_overscrolled_request_at_the_last_logical_line() {
+    let origins = origins_with_one_huge_wrapped_line_then_three_short_lines();
+
+    let actual = resolve_folded_back_logical_line(&origins, 47, 9);
+
+    assert_eq!(3, actual);
+}
+
+#[test]
+fn should_fall_back_to_zero_when_origins_is_empty() {
+    let actual = resolve_folded_back_logical_line(&[], 0, 5);
+
+    assert_eq!(0, actual);
+}

--- a/rinkaku-tui/src/ui/scroll_tests/wrap_origins.rs
+++ b/rinkaku-tui/src/ui/scroll_tests/wrap_origins.rs
@@ -1,0 +1,127 @@
+use super::*;
+
+// --- wrap_lines_with_origins / pair_wrap_with_origins: per-row logical-line
+// index ---
+
+#[test]
+fn should_map_every_display_row_to_its_source_logical_line_when_one_line_wraps_into_three() {
+    let lines = vec![Line::raw("abcdefghij"), Line::raw("k")];
+
+    let (wrapped, origins) = wrap_lines_with_origins(&lines, 4);
+
+    assert_eq!(
+        vec![
+            Line::raw("abcd"),
+            Line::raw("efgh"),
+            Line::raw("ij"),
+            Line::raw("k")
+        ],
+        wrapped
+    );
+    assert_eq!(vec![0, 0, 0, 1], origins);
+}
+
+#[test]
+fn should_map_every_display_row_to_its_shared_logical_index_when_split_rows_wrap_unevenly() {
+    let left = vec![Line::raw("abcdefgh"), Line::raw("z")];
+    let right = vec![Line::raw("new")];
+
+    let (left_rows, right_rows, origins) = pair_wrap_with_origins(&left, &right, 4, 10);
+
+    assert_eq!(
+        vec![Line::raw("abcd"), Line::raw("efgh"), Line::raw("z")],
+        left_rows
+    );
+    assert_eq!(
+        vec![Line::raw("new"), Line::raw(""), Line::raw("")],
+        right_rows
+    );
+    assert_eq!(vec![0, 0, 1], origins);
+}
+
+// --- logical_line_to_display_row ---
+
+#[test]
+fn should_return_zero_when_content_is_empty() {
+    let actual = logical_line_to_display_row(&[], 0);
+
+    assert_eq!(0, actual);
+}
+
+#[test]
+fn should_return_the_first_display_row_of_a_logical_line_that_did_not_wrap() {
+    let origins = vec![0, 1, 2];
+
+    let actual = logical_line_to_display_row(&origins, 1);
+
+    assert_eq!(1, actual);
+}
+
+#[test]
+fn should_return_the_first_wrapped_row_when_the_target_logical_line_wraps_into_several_rows() {
+    // Logical line 0 wraps into display rows 0-2, logical line 1 is
+    // display row 3 — landing on logical line 0 must resolve to its
+    // *first* row (0), not any of its later wrapped rows.
+    let origins = vec![0, 0, 0, 1];
+
+    let actual = logical_line_to_display_row(&origins, 0);
+
+    assert_eq!(0, actual);
+}
+
+#[test]
+fn should_return_one_past_the_last_display_row_when_logical_line_overscrolls() {
+    let origins = vec![0, 0, 1];
+
+    let actual = logical_line_to_display_row(&origins, 5);
+
+    assert_eq!(3, actual);
+}
+
+// --- display_row_to_logical_line ---
+
+#[test]
+fn should_return_zero_when_origins_is_empty() {
+    let actual = display_row_to_logical_line(&[], 0);
+
+    assert_eq!(0, actual);
+}
+
+#[test]
+fn should_resolve_every_wrapped_row_of_a_logical_line_to_the_same_logical_index() {
+    // Logical line 0 wraps into display rows 0-2 — all three must
+    // resolve back to logical line 0, matching the reverse-lookup
+    // behavior `crate::diff_shape::symbol_id_for_scroll_line` needs once
+    // `App::right_pane_scroll` is folded back through this conversion
+    // (symptom 2 of the scroll-unit bug: without it, scrolling past a
+    // wrapped section always resolved to the last symbol instead of the
+    // one actually on screen).
+    let origins = vec![0, 0, 0, 1];
+
+    assert_eq!(0, display_row_to_logical_line(&origins, 0));
+    assert_eq!(0, display_row_to_logical_line(&origins, 1));
+    assert_eq!(0, display_row_to_logical_line(&origins, 2));
+    assert_eq!(1, display_row_to_logical_line(&origins, 3));
+}
+
+#[test]
+fn should_fall_back_to_the_last_origin_when_display_row_is_past_the_end() {
+    let origins = vec![0, 1, 2];
+
+    let actual = display_row_to_logical_line(&origins, 100);
+
+    assert_eq!(2, actual);
+}
+
+// --- round trip ---
+
+#[test]
+fn should_round_trip_a_logical_line_through_display_row_conversion_when_it_wraps() {
+    let lines = vec![Line::raw("abcdefghij"), Line::raw("k"), Line::raw("lmno")];
+    let (_wrapped, origins) = wrap_lines_with_origins(&lines, 4);
+
+    let display_row = logical_line_to_display_row(&origins, 2);
+    let actual = display_row_to_logical_line(&origins, display_row);
+
+    assert_eq!(2, actual);
+}


### PR DESCRIPTION
## Summary

Fixes two diff-pane sync bugs with a single root cause: `App::right_pane_scroll` was written in **pre-wrap logical lines** by the symbol→scroll path (`diff_shape::walk_sections` and friends) but consumed as **post-wrap display rows** by the renderer (`render_scrollable_pane`). Whenever any line wrapped, the two sides disagreed:

1. Selecting a symbol in the left pane jumped the diff pane short of that symbol's anchor line (worse in split view, where columns are narrower).
2. Scrolling the diff pane made the reverse-synced tree cursor stick on the last symbol, because the scroll value overshot the logical-line total.

## Fix (ADR 0052)

`right_pane_scroll` is now **always a pre-wrap logical-line offset**; wrap knowledge is confined to the renderer. `render_scrollable_pane` builds a logical-line→display-row origin map (`wrap_lines_with_origins` / `pair_wrap_with_origins`), converts before clamping, and folds the applied value back to logical lines for the post-draw write-back.

A follow-up fix (found by this PR's own dynamic-verification pass) closes a fixed point in that fold-back: when the display-row clamp landed inside a huge wrapped line's span, the folded-back value cancelled the requested scroll and `Down` stopped advancing. `resolve_folded_back_logical_line` now lower-bounds the fold-back at the requested logical line (capped at the last origin), so repeated `Down` always reaches the last logical line.

## Verification

- New regression tests use fixtures where wrapping actually occurs (the tests added with the original symptom report never wrapped, which is why they missed this): anchor-landing on selection (unified + split), monotonic reverse sync, monotonic advance past a huge wrapped leading line at viewport heights 2/3/4, and no Down/Up oscillation. All confirmed failing before their respective fixes.
- Static (map-assisted) review: unit-contract consistency confirmed across every `right_pane_scroll` read/write site; no blockers.
- Dynamic pass (ratatui TestBackend, headless) plus real-binary checks: non-TTY stdin/stdout, empty input, bad refs, malformed input — no panics.
- `make test` (860) and `make lint` (fmt + clippy `-D warnings`) pass.

## Known follow-up (pre-existing, not introduced here)

`Ctrl-d`/`Ctrl-u` half-page scrolling adds `viewport_height / 2` (a display-row quantity) directly to the logical-line field — a coarse approximation that predates this PR and now visibly contradicts the written contract. Fixing it needs viewport-height-in-logical-lines plumbing; deferred to a follow-up.

## Notes

- Parallel PR #169 (per-symbol hunk splitting, ADR 0053) touches adjacent test files; whichever lands second may need a trivial rebase.