### PR TITLE
feat(tui): auto-open the update prompt at startup and fix frozen prompt keys

### DIFF
--- a/docs/adr/0056-tui-update-prompt-auto-open-and-freeze-fix.md
+++ b/docs/adr/0056-tui-update-prompt-auto-open-and-freeze-fix.md
@@ -1,0 +1,167 @@
+# 0056. TUI: auto-open the update prompt at startup, fix its dead keys, and stop the silent self-update stall
+
+- Status: Accepted
+- Date: 2026-07-16
+
+## Context
+
+ADR 0054 shipped a status-line hint plus a `u`-triggered confirmation
+popup for the TUI's background update check, deliberately choosing
+**not** to auto-open the popup: "an unprompted modal stealing keystrokes
+mid-review ... would be a materially worse experience than a quiet
+status-line hint." In practice, users did not notice the status-line
+hint (it sits in the bottom-right corner, easy to miss while focused on
+a diff), so the update went unnoticed for weeks at a time — defeating
+the whole feature's purpose.
+
+Separately, a user reported that pressing `u` and confirming appeared to
+**freeze the app** on v0.6.11. Investigating end-to-end (version-check
+thread, `App`/`run_app` dispatch, `TuiSession`'s terminal-lifecycle
+postamble, and `rinkaku/src/self_update.rs`'s use of the `self_update`
+crate) found two independent, real defects, plus confirmed one part of
+the design already correctly guards against the classic version of this
+bug:
+
+1. **A real dead-key bug**: `rinkaku-tui/src/input_translate.rs`'s
+   `translate_key` had no short-circuit for
+   `App::update_prompt_open()`, unlike every other modal in this crate
+   (the `?` help overlay, the jump-target popup, the review overlay all
+   have one). While the update popup was open, Enter translated to
+   `InputKey::Open` (not `PopupConfirm`), Esc translated to `None` or
+   `FocusLeft`, and `q` translated to `InputKey::Quit` — none of which
+   `App::handle_key`'s `update_prompt_open` branch recognizes (it only
+   reacts to `PopupConfirm`/`PopupCancel`, treating everything else as
+   the intentional confirm/cancel `_ => {}` no-op every other modal in
+   this crate also uses). The popup's own two hint labels ("[Enter]
+   update & quit [Esc] not now") were lies: pressing either key did
+   nothing at all. This is confirmed the primary cause of the reported
+   freeze — the popup simply never responded to the keys its own hint
+   text told the user to press, which is indistinguishable from a hang
+   without reading the dispatch code. Existing tests never caught this
+   because `rinkaku-tui/src/app/tests/update_prompt.rs` only ever
+   constructed `InputKey::PopupConfirm`/`PopupCancel` directly, bypassing
+   `translate_key` entirely — the same class of gap ADR 0022's
+   `pending_prefix` regression already taught this crate to distrust
+   (`event_loop::dispatch_non_source_key`'s own doc comment).
+2. **A real, if less severe, silent-stall gap**: once the update *does*
+   run (after the terminal is correctly restored — see below),
+   `run_self_update`'s builder sets `.show_output(false)` (deliberately,
+   to suppress the `self_update` crate's own misleading "*NOT*
+   compatible" line — see that function's existing doc comment). This
+   also suppresses every intermediate message inside the crate's
+   `update_extended()`, including a **second**, independent
+   `/releases` API call it makes internally (in addition to the one
+   `run_self_update` already made to decide whether an update exists at
+   all) and the "Downloading..."/"Replacing binary file..." lines. On a
+   slow connection, or when the release asset's response has no
+   `Content-Length` header (no progress bar at all in that case), the
+   window between "New release found: ..." and the final "Updated ..."
+   line is completely silent — no spinner, no dots, nothing — which
+   looks exactly like a hang.
+3. **Already correct, not a bug**: `main.rs`'s composition root already
+   defers the actual `run_self_update(true)` call until after
+   `TuiSession::run`'s terminal-restoring postamble has completed (its
+   own doc comment: "the update itself runs only after the block above
+   has already restored the terminal"), and the version-check thread is
+   a detached, never-joined `std::thread::spawn` whose result reaches
+   `App` only via a non-blocking `try_recv()` on the existing 100ms poll
+   tick. Neither of those — the classic "blocking IO while the
+   alternate screen/raw mode is still active" freeze shape — was
+   present. This ADR's fixes are additive to that existing design, not a
+   rewrite of it.
+
+## Decision
+
+**Keep in-app self-update.** Both defects found are concrete and fixable
+without touching the `self_update` crate's fundamentally synchronous
+API or `main.rs`'s existing "update runs after teardown" ordering, so
+there is no need to fall back to a guidance-only prompt.
+
+**Fix 1: `translate_key` gains an `App::update_prompt_open()`
+short-circuit**, mirroring the jump-target popup's own structure
+immediately above it: Enter maps to `PopupConfirm`, Esc/`q` map to
+`PopupCancel`, every other key is swallowed. Placed after the jump-popup
+check (the two popups can never be open together, per
+`InputKey::OpenUpdatePrompt`'s own gating) and before the ordinary
+entry-view key matching, so no future key mapping can silently reach
+past it the way Enter/Esc/`q` did before this fix.
+
+**Fix 2: `run_self_update` wraps the `updater.update()` call in the
+existing `Spinner`** (`rinkaku/src/spinner.rs`, already used for the
+non-TUI analysis pipeline's own "long synchronous call, no feedback"
+problem) rather than flipping `show_output(true)` back on, which would
+reintroduce the misleading "*NOT* compatible" line
+`build_updater`'s doc comment already explains rejecting.
+`Spinner::start`/`finish_and_clear` bracket the one call that can take
+an unbounded, unpredictable amount of wall-clock time silently.
+
+**Change: the update popup now auto-opens** the first time
+`App::notify_update_available` is called, unless the reviewer already
+dismissed it once this session — reversing ADR 0054's "popup never
+auto-opens" decision now that the two defects above are fixed. The
+original worry (an unprompted modal stealing keystrokes mid-review) is
+judged an acceptable trade against the status-line hint's demonstrated
+failure mode (silently ignored for weeks). A new `App` field,
+`update_prompt_dismissed`, tracks whether `PopupCancel` has already
+closed the popup this session; a free function,
+`should_auto_open_update_prompt(update_available: bool,
+update_prompt_dismissed: bool) -> bool`, decides this and is
+deliberately not a method on `App` — a backlogged startup splash screen
+is expected to want the identical "show once, don't reopen after an
+explicit dismissal" decision, and a free function taking plain `bool`s
+can be reused there without depending on `App`'s internals. The
+status-line hint and `u`-to-reopen both keep working unchanged after a
+dismissal — only the very first appearance is now automatic.
+
+## Alternatives
+
+- **Drop in-app update execution, guidance-only prompt.** Rejected: both
+  root causes found are narrowly-scoped, low-risk fixes (a missing
+  `match` arm in `translate_key`, a spinner around one already-isolated
+  call), not evidence of a structurally unfixable synchronous API. The
+  user's own stated policy is to keep in-app execution when the freeze
+  is fixable.
+- **Flip `show_output(true)` back on to silence Fix 2's gap.** Rejected:
+  reintroduces the `self_update` crate's own "*NOT* compatible" line for
+  any ordinary pre-1.0 minor bump, which `build_updater`'s existing doc
+  comment already documents as actively misleading for this project.
+- **Skip the second, redundant `/releases` call inside
+  `updater.update()`** by teaching `run_self_update` to reuse the
+  `Release` it already fetched via `get_latest_release()`, rather than
+  letting `update()` re-fetch it. Rejected for this PR: `update()`'s
+  `Result<Status>` return does not expose an entry point that accepts an
+  already-fetched `Release` (the crate always re-resolves the release
+  list itself), so avoiding the second call would mean re-implementing
+  `update_extended()`'s download/extract/replace sequence by hand
+  instead of calling the crate's own `update()` — a materially larger,
+  riskier change than wrapping the existing call in a spinner. Noted as
+  a possible follow-up if the crate ever adds a "confirm this pre-fetched
+  release" entry point.
+- **Auto-open only on the very first frame after the version-check
+  thread reports, versus on every `notify_update_available` call.**
+  Equivalent in practice: `main.rs`'s channel only ever sends one
+  message per session (the check thread runs once at startup and exits),
+  so `notify_update_available` is itself only ever called once — the
+  `update_prompt_dismissed` guard is what actually matters, guarding
+  against a hypothetical future caller that notifies more than once.
+
+## Consequences
+
+- `rinkaku-tui/src/input_translate.rs`'s `translate_key` gains one new
+  short-circuit block; no signature change.
+- `rinkaku-tui/src/app/mod.rs`'s `App` gains one new field
+  (`update_prompt_dismissed`) and one new free function
+  (`should_auto_open_update_prompt`); `notify_update_available`'s
+  behavior changes from "never opens the popup" to "opens it once,
+  unless already dismissed this session" — every existing test that
+  asserted the old "does not auto-open" behavior was updated to dismiss
+  the popup first where that state is still what the test needs to
+  reach.
+- `rinkaku/src/self_update.rs`'s `run_self_update` gains a `Spinner`
+  around `updater.update()`; behavior is otherwise unchanged (same
+  network calls, same final messages).
+- No public output format changed; no other crate's contract changed.
+- `docs/tui.md`/the `?` help overlay's `U` row text is unaffected — the
+  keys and their meaning are unchanged, only their previously-broken
+  wiring is fixed and the popup's opening trigger widens from
+  `u`-only to `u`-or-automatic-on-first-availability.

--- a/docs/adr/0056-tui-update-prompt-auto-open-and-freeze-fix.md
+++ b/docs/adr/0056-tui-update-prompt-auto-open-and-freeze-fix.md
@@ -105,13 +105,20 @@ failure mode (silently ignored for weeks). A new `App` field,
 `update_prompt_dismissed`, tracks whether `PopupCancel` has already
 closed the popup this session; a free function,
 `should_auto_open_update_prompt(update_available: bool,
-update_prompt_dismissed: bool) -> bool`, decides this and is
-deliberately not a method on `App` — a backlogged startup splash screen
+update_prompt_dismissed: bool, no_other_modal_active: bool) -> bool`,
+decides this and is deliberately not a method on `App` — a backlogged startup splash screen
 is expected to want the identical "show once, don't reopen after an
 explicit dismissal" decision, and a free function taking plain `bool`s
 can be reused there without depending on `App`'s internals. The
 status-line hint and `u`-to-reopen both keep working unchanged after a
-dismissal — only the very first appearance is now automatic.
+dismissal — only the very first appearance is now automatic. An
+already-open modal (the help overlay or the jump popup) takes priority:
+`notify_update_available` will not auto-open the update prompt over
+one, since the renderer draws the update prompt topmost while
+`translate_key` still routes keys to whichever modal it checks first,
+and the two would otherwise disagree about what is actually receiving
+input. The reviewer still reaches the popup via `u` after closing the
+other modal.
 
 ## Alternatives
 
@@ -153,10 +160,10 @@ dismissal — only the very first appearance is now automatic.
   (`update_prompt_dismissed`) and one new free function
   (`should_auto_open_update_prompt`); `notify_update_available`'s
   behavior changes from "never opens the popup" to "opens it once,
-  unless already dismissed this session" — every existing test that
-  asserted the old "does not auto-open" behavior was updated to dismiss
-  the popup first where that state is still what the test needs to
-  reach.
+  unless already dismissed this session or another modal is currently
+  open" — every existing test that asserted the old "does not
+  auto-open" behavior was updated to dismiss the popup first where that
+  state is still what the test needs to reach.
 - `rinkaku/src/self_update.rs`'s `run_self_update` gains a `Spinner`
   around `updater.update()`; behavior is otherwise unchanged (same
   network calls, same final messages).

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -107,7 +107,7 @@ Press `?` in the TUI for the always-up-to-date table.
 | `ctrl-o` / `ctrl-i` | Jump back / forward through the jumplist |
 | `n` / `N` | Compose a review note / open the notes list ([ADR 0048](adr/0048-tui-review-actions.md)) |
 | `w` / `W` | Open the current PR's page in a web browser, `--pr` mode only ([ADR 0050](adr/0050-tui-open-pr-in-browser.md)) |
-| `U` | Prompt to self-update, only shown once a newer release is found ([ADR 0054](adr/0054-tui-update-available-prompt.md)) |
+| `U` | Prompt to self-update; opens automatically once a newer release is found, or reopens it after a dismissal ([ADR 0054](adr/0054-tui-update-available-prompt.md), [ADR 0056](adr/0056-tui-update-prompt-auto-open-and-freeze-fix.md)) |
 | `?` | Toggle the help overlay |
 | `q` / `ctrl-c` | Quit (from the entry view); `esc`/`q` also returns from the source view |
 

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -150,6 +150,7 @@ impl App {
                 }
                 InputKey::PopupCancel => {
                     self.update_prompt_open = false;
+                    self.update_prompt_dismissed = true;
                 }
                 _ => {}
             }

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -360,10 +360,11 @@ pub struct App {
     /// found, if any (`main.rs`'s version-check thread, delivered via
     /// [`Self::notify_update_available`]) — `None` until that check
     /// completes or finds nothing newer. Drives the status line's update
-    /// hint and whether `U` opens [`Self::update_prompt_open`] at all.
+    /// hint and whether `u` opens [`Self::update_prompt_open`] at all.
     update_available: Option<String>,
-    /// Whether the update confirmation popup (`U`, only reachable once
-    /// [`Self::update_available`] is `Some`) is currently open. Mirrors
+    /// Whether the update confirmation popup is currently open — reachable
+    /// via `u` (once [`Self::update_available`] is `Some`) or auto-opened by
+    /// [`Self::notify_update_available`] (ADR 0056). Mirrors
     /// [`Self::jump_popup`]'s flag-not-`Screen` shape for the same reason:
     /// it sits on top of whatever was already showing and must not disturb
     /// that state.
@@ -603,12 +604,17 @@ impl App {
     /// [`Self::update_prompt_open`] via [`should_auto_open_update_prompt`]
     /// (ADR 0056, superseding ADR 0054's original "never auto-opens"
     /// decision) unless the reviewer already dismissed the prompt once
-    /// this session.
+    /// this session, or another modal (help overlay, jump popup) is
+    /// currently on screen — the renderer draws the update prompt on top
+    /// of everything else, but key routing checks those modals first, so
+    /// auto-opening over one of them would show the prompt while still
+    /// routing keys to the hidden modal underneath.
     pub fn notify_update_available(&mut self, version: impl Into<String>) {
         self.update_available = Some(version.into());
         if should_auto_open_update_prompt(
             self.update_available.is_some(),
             self.update_prompt_dismissed,
+            !self.help_open && self.jump_popup.is_none(),
         ) {
             self.update_prompt_open = true;
         }
@@ -967,9 +973,14 @@ impl App {
 
 /// Whether the update prompt should auto-open now that an update is known
 /// to be available, given whether the reviewer has already dismissed it
-/// once this session. Extracted as a free function (rather than inlined in
+/// once this session and whether no other modal is currently active.
+/// Extracted as a free function (rather than inlined in
 /// [`App::notify_update_available`]) so a future startup splash screen can
 /// reuse this exact decision without depending on `App`'s internals.
-fn should_auto_open_update_prompt(update_available: bool, update_prompt_dismissed: bool) -> bool {
-    update_available && !update_prompt_dismissed
+fn should_auto_open_update_prompt(
+    update_available: bool,
+    update_prompt_dismissed: bool,
+    no_other_modal_active: bool,
+) -> bool {
+    update_available && !update_prompt_dismissed && no_other_modal_active
 }

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -368,6 +368,12 @@ pub struct App {
     /// it sits on top of whatever was already showing and must not disturb
     /// that state.
     update_prompt_open: bool,
+    /// Whether the reviewer has already closed the update prompt once this
+    /// session (`PopupCancel` while it was open) — kept separate from
+    /// [`Self::update_prompt_open`] so [`should_auto_open_update_prompt`]
+    /// can tell "never shown yet" from "shown and dismissed" and not
+    /// reopen the popup out from under a reviewer who just closed it.
+    update_prompt_dismissed: bool,
     /// Whether the reviewer confirmed the update popup — `run_app`/
     /// `TuiSession::run` read this once [`Self::should_quit`] is set to
     /// decide whether to run `self-update` after the terminal is restored.
@@ -411,6 +417,7 @@ impl App {
             review_sink_a_available: false,
             update_available: None,
             update_prompt_open: false,
+            update_prompt_dismissed: false,
             update_requested: false,
         }
     }
@@ -592,13 +599,19 @@ impl App {
     /// version-check thread's `mpsc::Receiver` yields a version string
     /// (`main.rs`'s composition root spawns that thread; this method is
     /// the only seam through which its result reaches `App`, keeping this
-    /// module free of the thread/channel itself). Deliberately does not
-    /// open [`Self::update_prompt_open`] on its own — the popup is only
-    /// ever opened by an explicit `U` press
-    /// ([`InputKey::OpenUpdatePrompt`]'s own doc comment on why an
-    /// unprompted popup would be a bad surprise mid-review).
+    /// module free of the thread/channel itself). Auto-opens
+    /// [`Self::update_prompt_open`] via [`should_auto_open_update_prompt`]
+    /// (ADR 0056, superseding ADR 0054's original "never auto-opens"
+    /// decision) unless the reviewer already dismissed the prompt once
+    /// this session.
     pub fn notify_update_available(&mut self, version: impl Into<String>) {
         self.update_available = Some(version.into());
+        if should_auto_open_update_prompt(
+            self.update_available.is_some(),
+            self.update_prompt_dismissed,
+        ) {
+            self.update_prompt_open = true;
+        }
     }
 
     /// The detail-pane content for the row currently under the cursor
@@ -950,4 +963,13 @@ impl App {
         }
         self
     }
+}
+
+/// Whether the update prompt should auto-open now that an update is known
+/// to be available, given whether the reviewer has already dismissed it
+/// once this session. Extracted as a free function (rather than inlined in
+/// [`App::notify_update_available`]) so a future startup splash screen can
+/// reuse this exact decision without depending on `App`'s internals.
+fn should_auto_open_update_prompt(update_available: bool, update_prompt_dismissed: bool) -> bool {
+    update_available && !update_prompt_dismissed
 }

--- a/rinkaku-tui/src/app/tests/update_prompt.rs
+++ b/rinkaku-tui/src/app/tests/update_prompt.rs
@@ -1,5 +1,5 @@
 use super::empty_report;
-use crate::app::{App, InputKey};
+use crate::app::{App, InputKey, JumpCandidate};
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 
@@ -20,12 +20,39 @@ fn should_set_update_available_and_auto_open_prompt_when_notified() {
 }
 
 #[test]
+fn should_not_auto_open_prompt_when_notified_while_help_overlay_is_open() {
+    let report = empty_report();
+    let mut app = App::new(&report).handle_key(InputKey::ToggleHelp);
+
+    app.notify_update_available("1.2.3");
+
+    assert_eq!(Some("1.2.3"), app.update_available());
+    assert_eq!(false, app.update_prompt_open());
+    assert_eq!(true, app.help_open());
+}
+
+#[test]
+fn should_not_auto_open_prompt_when_notified_while_jump_popup_is_open() {
+    let report = empty_report();
+    let mut app = App::new(&report).open_jump_popup(vec![JumpCandidate {
+        id: "lib.rs::foo".to_string(),
+        name: "foo".to_string(),
+        path: "lib.rs".to_string(),
+    }]);
+
+    app.notify_update_available("1.2.3");
+
+    assert_eq!(Some("1.2.3"), app.update_available());
+    assert_eq!(false, app.update_prompt_open());
+    assert_eq!(true, app.jump_popup().is_some());
+}
+
+#[test]
 fn should_not_reopen_prompt_when_notified_again_after_dismissal() {
     let report = empty_report();
     let mut app = App::new(&report);
     app.notify_update_available("1.2.3");
-    let app = app.handle_key(InputKey::PopupCancel);
-    let mut app = app;
+    let mut app = app.handle_key(InputKey::PopupCancel);
 
     app.notify_update_available("1.2.4");
 
@@ -103,17 +130,22 @@ fn should_ignore_other_keys_while_update_prompt_is_open() {
 }
 
 #[rstest]
-#[case::should_open_when_available_and_not_dismissed(true, false, true)]
-#[case::should_not_open_when_unavailable(false, false, false)]
-#[case::should_not_reopen_when_already_dismissed(true, true, false)]
-#[case::should_not_open_when_unavailable_and_dismissed(false, true, false)]
-fn should_decide_auto_open_from_availability_and_dismissal(
+#[case::should_open_when_available_and_not_dismissed_and_no_other_modal(true, false, true, true)]
+#[case::should_not_open_when_unavailable(false, false, true, false)]
+#[case::should_not_reopen_when_already_dismissed(true, true, true, false)]
+#[case::should_not_open_when_unavailable_and_dismissed(false, true, true, false)]
+#[case::should_not_open_when_other_modal_active(true, false, false, false)]
+fn should_decide_auto_open_from_availability_dismissal_and_other_modal(
     #[case] update_available: bool,
     #[case] update_prompt_dismissed: bool,
+    #[case] no_other_modal_active: bool,
     #[case] expected: bool,
 ) {
-    let actual =
-        super::super::should_auto_open_update_prompt(update_available, update_prompt_dismissed);
+    let actual = super::super::should_auto_open_update_prompt(
+        update_available,
+        update_prompt_dismissed,
+        no_other_modal_active,
+    );
 
     assert_eq!(expected, actual);
 }

--- a/rinkaku-tui/src/app/tests/update_prompt.rs
+++ b/rinkaku-tui/src/app/tests/update_prompt.rs
@@ -1,19 +1,35 @@
 use super::empty_report;
 use crate::app::{App, InputKey};
 use pretty_assertions::assert_eq;
+use rstest::rstest;
 
-// Update-available prompt tests (ADR 0054): `notify_update_available`,
-// `OpenUpdatePrompt`'s gating on `update_available`, and the popup's own
-// `PopupConfirm`/`PopupCancel` handling.
+// Update-available prompt tests (ADR 0054, amended to auto-open at
+// startup): `notify_update_available`, `OpenUpdatePrompt`'s gating on
+// `update_available`, and the popup's own `PopupConfirm`/`PopupCancel`
+// handling.
 
 #[test]
-fn should_set_update_available_when_notified() {
+fn should_set_update_available_and_auto_open_prompt_when_notified() {
     let report = empty_report();
     let mut app = App::new(&report);
 
     app.notify_update_available("1.2.3");
 
     assert_eq!(Some("1.2.3"), app.update_available());
+    assert_eq!(true, app.update_prompt_open());
+}
+
+#[test]
+fn should_not_reopen_prompt_when_notified_again_after_dismissal() {
+    let report = empty_report();
+    let mut app = App::new(&report);
+    app.notify_update_available("1.2.3");
+    let app = app.handle_key(InputKey::PopupCancel);
+    let mut app = app;
+
+    app.notify_update_available("1.2.4");
+
+    assert_eq!(Some("1.2.4"), app.update_available());
     assert_eq!(false, app.update_prompt_open());
 }
 
@@ -28,10 +44,11 @@ fn should_not_open_update_prompt_when_open_update_prompt_is_pressed_and_no_updat
 }
 
 #[test]
-fn should_open_update_prompt_when_open_update_prompt_is_pressed_and_an_update_is_available() {
+fn should_reopen_update_prompt_when_open_update_prompt_is_pressed_after_dismissal() {
     let report = empty_report();
     let mut app = App::new(&report);
     app.notify_update_available("1.2.3");
+    let app = app.handle_key(InputKey::PopupCancel);
 
     let app = app.handle_key(InputKey::OpenUpdatePrompt);
 
@@ -83,4 +100,20 @@ fn should_ignore_other_keys_while_update_prompt_is_open() {
 
     assert_eq!(true, app.update_prompt_open());
     assert_eq!(false, app.should_quit());
+}
+
+#[rstest]
+#[case::should_open_when_available_and_not_dismissed(true, false, true)]
+#[case::should_not_open_when_unavailable(false, false, false)]
+#[case::should_not_reopen_when_already_dismissed(true, true, false)]
+#[case::should_not_open_when_unavailable_and_dismissed(false, true, false)]
+fn should_decide_auto_open_from_availability_and_dismissal(
+    #[case] update_available: bool,
+    #[case] update_prompt_dismissed: bool,
+    #[case] expected: bool,
+) {
+    let actual =
+        super::super::should_auto_open_update_prompt(update_available, update_prompt_dismissed);
+
+    assert_eq!(expected, actual);
 }

--- a/rinkaku-tui/src/input_translate.rs
+++ b/rinkaku-tui/src/input_translate.rs
@@ -33,6 +33,11 @@ use ratatui::crossterm::event::{self, KeyCode, KeyModifiers};
 /// `j`/`k`/Up/Down move its own selection, Enter confirms (`PopupConfirm`),
 /// Esc cancels (`PopupCancel`), and every other key is swallowed.
 ///
+/// `app.update_prompt_open()` (ADR 0054) is the next short-circuit: Enter
+/// confirms (`PopupConfirm`), Esc/`q` cancel (`PopupCancel`), and every
+/// other key is swallowed — the same shape as the jump popup above, minus
+/// its own Up/Down selection (this popup has none).
+///
 /// `app.pending_prefix()` (ADR 0022) is consulted only for `d`/`r`: when a
 /// `g` press is still pending, `d` resolves to `GotoDefinition` and `r` to
 /// `GotoReferences` instead of their own ordinary meanings (`ToggleDiff`/
@@ -112,6 +117,17 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
             KeyCode::Down | KeyCode::Char('j') => Some(InputKey::Down),
             KeyCode::Enter => Some(InputKey::PopupConfirm),
             KeyCode::Esc => Some(InputKey::PopupCancel),
+            _ => None,
+        };
+    }
+
+    // Without this short-circuit, Enter/Esc/`q` fell through to their
+    // ordinary entry-view meanings, none of which `App::handle_key`'s
+    // `update_prompt_open` branch recognizes as confirm/cancel (ADR 0056).
+    if app.update_prompt_open() {
+        return match code {
+            KeyCode::Enter => Some(InputKey::PopupConfirm),
+            KeyCode::Esc | KeyCode::Char('q') => Some(InputKey::PopupCancel),
             _ => None,
         };
     }

--- a/rinkaku-tui/src/input_translate_tests/translate_key.rs
+++ b/rinkaku-tui/src/input_translate_tests/translate_key.rs
@@ -671,3 +671,51 @@ fn should_not_normalize_fullwidth_characters_while_composing_a_note() {
 
     assert_eq!(Some(InputKey::ComposeChar('ｎ')), actual);
 }
+
+#[test]
+fn should_translate_enter_to_popup_confirm_while_update_prompt_open() {
+    let report = empty_report();
+    let mut app = App::new(&report);
+    app.notify_update_available("1.2.3");
+    let app = app.handle_key(InputKey::OpenUpdatePrompt);
+
+    let actual = translate_key(KeyCode::Enter, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::PopupConfirm), actual);
+}
+
+#[test]
+fn should_translate_esc_to_popup_cancel_while_update_prompt_open() {
+    let report = empty_report();
+    let mut app = App::new(&report);
+    app.notify_update_available("1.2.3");
+    let app = app.handle_key(InputKey::OpenUpdatePrompt);
+
+    let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::PopupCancel), actual);
+}
+
+#[test]
+fn should_translate_lowercase_q_to_popup_cancel_while_update_prompt_open() {
+    let report = empty_report();
+    let mut app = App::new(&report);
+    app.notify_update_available("1.2.3");
+    let app = app.handle_key(InputKey::OpenUpdatePrompt);
+
+    let actual = translate_key(KeyCode::Char('q'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::PopupCancel), actual);
+}
+
+#[test]
+fn should_swallow_unrelated_key_while_update_prompt_open() {
+    let report = empty_report();
+    let mut app = App::new(&report);
+    app.notify_update_available("1.2.3");
+    let app = app.handle_key(InputKey::OpenUpdatePrompt);
+
+    let actual = translate_key(KeyCode::Char('d'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
+}

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -379,11 +379,14 @@ mod tests {
     }
 
     #[test]
-    fn should_draw_update_prompt_with_version_when_update_prompt_is_open() {
+    fn should_draw_update_prompt_with_version_as_soon_as_notified() {
+        // No `OpenUpdatePrompt` key press here — this pins the
+        // auto-open-at-startup behavior: `notify_update_available` alone
+        // must be enough for the prompt to already be on screen the very
+        // next frame, not only after an explicit `u` press.
         let report = report_with_one_symbol();
         let mut app = App::new(&report);
         app.notify_update_available("1.2.3");
-        let app = app.handle_key(crate::app::InputKey::OpenUpdatePrompt);
         let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
 
         terminal
@@ -414,6 +417,9 @@ mod tests {
         let report = report_with_one_symbol();
         let mut app = App::new(&report);
         app.notify_update_available("1.2.3");
+        // `notify_update_available` auto-opens the prompt; dismiss it here
+        // to reach the "notified but closed" state this test covers.
+        let app = app.handle_key(crate::app::InputKey::PopupCancel);
         let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
 
         terminal
@@ -435,5 +441,37 @@ mod tests {
 
         let text = buffer_text(&terminal);
         assert!(!text.contains("Update available"));
+    }
+
+    #[test]
+    fn should_redraw_update_prompt_when_reopened_after_dismissal() {
+        let report = report_with_one_symbol();
+        let mut app = App::new(&report);
+        app.notify_update_available("1.2.3");
+        let app = app
+            .handle_key(crate::app::InputKey::PopupCancel)
+            .handle_key(crate::app::InputKey::OpenUpdatePrompt);
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    &app,
+                    &report,
+                    &crate::diff_shape::DiffPaneContent::Empty,
+                    &[],
+                    &BlastRadiusSelection::NotApplicable,
+                    None,
+                    &[],
+                    &crate::note_markers::NoteMarkers::default(),
+                    Locale::English,
+                );
+            })
+            .expect("draw");
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Update available"));
+        assert!(text.contains("Update rinkaku to v1.2.3?"));
     }
 }

--- a/rinkaku/src/self_update.rs
+++ b/rinkaku/src/self_update.rs
@@ -12,6 +12,7 @@
 //! See README's Release section for how `rinkaku` and `rinkaku-core` are
 //! versioned and tagged independently.
 
+use crate::spinner::Spinner;
 use anyhow::{Context, Result};
 use std::io::IsTerminal;
 
@@ -171,11 +172,17 @@ pub fn run_self_update(yes: bool) -> Result<()> {
         }
     }
 
+    // `update()` runs silently under `show_output(false)` (`build_updater`'s
+    // doc comment) for as long as its network calls take, which otherwise
+    // reads as a hang (ADR 0056).
+    let spinner = Spinner::start("Updating...");
     let status = updater.update().context(
         "self-update failed; if this is a permission error, try again with sudo, \
          or update via the package manager you installed rinkaku with \
          (e.g. `brew upgrade` or `cargo install rinkaku`)",
-    )?;
+    );
+    spinner.finish_and_clear();
+    let status = status?;
 
     if status.updated() {
         println!(


### PR DESCRIPTION
## Summary

Addresses two reports about the self-update experience (ADR 0056):

1. **Fix: update prompt appeared frozen.** While the update prompt was open, `translate_key` had no modal short-circuit (unlike the help overlay, jump popup, and review overlays), so Enter/Esc/`q` never translated to `PopupConfirm`/`PopupCancel` — the prompt advertised "[Enter] update & quit  [Esc] not now" but no key did anything. Existing tests missed it because they constructed `InputKey::PopupConfirm/PopupCancel` directly, bypassing `translate_key`. A short-circuit is added in the same priority chain as the other modals.
2. **Feat: the update notice is easy to miss.** It only appeared as a status-line suffix. The prompt now auto-opens once when the background version check reports a newer release, gated by the pure function `should_auto_open_update_prompt`: it does not auto-open if the user already dismissed it (Esc/`q`) or while another modal (help overlay, jump popup) is active. `u` reopens it at any time; the status-line suffix stays.

Also wraps the actual updater run in the existing `Spinner` so the download/replace window (previously fully silent) shows progress. In-app self-update is kept — the freeze was an input-routing bug, not a flaw in the update mechanism itself.

## ADR

- `docs/adr/0056-tui-update-prompt-auto-open-and-freeze-fix.md`

## Testing

- TDD; new `translate_key` routing tests for Enter/Esc/`q` while the prompt is open, state-machine tests for auto-open/dismiss/reopen, `TestBackend` render tests, and no-auto-open-over-other-modal cases.
- `make test`: 925 passed. `make lint`: clean (fmt + clippy `-D warnings`).
- Static map-assisted review pass done; its should-fix (modal collision) and nits are fixed in the last commit.
- Real-binary verification of the startup popup is planned post-merge with a version-lowered local build, before merging the release PR.

Not verified end-to-end: actual binary replacement against a live GitHub release (impractical against the installed binary); the updater path is unchanged apart from the spinner wrapper.