### PR TITLE
feat(tui): vim-like search in source view + help overlay Global group split

### DIFF
--- a/docs/adr/0057-tui-source-view-search.md
+++ b/docs/adr/0057-tui-source-view-search.md
@@ -1,0 +1,243 @@
+# 0057. TUI source view search, and splitting the help overlay's Global group by screen
+
+- Status: Accepted
+- Date: 2026-07-16
+
+## Context
+
+`Screen::Source` (ADR 0026) already gives a reviewer line-by-line and
+half-page motion through a symbol's file, but no way to jump to a
+specific place by content — finding a call site or a string literal
+several hundred lines away still means scrolling past everything in
+between. A vim-like `/` search is the obvious gap: every other motion
+primitive in this screen already mirrors a vim idiom (`j`/`k`,
+`Ctrl-d`/`Ctrl-u`, `gg`/`G`), so `/`, `n`, `N` complete the set rather
+than introducing an unrelated interaction style.
+
+Extending search to the Entry screen's Diff pane is out of scope here —
+that pane's content is shaped/grouped per symbol (`crate::diff_shape`)
+rather than a flat line list, so "what a match position means" would
+need its own design (does a match jump reset the diff-focus auto-scroll?
+does it search across the whole file or only the selected symbol's
+section?). None of those questions are settled by this ADR; Source view
+alone has a flat `Vec<String>` of lines, an already-simple case worth
+shipping on its own.
+
+Separately, PR #177 (`?` help overlay per-screen filtering) shipped
+`applicable_help_groups`, which already splits the overlay into
+`TreeFocus`/`RightFocus`/`SourceView`/`Review`/`Global` groups filtered
+by the reviewer's current screen/focus — except `Global` is not actually
+global: on `Screen::Source`, `App::handle_key`'s catch-all arm
+(`(Screen::Source { .. }, _, _) => {}`) swallows `d`/`r`/`o`/`s`/
+`ctrl-o`/`ctrl-i` as no-ops, while `v`/`w`/`u`/`gd`/`gr`/`?`/`q` do work
+there (`ToggleSplitView` has its own dedicated Source-screen arm; `w`/`u`
+are dispatched before `App::handle_key`'s Source catch-all even runs,
+per `crate::event_loop::run_app`'s inline special-casing; `gd`/`gr`
+degrade to a "not applicable" status message rather than a true no-op,
+since `resolve_goto` still runs, but produce no navigation effect on this
+screen either way). PR #177's own body recorded this as a known,
+deliberately deferred limitation. This ADR resolves it as a byproduct of
+adding the new Source-screen bindings, since both changes touch
+`help.rs`'s group table.
+
+## Decision
+
+### Search (Source view only)
+
+**1. `/` starts Source-screen-only search mode.** Pressing `/` while
+`Screen::Source` is open enters composing mode; `/` is otherwise unbound
+on this screen today, so no existing gesture is displaced. `/` is *not*
+translated to a search action anywhere else (`Screen::Entry`, the help
+overlay, any popup) — `crate::input_translate::translate_key` only
+recognizes it while `on_source_screen` and no higher-priority modal
+(review overlay, jump popup, update prompt) is open, mirroring how
+`InputKey::Source`'s own `s` binding is likewise screen-scoped.
+
+**2. Composing-mode key handling**, modeled directly on the review
+overlay's `Compose` mode (`ReviewMode::Compose`, ADR 0048) rather than a
+new pattern:
+
+- Printable characters append to the query buffer.
+- Backspace removes the last character.
+- Enter confirms the search: computes matches, jumps to the first match
+  at or after the current `scroll_top`, and leaves composing mode.
+- Esc cancels: discards the in-progress buffer and returns to plain
+  reading with no active search (any *previous* confirmed search's
+  matches/highlighting are also cleared — cancel means "stop searching
+  altogether", not "revert to the last confirmed query"). Esc has this
+  same clearing effect even outside composing mode, whenever a confirmed
+  search is still active (matching vim's own `/`-then-Esc convention of
+  dismissing the highlight): `crate::input_translate::translate_key`
+  checks `app.search().query().is_some()` and emits `SearchCancel` before
+  falling through to the screen's ordinary `Back` meaning, so a reviewer
+  backing out of a search does not also lose their place by leaving the
+  screen in the same keypress.
+
+**3. The status line doubles as a minibuffer.** While composing,
+`crate::ui::status::draw_status_line` renders `/` followed by the
+buffer's current contents in place of the ordinary help-hint text, the
+same "status line is the one line available for transient input/output"
+role the line already plays for `App::status`'s transient messages.
+No separate popup/overlay is introduced for this — a one-line buffer
+does not need one, and a popup would additionally have to solve focus
+routing this composing mode already gets by piggybacking on
+`ReviewMode::Compose`'s existing "one key space, one modal priority
+slot" precedent (`App::handle_key`'s own doc comment on why the review
+overlay is checked first).
+
+**4. `n` / `N` jump to next/previous match**, wrap-around, vim
+convention (`n` repeats the last search forward, `N` repeats it
+backward). Both are Source-screen-only bindings — `crate::input_translate::translate_key`
+only emits `InputKey::SearchNext`/`SearchPrev` for `n`/`N` while
+`on_source_screen`, so they do not collide with the Entry screen's
+existing `n` (`NoteCompose`, ADR 0048) / `N` (`NotesList`) review-note
+bindings, which stay exactly as they are.
+
+`N` (uppercase) is acceptable here under this project's "no arbitrary
+case-insensitive keybindings" convention (uppercase is reserved for a
+distinct operation from its lowercase counterpart, not a case-insensitive
+alias — see PR #177, which dropped the case-insensitive uppercase
+aliases this convention now forbids) because `N` means "jump to the
+*previous* match", a genuinely separate operation from `n`'s "jump to
+the *next* match" — not a case-insensitive spelling of the same action.
+This is the same justification ADR 0026 already gives for `gg` vs. `G`
+(top vs. bottom are different destinations, not the same one typed two
+ways).
+
+When no search is active (never confirmed a query this screen-visit, or
+the last confirmed query had zero matches), `n`/`N` are no-ops — there is
+nothing to jump between.
+
+**5. Match semantics: literal substring search with smartcase.** Not
+regex — v1 scope is "find this text", and a regex engine is a
+disproportionate dependency for that. Smartcase (the vim/ripgrep
+convention already familiar to this feature's target audience): a query
+that is entirely lowercase searches case-insensitively; a query
+containing any uppercase character searches case-sensitively. This
+needs no configuration surface (no separate "case sensitive" toggle) and
+matches what a vim-literate reviewer already expects from `/`.
+
+**6. Matched-line highlighting reuses `source_screen.rs`'s existing
+diff-overlay background-color-blend approach** — the same `Option<Color>`
+background-tint composition `unchanged_line`/`SOURCE_HIGHLIGHT_BG`/
+`ADDED_BG` already layer (ADR 0018's "token foreground + line-level
+background tint", extended by ADR 0046's diff overlay). A new
+`SEARCH_MATCH_BG`/`SEARCH_CURRENT_MATCH_BG` pair of tint constants is
+added to that same layering, not a new rendering path — search
+highlighting composes with the existing symbol-range tint and diff
+overlay exactly the way those two already compose with each other,
+using the same "more specific signal wins" precedent
+(`unchanged_line`'s own doc comment: `diff_bg.or(is_highlighted...)`)
+extended one level further: `diff_bg.or(match_bg).or(range_bg)`. The
+*current* match (the one `n`/`N`/the confirming Enter just navigated to)
+uses a visually distinguishable tint from other matches on screen
+(`SEARCH_CURRENT_MATCH_BG`, brighter/more saturated than
+`SEARCH_MATCH_BG`) — a reviewer scanning a screen with several matches
+needs to see which one the cursor actually landed on without counting.
+
+**7. Status line shows `N/M` after confirming a search.** Once a query is
+confirmed (Enter, or a `n`/`N` jump), the status line's help-hint segment
+is replaced by `/query — N/M` (`N` = current match's 1-based position,
+`M` = total match count) until the reviewer presses a key that leaves
+search context (Esc, `Back`, or starting a new `/` search). Zero matches
+render as `/query — no matches` — `N/M` has no sensible value when
+`M == 0`, so this is a distinct display case, not `0/0`.
+
+### Help overlay: split Global by screen reachability
+
+**8. `HelpGroup::Global` splits into two groups**, along the exact fault
+line PR #177's own "Known limitation" section already identified:
+
+- `HelpGroup::Global` (kept name, narrowed content): bindings valid on
+  *every* screen — `v`, `w`, `u`, `gd`, `gr`, `?`, `q`/`ctrl-c`. This is
+  the literal truth of "global" the name already claimed.
+- `HelpGroup::EntryOnly` (new): bindings that only do something on
+  `Screen::Entry` — `d`, `r`, `o`, `s`, `ctrl-o`, `ctrl-i`. Applicable
+  only when `!on_source_screen` (mirroring `HelpGroup::TreeFocus`/
+  `HelpGroup::RightFocus`/`HelpGroup::Review`'s existing
+  `is_group_applicable` shape, which already gates each on screen/focus
+  reachability rather than always showing every group).
+
+**9. `/`, `n`, `N` are added to `HelpGroup::SourceView`** (already
+Source-screen-scoped, already filtered by `is_group_applicable`), rather
+than a new group — they belong with the other Source-screen-only motion
+bindings that group already lists (`j`/`k`, `Ctrl-d`/`Ctrl-u`, `gg`/`G`,
+`Esc`/`q`).
+
+Net effect: `Screen::Source`'s help view now shows `SourceView` (with
+the three new search bindings) and `Global` (the narrowed, now-actually-
+global set) — no more `EntryOnly` bindings advertised as pressable on a
+screen where they are silently swallowed.
+
+## Alternatives
+
+- **Regex search.** Rejected for v1: adds a dependency and a failure
+  mode (invalid pattern while composing) neither vim's own `/` nor this
+  feature's actual driving need — "find this text" — requires. Could be
+  added later as an opt-in prefix (e.g. a leading backslash) without
+  breaking this ADR's literal-substring contract, if a concrete need
+  surfaces.
+- **Search across the Entry screen's Diff pane too, in this same ADR.**
+  Rejected per Context above — the Diff pane's shaped/grouped content
+  raises match-semantics questions (per-section vs. whole-file, and how
+  a match interacts with ADR 0027's diff-focus auto-scroll) this ADR
+  does not need to answer to ship Source-view search, and conflating the
+  two would block the simpler, already-well-defined case on the harder
+  one's design. Left as explicit future work.
+- **A dedicated popup for the search buffer instead of the status
+  line.** Rejected: a one-line buffer is exactly what the status line
+  already exists to show (`App::status`'s transient-message precedent),
+  and a popup would need to solve the same modal-priority-slot problem
+  `ReviewMode::Compose` already solves — reusing that shape (decision 2)
+  is strictly less new surface than a second popup type.
+- **A new top-level `SearchState` enum embedded directly on `App` as
+  several fields (query, mode flag, matches, cursor) rather than one
+  struct.** Rejected: `ReviewState` already establishes the "one
+  field on `App`, one owning module with its own transitions" pattern
+  for exactly this kind of self-contained per-feature state (ADR
+  0048's Module boundary decision) — `SearchState` follows that
+  precedent instead of scattering four loose fields across `App`
+  the way state looked before ADR 0048.
+- **Recompute matches inside the render path (`crate::ui::source_screen`)
+  on every draw.** Rejected on the same grounds ADR 0020's diff-shaping
+  decision and this crate's `terminal.draw`-runs-on-idle-poll-ticks
+  invariant already establish (`crate::event_loop::run_app`'s own doc
+  comment on `diff_highlights`): matches are computed once, when the
+  query changes or a search confirms, cached on `SearchState`, and the
+  render path only reads the cached positions.
+- **Case-insensitive `n`/`N` aliasing (accept both cases for either
+  binding).** Rejected per this project's "no arbitrary case-insensitive
+  keybindings" convention — see decision 4's justification for why `N`
+  survives that convention as a distinct operation rather than an alias.
+
+## Consequences
+
+- `App` gains one new field, `search: SearchState` (mirroring
+  `review: ReviewState`), and the priority-check chain in
+  `App::handle_key` gains one more early-return branch, ordered
+  correctly relative to the existing review/help/jump-popup/update-prompt
+  checks (composing-mode input must not leak into any of those, the same
+  way `ReviewMode::Compose` already guards itself first).
+- `InputKey` gains `SearchStart`, `SearchChar(char)`, `SearchBackspace`,
+  `SearchConfirm`, `SearchCancel`, `SearchNext`, `SearchPrev` — modeled
+  one-for-one on the `NoteCompose`/`ComposeChar`/`ComposeBackspace`/
+  `PopupConfirm`/`PopupCancel` precedent, kept as distinct variants
+  (rather than reusing `ComposeChar`/`ComposeBackspace`) so a reviewer
+  cannot end up composing a search query into a review note or vice versa
+  through a shared variant that both modes happen to interpret.
+- `crate::input_translate::translate_key` gains a `Screen::Source` +
+  search-composing early return, structurally parallel to the existing
+  `ReviewMode::Compose` early return at the top of the function.
+- `source_screen.rs` gains the match-highlighting tint constants and a
+  small amount of layering logic in `unchanged_line`; no new rendering
+  mechanism.
+- `help.rs`'s `HelpGroup` enum gains `EntryOnly`; `Global`'s binding list
+  shrinks to the truly-global subset; `SourceView`'s binding list grows
+  by three. `is_group_applicable`'s `Global => true` arm is joined by an
+  `EntryOnly => !on_source_screen` arm.
+- No backward-compatibility concern: the TUI has never shipped a release
+  carrying these bindings, so `/`/`n`/`N` on the Source screen and the
+  Global/EntryOnly split are both strict additions/corrections, not
+  breaking changes to any real user.
+- Future work (not this ADR): extending search to the Entry screen's
+  Diff pane, and an opt-in regex mode.

--- a/docs/adr/0057-tui-source-view-search.md
+++ b/docs/adr/0057-tui-source-view-search.md
@@ -71,7 +71,17 @@ new pattern:
   checks `app.search().query().is_some()` and emits `SearchCancel` before
   falling through to the screen's ordinary `Back` meaning, so a reviewer
   backing out of a search does not also lose their place by leaving the
-  screen in the same keypress.
+  screen in the same keypress. Leaving Source by *any* path — `Esc` above,
+  or `q`/`InputKey::Back` — clears search the same way: `App::handle_key`'s
+  `(Screen::Source, _, InputKey::Back)` arm cancels `search`
+  unconditionally, so re-entering Source on a different symbol never shows
+  a stale query/match count against unrelated content.
+- Enter confirming against a Source screen whose file failed to load (no
+  `Ok` `source_content` — a deleted file, a permission error) cancels the
+  search rather than leaving it composing: neither `/` nor Enter is gated
+  on load success, so this is reachable, not just defensive, and leaving
+  Enter a no-op would trap the reviewer in the minibuffer with only Esc as
+  a way out.
 
 **3. The status line doubles as a minibuffer.** While composing,
 `crate::ui::status::draw_status_line` renders `/` followed by the

--- a/docs/experiments/0001-map-assisted-llm-review/rounds/037.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/037.md
@@ -1,0 +1,47 @@
+# Round 37
+
+- Subject: PR #182 — TUI source-screen search: adds `SearchState`/
+  `SearchMode` and wires a modal search input, `q`/`Esc` clearing, and
+  `SearchConfirm` dispatch into the existing key-handling and
+  event-loop machinery.
+- Protocol: two agents — one map-assisted static-review pass, one
+  dynamic-verification pass — run against the branch in a shared
+  worktree.
+- **Map delivery**: `rinkaku --base main --format md`, built from a
+  trusted `main` checkout at `24cc8b1`, run before reading the diff.
+- **Map hit 1**: high fan-in changed symbols (`App` — 6 users,
+  `SearchState`/`SearchMode` — 4 users, `InputKey` — 3 users) correctly
+  steered the static reviewer to the field addition in `app/mod.rs`
+  and the modal-priority check in `handle_key.rs`.
+- **Map hit 2**: the `## File sizes` section flagged a warn-level entry
+  for `app/mod.rs` crossing 986→1011 lines (the 1000-line threshold).
+  The raw diff alone shows only +25 lines added; the absolute line
+  count crossing the threshold would have been missed without the map.
+- **Map miss**: both blockers found this round live entirely in
+  control-flow branches inside single functions — `translate_key` in
+  `input_translate.rs` (the `q`/`Esc` search-clear asymmetry) and the
+  dispatch logic in `event_loop/mod.rs` (`SearchConfirm` no-op on
+  failed source load) — neither shows up on the symbol graph. Both
+  were found only by the independent full-text-reading pass, not the
+  map-assisted one.
+- **Dynamic pass**: 15 scenarios verified via ratatui `TestBackend`,
+  all passing. The dynamic pass independently reproduced blocker 1
+  (stale search state surviving a screen transition), cross-confirming
+  the static pass's finding via a different method. It also caught a
+  comment-discipline violation: a doc comment enumerating behavior
+  examples instead of stating WHY.
+- Severity summary: 2 blockers (`q`/`Esc` search-clear asymmetry;
+  `SearchConfirm` no-op on failed source load), 1 comment-discipline
+  nit. All fixed in `d36e7bf`, with 4 new regression tests added.
+- Process note: during this round, a dynamic reviewer's scratch test
+  content transiently appeared in the shared worktree and was observed
+  by the static reviewer before being cleaned up (final state was
+  clean, nothing was committed). Flagging as a risk for future rounds
+  that share a single worktree across parallel reviewers: shared-
+  worktree state can leak between parallel review agents.
+- Takeaway: both blockers are further instances of the recurring
+  pattern from rounds 35-36 — high fan-in correctly routed attention to
+  the right modules (`app/mod.rs`, `handle_key.rs`), but the actual
+  defects were control-flow disagreements between sibling code paths
+  with no footprint on any signature or fan-in count, findable only by
+  reading the branches side by side.

--- a/rinkaku-tui/locales/en.yml
+++ b/rinkaku-tui/locales/en.yml
@@ -9,6 +9,7 @@ help:
     source_view: "Source view"
     review: "Review"
     global: "Global"
+    entry_only: "Entry screen only"
   binding:
     move_cursor: "Move the cursor"
     expand_collapse_open: "Expand/collapse a directory row, or open a file/symbol row (moves focus right)"
@@ -24,6 +25,8 @@ help:
     scroll_source_pane_line: "Scroll the source pane by one line"
     scroll_source_pane_half_page: "Scroll the source pane by half a page"
     jump_file_top_bottom: "Jump to the top / bottom of the file"
+    start_search: "Start a search"
+    jump_next_prev_match: "Jump to the next / previous search match"
     return_to_entry_view: "Return to the entry view"
     compose_review_note: "Compose a review note over the symbol under the cursor"
     open_review_notes_list: "Open the review notes list"

--- a/rinkaku-tui/locales/ja.yml
+++ b/rinkaku-tui/locales/ja.yml
@@ -9,6 +9,7 @@ help:
     source_view: "ソースビュー"
     review: "レビュー"
     global: "グローバル"
+    entry_only: "エントリー画面のみ"
   binding:
     move_cursor: "カーソルを移動"
     expand_collapse_open: "ディレクトリ行を開閉、またはファイル/シンボル行を開く（フォーカスが右に移動）"
@@ -24,6 +25,8 @@ help:
     scroll_source_pane_line: "ソースペインを1行スクロール"
     scroll_source_pane_half_page: "ソースペインを半ページ分スクロール"
     jump_file_top_bottom: "ファイルの先頭/末尾へジャンプ"
+    start_search: "検索を開始"
+    jump_next_prev_match: "次/前の検索結果へジャンプ"
     return_to_entry_view: "エントリービューに戻る"
     compose_review_note: "カーソル位置のシンボルにレビューノートを作成"
     open_review_notes_list: "レビューノート一覧を開く"

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -98,6 +98,36 @@ impl App {
             return self;
         }
 
+        // Source-view search composing (ADR 0057) takes over the key space
+        // next, mirroring the review overlay's own priority just above —
+        // checked ahead of the help overlay for the identical reason: a
+        // reviewer mid-query must never have a stray `?` yank focus away
+        // into the help overlay instead of typing a literal `?` into their
+        // search. Only reachable while composing (`crate::input_translate::
+        // translate_key` only emits `SearchChar`/`SearchBackspace`/
+        // `SearchCancel` for other keys while composing, and only on
+        // `Screen::Source`), so every other key this function processes is
+        // unaffected by this branch existing.
+        if matches!(
+            self.search.mode(),
+            crate::search::SearchMode::Composing { .. }
+        ) {
+            self.search = match key {
+                InputKey::SearchChar(c) => self.search.clone().push_char(c),
+                InputKey::SearchBackspace => self.search.clone().backspace(),
+                InputKey::SearchCancel => self.search.clone().cancel(),
+                // `SearchConfirm` needs the Source view's lines, which this
+                // function has no access to — `crate::event_loop::run_app`
+                // special-cases it before dispatch and never routes it
+                // through `handle_key` at all (mirroring
+                // `InputKey::NoteCompose`'s identical "IO/derivation stays
+                // outside `App`" precedent), so this arm is unreachable in
+                // practice; kept only so the match stays exhaustive.
+                _ => self.search.clone(),
+            };
+            return self;
+        }
+
         if self.help_open {
             match key {
                 InputKey::ToggleHelp => {
@@ -321,6 +351,32 @@ impl App {
                     DiffViewMode::Unified => DiffViewMode::Split,
                     DiffViewMode::Split => DiffViewMode::Unified,
                 };
+            }
+            // ADR 0057: `/` starts composing a search query — the
+            // composing-mode branch above this match takes over from the
+            // next key onward, so this arm only needs to flip the mode on.
+            (Screen::Source { .. }, _, InputKey::SearchStart) => {
+                self.search = self.search.clone().start();
+            }
+            // `n`/`N` jump the confirmed query's current match, wrapping —
+            // a no-op with no confirmed matches (`SearchState::next`/`prev`'s
+            // own doc comment). Applying the jump to `scroll_top` itself
+            // happens in `crate::event_loop::run_app`, the same "App has no
+            // notion of the pane's rendered height/content" split ADR 0026's
+            // hunk-jump arms already use — this arm only advances which
+            // match is current.
+            (Screen::Source { .. }, _, InputKey::SearchNext) => {
+                self.search = self.search.clone().next();
+            }
+            (Screen::Source { .. }, _, InputKey::SearchPrev) => {
+                self.search = self.search.clone().prev();
+            }
+            // Esc while a confirmed search is active (`crate::input_translate::
+            // translate_key`'s own doc comment on why this arrives as
+            // `SearchCancel` rather than `Back` in that case): clears the
+            // search without leaving the screen.
+            (Screen::Source { .. }, _, InputKey::SearchCancel) => {
+                self.search = self.search.clone().cancel();
             }
             // Every other key is a no-op while the source view is open —
             // navigation/reordering only make sense against the entry
@@ -653,6 +709,22 @@ impl App {
             // above this match already intercepts it and opens the popup
             // otherwise. A no-op either way: nothing to confirm yet.
             (Screen::Entry, _, InputKey::OpenUpdatePrompt) => {}
+            // ADR 0057: search is Source-screen-only —
+            // `crate::input_translate::translate_key` never emits any of
+            // these six variants while `Screen::Entry`, so this arm is a
+            // no-op stub kept only for match exhaustiveness, mirroring
+            // `OpenPrInBrowser`'s own precedent just above.
+            (
+                Screen::Entry,
+                _,
+                InputKey::SearchStart
+                | InputKey::SearchChar(_)
+                | InputKey::SearchBackspace
+                | InputKey::SearchConfirm
+                | InputKey::SearchCancel
+                | InputKey::SearchNext
+                | InputKey::SearchPrev,
+            ) => {}
         }
 
         if !preserve_scroll && !preserve_scroll_after_jump {

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -117,12 +117,11 @@ impl App {
                 InputKey::SearchBackspace => self.search.clone().backspace(),
                 InputKey::SearchCancel => self.search.clone().cancel(),
                 // `SearchConfirm` needs the Source view's lines, which this
-                // function has no access to — `crate::event_loop::run_app`
-                // special-cases it before dispatch and never routes it
-                // through `handle_key` at all (mirroring
+                // function has no access to — `crate::event_loop::
+                // dispatch_search_confirm` handles it instead (mirroring
                 // `InputKey::NoteCompose`'s identical "IO/derivation stays
-                // outside `App`" precedent), so this arm is unreachable in
-                // practice; kept only so the match stays exhaustive.
+                // outside `App`" precedent), so this arm only needs to keep
+                // the match exhaustive.
                 _ => self.search.clone(),
             };
             return self;
@@ -280,8 +279,14 @@ impl App {
         let mut preserve_scroll_after_jump = false;
 
         match (&self.screen, self.focus, key) {
+            // Leaving Source (`q` or `Esc`) always clears `search` — ADR
+            // 0057 decision 2's "cancel means stop searching altogether"
+            // applies to every path out of this screen, not just the
+            // dedicated `SearchCancel` key, so a confirmed query cannot
+            // survive into a different symbol's Source view.
             (Screen::Source { .. }, _, InputKey::Back) => {
                 self.screen = Screen::Entry;
+                self.search = self.search.clone().cancel();
             }
             // ADR 0026: `j`/`k` scroll the source pane by one line — the
             // same "j/k scrolls the reading pane" rule ADR 0020 already

--- a/rinkaku-tui/src/app/input_key.rs
+++ b/rinkaku-tui/src/app/input_key.rs
@@ -233,4 +233,38 @@ pub enum InputKey {
     /// unprompted modal stealing keystrokes mid-review would be worse than
     /// a quiet, persistent status-line hint.
     OpenUpdatePrompt,
+    /// `/` on the Source screen (ADR 0057): starts composing a search
+    /// query. Source-screen-only — `crate::input_translate::translate_key`
+    /// never emits this variant while [`Screen::Entry`], so `/` has no
+    /// meaning there.
+    SearchStart,
+    /// A printable character typed while composing a search query —
+    /// mirrors [`Self::ComposeChar`]'s identical role for the review
+    /// overlay, kept as a distinct variant (rather than reusing
+    /// `ComposeChar`) so a reviewer cannot end up composing a search query
+    /// into a review note or vice versa through a shared variant both
+    /// modes happen to interpret.
+    SearchChar(char),
+    /// Backspace while composing a search query — mirrors
+    /// [`Self::ComposeBackspace`].
+    SearchBackspace,
+    /// Enter while composing a search query: confirms it, computing its
+    /// matches against the Source view's lines (data `App::handle_key`
+    /// has no access to, mirroring [`Self::NoteCompose`]'s own "IO/
+    /// derivation stays outside `App`" precedent) — `crate::event_loop::run_app`
+    /// special-cases this variant before dispatch rather than routing it
+    /// through `App::handle_key` at all.
+    SearchConfirm,
+    /// Esc while composing a search query, or while a confirmed search is
+    /// still active: cancels/clears it (ADR 0057 decision 2).
+    SearchCancel,
+    /// `n` on the Source screen (ADR 0057): jumps to the next match of the
+    /// last confirmed query, wrapping. Source-screen-only, so it does not
+    /// collide with [`Self::NoteCompose`]'s own `n` binding on the entry
+    /// screen.
+    SearchNext,
+    /// `N` on the Source screen: the reverse of [`Self::SearchNext`].
+    /// Source-screen-only, so it does not collide with [`Self::NotesList`]'s
+    /// own `N` binding on the entry screen.
+    SearchPrev,
 }

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -16,6 +16,7 @@ use crate::detail::{
 use crate::nav::Nav;
 use crate::order::{DirRank, OrderMode, rank_directories};
 use crate::review::ReviewState;
+use crate::search::SearchState;
 use crate::tree::{NodeKind, Tree, build_tree};
 use rinkaku_core::render::Report;
 use std::collections::HashMap;
@@ -347,6 +348,10 @@ pub struct App {
     /// decision; every review-specific transition lives on [`ReviewState`]
     /// itself, not here.
     review: ReviewState,
+    /// The Source-view search feature's own state (ADR 0057), following
+    /// [`Self::review`]'s identical "one field, own module" precedent —
+    /// every search-specific transition lives on [`SearchState`] itself.
+    search: SearchState,
     /// Whether sink A (posting a GitHub PR review) is on the export menu
     /// this session — mirrors whether `crate::session::TuiSession::run`
     /// was given a `PrContext`/submitter port, fixed for the session's
@@ -415,6 +420,7 @@ impl App {
             status: None,
             should_quit: false,
             review: ReviewState::default(),
+            search: SearchState::default(),
             review_sink_a_available: false,
             update_available: None,
             update_prompt_open: false,
@@ -550,6 +556,12 @@ impl App {
         &self.review
     }
 
+    /// The Source-view search feature's own state (ADR 0057) — see
+    /// [`crate::search::SearchState`]'s own doc comment.
+    pub fn search(&self) -> &SearchState {
+        &self.search
+    }
+
     /// Whether sink A (posting a GitHub PR review) is on the export menu
     /// this session — see [`Self::with_review_sink_a_available`]'s own doc
     /// comment. `crate::ui::review_overlay` reads this to keep the export
@@ -570,6 +582,19 @@ impl App {
     /// `handle_key`).
     pub fn with_review(mut self, review: ReviewState) -> Self {
         self.review = review;
+        self
+    }
+
+    /// Replaces `App`'s [`SearchState`] wholesale — used by
+    /// `crate::event_loop::run_app` for the one search transition that
+    /// needs data (the Source view's own source lines) `App::handle_key`
+    /// cannot derive itself: confirming a query
+    /// ([`InputKey::SearchConfirm`]'s own doc comment on why that key is
+    /// special-cased before dispatch rather than routed through
+    /// `handle_key`, mirroring [`Self::with_review`]'s identical precedent
+    /// for [`InputKey::NoteCompose`]).
+    pub fn with_search(mut self, search: SearchState) -> Self {
+        self.search = search;
         self
     }
 

--- a/rinkaku-tui/src/app/tests/mod.rs
+++ b/rinkaku-tui/src/app/tests/mod.rs
@@ -30,6 +30,8 @@
 //!   `JumpBack`/`JumpForward` jumplist (ADR 0022)
 //! - `review` — `handle_review_key`'s notes-list overlay dispatch (ADR
 //!   0048)
+//! - `search` — Source-view search composing/cancel/next/prev dispatch
+//!   (ADR 0057)
 //! - `update_prompt` — `notify_update_available`, `OpenUpdatePrompt`'s
 //!   `update_available` gating, and the update popup's own
 //!   `PopupConfirm`/`PopupCancel` handling (ADR 0054)
@@ -48,6 +50,7 @@ mod jump;
 mod review;
 mod right_pane;
 mod scroll_reset;
+mod search;
 mod source_screen;
 mod update_prompt;
 

--- a/rinkaku-tui/src/app/tests/search.rs
+++ b/rinkaku-tui/src/app/tests/search.rs
@@ -153,6 +153,31 @@ fn should_swallow_unrelated_keys_while_composing_a_search_query() {
 }
 
 #[test]
+fn should_clear_a_confirmed_search_when_leaving_source_via_back() {
+    // Regression: `q` (translated to `InputKey::Back`, same as `Esc` once
+    // no confirmed search is active) used to leave `search` untouched,
+    // so re-entering Source on a different symbol still showed the old
+    // query/matches/highlighting against unrelated content.
+    let report = report_with_one_symbol();
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .confirm(&["fn foo() {}".to_string()], 0);
+    let app = opened_source_screen(&report).with_search(search);
+    assert!(app.search().query().is_some());
+
+    let actual = app.handle_key(InputKey::Back);
+
+    assert_eq!(&SearchMode::Inactive, actual.search().mode());
+    assert_eq!(None, actual.search().query());
+    assert_eq!(
+        &[] as &[crate::search::MatchLine],
+        actual.search().matches()
+    );
+}
+
+#[test]
 fn should_not_start_composing_on_the_entry_screen() {
     // ADR 0057: search is Source-screen-only — `SearchStart` reaching
     // `handle_key` while `Screen::Entry` (defensively, since

--- a/rinkaku-tui/src/app/tests/search.rs
+++ b/rinkaku-tui/src/app/tests/search.rs
@@ -1,0 +1,167 @@
+//! Tests for `App::handle_key`'s Source-view search dispatch (ADR 0057):
+//! `/` starting composing, character/backspace composing, `Esc` cancel
+//! (both while composing and after a confirmed search), and the
+//! composing-mode priority check taking over the whole key space the same
+//! way the review overlay's own check does.
+
+use super::*;
+use crate::search::{SearchMode, SearchState};
+
+fn opened_source_screen(report: &Report) -> App {
+    App::new(report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Source)
+}
+
+#[test]
+fn should_start_composing_when_search_start_is_pressed_on_source_screen() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report);
+
+    let actual = app.handle_key(InputKey::SearchStart);
+
+    assert_eq!(
+        &SearchMode::Composing {
+            buffer: String::new()
+        },
+        actual.search().mode()
+    );
+}
+
+#[test]
+fn should_build_up_the_query_buffer_via_search_char() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report)
+        .handle_key(InputKey::SearchStart)
+        .handle_key(InputKey::SearchChar('f'))
+        .handle_key(InputKey::SearchChar('o'));
+
+    assert_eq!(
+        &SearchMode::Composing {
+            buffer: "fo".to_string()
+        },
+        app.search().mode()
+    );
+}
+
+#[test]
+fn should_remove_the_last_character_via_search_backspace() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report)
+        .handle_key(InputKey::SearchStart)
+        .handle_key(InputKey::SearchChar('f'))
+        .handle_key(InputKey::SearchChar('o'))
+        .handle_key(InputKey::SearchBackspace);
+
+    assert_eq!(
+        &SearchMode::Composing {
+            buffer: "f".to_string()
+        },
+        app.search().mode()
+    );
+}
+
+#[test]
+fn should_cancel_composing_when_search_cancel_is_pressed_while_composing() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report)
+        .handle_key(InputKey::SearchStart)
+        .handle_key(InputKey::SearchChar('f'))
+        .handle_key(InputKey::SearchCancel);
+
+    assert_eq!(&SearchMode::Inactive, app.search().mode());
+    assert_eq!(None, app.search().query());
+}
+
+#[test]
+fn should_clear_a_confirmed_search_when_search_cancel_is_pressed_outside_composing() {
+    let report = report_with_one_symbol();
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .confirm(&["fn foo() {}".to_string()], 0);
+    let app = opened_source_screen(&report)
+        .with_search(search)
+        .handle_key(InputKey::SearchCancel);
+
+    assert_eq!(None, app.search().query());
+    assert_eq!(&[] as &[crate::search::MatchLine], app.search().matches());
+}
+
+#[test]
+fn should_advance_to_the_next_match_when_search_next_is_pressed() {
+    let report = report_with_one_symbol();
+    let lines = vec![
+        "fn foo() {}".to_string(),
+        "fn bar() {}".to_string(),
+        "fn foo_helper() {}".to_string(),
+    ];
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&lines, 0);
+    let app = opened_source_screen(&report).with_search(search);
+    assert_eq!(Some(0), app.search().current_match());
+
+    let actual = app.handle_key(InputKey::SearchNext);
+
+    assert_eq!(Some(2), actual.search().current_match());
+}
+
+#[test]
+fn should_retreat_to_the_previous_match_when_search_prev_is_pressed() {
+    let report = report_with_one_symbol();
+    let lines = vec![
+        "fn foo() {}".to_string(),
+        "fn bar() {}".to_string(),
+        "fn foo_helper() {}".to_string(),
+    ];
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&lines, 0);
+    let app = opened_source_screen(&report).with_search(search);
+
+    let actual = app.handle_key(InputKey::SearchPrev);
+
+    assert_eq!(Some(2), actual.search().current_match());
+}
+
+#[test]
+fn should_swallow_unrelated_keys_while_composing_a_search_query() {
+    // Mirrors the review overlay's own "takes over the whole key space"
+    // invariant (`App::handle_key`'s doc comment): while composing, a key
+    // that would otherwise mean something else (`ToggleHelp`) must not
+    // reach its ordinary meaning.
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report)
+        .handle_key(InputKey::SearchStart)
+        .handle_key(InputKey::ToggleHelp);
+
+    assert_eq!(
+        &SearchMode::Composing {
+            buffer: String::new()
+        },
+        app.search().mode()
+    );
+    assert!(!app.help_open());
+}
+
+#[test]
+fn should_not_start_composing_on_the_entry_screen() {
+    // ADR 0057: search is Source-screen-only — `SearchStart` reaching
+    // `handle_key` while `Screen::Entry` (defensively, since
+    // `crate::input_translate::translate_key` never emits it there) must
+    // be a no-op.
+    let report = report_with_one_symbol();
+    let app = App::new(&report);
+
+    let actual = app.handle_key(InputKey::SearchStart);
+
+    assert_eq!(&SearchMode::Inactive, actual.search().mode());
+}

--- a/rinkaku-tui/src/event_loop/mod.rs
+++ b/rinkaku-tui/src/event_loop/mod.rs
@@ -301,6 +301,40 @@ pub(crate) fn run_app(
                 // documents did).
                 let snapshot = derive_selection_snapshot(&app, report, &diff_hunks);
                 app = dispatch_note_compose_key(app, snapshot);
+            } else if let InputKey::SearchConfirm = input_key {
+                // ADR 0057: needs the Source view's own lines to compute
+                // matches, which `App::handle_key` has no access to
+                // (mirrors `InputKey::NoteCompose`'s own "IO/derivation
+                // stays outside `App`" precedent just above). A no-op when
+                // `source_content` is not a loaded `Ok` view (defensive —
+                // `SearchConfirm` is only reachable while composing, which
+                // in turn is only reachable via `/` on an already-open
+                // `Screen::Source`, so a loaded view should always be
+                // present by then).
+                if let Some(Ok(highlighted)) = source_content.as_ref() {
+                    let from_line = match app.screen() {
+                        Screen::Source { scroll_top, .. } => *scroll_top,
+                        Screen::Entry => 0,
+                    };
+                    let search = app
+                        .search()
+                        .clone()
+                        .confirm(&highlighted.view.lines, from_line);
+                    app = app.with_search(search);
+                    app = jump_source_scroll_to_current_match(app);
+                } else {
+                    app = app.handle_key(input_key);
+                }
+            } else if matches!(input_key, InputKey::SearchNext | InputKey::SearchPrev) {
+                // ADR 0057: `App::handle_key` already advances/retreats
+                // `SearchState`'s current match (no external data needed
+                // for that step); this loop's own job is folding the
+                // resulting match line into `Screen::Source::scroll_top`,
+                // the same split `InputKey::Source`'s own back-fill above
+                // uses between "what changed" (`App`) and "how that maps
+                // onto the viewport" (`run_app`).
+                app = app.handle_key(input_key);
+                app = jump_source_scroll_to_current_match(app);
             } else if let InputKey::OpenPrInBrowser = input_key {
                 // ADR 0050: needs `review_ports.pr_context`/`.browser`,
                 // neither of which `App::handle_key` has access to (mirrors
@@ -570,6 +604,22 @@ fn dispatch_non_source_key(
 /// [`RightPane::Diff`]: crate::app::RightPane::Diff
 fn should_recompute_diff_pane_content(app: &App) -> bool {
     matches!(app.screen(), Screen::Entry) && app.right_pane() == crate::app::RightPane::Diff
+}
+
+/// Moves `Screen::Source::scroll_top` to `app.search()`'s current match
+/// line, if any — a no-op (returning `app` unchanged) when there is no
+/// current match ([`crate::search::SearchState::current_match`] is `None`,
+/// e.g. a confirmed query with zero matches) or the screen is not
+/// [`Screen::Source`]. Kept as a small wrapper around
+/// [`App::with_source_scroll_top`] (already a no-op on [`Screen::Entry`],
+/// per that method's own doc comment) rather than inlined at each of this
+/// module's three call sites (`SearchConfirm`, `SearchNext`, `SearchPrev`)
+/// sharing the exact same "match line -> scroll target" mapping.
+fn jump_source_scroll_to_current_match(app: App) -> App {
+    match app.search().current_match() {
+        Some(line) => app.with_source_scroll_top(line),
+        None => app,
+    }
 }
 
 /// Whether `crate::event_loop::run_app`'s [`InputKey::Source`] arm should

--- a/rinkaku-tui/src/event_loop/mod.rs
+++ b/rinkaku-tui/src/event_loop/mod.rs
@@ -305,26 +305,13 @@ pub(crate) fn run_app(
                 // ADR 0057: needs the Source view's own lines to compute
                 // matches, which `App::handle_key` has no access to
                 // (mirrors `InputKey::NoteCompose`'s own "IO/derivation
-                // stays outside `App`" precedent just above). A no-op when
-                // `source_content` is not a loaded `Ok` view (defensive —
-                // `SearchConfirm` is only reachable while composing, which
-                // in turn is only reachable via `/` on an already-open
-                // `Screen::Source`, so a loaded view should always be
-                // present by then).
-                if let Some(Ok(highlighted)) = source_content.as_ref() {
-                    let from_line = match app.screen() {
-                        Screen::Source { scroll_top, .. } => *scroll_top,
-                        Screen::Entry => 0,
-                    };
-                    let search = app
-                        .search()
-                        .clone()
-                        .confirm(&highlighted.view.lines, from_line);
-                    app = app.with_search(search);
-                    app = jump_source_scroll_to_current_match(app);
-                } else {
-                    app = app.handle_key(input_key);
-                }
+                // stays outside `App`" precedent just above). See
+                // `dispatch_search_confirm`'s own doc comment for what
+                // happens when `source_content` is not a loaded `Ok` view —
+                // reachable whenever the Source screen is open against a
+                // file that failed to load, since neither `/` nor Enter is
+                // gated on load success.
+                app = dispatch_search_confirm(app, source_content.as_ref());
             } else if matches!(input_key, InputKey::SearchNext | InputKey::SearchPrev) {
                 // ADR 0057: `App::handle_key` already advances/retreats
                 // `SearchState`'s current match (no external data needed
@@ -619,6 +606,38 @@ fn jump_source_scroll_to_current_match(app: App) -> App {
     match app.search().current_match() {
         Some(line) => app.with_source_scroll_top(line),
         None => app,
+    }
+}
+
+/// Applies [`InputKey::SearchConfirm`] against `source_content` — extracted
+/// from `run_app`'s inline dispatch so this branch is unit-testable without
+/// a live terminal (mirrors `jump_source_scroll_to_current_match`'s own
+/// "small wrapper, pulled out for the shared/testable step" precedent).
+///
+/// When `source_content` is not a loaded `Ok` view (the Source screen open
+/// against a file that failed to read — e.g. deleted mid-review, or a
+/// permission error), confirming cancels the search instead of leaving it
+/// composing: `App::handle_key`'s own `SearchConfirm` arm is a documented
+/// no-op (it has no lines to match against), and letting Enter do nothing
+/// here trapped the reviewer in the minibuffer with no way out except Esc.
+fn dispatch_search_confirm(
+    app: App,
+    source_content: Option<&Result<source::HighlightedSourceView, String>>,
+) -> App {
+    if let Some(Ok(highlighted)) = source_content {
+        let from_line = match app.screen() {
+            Screen::Source { scroll_top, .. } => *scroll_top,
+            Screen::Entry => 0,
+        };
+        let search = app
+            .search()
+            .clone()
+            .confirm(&highlighted.view.lines, from_line);
+        let app = app.with_search(search);
+        jump_source_scroll_to_current_match(app)
+    } else {
+        let search = app.search().clone().cancel();
+        app.with_search(search)
     }
 }
 

--- a/rinkaku-tui/src/event_loop/tests.rs
+++ b/rinkaku-tui/src/event_loop/tests.rs
@@ -2,15 +2,16 @@
 //! recompute gates (`should_recompute_diff_pane_content`,
 //! `should_recompute_blast_radius_selection`), the source-cache reload gate
 //! (`should_reload_source_content`), the scroll-key classifier
-//! (`is_scroll_input_key`), and `dispatch_non_source_key`'s `gd`/`gr`
-//! pending-prefix/jumplist regression coverage. `resolve_goto` and
+//! (`is_scroll_input_key`), `dispatch_non_source_key`'s `gd`/`gr`
+//! pending-prefix/jumplist regression coverage, and `dispatch_search_confirm`'s
+//! loaded-vs-failed source content branching. `resolve_goto` and
 //! `apply_diff_pane_selection_effects`/`sync_target_for_scroll`/
 //! `should_apply_hunk_jump`/`jump_scroll_target` have their own test trees
 //! in the sibling `goto`/`scroll_sync` submodules.
 
-use crate::app::{self, App, InputKey};
+use crate::app::{self, App, InputKey, Screen};
 use crate::diff_shape;
-use crate::event_loop::{dispatch_non_source_key, is_scroll_input_key};
+use crate::event_loop::{dispatch_non_source_key, dispatch_search_confirm, is_scroll_input_key};
 use pretty_assertions::assert_eq;
 use rinkaku_core::graph::SymbolGraph;
 use rinkaku_core::render::Report;
@@ -126,10 +127,17 @@ pub(super) fn report_with_symbols_and_edges(
 }
 
 pub(super) fn dummy_view(path: &str) -> crate::source::HighlightedSourceView {
+    dummy_view_with_lines(path, vec![])
+}
+
+pub(super) fn dummy_view_with_lines(
+    path: &str,
+    lines: Vec<String>,
+) -> crate::source::HighlightedSourceView {
     crate::source::HighlightedSourceView {
         view: crate::source::SourceView {
             path: path.to_string(),
-            lines: vec![],
+            lines,
             highlight_start: 1,
             highlight_end: 1,
         },
@@ -566,4 +574,78 @@ fn should_restore_the_scroll_offset_the_reviewer_was_at_when_jumping_back_after_
         app.right_pane_scroll(),
         "jumping back must restore the scroll offset recorded when gd was pressed, not 0"
     );
+}
+
+// --- dispatch_search_confirm ---
+
+#[test]
+fn should_confirm_and_jump_to_first_match_when_source_content_loaded_ok() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Source)
+        .handle_key(InputKey::SearchStart)
+        .handle_key(InputKey::SearchChar('f'))
+        .handle_key(InputKey::SearchChar('o'))
+        .handle_key(InputKey::SearchChar('o'));
+    let loaded: Result<crate::source::HighlightedSourceView, String> = Ok(dummy_view_with_lines(
+        "lib.rs",
+        vec!["fn foo() {}".to_string()],
+    ));
+
+    let actual = dispatch_search_confirm(app, Some(&loaded));
+
+    assert_eq!(
+        Some("foo".to_string()),
+        actual.search().query().map(str::to_string)
+    );
+    assert_eq!(&[0], actual.search().matches());
+    assert_eq!(
+        Screen::Source {
+            symbol_id: "lib.rs::foo".to_string(),
+            scroll_top: 0,
+        },
+        actual.screen().clone()
+    );
+}
+
+#[test]
+fn should_cancel_the_search_when_source_content_failed_to_load() {
+    // Regression: the Source screen can be open with `source_content` as
+    // `Some(Err(_))` (file deleted, permission error, ...) — `/` is not
+    // gated on load success, so composing a query and pressing Enter here
+    // used to fall through to `App::handle_key`'s own `SearchConfirm` arm,
+    // a documented no-op, trapping the reviewer in the minibuffer with no
+    // way out except Esc.
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Source)
+        .handle_key(InputKey::SearchStart)
+        .handle_key(InputKey::SearchChar('f'))
+        .handle_key(InputKey::SearchChar('o'));
+    let failed: Result<crate::source::HighlightedSourceView, String> =
+        Err("failed to read".to_string());
+
+    let actual = dispatch_search_confirm(app, Some(&failed));
+
+    assert_eq!(&crate::search::SearchMode::Inactive, actual.search().mode());
+    assert_eq!(None, actual.search().query());
+}
+
+#[test]
+fn should_cancel_the_search_when_source_content_is_absent() {
+    // Same defensive case as the failed-load test above, for the
+    // `source_content == None` half of "not a loaded `Ok` view".
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Source)
+        .handle_key(InputKey::SearchStart)
+        .handle_key(InputKey::SearchChar('f'));
+
+    let actual = dispatch_search_confirm(app, None);
+
+    assert_eq!(&crate::search::SearchMode::Inactive, actual.search().mode());
+    assert_eq!(None, actual.search().query());
 }

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -62,6 +62,12 @@ pub enum HelpGroup {
     SourceView,
     Review,
     Global,
+    /// Bindings that only do something on [`Screen::Entry`] (ADR 0057):
+    /// `d`/`r`/`o`/`s`/`ctrl-o`/`ctrl-i` are swallowed as no-ops by
+    /// `App::handle_key`'s `Screen::Source` catch-all arm, so listing them
+    /// under [`Self::Global`] (as PR #177 originally did) was misleading —
+    /// see this ADR's own Context for the exact fault line.
+    EntryOnly,
 }
 
 /// One named group of [`KeyBinding`]s — "Tree focus", "Right focus", or
@@ -164,6 +170,15 @@ fn source_screen_bindings(locale: Locale) -> Vec<KeyBinding> {
                 .into_owned(),
         },
         KeyBinding {
+            keys: "/",
+            description: rust_i18n::t!("help.binding.start_search", locale = tag).into_owned(),
+        },
+        KeyBinding {
+            keys: "n / N",
+            description: rust_i18n::t!("help.binding.jump_next_prev_match", locale = tag)
+                .into_owned(),
+        },
+        KeyBinding {
             keys: "esc / q",
             description: rust_i18n::t!("help.binding.return_to_entry_view", locale = tag)
                 .into_owned(),
@@ -192,31 +207,17 @@ fn review_bindings(locale: Locale) -> Vec<KeyBinding> {
     ]
 }
 
+/// Bindings valid on *every* screen (ADR 0057 decision 8) — the literal
+/// truth of "global" the group's name already claimed, narrowed from PR
+/// #177's original (broader, but inaccurate) set by moving the
+/// Entry-screen-only bindings out to [`entry_only_bindings`].
 fn global_bindings(locale: Locale) -> Vec<KeyBinding> {
     let tag = locale.tag();
     vec![
         KeyBinding {
-            keys: "d",
-            description: rust_i18n::t!("help.binding.toggle_detail_diff", locale = tag)
-                .into_owned(),
-        },
-        KeyBinding {
-            keys: "r",
-            description: rust_i18n::t!("help.binding.toggle_blast_radius", locale = tag)
-                .into_owned(),
-        },
-        KeyBinding {
             keys: "v",
             description: rust_i18n::t!("help.binding.toggle_unified_split", locale = tag)
                 .into_owned(),
-        },
-        KeyBinding {
-            keys: "o",
-            description: rust_i18n::t!("help.binding.toggle_order_mode", locale = tag).into_owned(),
-        },
-        KeyBinding {
-            keys: "s",
-            description: rust_i18n::t!("help.binding.open_source_view", locale = tag).into_owned(),
         },
         KeyBinding {
             keys: "gd",
@@ -225,14 +226,6 @@ fn global_bindings(locale: Locale) -> Vec<KeyBinding> {
         KeyBinding {
             keys: "gr",
             description: rust_i18n::t!("help.binding.jump_to_caller", locale = tag).into_owned(),
-        },
-        KeyBinding {
-            keys: "ctrl-o",
-            description: rust_i18n::t!("help.binding.jump_back", locale = tag).into_owned(),
-        },
-        KeyBinding {
-            keys: "ctrl-i",
-            description: rust_i18n::t!("help.binding.jump_forward", locale = tag).into_owned(),
         },
         KeyBinding {
             keys: "w",
@@ -252,6 +245,42 @@ fn global_bindings(locale: Locale) -> Vec<KeyBinding> {
         KeyBinding {
             keys: "q / ctrl-c",
             description: rust_i18n::t!("help.binding.quit", locale = tag).into_owned(),
+        },
+    ]
+}
+
+/// Bindings that only do something on [`Screen::Entry`] (ADR 0057 decision
+/// 8) — `d`/`r`/`o`/`s` toggle Entry-only panes/screens, and `ctrl-o`/
+/// `ctrl-i` walk the jumplist, which only Entry-screen navigation ever
+/// populates.
+fn entry_only_bindings(locale: Locale) -> Vec<KeyBinding> {
+    let tag = locale.tag();
+    vec![
+        KeyBinding {
+            keys: "d",
+            description: rust_i18n::t!("help.binding.toggle_detail_diff", locale = tag)
+                .into_owned(),
+        },
+        KeyBinding {
+            keys: "r",
+            description: rust_i18n::t!("help.binding.toggle_blast_radius", locale = tag)
+                .into_owned(),
+        },
+        KeyBinding {
+            keys: "o",
+            description: rust_i18n::t!("help.binding.toggle_order_mode", locale = tag).into_owned(),
+        },
+        KeyBinding {
+            keys: "s",
+            description: rust_i18n::t!("help.binding.open_source_view", locale = tag).into_owned(),
+        },
+        KeyBinding {
+            keys: "ctrl-o",
+            description: rust_i18n::t!("help.binding.jump_back", locale = tag).into_owned(),
+        },
+        KeyBinding {
+            keys: "ctrl-i",
+            description: rust_i18n::t!("help.binding.jump_forward", locale = tag).into_owned(),
         },
     ]
 }
@@ -284,6 +313,11 @@ fn keymap_groups(locale: Locale) -> Vec<KeyBindingGroup> {
             title: rust_i18n::t!("help.group.global", locale = tag).into_owned(),
             bindings: global_bindings(locale),
         },
+        KeyBindingGroup {
+            id: HelpGroup::EntryOnly,
+            title: rust_i18n::t!("help.group.entry_only", locale = tag).into_owned(),
+            bindings: entry_only_bindings(locale),
+        },
     ]
 }
 
@@ -296,7 +330,10 @@ fn keymap_groups(locale: Locale) -> Vec<KeyBindingGroup> {
 /// [`HelpGroup::SourceView`] only under [`Screen::Source`];
 /// [`HelpGroup::Review`]'s `n`/`N` only under [`Screen::Entry`] (regardless
 /// of `Focus`, per `review_flow::derive_selection_snapshot` and
-/// `App::handle_key`'s own `NotesList` arm); [`HelpGroup::Global`] always.
+/// `App::handle_key`'s own `NotesList` arm); [`HelpGroup::Global`] always;
+/// [`HelpGroup::EntryOnly`] (ADR 0057) only under [`Screen::Entry`] —
+/// `d`/`r`/`o`/`s`/`ctrl-o`/`ctrl-i` are no-ops on [`Screen::Source`]
+/// (`App::handle_key`'s own Source-screen catch-all arm).
 fn is_group_applicable(group: HelpGroup, screen: &Screen, focus: Focus) -> bool {
     let on_source_screen = matches!(screen, Screen::Source { .. });
     match group {
@@ -305,6 +342,7 @@ fn is_group_applicable(group: HelpGroup, screen: &Screen, focus: Focus) -> bool 
         HelpGroup::SourceView => on_source_screen,
         HelpGroup::Review => !on_source_screen,
         HelpGroup::Global => true,
+        HelpGroup::EntryOnly => !on_source_screen,
     }
 }
 

--- a/rinkaku-tui/src/help/tests.rs
+++ b/rinkaku-tui/src/help/tests.rs
@@ -16,7 +16,8 @@ fn should_list_keymap_groups_in_tree_right_source_review_global_order() {
             "Right focus",
             "Source view",
             "Review",
-            "Global"
+            "Global",
+            "Entry screen only",
         ],
         titles
     );
@@ -46,6 +47,27 @@ fn should_document_source_view_scroll_bindings_in_the_source_view_group() {
     assert!(keys.contains(&"ctrl-d / ctrl-u"));
     assert!(keys.contains(&"gg / G"));
     assert!(keys.contains(&"esc / q"));
+}
+
+#[test]
+fn should_document_search_bindings_in_the_source_view_group() {
+    // ADR 0057: `/`/`n`/`N` are added to the Source view group alongside
+    // the other Source-screen-only motion bindings.
+    let content = help_content(Locale::English);
+    let source_view = content
+        .keymap_groups
+        .iter()
+        .find(|group| group.title == "Source view")
+        .expect("Source view group present");
+
+    let keys: Vec<&str> = source_view
+        .bindings
+        .iter()
+        .map(|binding| binding.keys)
+        .collect();
+
+    assert!(keys.contains(&"/"));
+    assert!(keys.contains(&"n / N"));
 }
 
 #[test]
@@ -134,7 +156,11 @@ fn should_include_a_glossary_entry_for_jumplist() {
 }
 
 #[test]
-fn should_document_gd_gr_and_jumplist_bindings_in_the_global_group() {
+fn should_document_gd_and_gr_bindings_in_the_global_group() {
+    // ADR 0057: gd/gr are the truly-global half of what PR #177's Global
+    // group originally listed — jumplist navigation (ctrl-o/ctrl-i) moved
+    // to the new Entry-only group, since a jumplist is only ever
+    // populated by Entry-screen navigation.
     let content = help_content(Locale::English);
     let global = content
         .keymap_groups
@@ -146,8 +172,29 @@ fn should_document_gd_gr_and_jumplist_bindings_in_the_global_group() {
 
     assert!(keys.contains(&"gd"));
     assert!(keys.contains(&"gr"));
+}
+
+#[test]
+fn should_document_jumplist_bindings_in_the_entry_only_group() {
+    let content = help_content(Locale::English);
+    let entry_only = content
+        .keymap_groups
+        .iter()
+        .find(|group| group.title == "Entry screen only")
+        .expect("Entry screen only group present");
+
+    let keys: Vec<&str> = entry_only
+        .bindings
+        .iter()
+        .map(|binding| binding.keys)
+        .collect();
+
     assert!(keys.contains(&"ctrl-o"));
     assert!(keys.contains(&"ctrl-i"));
+    assert!(keys.contains(&"d"));
+    assert!(keys.contains(&"r"));
+    assert!(keys.contains(&"o"));
+    assert!(keys.contains(&"s"));
 }
 
 #[test]
@@ -205,23 +252,33 @@ fn source_screen() -> Screen {
 }
 
 #[test]
-fn should_show_tree_focus_review_and_global_groups_when_tree_focused_on_entry_screen() {
+fn should_show_tree_focus_review_global_and_entry_only_groups_when_tree_focused_on_entry_screen() {
     let groups = applicable_help_groups(Locale::English, &Screen::Entry, Focus::Tree);
     let titles: Vec<&str> = groups.iter().map(|group| group.title.as_str()).collect();
 
-    assert_eq!(vec!["Tree focus", "Review", "Global"], titles);
+    assert_eq!(
+        vec!["Tree focus", "Review", "Global", "Entry screen only"],
+        titles
+    );
 }
 
 #[test]
-fn should_show_right_focus_review_and_global_groups_when_right_focused_on_entry_screen() {
+fn should_show_right_focus_review_global_and_entry_only_groups_when_right_focused_on_entry_screen()
+{
     let groups = applicable_help_groups(Locale::English, &Screen::Entry, Focus::Right);
     let titles: Vec<&str> = groups.iter().map(|group| group.title.as_str()).collect();
 
-    assert_eq!(vec!["Right focus", "Review", "Global"], titles);
+    assert_eq!(
+        vec!["Right focus", "Review", "Global", "Entry screen only"],
+        titles
+    );
 }
 
 #[test]
 fn should_show_only_source_view_and_global_groups_on_source_screen_regardless_of_focus() {
+    // ADR 0057: the Entry-only group (d/r/o/s/ctrl-o/ctrl-i) must not
+    // appear here — those bindings are no-ops on the Source screen, the
+    // exact PR #177 "known limitation" this ADR resolves.
     let groups = applicable_help_groups(Locale::English, &source_screen(), Focus::Tree);
     let titles: Vec<&str> = groups.iter().map(|group| group.title.as_str()).collect();
 

--- a/rinkaku-tui/src/input_translate.rs
+++ b/rinkaku-tui/src/input_translate.rs
@@ -9,6 +9,7 @@
 
 use crate::app::{self, App, InputKey, Screen};
 use crate::review;
+use crate::search::SearchMode;
 use ratatui::crossterm::event::{self, KeyCode, KeyModifiers};
 
 /// Translates a raw `crossterm` key press into this crate's
@@ -79,6 +80,27 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         review::ReviewMode::Idle => {}
     }
 
+    // Search composing (ADR 0057) is checked next, mirroring the review
+    // overlay's own early-return shape just above: while composing a
+    // query, every printable character (including keys that would
+    // otherwise mean something else, like `?`) must land in the query
+    // buffer. Only reachable on `Screen::Source` — `InputKey::SearchStart`
+    // is likewise only ever emitted there (below), so this branch is
+    // unreachable on `Screen::Entry` in practice, but gated on
+    // `on_source_screen` defensively rather than relying on that
+    // invariant, the same defensive style `FocusLeft`'s Esc arm below
+    // already uses.
+    let on_source_screen = matches!(app.screen(), Screen::Source { .. });
+    if on_source_screen && matches!(app.search().mode(), SearchMode::Composing { .. }) {
+        return match code {
+            KeyCode::Enter => Some(InputKey::SearchConfirm),
+            KeyCode::Esc => Some(InputKey::SearchCancel),
+            KeyCode::Backspace => Some(InputKey::SearchBackspace),
+            KeyCode::Char(c) => Some(InputKey::SearchChar(c)),
+            _ => None,
+        };
+    }
+
     if app.help_open() {
         // The overlay's own content can run longer than its box (this
         // feature's whole reason for existing) — `j`/`k`/`Ctrl-d`/`Ctrl-u`/
@@ -132,7 +154,6 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         };
     }
 
-    let on_source_screen = matches!(app.screen(), Screen::Source { .. });
     let right_focused = app.focus() == app::Focus::Right;
 
     if app.pending_prefix() == Some(app::PendingPrefix::G) {
@@ -223,13 +244,23 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         KeyCode::Char(']') => Some(InputKey::NextHunk),
         KeyCode::Char('[') => Some(InputKey::PrevHunk),
         KeyCode::Char('s') => Some(InputKey::Source),
+        // `/` (ADR 0057): starts composing a Source-view search query.
+        // Source-screen-only — unbound on the entry screen, where a diff
+        // pane search is future work (ADR 0057's own Alternatives).
+        KeyCode::Char('/') if on_source_screen => Some(InputKey::SearchStart),
+        // `n`/`N` (ADR 0057): jump to the next/previous search match.
+        // Source-screen-only, checked ahead of the entry-screen `n`/`N`
+        // arms just below so the two never collide — a search never has
+        // more than [`SearchState::matches`] to navigate on this screen,
+        // and the entry screen's review-note `n`/`N` (ADR 0048) are
+        // unaffected since this arm never matches there.
+        KeyCode::Char('n') if on_source_screen => Some(InputKey::SearchNext),
+        KeyCode::Char('N') if on_source_screen => Some(InputKey::SearchPrev),
         // `n` (ADR 0048): opens the review-note compose overlay over the
         // row under the cursor. `N`: opens the review-notes list overlay.
         // Both are only meaningful on the entry screen (Source-screen
-        // rows have no `SelectionSnapshot` to compose against), but
-        // translated context-free here like every other key in this
-        // block — `App::handle_key`'s own `Screen::Source` catch-all arm
-        // already no-ops every non-scroll key there.
+        // rows have no `SelectionSnapshot` to compose against, and are
+        // shadowed by the search bindings just above there anyway).
         KeyCode::Char('n') => Some(InputKey::NoteCompose),
         KeyCode::Char('N') => Some(InputKey::NotesList),
         // `w` (ADR 0050): opens the current PR's page in a web browser —
@@ -249,6 +280,15 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         // sets `pending_prefix` from this variant unconditionally.
         KeyCode::Char('g') => Some(InputKey::PendingGoto),
         KeyCode::Char('?') => Some(InputKey::ToggleHelp),
+        // ADR 0057: Esc's first press clears an active confirmed search
+        // (matching vim's own `/`-then-Esc convention of dismissing the
+        // highlight before leaving) rather than immediately returning to
+        // the entry view — checked ahead of the plain `Back` arm just
+        // below so a reviewer backing out of a search does not also lose
+        // their place in the file.
+        KeyCode::Esc if on_source_screen && app.search().query().is_some() => {
+            Some(InputKey::SearchCancel)
+        }
         KeyCode::Esc if on_source_screen => Some(InputKey::Back),
         KeyCode::Char('q') if on_source_screen => Some(InputKey::Back),
         KeyCode::Char('q') => Some(InputKey::Quit),

--- a/rinkaku-tui/src/input_translate_tests/mod.rs
+++ b/rinkaku-tui/src/input_translate_tests/mod.rs
@@ -7,7 +7,10 @@
 //!   plain keymap and the help-overlay / jump-popup "swallow" contracts
 //!   (ADR 0020, ADR 0022, ADR 0026)
 //! - `translate_mouse` — mouse-wheel/click translation
+//! - `search` — Source-view search bindings (ADR 0057): `/`, `n`/`N`
+//!   scoping, and the composing-mode early return
 
+mod search;
 mod translate_key;
 mod translate_mouse;
 

--- a/rinkaku-tui/src/input_translate_tests/search.rs
+++ b/rinkaku-tui/src/input_translate_tests/search.rs
@@ -1,0 +1,162 @@
+//! `translate_key` tests for ADR 0057's Source-view search bindings: `/`
+//! starting a query, the composing-mode early return, `n`/`N` being
+//! Source-screen-only (and not colliding with the entry screen's own
+//! review-note `n`/`N`), and Esc's dual "cancel search" / "back" meaning.
+
+use super::{empty_report, report_with_one_symbol};
+use crate::app::{App, InputKey};
+use crate::input_translate::translate_key;
+use crate::search::SearchState;
+use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+
+fn opened_source_screen(report: &rinkaku_core::render::Report) -> App {
+    App::new(report)
+        .handle_key(InputKey::Down)
+        .handle_key(InputKey::Source)
+}
+
+#[test]
+fn should_translate_slash_to_search_start_on_source_screen() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report);
+
+    let actual = translate_key(KeyCode::Char('/'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchStart), actual);
+}
+
+#[test]
+fn should_not_translate_slash_at_all_on_entry_screen() {
+    // ADR 0057: search is Source-screen-only — `/` has no meaning on the
+    // entry screen (diff-pane search is explicit future work, not this
+    // ADR's scope).
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('/'), KeyModifiers::NONE, &app);
+
+    assert_eq!(None, actual);
+}
+
+#[test]
+fn should_translate_n_to_search_next_on_source_screen() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report);
+
+    let actual = translate_key(KeyCode::Char('n'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchNext), actual);
+}
+
+#[test]
+fn should_translate_uppercase_n_to_search_prev_on_source_screen() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report);
+
+    let actual = translate_key(KeyCode::Char('N'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchPrev), actual);
+}
+
+#[test]
+fn should_translate_n_to_note_compose_on_entry_screen() {
+    // Unaffected by ADR 0057: the entry screen's own `n` (ADR 0048) keeps
+    // its pre-existing meaning, since the search bindings are gated on
+    // `on_source_screen`.
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('n'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::NoteCompose), actual);
+}
+
+#[test]
+fn should_translate_uppercase_n_to_notes_list_on_entry_screen() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('N'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::NotesList), actual);
+}
+
+#[test]
+fn should_translate_printable_char_to_search_char_while_composing() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report).with_search(SearchState::default().start());
+
+    let actual = translate_key(KeyCode::Char('f'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchChar('f')), actual);
+}
+
+#[test]
+fn should_translate_question_mark_to_search_char_while_composing() {
+    // Mirrors the review overlay's own "a literal `?` must reach the
+    // buffer, not the help overlay" precedent (`translate_key`'s own doc
+    // comment) — the same must hold for a search query.
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report).with_search(SearchState::default().start());
+
+    let actual = translate_key(KeyCode::Char('?'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchChar('?')), actual);
+}
+
+#[test]
+fn should_translate_backspace_to_search_backspace_while_composing() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report).with_search(SearchState::default().start());
+
+    let actual = translate_key(KeyCode::Backspace, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchBackspace), actual);
+}
+
+#[test]
+fn should_translate_enter_to_search_confirm_while_composing() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report).with_search(SearchState::default().start());
+
+    let actual = translate_key(KeyCode::Enter, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchConfirm), actual);
+}
+
+#[test]
+fn should_translate_esc_to_search_cancel_while_composing() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report).with_search(SearchState::default().start());
+
+    let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchCancel), actual);
+}
+
+#[test]
+fn should_translate_esc_to_search_cancel_when_a_confirmed_search_is_active() {
+    // ADR 0057: Esc's first press clears an active confirmed search
+    // rather than immediately leaving the screen.
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .confirm(&["fn foo() {}".to_string()], 0);
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report).with_search(search);
+
+    let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchCancel), actual);
+}
+
+#[test]
+fn should_translate_esc_to_back_when_no_search_is_active_on_source_screen() {
+    let report = report_with_one_symbol();
+    let app = opened_source_screen(&report);
+    assert_eq!(None, app.search().query());
+
+    let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::Back), actual);
+}

--- a/rinkaku-tui/src/lib.rs
+++ b/rinkaku-tui/src/lib.rs
@@ -55,6 +55,7 @@ pub mod order;
 pub mod review;
 mod review_flow;
 pub mod row_view;
+pub mod search;
 mod session;
 pub mod source;
 pub mod source_diff;

--- a/rinkaku-tui/src/search.rs
+++ b/rinkaku-tui/src/search.rs
@@ -1,0 +1,226 @@
+//! Vim-like search in the Source view (ADR 0057): a pure state machine
+//! (`SearchState`) for composing a query and stepping through its matches,
+//! decoupled from `crate::ui` the same way `crate::review::ReviewState`
+//! (ADR 0048) is decoupled from the rest of the TUI — `App` holds exactly
+//! one field of it, every transition lives on `SearchState` itself.
+//!
+//! Match computation (`find_matches`/`smartcase_matches_line`) and
+//! navigation (`next_match_index`/`prev_match_index`) are free functions
+//! taking plain data in and returning plain data out, so they are
+//! unit-testable without constructing an `App` or a `SearchState` at all.
+
+/// Whether the query composing buffer is active, or a query has already
+/// been confirmed (and its matches computed) — mirrors
+/// [`crate::review::ReviewMode`]'s own "distinct phases of one feature"
+/// shape.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum SearchMode {
+    #[default]
+    Inactive,
+    Composing {
+        buffer: String,
+    },
+}
+
+/// One matched line, 0-based, into the source view's `Vec<String>` of
+/// lines — the same 0-based indexing [`crate::app::Screen::Source::scroll_top`]
+/// already uses, so a match can be turned into a scroll target with no
+/// coordinate conversion.
+pub type MatchLine = usize;
+
+/// The Source-view search feature's own state (ADR 0057's Module boundary
+/// decision, following [`crate::review::ReviewState`]'s precedent): the
+/// composing buffer or confirmed query, the confirmed query's computed
+/// matches, and which one is current. Every method here is a pure state
+/// transition — no IO, no `ratatui` types.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SearchState {
+    mode: SearchMode,
+    /// The last *confirmed* query — kept independent of `mode` so it
+    /// survives `mode` returning to [`SearchMode::Inactive`] after
+    /// confirming (unlike `mode`, which only holds a query while
+    /// composing): `n`/`N` need the confirmed query's matches long after
+    /// composing has ended, the same way vim's `/` search stays repeatable
+    /// via `n`/`N` after the search prompt itself has closed.
+    query: Option<String>,
+    matches: Vec<MatchLine>,
+    current: usize,
+}
+
+impl SearchState {
+    pub fn mode(&self) -> &SearchMode {
+        &self.mode
+    }
+
+    /// The last confirmed query, if any — `None` before the first
+    /// confirmed search, or after [`Self::cancel`] clears it.
+    pub fn query(&self) -> Option<&str> {
+        self.query.as_deref()
+    }
+
+    pub fn matches(&self) -> &[MatchLine] {
+        &self.matches
+    }
+
+    /// The confirmed query's current match count and 1-based position —
+    /// `None` when there is no confirmed query at all, `Some((0, 0))` for a
+    /// confirmed query with zero matches (the status line's own "no
+    /// matches" case, ADR 0057 decision 7 — distinct from `None`, which
+    /// means "not searching", not "searched and found nothing").
+    pub fn match_position(&self) -> Option<(usize, usize)> {
+        self.query.as_ref()?;
+        if self.matches.is_empty() {
+            return Some((0, 0));
+        }
+        Some((self.current + 1, self.matches.len()))
+    }
+
+    /// The current match's line, if any.
+    pub fn current_match(&self) -> Option<MatchLine> {
+        self.matches.get(self.current).copied()
+    }
+
+    /// Starts composing a new query — a no-op if already composing (Enter
+    /// confirms and Esc cancels are the only ways out of that state, `/`
+    /// pressed again mid-compose does not restart the buffer).
+    pub fn start(mut self) -> Self {
+        if matches!(self.mode, SearchMode::Inactive) {
+            self.mode = SearchMode::Composing {
+                buffer: String::new(),
+            };
+        }
+        self
+    }
+
+    /// Appends `c` to the composing buffer — a no-op outside
+    /// [`SearchMode::Composing`].
+    pub fn push_char(mut self, c: char) -> Self {
+        if let SearchMode::Composing { buffer } = &mut self.mode {
+            buffer.push(c);
+        }
+        self
+    }
+
+    /// Removes the last character from the composing buffer — a no-op
+    /// outside [`SearchMode::Composing`] or on an already-empty buffer.
+    pub fn backspace(mut self) -> Self {
+        if let SearchMode::Composing { buffer } = &mut self.mode {
+            buffer.pop();
+        }
+        self
+    }
+
+    /// Confirms the composing buffer against `lines`, computing its matches
+    /// and jumping to the first match at or after `from_line` (wrapping to
+    /// the first match overall if none are at or after it) — a no-op
+    /// outside [`SearchMode::Composing`]. An empty (or whitespace-only)
+    /// buffer cancels instead of confirming an empty query, mirroring
+    /// [`crate::review::ReviewState::confirm_compose`]'s identical "blank
+    /// buffer means abandon, not commit" rule.
+    pub fn confirm(mut self, lines: &[String], from_line: MatchLine) -> Self {
+        let SearchMode::Composing { buffer } = &self.mode else {
+            return self;
+        };
+        if buffer.trim().is_empty() {
+            return self.cancel();
+        }
+        let query = buffer.clone();
+        let matches = find_matches(lines, &query);
+        let current = matches
+            .iter()
+            .position(|&line| line >= from_line)
+            .unwrap_or(0);
+        self.query = Some(query);
+        self.matches = matches;
+        self.current = current;
+        self.mode = SearchMode::Inactive;
+        self
+    }
+
+    /// Cancels composing (or clears an already-confirmed search) and
+    /// discards every trace of it — ADR 0057 decision 2: cancel means "stop
+    /// searching altogether", not "revert to the last confirmed query".
+    pub fn cancel(mut self) -> Self {
+        self.mode = SearchMode::Inactive;
+        self.query = None;
+        self.matches.clear();
+        self.current = 0;
+        self
+    }
+
+    /// Jumps to the next match, wrapping to the first — a no-op with no
+    /// confirmed matches.
+    pub fn next(mut self) -> Self {
+        if let Some(index) = next_match_index(self.matches.len(), self.current) {
+            self.current = index;
+        }
+        self
+    }
+
+    /// Jumps to the previous match, wrapping to the last — a no-op with no
+    /// confirmed matches.
+    pub fn prev(mut self) -> Self {
+        if let Some(index) = prev_match_index(self.matches.len(), self.current) {
+            self.current = index;
+        }
+        self
+    }
+}
+
+/// Whether `query` should be matched case-sensitively under the smartcase
+/// rule (ADR 0057 decision 5, the vim/ripgrep convention): a query
+/// containing any uppercase character is case-sensitive; an all-lowercase
+/// query (including one with no letters at all) is case-insensitive.
+pub fn is_case_sensitive(query: &str) -> bool {
+    query.chars().any(char::is_uppercase)
+}
+
+/// Whether `line` contains `query` as a literal substring under the
+/// smartcase rule — the single-line primitive [`find_matches`] applies to
+/// every line.
+pub fn smartcase_matches_line(line: &str, query: &str) -> bool {
+    if is_case_sensitive(query) {
+        line.contains(query)
+    } else {
+        line.to_lowercase().contains(&query.to_lowercase())
+    }
+}
+
+/// Every 0-based line index in `lines` containing `query` as a literal
+/// smartcase substring, in ascending order — an empty `query` matches
+/// nothing (mirrors [`SearchState::confirm`]'s own "blank buffer cancels"
+/// rule: an empty query reaching this function at all would otherwise
+/// match every line, which is never a useful search result).
+pub fn find_matches(lines: &[String], query: &str) -> Vec<MatchLine> {
+    if query.is_empty() {
+        return Vec::new();
+    }
+    lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| smartcase_matches_line(line, query))
+        .map(|(index, _)| index)
+        .collect()
+}
+
+/// The next match index into a `total`-length match list after `current`,
+/// wrapping to `0` — `None` when `total == 0` (nothing to navigate).
+pub fn next_match_index(total: usize, current: usize) -> Option<usize> {
+    if total == 0 {
+        return None;
+    }
+    Some((current + 1) % total)
+}
+
+/// The previous match index into a `total`-length match list before
+/// `current`, wrapping to `total - 1` — `None` when `total == 0`.
+pub fn prev_match_index(total: usize, current: usize) -> Option<usize> {
+    if total == 0 {
+        return None;
+    }
+    Some((current + total - 1) % total)
+}
+
+#[cfg(test)]
+#[path = "search_tests.rs"]
+mod tests;

--- a/rinkaku-tui/src/search_tests.rs
+++ b/rinkaku-tui/src/search_tests.rs
@@ -1,0 +1,346 @@
+use super::*;
+use pretty_assertions::assert_eq;
+use rstest::rstest;
+
+// --- is_case_sensitive / smartcase_matches_line ---
+
+#[rstest]
+#[case::should_be_insensitive_when_query_is_all_lowercase("foo", false)]
+#[case::should_be_sensitive_when_query_has_any_uppercase("Foo", true)]
+#[case::should_be_sensitive_when_query_is_all_uppercase("FOO", true)]
+#[case::should_be_insensitive_when_query_has_no_letters("123", false)]
+fn should_detect_case_sensitivity_per_smartcase_rule(#[case] query: &str, #[case] expected: bool) {
+    let actual = is_case_sensitive(query);
+    assert_eq!(expected, actual);
+}
+
+#[rstest]
+#[case::should_match_case_insensitively_when_query_is_lowercase("let Foo = 1;", "foo", true)]
+#[case::should_match_case_sensitively_when_query_has_uppercase("let Foo = 1;", "Foo", true)]
+#[case::should_not_match_case_sensitively_when_case_differs("let foo = 1;", "Foo", false)]
+#[case::should_match_plain_substring("hello world", "wor", true)]
+#[case::should_not_match_when_substring_absent("hello world", "xyz", false)]
+fn should_apply_smartcase_when_matching_a_line(
+    #[case] line: &str,
+    #[case] query: &str,
+    #[case] expected: bool,
+) {
+    let actual = smartcase_matches_line(line, query);
+    assert_eq!(expected, actual);
+}
+
+// --- find_matches ---
+
+#[test]
+fn should_return_empty_matches_when_query_is_empty() {
+    let lines = vec!["foo".to_string(), "bar".to_string()];
+
+    let actual = find_matches(&lines, "");
+
+    assert_eq!(Vec::<MatchLine>::new(), actual);
+}
+
+#[test]
+fn should_return_no_matches_when_query_is_absent_from_every_line() {
+    let lines = vec!["foo".to_string(), "bar".to_string()];
+
+    let actual = find_matches(&lines, "xyz");
+
+    assert_eq!(Vec::<MatchLine>::new(), actual);
+}
+
+#[test]
+fn should_return_every_matching_line_index_in_ascending_order() {
+    let lines = vec![
+        "fn foo() {}".to_string(),
+        "fn bar() {}".to_string(),
+        "fn foo_helper() {}".to_string(),
+    ];
+
+    let actual = find_matches(&lines, "foo");
+
+    assert_eq!(vec![0usize, 2usize], actual);
+}
+
+#[test]
+fn should_respect_smartcase_when_finding_matches() {
+    let lines = vec!["let Foo = 1;".to_string(), "let bar = 2;".to_string()];
+
+    let actual = find_matches(&lines, "Foo");
+
+    assert_eq!(vec![0usize], actual);
+}
+
+// --- next_match_index / prev_match_index ---
+
+#[rstest]
+#[case::should_advance_to_next_index(3, 0, Some(1))]
+#[case::should_wrap_to_first_from_last(3, 2, Some(0))]
+#[case::should_return_none_when_no_matches(0, 0, None)]
+fn should_compute_next_match_index(
+    #[case] total: usize,
+    #[case] current: usize,
+    #[case] expected: Option<usize>,
+) {
+    let actual = next_match_index(total, current);
+    assert_eq!(expected, actual);
+}
+
+#[rstest]
+#[case::should_retreat_to_previous_index(3, 1, Some(0))]
+#[case::should_wrap_to_last_from_first(3, 0, Some(2))]
+#[case::should_return_none_when_no_matches(0, 0, None)]
+fn should_compute_prev_match_index(
+    #[case] total: usize,
+    #[case] current: usize,
+    #[case] expected: Option<usize>,
+) {
+    let actual = prev_match_index(total, current);
+    assert_eq!(expected, actual);
+}
+
+// --- SearchState transitions ---
+
+#[test]
+fn should_start_composing_with_an_empty_buffer_when_inactive() {
+    let state = SearchState::default().start();
+
+    assert_eq!(
+        &SearchMode::Composing {
+            buffer: String::new()
+        },
+        state.mode()
+    );
+}
+
+#[test]
+fn should_not_restart_the_buffer_when_start_is_pressed_while_already_composing() {
+    let state = SearchState::default().start().push_char('a').start();
+
+    assert_eq!(
+        &SearchMode::Composing {
+            buffer: "a".to_string()
+        },
+        state.mode()
+    );
+}
+
+#[test]
+fn should_build_up_the_composing_buffer_via_push_char() {
+    let state = SearchState::default().start().push_char('f').push_char('o');
+
+    assert_eq!(
+        &SearchMode::Composing {
+            buffer: "fo".to_string()
+        },
+        state.mode()
+    );
+}
+
+#[test]
+fn should_ignore_push_char_when_not_composing() {
+    let state = SearchState::default().push_char('a');
+
+    assert_eq!(&SearchMode::Inactive, state.mode());
+}
+
+#[test]
+fn should_remove_the_last_character_via_backspace() {
+    let state = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .backspace();
+
+    assert_eq!(
+        &SearchMode::Composing {
+            buffer: "f".to_string()
+        },
+        state.mode()
+    );
+}
+
+#[test]
+fn should_ignore_backspace_on_an_already_empty_buffer() {
+    let state = SearchState::default().start().backspace();
+
+    assert_eq!(
+        &SearchMode::Composing {
+            buffer: String::new()
+        },
+        state.mode()
+    );
+}
+
+#[test]
+fn should_confirm_a_query_and_compute_its_matches() {
+    let lines = vec![
+        "fn foo() {}".to_string(),
+        "fn bar() {}".to_string(),
+        "fn foo_helper() {}".to_string(),
+    ];
+    let state = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&lines, 0);
+
+    assert_eq!(&SearchMode::Inactive, state.mode());
+    assert_eq!(Some("foo"), state.query());
+    assert_eq!(&[0usize, 2usize], state.matches());
+    assert_eq!(Some(0), state.current_match());
+    assert_eq!(Some((1, 2)), state.match_position());
+}
+
+#[test]
+fn should_jump_to_the_first_match_at_or_after_from_line_when_confirming() {
+    let lines = vec![
+        "fn foo() {}".to_string(),
+        "fn bar() {}".to_string(),
+        "fn foo_helper() {}".to_string(),
+    ];
+    let state = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&lines, 1);
+
+    assert_eq!(Some(2), state.current_match());
+    assert_eq!(Some((2, 2)), state.match_position());
+}
+
+#[test]
+fn should_wrap_to_the_first_match_when_from_line_is_past_every_match() {
+    let lines = vec!["fn foo() {}".to_string(), "fn bar() {}".to_string()];
+    let state = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&lines, 1);
+
+    assert_eq!(Some(0), state.current_match());
+}
+
+#[test]
+fn should_report_zero_match_position_when_confirmed_query_has_no_matches() {
+    let lines = vec!["fn bar() {}".to_string()];
+    let state = SearchState::default()
+        .start()
+        .push_char('x')
+        .push_char('y')
+        .push_char('z')
+        .confirm(&lines, 0);
+
+    assert_eq!(Some("xyz"), state.query());
+    assert_eq!(Some((0, 0)), state.match_position());
+    assert_eq!(None, state.current_match());
+}
+
+#[test]
+fn should_report_no_match_position_when_no_query_was_ever_confirmed() {
+    let state = SearchState::default();
+
+    assert_eq!(None, state.match_position());
+}
+
+#[test]
+fn should_cancel_composing_instead_of_confirming_an_empty_buffer() {
+    let lines = vec!["fn foo() {}".to_string()];
+    let state = SearchState::default().start().confirm(&lines, 0);
+
+    assert_eq!(&SearchMode::Inactive, state.mode());
+    assert_eq!(None, state.query());
+}
+
+#[test]
+fn should_cancel_composing_instead_of_confirming_a_whitespace_only_buffer() {
+    let lines = vec!["fn foo() {}".to_string()];
+    let state = SearchState::default()
+        .start()
+        .push_char(' ')
+        .confirm(&lines, 0);
+
+    assert_eq!(&SearchMode::Inactive, state.mode());
+    assert_eq!(None, state.query());
+}
+
+#[test]
+fn should_ignore_confirm_when_not_composing() {
+    let lines = vec!["fn foo() {}".to_string()];
+    let state = SearchState::default().confirm(&lines, 0);
+
+    assert_eq!(&SearchMode::Inactive, state.mode());
+    assert_eq!(None, state.query());
+}
+
+#[test]
+fn should_clear_everything_on_cancel_after_a_confirmed_search() {
+    let lines = vec!["fn foo() {}".to_string()];
+    let state = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&lines, 0)
+        .cancel();
+
+    assert_eq!(&SearchMode::Inactive, state.mode());
+    assert_eq!(None, state.query());
+    assert_eq!(&[] as &[MatchLine], state.matches());
+    assert_eq!(None, state.match_position());
+}
+
+#[test]
+fn should_advance_to_the_next_match_and_wrap() {
+    let lines = vec![
+        "fn foo() {}".to_string(),
+        "fn bar() {}".to_string(),
+        "fn foo_helper() {}".to_string(),
+    ];
+    let mut state = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&lines, 0);
+    assert_eq!(Some(0), state.current_match());
+
+    state = state.next();
+    assert_eq!(Some(2), state.current_match());
+
+    state = state.next();
+    assert_eq!(Some(0), state.current_match());
+}
+
+#[test]
+fn should_retreat_to_the_previous_match_and_wrap() {
+    let lines = vec![
+        "fn foo() {}".to_string(),
+        "fn bar() {}".to_string(),
+        "fn foo_helper() {}".to_string(),
+    ];
+    let mut state = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&lines, 0);
+    assert_eq!(Some(0), state.current_match());
+
+    state = state.prev();
+    assert_eq!(Some(2), state.current_match());
+}
+
+#[test]
+fn should_ignore_next_and_prev_when_there_are_no_confirmed_matches() {
+    let state = SearchState::default();
+
+    let after_next = state.clone().next();
+    let after_prev = state.prev();
+
+    assert_eq!(SearchState::default(), after_next);
+    assert_eq!(SearchState::default(), after_prev);
+}

--- a/rinkaku-tui/src/ui/mod.rs
+++ b/rinkaku-tui/src/ui/mod.rs
@@ -225,6 +225,8 @@ pub fn draw(
                 source_content,
                 diff_hunks,
                 app.diff_view_mode(),
+                app.search().matches(),
+                app.search().current_match(),
                 body,
             );
             DrawOutcome {

--- a/rinkaku-tui/src/ui/source_screen.rs
+++ b/rinkaku-tui/src/ui/source_screen.rs
@@ -318,13 +318,9 @@ pub(crate) fn source_lines(
         .collect()
 }
 
-/// The search-match background tint for 0-based `line_index` (ADR 0057
-/// decision 6): [`SEARCH_CURRENT_MATCH_BG`] when `line_index` is
-/// `search_current`, [`SEARCH_MATCH_BG`] when it is any other entry in
-/// `search_matches`, `None` otherwise. Extracted as its own pure lookup so
-/// [`source_lines`]'s three call sites (unchanged, overlay-unchanged,
-/// overlay-added) share one definition of "is this line a match" rather
-/// than repeating the `contains`/equality check inline at each.
+/// Extracted so [`source_lines`]'s three call sites share one definition of
+/// "is this line a match" (ADR 0057 decision 6) rather than repeating the
+/// check inline at each.
 fn search_match_bg(
     line_index: usize,
     search_matches: &[MatchLine],
@@ -349,13 +345,10 @@ fn search_match_bg(
 /// for [`marker_span`]'s `+` glyph, pairing this line's gutter with
 /// [`removed_line`]'s own `-` gutter for the same diff signal.
 ///
-/// `search_bg` (ADR 0057 decision 6) layers between `diff_bg` and the
-/// symbol-range tint in the same `.or()` chain, one level more specific
-/// than the diff overlay: a line that is both a diff-added line and a
-/// search match keeps showing `ADDED_BG` (the diff signal is what a
-/// reviewer drilled into this symbol's file to see in the first place),
-/// while a match on an otherwise-unchanged line shows the search tint
-/// ahead of the plain symbol-range highlight.
+/// `search_bg` (ADR 0057 decision 6) layers into the same `.or()` chain,
+/// below `diff_bg`: the diff signal is what a reviewer drilled into this
+/// symbol's file to see in the first place, so it wins when a line is both
+/// diff-added and a search match.
 fn unchanged_line(
     source: &SourceView,
     token_highlights: &[crate::highlight::LineHighlight],

--- a/rinkaku-tui/src/ui/source_screen.rs
+++ b/rinkaku-tui/src/ui/source_screen.rs
@@ -9,6 +9,7 @@ use super::scroll::{Body, render_scrollable_pane};
 use super::style::{gap_span, pane_border_style, styled_content_spans};
 use crate::app::DiffViewMode;
 use crate::diff_view::{DiffLineKind, FileHunks};
+use crate::search::MatchLine;
 use crate::source::{HighlightedSourceView, SourceView};
 use crate::source_diff::{OverlayRow, overlay_source_lines, rows_in_source_range};
 use crate::source_split::{SourceSplitRow, SourceSplitRowKind, split_source_rows};
@@ -17,6 +18,18 @@ use ratatui::layout::Rect;
 use ratatui::style::Color;
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Paragraph, Wrap};
+
+/// Background tint for a Source-view search match (ADR 0057 decision 6),
+/// layered into the same `Option<Color>` composition
+/// [`unchanged_line`]/[`ADDED_BG`]/[`SOURCE_HIGHLIGHT_BG`] already share —
+/// dim indexed yellow, distinct from both the diff overlay's green/red and
+/// the drilled-into symbol's gray so a match reads as its own signal.
+pub(crate) const SEARCH_MATCH_BG: Color = Color::Indexed(58);
+/// Background tint for the *current* search match — brighter/more
+/// saturated than [`SEARCH_MATCH_BG`] so a reviewer scanning a screen with
+/// several matches can see which one the cursor actually landed on
+/// without counting (ADR 0057 decision 6).
+pub(crate) const SEARCH_CURRENT_MATCH_BG: Color = Color::Indexed(100);
 
 #[cfg(test)]
 #[path = "source_screen_tests/mod.rs"]
@@ -75,6 +88,21 @@ pub(crate) const SOURCE_HIGHLIGHT_BG: Color = Color::DarkGray;
 /// or `split_source_rows` itself returns `None` (the same drift that
 /// disables the unified overlay disables reconstructing an old side to
 /// split against, ADR 0049 decision 6).
+///
+/// `search_matches`/`search_current` (ADR 0057) are `App::search()`'s
+/// already-computed match line indices and current-match line, threaded in
+/// unchanged rather than recomputed here — the same "no content derived
+/// from selection state is computed inside the render path" invariant ADR
+/// 0020 already established for the diff pane's shaped content, extended
+/// to this screen's search highlighting.
+// This function's parameter list already sat at clippy's 7-argument
+// threshold before ADR 0057 added `search_matches`/`search_current`;
+// every existing parameter is an independently-computed piece of content
+// `crate::event_loop::run_app` must not recompute inside the draw path
+// (this function's own doc comment), mirroring `crate::ui::draw`'s
+// identical `#[allow]` and its own comment on why bundling into a struct
+// would not reduce the actual coupling.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn draw_source_screen(
     frame: &mut Frame,
     symbol_id: &str,
@@ -82,6 +110,8 @@ pub(crate) fn draw_source_screen(
     source_content: Option<&Result<HighlightedSourceView, String>>,
     diff_hunks: &[FileHunks],
     diff_view_mode: DiffViewMode,
+    search_matches: &[MatchLine],
+    search_current: Option<MatchLine>,
     area: Rect,
 ) {
     let highlighted = match source_content {
@@ -143,7 +173,12 @@ pub(crate) fn draw_source_screen(
 
     match split_rows {
         Some(split_rows) => {
-            let (left, right) = source_split_lines(&highlighted.token_highlights, &split_rows);
+            let (left, right) = source_split_lines(
+                &highlighted.token_highlights,
+                &split_rows,
+                search_matches,
+                search_current,
+            );
             render_scrollable_pane(
                 frame,
                 &title,
@@ -168,6 +203,8 @@ pub(crate) fn draw_source_screen(
                 overlay.as_deref(),
                 start,
                 end,
+                search_matches,
+                search_current,
             );
             let paragraph = Paragraph::new(lines).block(block);
             frame.render_widget(paragraph, area);
@@ -228,6 +265,8 @@ pub(crate) fn source_lines(
     overlay: Option<&[OverlayRow]>,
     start: usize,
     end: usize,
+    search_matches: &[MatchLine],
+    search_current: Option<MatchLine>,
 ) -> Vec<Line<'static>> {
     let Some(overlay) = overlay else {
         return source.lines[start..end]
@@ -235,7 +274,8 @@ pub(crate) fn source_lines(
             .enumerate()
             .map(|(offset, text)| {
                 let line_index = start + offset;
-                unchanged_line(source, token_highlights, line_index, text, None)
+                let search_bg = search_match_bg(line_index, search_matches, search_current);
+                unchanged_line(source, token_highlights, line_index, text, None, search_bg)
             })
             .collect();
     };
@@ -246,20 +286,57 @@ pub(crate) fn source_lines(
             OverlayRow::Unchanged {
                 line_number,
                 content,
-            } => unchanged_line(source, token_highlights, line_number - 1, content, None),
+            } => {
+                let line_index = line_number - 1;
+                let search_bg = search_match_bg(line_index, search_matches, search_current);
+                unchanged_line(
+                    source,
+                    token_highlights,
+                    line_index,
+                    content,
+                    None,
+                    search_bg,
+                )
+            }
             OverlayRow::Added {
                 line_number,
                 content,
-            } => unchanged_line(
-                source,
-                token_highlights,
-                line_number - 1,
-                content,
-                Some(ADDED_BG),
-            ),
+            } => {
+                let line_index = line_number - 1;
+                let search_bg = search_match_bg(line_index, search_matches, search_current);
+                unchanged_line(
+                    source,
+                    token_highlights,
+                    line_index,
+                    content,
+                    Some(ADDED_BG),
+                    search_bg,
+                )
+            }
             OverlayRow::Removed { content } => removed_line(content),
         })
         .collect()
+}
+
+/// The search-match background tint for 0-based `line_index` (ADR 0057
+/// decision 6): [`SEARCH_CURRENT_MATCH_BG`] when `line_index` is
+/// `search_current`, [`SEARCH_MATCH_BG`] when it is any other entry in
+/// `search_matches`, `None` otherwise. Extracted as its own pure lookup so
+/// [`source_lines`]'s three call sites (unchanged, overlay-unchanged,
+/// overlay-added) share one definition of "is this line a match" rather
+/// than repeating the `contains`/equality check inline at each.
+fn search_match_bg(
+    line_index: usize,
+    search_matches: &[MatchLine],
+    search_current: Option<MatchLine>,
+) -> Option<Color> {
+    if search_current == Some(line_index) {
+        Some(SEARCH_CURRENT_MATCH_BG)
+    } else if search_matches.contains(&line_index) {
+        Some(SEARCH_MATCH_BG)
+    } else {
+        None
+    }
 }
 
 /// Renders one source-file line (`text`, at 0-based `line_index`) with its
@@ -271,17 +348,28 @@ pub(crate) fn source_lines(
 /// `diff_bg` of `Some(ADDED_BG)` also swaps the gutter's usual blank space
 /// for [`marker_span`]'s `+` glyph, pairing this line's gutter with
 /// [`removed_line`]'s own `-` gutter for the same diff signal.
+///
+/// `search_bg` (ADR 0057 decision 6) layers between `diff_bg` and the
+/// symbol-range tint in the same `.or()` chain, one level more specific
+/// than the diff overlay: a line that is both a diff-added line and a
+/// search match keeps showing `ADDED_BG` (the diff signal is what a
+/// reviewer drilled into this symbol's file to see in the first place),
+/// while a match on an otherwise-unchanged line shows the search tint
+/// ahead of the plain symbol-range highlight.
 fn unchanged_line(
     source: &SourceView,
     token_highlights: &[crate::highlight::LineHighlight],
     line_index: usize,
     text: &str,
     diff_bg: Option<Color>,
+    search_bg: Option<Color>,
 ) -> Line<'static> {
     let line_number = line_index + 1;
     let is_highlighted =
         line_number >= source.highlight_start && line_number <= source.highlight_end;
-    let bg = diff_bg.or(is_highlighted.then_some(SOURCE_HIGHLIGHT_BG));
+    let bg = diff_bg
+        .or(search_bg)
+        .or(is_highlighted.then_some(SOURCE_HIGHLIGHT_BG));
     let is_added = diff_bg == Some(ADDED_BG);
 
     let mut spans = vec![gap_span(&format!("{line_number:>5}"), bg)];
@@ -323,9 +411,18 @@ fn removed_line(content: &str) -> Line<'static> {
 /// [`SourceSplitRow`] becomes one line on each side — a `None` cell renders
 /// as a blank filler line, matching the diff pane's own split-view filler
 /// convention (`crate::ui::diff_pane::split_side_line`).
+///
+/// `search_matches`/`search_current` (ADR 0057) only apply to the right
+/// (new-side) column: a match is found against `source.lines`, which are
+/// the file's *current* content — the left (old-side) column has no
+/// corresponding source line of its own to match against, the same reason
+/// [`source_split_side_line`] already gives `token_highlights` only to the
+/// new side.
 fn source_split_lines(
     token_highlights: &[crate::highlight::LineHighlight],
     split_rows: &[SourceSplitRow],
+    search_matches: &[MatchLine],
+    search_current: Option<MatchLine>,
 ) -> (Vec<Line<'static>>, Vec<Line<'static>>) {
     let mut left = Vec::with_capacity(split_rows.len());
     let mut right = Vec::with_capacity(split_rows.len());
@@ -340,12 +437,18 @@ fn source_split_lines(
             DiffLineKind::Removed,
             left_bg,
             None,
+            None,
         ));
+        let right_search_bg = row
+            .right
+            .as_ref()
+            .and_then(|cell| search_match_bg(cell.line_number - 1, search_matches, search_current));
         right.push(source_split_side_line(
             row.right.as_ref(),
             DiffLineKind::Added,
-            right_bg,
+            right_bg.or(right_search_bg),
             Some(token_highlights),
+            right_search_bg,
         ));
     }
     (left, right)
@@ -361,17 +464,25 @@ fn source_split_lines(
 /// which has no highlight data of its own — the unified overlay's
 /// [`removed_line`] makes the same call for old-side-only text — and
 /// always renders as plain gap-styled text plus `bg`.
+///
+/// `search_bg` (ADR 0057) only ever arrives `Some` on the new side (see
+/// [`source_split_lines`]'s own doc comment) — passed separately from `bg`
+/// (which already carries `search_bg` folded in when no diff tint applies)
+/// so this function can tell "a bare search match" apart from "a changed
+/// row" when deciding whether to draw the `+`/`-` marker glyph: a search
+/// match alone is not a diff change and must not gain one.
 fn source_split_side_line(
     cell: Option<&crate::source_split::SourceSplitLine>,
     marker_kind: DiffLineKind,
     bg: Option<Color>,
     token_highlights: Option<&[crate::highlight::LineHighlight]>,
+    search_bg: Option<Color>,
 ) -> Line<'static> {
     let Some(cell) = cell else {
         return Line::raw("");
     };
 
-    let marker = bg.is_some();
+    let marker = bg.is_some() && bg != search_bg;
     let mut spans = vec![gap_span(&format!("{:>5}", cell.line_number), bg)];
     spans.push(if marker {
         marker_span(marker_kind, bg)

--- a/rinkaku-tui/src/ui/source_screen_tests/error_handling.rs
+++ b/rinkaku-tui/src/ui/source_screen_tests/error_handling.rs
@@ -6,7 +6,13 @@ fn should_draw_source_screen_title_and_error_message_when_file_is_missing() {
     let app = App::new(&report)
         .handle_key(crate::app::InputKey::Down)
         .handle_key(crate::app::InputKey::Source);
-    let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+    // Wider than the default 80 columns used elsewhere in this test
+    // module: the Source screen's status-line hint text grew past 80
+    // columns once ADR 0057 added the `/`/`n`/`N` search bindings, and
+    // the status line intentionally does not wrap (mirrors
+    // `should_draw_status_line_help_text_on_entry_screen`'s identical
+    // widening for the same reason).
+    let mut terminal = Terminal::new(TestBackend::new(100, 20)).expect("terminal");
     let source_content = missing_file_source_content(&report, "lib.rs::foo");
 
     terminal

--- a/rinkaku-tui/src/ui/source_screen_tests/mod.rs
+++ b/rinkaku-tui/src/ui/source_screen_tests/mod.rs
@@ -8,6 +8,8 @@
 //! - `overlay` — ADR 0046's unified added/removed diff overlay, including
 //!   the working-tree-drift fallback
 //! - `split_view` — ADR 0049's side-by-side rendering of that overlay
+//! - `search` — ADR 0057's search match highlighting (current vs.
+//!   non-current match background tint)
 
 use super::*;
 use crate::app::{App, BlastRadiusSelection};
@@ -24,6 +26,7 @@ use rinkaku_core::render::{FileReport, Report};
 mod error_handling;
 mod highlighting;
 mod overlay;
+mod search;
 mod split_view;
 
 pub(super) fn symbol(id: &str, name: &str) -> ExtractedSymbol {

--- a/rinkaku-tui/src/ui/source_screen_tests/search.rs
+++ b/rinkaku-tui/src/ui/source_screen_tests/search.rs
@@ -1,0 +1,145 @@
+//! Tests for the Source-view search match highlighting (ADR 0057):
+//! `crate::ui::source_screen`'s reuse of the existing diff-overlay
+//! bg-blend mechanism (`SEARCH_MATCH_BG`/`SEARCH_CURRENT_MATCH_BG`) for a
+//! non-current and the current match respectively.
+
+use super::*;
+use crate::search::SearchState;
+
+fn draw_source_screen_with_search(
+    report: &Report,
+    repo_root: &std::path::Path,
+    search: SearchState,
+) -> Terminal<TestBackend> {
+    let app = App::new(report)
+        .handle_key(crate::app::InputKey::Down)
+        .handle_key(crate::app::InputKey::Source)
+        .with_search(search);
+    let source_content = Some(crate::source::load_highlighted_symbol_source(
+        report,
+        "lib.rs::foo",
+        repo_root,
+        &crate::source::WorkingTreeSourceReader,
+    ));
+    let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                source_content.as_ref(),
+                &[],
+                &crate::note_markers::NoteMarkers::default(),
+                Locale::English,
+            );
+        })
+        .expect("draw");
+
+    terminal
+}
+
+#[test]
+fn should_apply_current_match_background_to_the_confirmed_current_match_line() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        dir.path().join("lib.rs"),
+        "fn foo() {}\nfn bar() {}\nfn foo_helper() {}\n",
+    )
+    .expect("write file");
+    let report = report_with_one_symbol();
+    let lines = vec![
+        "fn foo() {}".to_string(),
+        "fn bar() {}".to_string(),
+        "fn foo_helper() {}".to_string(),
+    ];
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&lines, 0);
+
+    let terminal = draw_source_screen_with_search(&report, dir.path(), search);
+
+    // Line 1 (index 0) is the current match.
+    let style = find_cell_style(&terminal, "1 | fn foo() {}", "fn");
+    assert_eq!(Some(SEARCH_CURRENT_MATCH_BG), style.bg);
+}
+
+#[test]
+fn should_apply_plain_match_background_to_a_non_current_match_line() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        dir.path().join("lib.rs"),
+        "fn foo() {}\nfn bar() {}\nfn foo_helper() {}\n",
+    )
+    .expect("write file");
+    let report = report_with_one_symbol();
+    let lines = vec![
+        "fn foo() {}".to_string(),
+        "fn bar() {}".to_string(),
+        "fn foo_helper() {}".to_string(),
+    ];
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&lines, 0);
+
+    let terminal = draw_source_screen_with_search(&report, dir.path(), search);
+
+    // Line 3 (index 2) is a match but not the current one (current is
+    // line 1) — must carry the dimmer non-current tint, distinguishable
+    // from `SEARCH_CURRENT_MATCH_BG`.
+    let style = find_cell_style(&terminal, "3 | fn foo_helper() {}", "fn");
+    assert_eq!(Some(SEARCH_MATCH_BG), style.bg);
+}
+
+#[test]
+fn should_not_apply_any_match_background_to_a_non_matching_line() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        dir.path().join("lib.rs"),
+        "fn foo() {}\nfn bar() {}\nfn foo_helper() {}\n",
+    )
+    .expect("write file");
+    let report = report_with_one_symbol();
+    let lines = vec![
+        "fn foo() {}".to_string(),
+        "fn bar() {}".to_string(),
+        "fn foo_helper() {}".to_string(),
+    ];
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&lines, 0);
+
+    let terminal = draw_source_screen_with_search(&report, dir.path(), search);
+
+    // Line 2 ("fn bar() {}") contains neither the query nor falls inside
+    // the symbol's own highlighted range (`report_with_one_symbol`'s
+    // `LineRange { start: 1, end: 1 }`), so it must render with no
+    // background tint at all.
+    let style = find_cell_style(&terminal, "2 | fn bar() {}", "fn");
+    assert_eq!(Some(Color::Reset), style.bg);
+}
+
+#[test]
+fn should_apply_no_match_background_when_search_is_inactive() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(dir.path().join("lib.rs"), "fn foo() {}\nfn bar() {}\n").expect("write file");
+    let report = report_with_one_symbol();
+
+    let terminal = draw_source_screen_with_search(&report, dir.path(), SearchState::default());
+
+    let style = find_cell_style(&terminal, "2 | fn bar() {}", "fn");
+    assert_eq!(Some(Color::Reset), style.bg);
+}

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -3,6 +3,7 @@
 //! showing above it.
 
 use crate::app::{App, Screen};
+use crate::search::SearchMode;
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
@@ -61,6 +62,17 @@ pub(crate) fn draw_status_line(frame: &mut Frame, app: &App, report: &Report, ar
 /// is dropped when the vec is empty (mirrors ADR 0013's "High fan-in
 /// symbols is skipped when empty" rule, named per ADR 0034).
 pub(crate) fn status_line_text(app: &App, report: &Report) -> String {
+    // ADR 0057: while composing a Source-view search query, the status
+    // line becomes the query's own minibuffer — takes precedence over
+    // every other segment below (including `app.status()`'s transient
+    // message slot) the same way a real minibuffer replaces the status
+    // area rather than sharing it, since a reviewer typing a query needs
+    // to see exactly what they have typed with nothing else competing for
+    // the line.
+    if let SearchMode::Composing { buffer } = app.search().mode() {
+        return format!("/{buffer}");
+    }
+
     let help = match app.screen() {
         Screen::Entry => {
             let order = match app.order_mode() {
@@ -81,8 +93,25 @@ pub(crate) fn status_line_text(app: &App, report: &Report) -> String {
             format!("order: {order}  |  {keys}")
         }
         Screen::Source { .. } => {
-            "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  v: split  esc/q: back".to_string()
+            "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  v: split  /: search  n/N: next/prev match  esc/q: back".to_string()
         }
+    };
+
+    // ADR 0057 decision 7: once a query is confirmed, its match position
+    // (or the zero-match case) prefixes the help segment, mirroring how
+    // `app.status()`'s transient message is prefixed just below — both are
+    // "something the reviewer needs to see right now" ahead of the fixed
+    // key-hint reference.
+    let help = match app.search().match_position() {
+        Some((0, 0)) => format!(
+            "{query} — no matches  |  {help}",
+            query = search_query_label(app)
+        ),
+        Some((current, total)) => format!(
+            "{query} — {current}/{total}  |  {help}",
+            query = search_query_label(app)
+        ),
+        None => help,
     };
 
     let help = match file_size_warning_suffix(report) {
@@ -98,6 +127,17 @@ pub(crate) fn status_line_text(app: &App, report: &Report) -> String {
     match app.status() {
         Some(status) => format!("{status}  |  {help}"),
         None => help,
+    }
+}
+
+/// Formats `app.search()`'s confirmed query as `/query` for the status
+/// line's match-position segment — `""` (never actually reached, guarded
+/// by the `Some` match arms at this function's only call site) when no
+/// query was confirmed.
+fn search_query_label(app: &App) -> String {
+    match app.search().query() {
+        Some(query) => format!("/{query}"),
+        None => String::new(),
     }
 }
 
@@ -315,7 +355,8 @@ mod tests {
         // `InputKey::Open`'s own arm (see its doc comment in `crate::app`).
         // ADR 0026 adds this screen's own scroll bindings to the status
         // line so the reviewer can discover them without opening the
-        // help overlay first.
+        // help overlay first; ADR 0057 adds the `/`/`n`/`N` search
+        // bindings the same way.
         let report = report_with_one_symbol();
         let app = App::new(&report)
             .handle_key(crate::app::InputKey::Down)
@@ -324,7 +365,8 @@ mod tests {
         let actual = status_line_text(&app, &report);
 
         assert_eq!(
-            "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  v: split  esc/q: back".to_string(),
+            "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  v: split  /: search  n/N: next/prev match  esc/q: back"
+                .to_string(),
             actual
         );
     }


### PR DESCRIPTION
## Summary

Two related TUI changes, both recorded in ADR 0057:

1. **Vim-like `/` search in the Source screen.** Composing a query, confirming/canceling it, and stepping through matches with wraparound. Matching is literal-substring with smartcase. Match highlighting reuses the existing diff-overlay background-tint mechanism, with a distinct, brighter tint for the current match.
2. **Help overlay "Global" group split by screen reachability.** The overlay's `Global` group previously listed `d`/`r`/`o`/`s`/`ctrl-o`/`ctrl-i` as globally available, even though they are silently swallowed as no-ops on the Source screen (a limitation PR #177 documented and deferred). `Global` is now narrowed to keys that are actually valid on every screen (`v`, `w`, `u`, `gd`, `gr`, `?`, `q`/`ctrl-c`); the Entry-only bindings moved to a new "Entry screen only" group that is hidden while on the Source screen. The new `/`, `n`/`N` search bindings were added to the Source view group.

See ADR 0057 (`docs/adr/0057-tui-source-view-search.md`) for the full design rationale, including why search is scoped to the Source screen only (not the Entry screen's Diff pane — noted as future work) and why regex search is out of scope for v1.

## Keybindings

| Key | Behavior |
|---|---|
| `/` | Start composing a search query (Source screen only) |
| *printable chars* | Build up the query buffer while composing |
| Backspace | Remove the last character of the query buffer |
| Enter | Confirm the query, jump to the nearest match at/after the current position |
| Esc | Cancel composing, or clear an already-confirmed search (checked before falling through to the screen's ordinary "back" meaning) |
| `n` | Jump to the next match, wrapping (Source screen only) |
| `N` | Jump to the previous match, wrapping (Source screen only; does not collide with the Entry screen's own `N` = notes list) |

The status line doubles as the query minibuffer while composing (`/query`), and shows `N/M` match position (or "no matches") once a query is confirmed.

## Test approach

- Pure match/navigation logic (`crate::search`: `SearchState`, `find_matches`, `smartcase_matches_line`, `next_match_index`/`prev_match_index`) is unit-tested with rstest + pretty_assertions, no `App`/terminal involved.
- `App::handle_key`'s search dispatch (composing priority, cancel, next/prev) is tested directly against `App`.
- `crate::input_translate::translate_key`'s new bindings (including the composing-mode early return and the Esc dual meaning) are tested directly.
- Match highlighting (current vs. non-current tint, no-highlight cases) is tested with `ratatui::backend::TestBackend`, following this crate's existing rendering-test conventions.
- Help overlay group filtering is tested both at the pure `help_content`/`applicable_help_groups` level and via the existing `TestBackend`-based overlay tests.

`make test`: 990 passed. `make lint`: clean (fmt + clippy `-D warnings`).

## Follow-ups / deferred

- **Ctrl-d/Ctrl-u half-page scroll fix was NOT done in this PR.** The known issue (viewport height in *display rows* used directly as a *logical-line* step, violating ADR 0052's scroll-unit contract) requires changing `render_scrollable_pane`'s return signature across 5 call sites (Detail, Diff, Blast-radius, Help overlay, Source screen panes) to also surface a wrap-aware logical-line viewport height — a genuinely separate, moderately invasive change in a subsystem that has already needed one correctness amendment (ADR 0052's own). Given the size of this PR already, that fix is left for a dedicated follow-up PR + ADR 0052 amendment, rather than rushed in here.
- Diff-pane (Entry screen) search is explicitly out of scope for this ADR — noted as future work.
- Regex search is explicitly out of scope for v1.

## File size

`rinkaku-tui/src/app/mod.rs` grew from 986 to 1011 lines in this PR, crossing CLAUDE.md's 1000-line "warn" threshold. The addition itself was the ~25-line `search: SearchState` field plus its accessors — the same shape as the existing `review: ReviewState` field — so it did not on its own trigger a split; the file was already close to the threshold before this PR.

No split was done here to keep this PR scoped to the search feature and the help-overlay fix. Candidate future split targets: extracting the `Screen`/`RightPane`/`DiffViewMode` enums and the jumplist-related types (`JumplistEntry`, `PendingPrefix`) into their own module, leaving `App` itself and its accessors in `mod.rs`.
