### PR TITLE
feat(tui): drop uppercase key aliases and filter help overlay by focus

### DIFF
--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -15,7 +15,12 @@
 //! `rust_i18n::t!` (ADR 0055), which allocates and so cannot run in const
 //! context. Key labels (`keys`, `swatch`, `term`) stay `&'static str` —
 //! ADR 0055 scopes translation to prose, not key labels or term names.
+//!
+//! [`applicable_help_groups`] narrows [`help_content`]'s full keymap down to
+//! the groups reachable from the reviewer's current screen/focus, so the
+//! overlay never lists a binding that would be a no-op if pressed right now.
 
+use crate::app::{Focus, Screen};
 use crate::locale::Locale;
 
 /// One row of the keymap: the key(s) as displayed text, and what they do.
@@ -46,10 +51,24 @@ pub struct MarkerLegendEntry {
     pub explanation: String,
 }
 
+/// A [`KeyBindingGroup`]'s stable identity, independent of its localized
+/// [`KeyBindingGroup::title`] — [`applicable_help_groups`] filters on this
+/// rather than the title string so the filter does not have to special-case
+/// every [`Locale`] the title can render in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelpGroup {
+    TreeFocus,
+    RightFocus,
+    SourceView,
+    Review,
+    Global,
+}
+
 /// One named group of [`KeyBinding`]s — "Tree focus", "Right focus", or
 /// "Global" (ADR 0020's own focus/global split).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyBindingGroup {
+    pub id: HelpGroup,
     pub title: String,
     pub bindings: Vec<KeyBinding>,
 }
@@ -241,26 +260,68 @@ fn keymap_groups(locale: Locale) -> Vec<KeyBindingGroup> {
     let tag = locale.tag();
     vec![
         KeyBindingGroup {
+            id: HelpGroup::TreeFocus,
             title: rust_i18n::t!("help.group.tree_focus", locale = tag).into_owned(),
             bindings: tree_focus_bindings(locale),
         },
         KeyBindingGroup {
+            id: HelpGroup::RightFocus,
             title: rust_i18n::t!("help.group.right_focus", locale = tag).into_owned(),
             bindings: right_focus_bindings(locale),
         },
         KeyBindingGroup {
+            id: HelpGroup::SourceView,
             title: rust_i18n::t!("help.group.source_view", locale = tag).into_owned(),
             bindings: source_screen_bindings(locale),
         },
         KeyBindingGroup {
+            id: HelpGroup::Review,
             title: rust_i18n::t!("help.group.review", locale = tag).into_owned(),
             bindings: review_bindings(locale),
         },
         KeyBindingGroup {
+            id: HelpGroup::Global,
             title: rust_i18n::t!("help.group.global", locale = tag).into_owned(),
             bindings: global_bindings(locale),
         },
     ]
+}
+
+/// Whether `group` is reachable in the given `screen`/`focus` combination —
+/// the ground truth is `crate::input_translate::translate_key` and
+/// `crate::app::handle_key::App::handle_key`'s own match arms, not this
+/// module's group labels: [`HelpGroup::TreeFocus`]'s `space`
+/// (`InputKey::Select`) and [`HelpGroup::RightFocus`]'s scroll/`h`/`esc`
+/// bindings are only ever dispatched under their matching [`Focus`];
+/// [`HelpGroup::SourceView`] only under [`Screen::Source`];
+/// [`HelpGroup::Review`]'s `n`/`N` only under [`Screen::Entry`] (regardless
+/// of `Focus`, per `review_flow::derive_selection_snapshot` and
+/// `App::handle_key`'s own `NotesList` arm); [`HelpGroup::Global`] always.
+fn is_group_applicable(group: HelpGroup, screen: &Screen, focus: Focus) -> bool {
+    let on_source_screen = matches!(screen, Screen::Source { .. });
+    match group {
+        HelpGroup::TreeFocus => !on_source_screen && focus == Focus::Tree,
+        HelpGroup::RightFocus => !on_source_screen && focus == Focus::Right,
+        HelpGroup::SourceView => on_source_screen,
+        HelpGroup::Review => !on_source_screen,
+        HelpGroup::Global => true,
+    }
+}
+
+/// [`keymap_groups`] filtered down to the groups reachable in the given
+/// `screen`/`focus` combination (see [`is_group_applicable`]) — a group not
+/// applicable to the current context is omitted entirely, not merely
+/// reordered or dimmed, so the `?` overlay only ever lists bindings the
+/// reviewer can actually press right now.
+pub fn applicable_help_groups(
+    locale: Locale,
+    screen: &Screen,
+    focus: Focus,
+) -> Vec<KeyBindingGroup> {
+    keymap_groups(locale)
+        .into_iter()
+        .filter(|group| is_group_applicable(group.id, screen, focus))
+        .collect()
 }
 
 /// The tree pane's marker/badge legend, in the same added-like →

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -80,11 +80,11 @@ fn tree_focus_bindings(locale: Locale) -> Vec<KeyBinding> {
                 .into_owned(),
         },
         KeyBinding {
-            keys: "e / E",
+            keys: "e",
             description: rust_i18n::t!("help.binding.expand_every_row", locale = tag).into_owned(),
         },
         KeyBinding {
-            keys: "c / C",
+            keys: "c",
             description: rust_i18n::t!("help.binding.collapse_every_row", locale = tag)
                 .into_owned(),
         },
@@ -177,26 +177,26 @@ fn global_bindings(locale: Locale) -> Vec<KeyBinding> {
     let tag = locale.tag();
     vec![
         KeyBinding {
-            keys: "d / D",
+            keys: "d",
             description: rust_i18n::t!("help.binding.toggle_detail_diff", locale = tag)
                 .into_owned(),
         },
         KeyBinding {
-            keys: "r / R",
+            keys: "r",
             description: rust_i18n::t!("help.binding.toggle_blast_radius", locale = tag)
                 .into_owned(),
         },
         KeyBinding {
-            keys: "v / V",
+            keys: "v",
             description: rust_i18n::t!("help.binding.toggle_unified_split", locale = tag)
                 .into_owned(),
         },
         KeyBinding {
-            keys: "o / O",
+            keys: "o",
             description: rust_i18n::t!("help.binding.toggle_order_mode", locale = tag).into_owned(),
         },
         KeyBinding {
-            keys: "s / S",
+            keys: "s",
             description: rust_i18n::t!("help.binding.open_source_view", locale = tag).into_owned(),
         },
         KeyBinding {
@@ -216,12 +216,12 @@ fn global_bindings(locale: Locale) -> Vec<KeyBinding> {
             description: rust_i18n::t!("help.binding.jump_forward", locale = tag).into_owned(),
         },
         KeyBinding {
-            keys: "w / W",
+            keys: "w",
             description: rust_i18n::t!("help.binding.open_pr_in_browser", locale = tag)
                 .into_owned(),
         },
         KeyBinding {
-            keys: "U",
+            keys: "u",
             description: rust_i18n::t!("help.binding.prompt_self_update", locale = tag)
                 .into_owned(),
         },

--- a/rinkaku-tui/src/help/tests.rs
+++ b/rinkaku-tui/src/help/tests.rs
@@ -197,6 +197,37 @@ fn should_document_h_and_esc_as_the_return_to_tree_binding_in_right_focus_group(
     assert!(has_return_binding);
 }
 
+fn source_screen() -> Screen {
+    Screen::Source {
+        symbol_id: "lib.rs::foo".to_string(),
+        scroll_top: 0,
+    }
+}
+
+#[test]
+fn should_show_tree_focus_review_and_global_groups_when_tree_focused_on_entry_screen() {
+    let groups = applicable_help_groups(Locale::English, &Screen::Entry, Focus::Tree);
+    let titles: Vec<&str> = groups.iter().map(|group| group.title.as_str()).collect();
+
+    assert_eq!(vec!["Tree focus", "Review", "Global"], titles);
+}
+
+#[test]
+fn should_show_right_focus_review_and_global_groups_when_right_focused_on_entry_screen() {
+    let groups = applicable_help_groups(Locale::English, &Screen::Entry, Focus::Right);
+    let titles: Vec<&str> = groups.iter().map(|group| group.title.as_str()).collect();
+
+    assert_eq!(vec!["Right focus", "Review", "Global"], titles);
+}
+
+#[test]
+fn should_show_only_source_view_and_global_groups_on_source_screen_regardless_of_focus() {
+    let groups = applicable_help_groups(Locale::English, &source_screen(), Focus::Tree);
+    let titles: Vec<&str> = groups.iter().map(|group| group.title.as_str()).collect();
+
+    assert_eq!(vec!["Source view", "Global"], titles);
+}
+
 #[test]
 fn should_translate_move_cursor_description_to_japanese_when_locale_is_japanese() {
     let content = help_content(Locale::Japanese);

--- a/rinkaku-tui/src/help/tests.rs
+++ b/rinkaku-tui/src/help/tests.rs
@@ -177,7 +177,7 @@ fn should_document_open_pr_in_browser_binding_in_the_global_group() {
 
     let keys: Vec<&str> = global.bindings.iter().map(|binding| binding.keys).collect();
 
-    assert!(keys.contains(&"w / W"));
+    assert!(keys.contains(&"w"));
 }
 
 #[test]

--- a/rinkaku-tui/src/input_translate.rs
+++ b/rinkaku-tui/src/input_translate.rs
@@ -121,8 +121,8 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
 
     if app.pending_prefix() == Some(app::PendingPrefix::G) {
         match code {
-            KeyCode::Char('d') | KeyCode::Char('D') => return Some(InputKey::GotoDefinition),
-            KeyCode::Char('r') | KeyCode::Char('R') => return Some(InputKey::GotoReferences),
+            KeyCode::Char('d') => return Some(InputKey::GotoDefinition),
+            KeyCode::Char('r') => return Some(InputKey::GotoReferences),
             // `gg` (ADR 0026): scroll the reading pane to the top —
             // resolved here the same way `gd`/`gr` are, piggybacking on
             // the existing `g`-prefix state machine (ADR 0022) rather
@@ -149,9 +149,9 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         // certain conditions elsewhere).
         KeyCode::Char(' ') => Some(InputKey::Select),
         KeyCode::Enter => Some(InputKey::Open),
-        KeyCode::Char('e') | KeyCode::Char('E') => Some(InputKey::ExpandAll),
+        KeyCode::Char('e') => Some(InputKey::ExpandAll),
         KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::Quit),
-        KeyCode::Char('c') | KeyCode::Char('C') => Some(InputKey::CollapseAll),
+        KeyCode::Char('c') => Some(InputKey::CollapseAll),
         KeyCode::Char('o') if modifiers.contains(KeyModifiers::CONTROL) => Some(InputKey::JumpBack),
         // Ctrl-I and Tab share the same control code (0x09) at the terminal
         // protocol level — without Kitty's keyboard-enhancement protocol
@@ -167,7 +167,7 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         KeyCode::Char('i') if modifiers.contains(KeyModifiers::CONTROL) => {
             Some(InputKey::JumpForward)
         }
-        KeyCode::Char('o') | KeyCode::Char('O') => Some(InputKey::ToggleOrder),
+        KeyCode::Char('o') => Some(InputKey::ToggleOrder),
         // `Ctrl-d`/`Ctrl-u` (ADR 0026): half-page scroll on the reading
         // pane (`Screen::Source`, or `Screen::Entry` + `Focus::Right`).
         // Must come *before* the plain `Char('d')`/`Char('u')` arms —
@@ -182,9 +182,9 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
             Some(InputKey::ScrollHalfPageUp)
         }
-        KeyCode::Char('d') | KeyCode::Char('D') => Some(InputKey::ToggleDiff),
-        KeyCode::Char('r') | KeyCode::Char('R') => Some(InputKey::ToggleBlastRadius),
-        KeyCode::Char('v') | KeyCode::Char('V') => Some(InputKey::ToggleSplitView),
+        KeyCode::Char('d') => Some(InputKey::ToggleDiff),
+        KeyCode::Char('r') => Some(InputKey::ToggleBlastRadius),
+        KeyCode::Char('v') => Some(InputKey::ToggleSplitView),
         // `G` (`Shift-g`, ADR 0026): scroll to the bottom. Distinct from
         // single-key lowercase `g` (`PendingGoto` below), which is the
         // leading key of the `gd`/`gr`/`gg` two-key sequences resolved
@@ -206,7 +206,7 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         // so no existing gesture is lost by this simplification.
         KeyCode::Char(']') => Some(InputKey::NextHunk),
         KeyCode::Char('[') => Some(InputKey::PrevHunk),
-        KeyCode::Char('s') | KeyCode::Char('S') => Some(InputKey::Source),
+        KeyCode::Char('s') => Some(InputKey::Source),
         // `n` (ADR 0048): opens the review-note compose overlay over the
         // row under the cursor. `N`: opens the review-notes list overlay.
         // Both are only meaningful on the entry screen (Source-screen
@@ -216,16 +216,16 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         // already no-ops every non-scroll key there.
         KeyCode::Char('n') => Some(InputKey::NoteCompose),
         KeyCode::Char('N') => Some(InputKey::NotesList),
-        // `w`/`W` (ADR 0050): opens the current PR's page in a web browser —
+        // `w` (ADR 0050): opens the current PR's page in a web browser —
         // matches `gh` CLI's own `-w`/`--web` convention. Global regardless
         // of screen/focus, like `d`/`r`/`s`; `crate::lib::run_app`
         // special-cases the actual dispatch (it needs the session's
         // `PrContext`, which `App` doesn't hold).
-        KeyCode::Char('w') | KeyCode::Char('W') => Some(InputKey::OpenPrInBrowser),
-        // `U` (ADR 0054): opens the update confirmation popup. Global,
+        KeyCode::Char('w') => Some(InputKey::OpenPrInBrowser),
+        // `u` (ADR 0054): opens the update confirmation popup. Global,
         // like `w`/`d`/`r`/`s`; `App::handle_key`'s own arm no-ops unless
         // `App::update_available` is `Some`.
-        KeyCode::Char('u') | KeyCode::Char('U') => Some(InputKey::OpenUpdatePrompt),
+        KeyCode::Char('u') => Some(InputKey::OpenUpdatePrompt),
         // `g` (ADR 0022): the first half of the `gd`/`gr` two-key sequence.
         // Checked after the `pending_prefix` resolution above so a second
         // `g` press (`gg`, not a bound sequence today) simply restarts the

--- a/rinkaku-tui/src/input_translate_tests/translate_key.rs
+++ b/rinkaku-tui/src/input_translate_tests/translate_key.rs
@@ -112,13 +112,13 @@ fn should_translate_lowercase_r_to_toggle_blast_radius() {
 }
 
 #[test]
-fn should_translate_uppercase_r_to_toggle_blast_radius() {
+fn should_translate_uppercase_r_to_none() {
     let report = empty_report();
     let app = App::new(&report);
 
     let actual = translate_key(KeyCode::Char('R'), KeyModifiers::NONE, &app);
 
-    assert_eq!(Some(InputKey::ToggleBlastRadius), actual);
+    assert_eq!(None, actual);
 }
 
 #[test]
@@ -132,13 +132,13 @@ fn should_translate_lowercase_v_to_toggle_split_view() {
 }
 
 #[test]
-fn should_translate_uppercase_v_to_toggle_split_view() {
+fn should_translate_uppercase_v_to_none() {
     let report = empty_report();
     let app = App::new(&report);
 
     let actual = translate_key(KeyCode::Char('V'), KeyModifiers::NONE, &app);
 
-    assert_eq!(Some(InputKey::ToggleSplitView), actual);
+    assert_eq!(None, actual);
 }
 
 #[test]
@@ -322,6 +322,26 @@ fn should_translate_r_to_goto_references_when_g_is_pending() {
 }
 
 #[test]
+fn should_translate_uppercase_d_to_none_when_g_is_pending() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::PendingGoto);
+
+    let actual = translate_key(KeyCode::Char('D'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_uppercase_r_to_none_when_g_is_pending() {
+    let report = empty_report();
+    let app = App::new(&report).handle_key(InputKey::PendingGoto);
+
+    let actual = translate_key(KeyCode::Char('R'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
 fn should_translate_d_to_toggle_diff_when_no_prefix_is_pending() {
     let report = empty_report();
     let app = App::new(&report);
@@ -329,6 +349,16 @@ fn should_translate_d_to_toggle_diff_when_no_prefix_is_pending() {
     let actual = translate_key(KeyCode::Char('d'), KeyModifiers::NONE, &app);
 
     assert_eq!(Some(InputKey::ToggleDiff), actual);
+}
+
+#[test]
+fn should_translate_uppercase_d_to_none_when_no_prefix_is_pending() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('D'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
 }
 
 #[test]
@@ -391,6 +421,46 @@ fn should_translate_plain_o_to_toggle_order_without_control_modifier() {
     let actual = translate_key(KeyCode::Char('o'), KeyModifiers::NONE, &app);
 
     assert_eq!(Some(InputKey::ToggleOrder), actual);
+}
+
+#[test]
+fn should_translate_uppercase_o_to_none_without_control_modifier() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('O'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_uppercase_e_to_none() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('E'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_uppercase_c_to_none_without_control_modifier() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('C'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_uppercase_s_to_none() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('S'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
 }
 
 // ADR 0026 scroll bindings (translate_key half).
@@ -551,13 +621,13 @@ fn should_translate_lowercase_w_to_open_pr_in_browser() {
 }
 
 #[test]
-fn should_translate_uppercase_w_to_open_pr_in_browser() {
+fn should_translate_uppercase_w_to_none() {
     let report = empty_report();
     let app = App::new(&report);
 
     let actual = translate_key(KeyCode::Char('W'), KeyModifiers::NONE, &app);
 
-    assert_eq!(Some(InputKey::OpenPrInBrowser), actual);
+    assert_eq!(None, actual);
 }
 
 #[test]
@@ -571,13 +641,13 @@ fn should_translate_lowercase_u_to_open_update_prompt() {
 }
 
 #[test]
-fn should_translate_uppercase_u_to_open_update_prompt() {
+fn should_translate_uppercase_u_to_none_without_control_modifier() {
     let report = empty_report();
     let app = App::new(&report);
 
     let actual = translate_key(KeyCode::Char('U'), KeyModifiers::NONE, &app);
 
-    assert_eq!(Some(InputKey::OpenUpdatePrompt), actual);
+    assert_eq!(None, actual);
 }
 
 #[test]

--- a/rinkaku-tui/src/ui/help_overlay.rs
+++ b/rinkaku-tui/src/ui/help_overlay.rs
@@ -8,6 +8,7 @@
 
 use super::overlay::centered_rect;
 use super::scroll::{Body, render_scrollable_pane};
+use crate::app::{Focus, Screen};
 use crate::locale::Locale;
 use crate::row_view::{
     band_style, cyan_badge_style, risk_marker_style, split_badge_style, symbol_marker_span,
@@ -22,17 +23,22 @@ use ratatui::widgets::Clear;
 use rinkaku_core::extract::{Classification, SymbolKind};
 use rinkaku_core::file_size::FileSizeBand;
 
-/// The `?` help overlay's content laid out once for `locale`, independent
-/// of the pane's rendered size — extracted from [`draw_help_overlay`] so
-/// tests can pin its shape without a live `Frame`, mirroring how
-/// `crate::help::help_content` itself is already plain data rather than
-/// something computed at draw time (ADR 0055: locale-parameterized, not a
-/// `const`, since the underlying strings now come from `rust_i18n::t!`).
-fn help_overlay_lines(locale: Locale) -> Vec<Line<'static>> {
+/// The `?` help overlay's content laid out once for `locale`/`screen`/
+/// `focus`, independent of the pane's rendered size — extracted from
+/// [`draw_help_overlay`] so tests can pin its shape without a live `Frame`,
+/// mirroring how `crate::help::help_content` itself is already plain data
+/// rather than something computed at draw time (ADR 0055:
+/// locale-parameterized, not a `const`, since the underlying strings now
+/// come from `rust_i18n::t!`). Only the keymap groups are scoped to
+/// `screen`/`focus` (`crate::help::applicable_help_groups`) — the Markers
+/// legend and Glossary sections stay unconditional, since neither depends on
+/// which pane currently has focus.
+fn help_overlay_lines(locale: Locale, screen: &Screen, focus: Focus) -> Vec<Line<'static>> {
     let tag = locale.tag();
     let content = crate::help::help_content(locale);
+    let keymap_groups = crate::help::applicable_help_groups(locale, screen, focus);
     let mut lines: Vec<Line<'static>> = Vec::new();
-    for group in &content.keymap_groups {
+    for group in &keymap_groups {
         lines.push(Line::styled(
             group.title.clone(),
             Style::default().add_modifier(Modifier::BOLD),
@@ -172,10 +178,13 @@ fn badge_swatch_spans(label: &'static str, number_style: Style) -> Vec<Span<'sta
 /// content past a typical terminal's height) centered over `full_area`: a
 /// bordered box roughly 80%/90% of the frame's width/height (capped so it
 /// never claims more than the frame itself on a small terminal), listing
-/// every [`crate::help::help_content`] keymap group for `locale` (ADR
-/// 0055) followed by the glossary. [`Clear`] is rendered first so the
-/// overlay's background is opaque rather than letting the underlying
-/// frame's glyphs show through gaps in the overlay's own text.
+/// every keymap group applicable to `screen`/`focus`
+/// (`crate::help::applicable_help_groups`, scoped this way so the overlay
+/// never lists a binding that would be a no-op if pressed right now) for
+/// `locale` (ADR 0055) followed by the markers legend and glossary, both
+/// unconditional. [`Clear`] is rendered first so the overlay's background is
+/// opaque rather than letting the underlying frame's glyphs show through
+/// gaps in the overlay's own text.
 ///
 /// Scrolled via [`render_scrollable_pane`] — the same clamp/indicator/
 /// `Paragraph::scroll` machinery the Detail and Diff panes already share
@@ -194,11 +203,13 @@ pub(crate) fn draw_help_overlay(
     full_area: Rect,
     requested_scroll: usize,
     locale: Locale,
+    screen: &Screen,
+    focus: Focus,
 ) -> (usize, usize) {
     let overlay_area = centered_rect(full_area, 80, 90);
     frame.render_widget(Clear, overlay_area);
 
-    let lines = help_overlay_lines(locale);
+    let lines = help_overlay_lines(locale, screen, focus);
     let inner_height = overlay_area.height.saturating_sub(2) as usize;
     let title = format!(
         " {} ",

--- a/rinkaku-tui/src/ui/help_overlay/tests.rs
+++ b/rinkaku-tui/src/ui/help_overlay/tests.rs
@@ -297,10 +297,33 @@ fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
         .join("\n")
 }
 
+/// Every [`crate::help::HelpGroup`] title string, in [`crate::help::keymap_groups`]'s
+/// own display order — the full, unfiltered set this crate's group-filtering
+/// tests below check subsets of.
+const ALL_GROUP_TITLES: [&str; 5] = [
+    "Tree focus",
+    "Right focus",
+    "Source view",
+    "Review",
+    "Global",
+];
+
+/// Which of [`ALL_GROUP_TITLES`] are present in `text` (the overlay's
+/// rendered buffer), preserving [`ALL_GROUP_TITLES`]'s own order — the
+/// fully-qualified value each context test below compares against, rather
+/// than one `assert!(text.contains(...))` per heading.
+fn present_group_titles(text: &str) -> Vec<&'static str> {
+    ALL_GROUP_TITLES
+        .into_iter()
+        .filter(|title| text.contains(title))
+        .collect()
+}
+
 #[test]
 fn should_draw_help_overlay_with_keymap_markers_and_glossary_when_help_is_open() {
     let report = report_with_one_symbol();
     let app = App::new(&report).handle_key(crate::app::InputKey::ToggleHelp);
+    assert_eq!(crate::app::Focus::Tree, app.focus());
     // A 150x76 terminal (up from 150x74): taller again so the
     // overlay's 80% x 90% area still fits every keymap group —
     // now including the `U` update-prompt binding (ADR 0054) in the
@@ -330,14 +353,93 @@ fn should_draw_help_overlay_with_keymap_markers_and_glossary_when_help_is_open()
 
     let text = buffer_text(&terminal);
     assert!(text.contains("Help"));
-    assert!(text.contains("Tree focus"));
-    assert!(text.contains("Right focus"));
-    assert!(text.contains("Source view"));
-    assert!(text.contains("Global"));
+    // Tree focus (Focus::Tree, ADR 0020) hides the Right-focus and
+    // Source-view groups, which are only ever reachable from a different
+    // focus/screen (`crate::help::is_group_applicable`'s own doc comment).
+    assert_eq!(
+        vec!["Tree focus", "Review", "Global"],
+        present_group_titles(&text)
+    );
     assert!(text.contains("Markers"));
     assert!(text.contains("fan-in:N"));
     assert!(text.contains("Glossary"));
     assert!(text.contains("blast radius"));
+}
+
+#[test]
+fn should_hide_tree_focus_and_source_view_groups_when_right_focused_on_diff_pane() {
+    let report = report_with_one_symbol();
+    // `Open` on the symbol row (cursor starts there, `report_with_one_symbol`'s
+    // own single file/symbol tree) reaches Focus::Right + RightPane::Diff
+    // (ADR 0020) without leaving Screen::Entry.
+    let app = App::new(&report)
+        .handle_key(crate::app::InputKey::Open)
+        .handle_key(crate::app::InputKey::ToggleHelp);
+    assert_eq!(crate::app::Focus::Right, app.focus());
+    let mut terminal = Terminal::new(TestBackend::new(150, 76)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                None,
+                &[],
+                &crate::note_markers::NoteMarkers::default(),
+                Locale::English,
+            );
+        })
+        .expect("draw");
+
+    let text = buffer_text(&terminal);
+    assert_eq!(
+        vec!["Right focus", "Review", "Global"],
+        present_group_titles(&text)
+    );
+}
+
+#[test]
+fn should_show_only_source_view_and_global_groups_on_source_screen() {
+    let report = report_with_one_symbol();
+    // `report_with_one_symbol`'s tree starts with the cursor on the file
+    // row; `Down` moves it onto the symbol row `Source` (`s`) requires
+    // (`App::handle_key`'s own `InputKey::Source` arm only fires on a
+    // `NodeKind::Symbol` row) — the same sequence
+    // `should_show_source_view_scroll_hints_on_source_screen_regardless_of_focus`
+    // in `ui::status`'s own tests already uses.
+    let app = App::new(&report)
+        .handle_key(crate::app::InputKey::Down)
+        .handle_key(crate::app::InputKey::Source)
+        .handle_key(crate::app::InputKey::ToggleHelp);
+    assert!(matches!(app.screen(), crate::app::Screen::Source { .. }));
+    let mut terminal = Terminal::new(TestBackend::new(150, 76)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                None,
+                &[],
+                &crate::note_markers::NoteMarkers::default(),
+                Locale::English,
+            );
+        })
+        .expect("draw");
+
+    let text = buffer_text(&terminal);
+    // Review is hidden on the source screen: `n`/`N` (NoteCompose/NotesList)
+    // only dispatch on Screen::Entry (`review_flow::derive_selection_snapshot`,
+    // `App::handle_key`'s own `NotesList` arm).
+    assert_eq!(vec!["Source view", "Global"], present_group_titles(&text));
 }
 
 #[test]

--- a/rinkaku-tui/src/ui/mod.rs
+++ b/rinkaku-tui/src/ui/mod.rs
@@ -240,8 +240,14 @@ pub fn draw(
     draw_status_line(frame, app, report, status_area);
 
     if app.help_open() {
-        let (clamped_help_scroll, help_scroll_viewport_height) =
-            draw_help_overlay(frame, area, app.help_scroll(), locale);
+        let (clamped_help_scroll, help_scroll_viewport_height) = draw_help_overlay(
+            frame,
+            area,
+            app.help_scroll(),
+            locale,
+            app.screen(),
+            app.focus(),
+        );
         outcome.clamped_help_scroll = Some(clamped_help_scroll);
         outcome.help_scroll_viewport_height = Some(help_scroll_viewport_height);
     }


### PR DESCRIPTION
## Summary

Two related keymap/help changes:

1. **Drop uppercase aliases for single-case keybindings** — `e/E`, `c/C`, `o/O`, `d/D`, `r/R`, `v/V`, `s/S`, `w/W`, `u/U` (and the `gd`/`gr` sequence's `D`/`R`) no longer accept the uppercase variant; lowercase only. Uppercase letters are reserved for bindings with a distinct meaning: `G` (scroll to bottom) and `N` (notes list) are kept as-is since they differ from their lowercase counterparts. Help entries updated from `"x / X"` to `"x"` accordingly.
2. **Filter help overlay keymap groups by current context** — the `?` overlay now shows only the groups applicable to the current screen/focus, instead of always rendering all five. Irrelevant groups are omitted entirely (not dimmed). Applicability is derived from the real gating in `App::handle_key`, not from the display-only grouping:

   | Group | Tree focus | Right focus | Source screen |
   |---|---|---|---|
   | Tree focus | shown | hidden | hidden |
   | Right focus | hidden | shown | hidden |
   | Source view | hidden | hidden | shown |
   | Review | shown | shown | hidden |
   | Global | shown | shown | shown |

   The markers legend and glossary sections remain always visible.

## Known limitation (pre-existing, out of scope)

The "Global" group is coarser than its name suggests: on the Source screen, `d`/`r`/`o`/`s`/`ctrl-o`/`ctrl-i` are actually no-ops (swallowed by `handle_key`'s Source-screen catch-all), while `v`/`w`/`u`/`gd`/`gr` do work. This branch keeps the group intact and shows it everywhere; splitting Global into a truly-global subset is left for a follow-up.

## Testing

- TDD with headless `TestBackend` assertions: per-context help overlay rendering verified to omit non-applicable group headings.
- `make test`: 912 passed. `make lint`: clean (fmt + clippy `-D warnings`).
- Static map-assisted review pass completed (no blockers; the should-fix finding is the known limitation above).