### PR TITLE
feat(tui): tree cursor gg/G/Ctrl-d/Ctrl-u and entry-screen / search (ADR 0026 & 0057 amendments)

### DIFF
--- a/docs/adr/0026-tui-source-screen-scrolling.md
+++ b/docs/adr/0026-tui-source-screen-scrolling.md
@@ -198,3 +198,44 @@ behavior per screen" trap ADR 0020 exists to close.
   release (ADR 0015/0016), so this is a strict addition to the
   interaction model. `Ctrl-d`/`Ctrl-u`/`gg`/`G` were previously
   unbound on both screens.
+
+## Amendment: `Focus::Tree` moves the cursor instead of staying a no-op
+
+Decision 3's third bullet scoped `Focus::Tree` to a deliberate no-op,
+reasoned by analogy to `j`/`k` not scrolling the right pane while
+Tree-focused. Dogfooding found the analogy did not hold: `j`/`k` on the
+tree already move the cursor (`Nav::Action::CursorUp`/`CursorDown`) —
+they are not idle there the way they are on an unfocused right pane —
+so a reviewer reasonably expected `Ctrl-d`/`Ctrl-u`/`gg`/`G` to extend
+the same cursor motion, and instead got silence. Filed after a user
+report that these keys "did nothing" while the tree (the entry view's
+default focus) had the cursor.
+
+**The tree pane has no scroll-offset state of its own to reuse** —
+unlike `Screen::Source::scroll_top`/`App::right_pane_scroll`, it
+windows around the cursor position at draw time
+(`crate::ui::entry::draw_tree_pane`). So on `Focus::Tree` these four
+variants move `Nav`'s cursor directly rather than any scroll offset:
+
+- `Ctrl-d`/`Ctrl-u` → `Nav::Action::CursorPageDown(step)`/
+  `CursorPageUp(step)`, clamped to the first/last visible row. `step`
+  is half of the tree pane's own last-drawn inner height — a new
+  `DrawOutcome::tree_viewport_height` field, folded back by
+  `crate::run_app` into a `last_tree_viewport_height` the same way
+  decision 5 already does for `scroll_viewport_height`/
+  `help_scroll_viewport_height`.
+- `gg`/`G` → `Nav::Action::CursorTop`/`CursorBottom`, jumping straight
+  to the first/last visible row.
+
+`App::handle_scroll_key` gains four `(Screen::Entry, Focus::Tree, ...)`
+match arms alongside its existing `Focus::Right` ones; the tree pane's
+own viewport-height plumbing mirrors `right_pane_viewport_height`
+(a new `tree_pane_viewport_height(body: Rect)` sibling in
+`crate::ui`, same split, same border deduction) rather than
+introducing a different mechanism. The `?` help overlay's "Tree focus"
+group and the entry-view Tree-focus status-line hint both gain
+`ctrl-d/ctrl-u`/`gg / G` entries, matching decision 6's discoverability
+rule.
+
+No change to the `Screen::Source`/`Focus::Right` cases — this
+amendment only fills in the previously-unhandled third branch.

--- a/docs/adr/0057-tui-source-view-search.md
+++ b/docs/adr/0057-tui-source-view-search.md
@@ -251,3 +251,83 @@ screen where they are silently swallowed.
   breaking changes to any real user.
 - Future work (not this ADR): extending search to the Entry screen's
   Diff pane, and an opt-in regex mode.
+
+## Amendment: tree search on the entry screen
+
+A user report ("`/` does nothing on the entry screen") surfaced while
+implementing ADR 0026's own tree-cursor amendment in the same session.
+This ADR's Context already flagged the Entry screen's *Diff pane* as
+out of scope (shaped/grouped content, unresolved match-semantics
+questions) — but the entry view's other pane, the file/symbol tree on
+the left, has neither of those problems: it is already a flat,
+per-frame-recomputed list of rows (`Nav::rows`), the same shape
+`Vec<String>` of source lines this ADR already searches. Filling in
+that specific gap does not require answering any of the Diff-pane
+questions this ADR deferred.
+
+**Scope: tree rows only, `Focus::Tree`-only.** `/`/`n`/`N`/Esc-cancel
+now also fire on `Screen::Entry` while `Focus::Tree` (previously:
+`Screen::Source` only). `Focus::Right` is deliberately left
+untranslated — the Diff/Detail pane search this ADR's Context already
+declined to design is still undesigned, and reserving `/` there keeps
+that door open rather than accidentally claiming the key for tree
+search's own keyspace.
+
+**Search text per row, not the rendered line.** A `NodeKind::Symbol`
+row's search text is its own name (`SymbolRef::name`); every other row
+kind (`Dir`/`File`/`Section`/`TestGroup`) uses `TreeNode::path` — not
+`crate::row_view::relative_labels`' on-screen-truncated label, which
+exists purely to avoid repeating an ancestor directory's name on
+screen and would make matching depend on scroll position/collapse
+state in a way full paths do not. `crate::nav::row_search_texts` computes
+this per-row text; `crate::search::find_matches`/`SearchState` are reused
+completely unchanged — `MatchLine` is already just "an index into
+whatever flat `Vec<String>` was searched," and the tree case just gives
+it a second meaning ("index into `Nav::rows`") alongside its original
+one ("line number in the source file"), never both at once since the
+two screens are mutually exclusive.
+
+**Matches only currently-visible rows — no auto-expand into collapsed
+subtrees.** A match hidden under a collapsed ancestor (most commonly a
+`TestGroup`, collapsed by default per `Nav::new_collapsing_test_groups`)
+is not found. This mirrors `move_cursor_to_path`'s existing "no-op
+under a collapsed ancestor" contract rather than `move_cursor_to_symbol`'s
+"expand whatever stands in the way" one (`nav.rs`'s own doc comments
+contrast the two) — expanding on a match is a real usability
+improvement but adds a second, more invasive code path (full-tree walk
+independent of collapse state, then expand-and-relocate) this
+amendment does not need to ship the core feature. Left as explicit
+future work, the same way this ADR's own Alternatives section already
+defers the Diff-pane case rather than trying to solve every case at
+once.
+
+**The "jump target" is the tree cursor, not a scroll offset.**
+`crate::ui::entry::draw_tree_pane` windows around the cursor at draw
+time (ADR 0026's own amendment already establishes this for
+`Ctrl-d`/`Ctrl-u`/`gg`/`G`) — there is no `scroll_top`/`right_pane_scroll`
+equivalent for the tree to write into. A new `nav::Action::CursorTo(usize)`
+jumps the cursor directly to a visible-row index (clamped, mirroring
+every other `Action` variant's own bounds discipline), and a new
+`App::with_nav_cursor` wither applies it from `crate::event_loop`, the
+same "`App` has no notion of X, caller folds the computed jump target
+back in" split `App::with_source_scroll_top`/`with_right_pane_scroll`
+already use.
+
+**`dispatch_search_confirm`/the renamed `jump_search_match_into_view`
+now branch on `app.screen()`.** The Source branch is unchanged
+(needs `source_content`, loaded outside `App`); the new Entry branch
+needs no external content at all — `Nav`/`Tree` already live on `App`,
+so [`InputKey::SearchConfirm`] for tree search is computed entirely
+from data `App` already owns, unlike the Source case's IO-loaded lines.
+
+**Bindings/help/status line.** `?` overlay's "Tree focus" group gains
+`/`/`n`/`N` entries, reusing this ADR's own `start_search`/
+`jump_next_prev_match` locale strings verbatim (the description is
+gesture-shaped, not target-shaped — "start a search" reads the same
+regardless of what is being searched). The Tree-focus status-line hint
+gains the matching `/: search  n/N: next/prev match` segment.
+
+No change to the Source-screen search this ADR originally shipped —
+this amendment only fills in the tree-row half of the Entry-screen gap
+the original Context section explicitly carved out, leaving the
+Diff/Detail-pane half exactly as undesigned as it was.

--- a/docs/adr/0057-tui-source-view-search.md
+++ b/docs/adr/0057-tui-source-view-search.md
@@ -284,8 +284,22 @@ this per-row text; `crate::search::find_matches`/`SearchState` are reused
 completely unchanged — `MatchLine` is already just "an index into
 whatever flat `Vec<String>` was searched," and the tree case just gives
 it a second meaning ("index into `Nav::rows`") alongside its original
-one ("line number in the source file"), never both at once since the
-two screens are mutually exclusive.
+one ("line number in the source file").
+
+**The two meanings are kept apart by cancelling, not by screen
+exclusivity.** The screens are mutually exclusive but `SearchState` is a
+single field on `App` that outlives a screen transition, so the
+separation has to be enforced: `App::handle_key` cancels the search on
+the `Screen::Entry` -> `Screen::Source` transition, mirroring the
+`Back` arm that already cancelled the other direction. For the same
+reason — the indices are frozen at confirm time — every arm that
+reshapes the visible row list (`Select`/`Open` on a collapsible row,
+`ExpandAll`, `CollapseAll`, `ToggleOrder`) cancels too, per decision 2's
+"cancel means stop searching altogether". Recomputing the matches
+against the new row list was the alternative, and was rejected here: it
+would silently relocate the reviewer's current match to a row they never
+chose. Re-anchoring a search across a fold is left as future work
+alongside the collapsed-ancestor case below.
 
 **Matches only currently-visible rows — no auto-expand into collapsed
 subtrees.** A match hidden under a collapsed ancestor (most commonly a

--- a/rinkaku-tui/locales/en.yml
+++ b/rinkaku-tui/locales/en.yml
@@ -12,6 +12,8 @@ help:
     entry_only: "Entry screen only"
   binding:
     move_cursor: "Move the cursor"
+    scroll_tree_half_page: "Move the cursor by half a page"
+    jump_tree_top_bottom: "Jump to the top / bottom of the tree"
     expand_collapse_open: "Expand/collapse a directory row, or open a file/symbol row (moves focus right)"
     expand_collapse_row: "Expand/collapse a directory/file row (never moves focus)"
     expand_every_row: "Expand every row"

--- a/rinkaku-tui/locales/ja.yml
+++ b/rinkaku-tui/locales/ja.yml
@@ -12,6 +12,8 @@ help:
     entry_only: "エントリー画面のみ"
   binding:
     move_cursor: "カーソルを移動"
+    scroll_tree_half_page: "カーソルを半ページ分移動"
+    jump_tree_top_bottom: "ツリーの先頭/末尾へジャンプ"
     expand_collapse_open: "ディレクトリ行を開閉、またはファイル/シンボル行を開く（フォーカスが右に移動）"
     expand_collapse_row: "ディレクトリ/ファイル行を開閉（フォーカスは移動しない）"
     expand_every_row: "全行を展開"

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -418,8 +418,15 @@ impl App {
             (Screen::Entry, Focus::Right, InputKey::Down) => {
                 self.right_pane_scroll = self.right_pane_scroll.saturating_add(1);
             }
+            // A confirmed tree search holds row *indices* frozen at confirm
+            // time, so every arm that reshapes the visible row list must
+            // cancel it, per ADR 0057 decision 2's "cancel means stop
+            // searching altogether". Recomputing the matches against the new
+            // rows was rejected: it would silently relocate the reviewer's
+            // current match to a row they never chose.
             (Screen::Entry, Focus::Tree, InputKey::Select) => {
                 self.nav = self.nav.handle(Action::ToggleExpand, &self.tree);
+                self.search = self.search.clone().cancel();
             }
             // Gated on `Focus::Tree`, matching `InputKey::Open`'s own focus
             // requirement (finding: Space used to fire regardless of focus,
@@ -466,6 +473,7 @@ impl App {
                     | Some(NodeKind::Section(_))
                     | Some(NodeKind::TestGroup { .. }) => {
                         self.nav = self.nav.handle(Action::ToggleExpand, &self.tree);
+                        self.search = self.search.clone().cancel();
                     }
                     // File and symbol rows behave identically (dogfooding
                     // fix, `Self::Open`'s own doc comment): switch to the
@@ -489,9 +497,11 @@ impl App {
             }
             (Screen::Entry, _, InputKey::ExpandAll) => {
                 self.nav = self.nav.handle(Action::ExpandAll, &self.tree);
+                self.search = self.search.clone().cancel();
             }
             (Screen::Entry, _, InputKey::CollapseAll) => {
                 self.nav = self.nav.handle(Action::CollapseAll, &self.tree);
+                self.search = self.search.clone().cancel();
             }
             (Screen::Entry, _, InputKey::ToggleOrder) => {
                 self.order_mode = match self.order_mode {
@@ -499,6 +509,7 @@ impl App {
                     OrderMode::AlphaNumeric => OrderMode::Topological,
                 };
                 crate::order::order_tree(&mut self.tree, &self.ranks, self.order_mode);
+                self.search = self.search.clone().cancel();
             }
             (Screen::Entry, _, InputKey::Source) => {
                 let rows = self.nav.rows(&self.tree);
@@ -520,6 +531,7 @@ impl App {
                         symbol_id: symbol_ref.id.clone(),
                         scroll_top: 0,
                     };
+                    self.search = self.search.clone().cancel();
                 }
             }
             (Screen::Entry, _, InputKey::ToggleDiff) => {

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -848,8 +848,13 @@ impl App {
     /// - On [`Screen::Entry`] + [`Focus::Right`], acts on
     ///   [`Self::right_pane_scroll`], the same field plain `j`/`k`
     ///   already updates while Right-focused.
-    /// - On [`Screen::Entry`] + [`Focus::Tree`], a no-op — Tree-focused
-    ///   motion belongs on the tree cursor, not on any pane's scroll.
+    /// - On [`Screen::Entry`] + [`Focus::Tree`] (ADR 0026 amendment): acts
+    ///   on `self.nav`'s cursor via [`crate::nav::Action::CursorPageDown`]/
+    ///   [`crate::nav::Action::CursorPageUp`]/[`crate::nav::Action::CursorTop`]/
+    ///   [`crate::nav::Action::CursorBottom`] — the tree pane has no scroll
+    ///   offset of its own to move (it windows around the cursor at draw
+    ///   time, `crate::ui::entry::draw_tree_pane`'s own doc comment), so
+    ///   "half-page"/"top"/"bottom" here mean moving the cursor itself.
     ///
     /// `usize::MAX` is used as the "scroll to bottom" sentinel
     /// ([`InputKey::ScrollToBottom`]'s doc comment): the clamp-at-draw
@@ -938,10 +943,28 @@ impl App {
             (Screen::Entry, Focus::Right, InputKey::ScrollToBottom) => {
                 self.right_pane_scroll = usize::MAX;
             }
-            // Tree focus on the entry view, or any non-scroll key on the
-            // source screen — deliberate no-op. `crate::run_app` only
-            // calls this for the four scroll variants, so the non-scroll
-            // case is defensive.
+            // Tree focus on the entry view (ADR 0026 amendment): the tree
+            // pane has no scroll offset of its own — it windows around the
+            // cursor at draw time (`crate::ui::entry::draw_tree_pane`'s own
+            // doc comment) — so these four variants move `self.nav`'s
+            // cursor instead of any pane's scroll state. `step` (half of
+            // `viewport_height`, computed once at the top of this method)
+            // is the same half-page size the right pane/source pane use.
+            (Screen::Entry, Focus::Tree, InputKey::ScrollHalfPageDown) => {
+                self.nav = self.nav.handle(Action::CursorPageDown(step), &self.tree);
+            }
+            (Screen::Entry, Focus::Tree, InputKey::ScrollHalfPageUp) => {
+                self.nav = self.nav.handle(Action::CursorPageUp(step), &self.tree);
+            }
+            (Screen::Entry, Focus::Tree, InputKey::ScrollToTop) => {
+                self.nav = self.nav.handle(Action::CursorTop, &self.tree);
+            }
+            (Screen::Entry, Focus::Tree, InputKey::ScrollToBottom) => {
+                self.nav = self.nav.handle(Action::CursorBottom, &self.tree);
+            }
+            // Any non-scroll key on the source screen — deliberate no-op.
+            // `crate::run_app` only calls this for the four scroll
+            // variants, so this arm is defensive.
             _ => {}
         }
         self

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -897,7 +897,10 @@ impl App {
     /// `Focus::Right` branch and silently scroll the right pane *behind*
     /// the overlay while it looked closed to the reviewer.
     pub fn handle_scroll_key(mut self, key: InputKey, viewport_height: usize) -> Self {
-        let step = viewport_height / 2;
+        // Floored at 1 so a viewport too short to have a half page still
+        // moves by a row, matching vim's own `Ctrl-d`/`Ctrl-u`; without it
+        // these keys are silently inert on 3-4 row terminals.
+        let step = (viewport_height / 2).max(1);
         if self.help_open {
             match key {
                 InputKey::ScrollHalfPageDown => {

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -740,11 +740,10 @@ impl App {
             // above this match already intercepts it and opens the popup
             // otherwise. A no-op either way: nothing to confirm yet.
             (Screen::Entry, _, InputKey::OpenUpdatePrompt) => {}
-            // ADR 0057: search is Source-screen-only —
-            // `crate::input_translate::translate_key` never emits any of
-            // these six variants while `Screen::Entry`, so this arm is a
-            // no-op stub kept only for match exhaustiveness, mirroring
-            // `OpenPrInBrowser`'s own precedent just above.
+            // The `Focus::Tree` half of these variants is handled by the
+            // dedicated arms above (ADR 0057 amendment, tree search); this
+            // arm is the `Focus::Right` fallthrough, where search is not
+            // offered and every variant is a no-op.
             (
                 Screen::Entry,
                 _,

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -98,16 +98,20 @@ impl App {
             return self;
         }
 
-        // Source-view search composing (ADR 0057) takes over the key space
-        // next, mirroring the review overlay's own priority just above —
-        // checked ahead of the help overlay for the identical reason: a
-        // reviewer mid-query must never have a stray `?` yank focus away
-        // into the help overlay instead of typing a literal `?` into their
-        // search. Only reachable while composing (`crate::input_translate::
-        // translate_key` only emits `SearchChar`/`SearchBackspace`/
-        // `SearchCancel` for other keys while composing, and only on
-        // `Screen::Source`), so every other key this function processes is
-        // unaffected by this branch existing.
+        // Search composing (ADR 0057, tree search by amendment) takes over
+        // the key space next, mirroring the review overlay's own priority
+        // just above — checked ahead of the help overlay for the identical
+        // reason: a reviewer mid-query must never have a stray `?` yank
+        // focus away into the help overlay instead of typing a literal `?`
+        // into their search. Only reachable while composing
+        // (`crate::input_translate::translate_key` only emits `SearchChar`/
+        // `SearchBackspace`/`SearchCancel` for other keys while composing,
+        // and only on `Screen::Source` or `Screen::Entry` + `Focus::Tree`),
+        // so every other key this function processes is unaffected by this
+        // branch existing. Screen-agnostic on purpose — the two search
+        // targets (Source-view lines, tree rows) share this exact composing
+        // shape, so there is nothing screen-specific left to check once
+        // `SearchMode::Composing` is already active.
         if matches!(
             self.search.mode(),
             crate::search::SearchMode::Composing { .. }
@@ -357,30 +361,40 @@ impl App {
                     DiffViewMode::Split => DiffViewMode::Unified,
                 };
             }
-            // ADR 0057: `/` starts composing a search query — the
-            // composing-mode branch above this match takes over from the
+            // ADR 0057 (extended to `Screen::Entry` + `Focus::Tree` by
+            // amendment, tree search): `/` starts composing a search query —
+            // the composing-mode branch above this match takes over from the
             // next key onward, so this arm only needs to flip the mode on.
-            (Screen::Source { .. }, _, InputKey::SearchStart) => {
+            // Entry-screen tree search is `Focus::Tree`-only — `Focus::Right`
+            // falls through to that screen's own arms/catch-all below
+            // unchanged, leaving `/` reserved for a possible future Diff-pane
+            // search (ADR 0057's own Alternatives) rather than colliding
+            // with it now.
+            (Screen::Source { .. }, _, InputKey::SearchStart)
+            | (Screen::Entry, Focus::Tree, InputKey::SearchStart) => {
                 self.search = self.search.clone().start();
             }
             // `n`/`N` jump the confirmed query's current match, wrapping —
             // a no-op with no confirmed matches (`SearchState::next`/`prev`'s
-            // own doc comment). Applying the jump to `scroll_top` itself
-            // happens in `crate::event_loop::run_app`, the same "App has no
-            // notion of the pane's rendered height/content" split ADR 0026's
-            // hunk-jump arms already use — this arm only advances which
-            // match is current.
-            (Screen::Source { .. }, _, InputKey::SearchNext) => {
+            // own doc comment). Applying the jump to `scroll_top`/the tree
+            // cursor itself happens in `crate::event_loop::run_app`, the
+            // same "App has no notion of the pane's rendered height/content"
+            // split ADR 0026's hunk-jump arms already use — this arm only
+            // advances which match is current.
+            (Screen::Source { .. }, _, InputKey::SearchNext)
+            | (Screen::Entry, Focus::Tree, InputKey::SearchNext) => {
                 self.search = self.search.clone().next();
             }
-            (Screen::Source { .. }, _, InputKey::SearchPrev) => {
+            (Screen::Source { .. }, _, InputKey::SearchPrev)
+            | (Screen::Entry, Focus::Tree, InputKey::SearchPrev) => {
                 self.search = self.search.clone().prev();
             }
             // Esc while a confirmed search is active (`crate::input_translate::
             // translate_key`'s own doc comment on why this arrives as
-            // `SearchCancel` rather than `Back` in that case): clears the
-            // search without leaving the screen.
-            (Screen::Source { .. }, _, InputKey::SearchCancel) => {
+            // `SearchCancel` rather than `Back`/`FocusLeft` in that case):
+            // clears the search without leaving the screen/pane.
+            (Screen::Source { .. }, _, InputKey::SearchCancel)
+            | (Screen::Entry, Focus::Tree, InputKey::SearchCancel) => {
                 self.search = self.search.clone().cancel();
             }
             // Every other key is a no-op while the source view is open —

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -13,7 +13,7 @@ use crate::detail::{
     DetailView, DirDetail, FileDetail, SymbolMention, build_detail, build_dir_detail,
     build_file_detail,
 };
-use crate::nav::Nav;
+use crate::nav::{self, Nav};
 use crate::order::{DirRank, OrderMode, rank_directories};
 use crate::review::ReviewState;
 use crate::search::SearchState;
@@ -992,6 +992,20 @@ impl App {
                 scroll_top,
             };
         }
+        self
+    }
+
+    /// Jumps the tree cursor directly to visible-row `index` (ADR 0057
+    /// amendment: tree search) — `crate::event_loop::run_app` calls this
+    /// once a confirmed search's current match is known, the same
+    /// "`App` has no notion of X, caller computes it and folds it back"
+    /// split [`Self::with_source_scroll_top`]/[`Self::with_right_pane_scroll`]
+    /// already use for their own screen-specific jump targets. Delegates to
+    /// [`nav::Action::CursorTo`] rather than writing `self.nav` directly, so
+    /// the same out-of-bounds clamp every other cursor motion gets applies
+    /// here too.
+    pub fn with_nav_cursor(mut self, index: usize) -> Self {
+        self.nav = self.nav.handle(nav::Action::CursorTo(index), &self.tree);
         self
     }
 }

--- a/rinkaku-tui/src/app/tests/mod.rs
+++ b/rinkaku-tui/src/app/tests/mod.rs
@@ -8,8 +8,10 @@
 //!   for file/symbol/directory rows
 //! - `source_screen` — `Source`/`Back` transitions and all
 //!   `Screen::Source` scroll behaviors (ADR 0026: `j`/`k`,
-//!   half-page/`gg`/`G`), plus the entry-view `handle_scroll_key`
-//!   variants that act on `right_pane_scroll` while `Focus::Right`
+//!   half-page/`gg`/`G`), the entry-view `handle_scroll_key` variants
+//!   that act on `right_pane_scroll` while `Focus::Right`, and (ADR
+//!   0026 amendment) the same variants moving the tree cursor while
+//!   `Focus::Tree`
 //! - `right_pane` — right-pane toggles (`ToggleDiff`,
 //!   `ToggleBlastRadius`), `blast_radius_return_pane`,
 //!   `selected_blast_radius_view`, `with_entry_pivot`, and

--- a/rinkaku-tui/src/app/tests/search.rs
+++ b/rinkaku-tui/src/app/tests/search.rs
@@ -1,10 +1,16 @@
-//! Tests for `App::handle_key`'s Source-view search dispatch (ADR 0057):
-//! `/` starting composing, character/backspace composing, `Esc` cancel
-//! (both while composing and after a confirmed search), and the
-//! composing-mode priority check taking over the whole key space the same
-//! way the review overlay's own check does.
+//! Tests for `App::handle_key`'s search dispatch: the original Source-view
+//! search (ADR 0057) — `/` starting composing, character/backspace
+//! composing, `Esc` cancel (both while composing and after a confirmed
+//! search), and the composing-mode priority check taking over the whole key
+//! space the same way the review overlay's own check does — plus the tree
+//! search amendment (ADR 0057 amendment): the same four dispatch keys
+//! (`SearchStart`/`SearchNext`/`SearchPrev`/`SearchCancel`) reaching
+//! `Screen::Entry` + `Focus::Tree` instead, and staying a no-op on
+//! `Focus::Right`. `App::with_nav_cursor` (the tree-search jump primitive)
+//! is also pinned here, alongside the dispatch it backs.
 
 use super::*;
+use crate::app::Focus;
 use crate::search::{SearchMode, SearchState};
 
 fn opened_source_screen(report: &Report) -> App {
@@ -178,15 +184,99 @@ fn should_clear_a_confirmed_search_when_leaving_source_via_back() {
 }
 
 #[test]
-fn should_not_start_composing_on_the_entry_screen() {
-    // ADR 0057: search is Source-screen-only — `SearchStart` reaching
-    // `handle_key` while `Screen::Entry` (defensively, since
-    // `crate::input_translate::translate_key` never emits it there) must
-    // be a no-op.
+fn should_not_start_composing_on_the_entry_screen_while_focus_right() {
+    // ADR 0057 amendment: tree search is `Focus::Tree`-only on the entry
+    // screen — `SearchStart` reaching `handle_key` while `Focus::Right`
+    // (defensively, since `crate::input_translate::translate_key` never
+    // emits it there) must still be a no-op.
     let report = report_with_one_symbol();
-    let app = App::new(&report);
+    let app = App::new(&report).handle_key(InputKey::Open);
+    assert_eq!(Focus::Right, app.focus());
 
     let actual = app.handle_key(InputKey::SearchStart);
 
     assert_eq!(&SearchMode::Inactive, actual.search().mode());
+}
+
+// ADR 0057 amendment: tree search (Entry screen, Focus::Tree).
+
+#[test]
+fn should_start_composing_on_the_entry_screen_while_focus_tree() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report);
+    assert_eq!(Focus::Tree, app.focus());
+
+    let actual = app.handle_key(InputKey::SearchStart);
+
+    assert_eq!(
+        &SearchMode::Composing {
+            buffer: String::new()
+        },
+        actual.search().mode()
+    );
+}
+
+#[test]
+fn should_advance_to_the_next_tree_match_when_search_next_is_pressed() {
+    let report = report_with_one_symbol();
+    let texts = vec![
+        "foo".to_string(),
+        "foobar".to_string(),
+        "barfoo".to_string(),
+    ];
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&texts, 0);
+    let app = App::new(&report).with_search(search);
+    assert_eq!(Some(0), app.search().current_match());
+
+    let actual = app.handle_key(InputKey::SearchNext);
+
+    assert_eq!(Some(1), actual.search().current_match());
+}
+
+#[test]
+fn should_retreat_to_the_previous_tree_match_when_search_prev_is_pressed() {
+    let report = report_with_one_symbol();
+    let texts = vec!["foo".to_string(), "foobar".to_string()];
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .confirm(&texts, 0);
+    let app = App::new(&report).with_search(search);
+    assert_eq!(Some(0), app.search().current_match());
+
+    let actual = app.handle_key(InputKey::SearchPrev);
+
+    assert_eq!(Some(1), actual.search().current_match());
+}
+
+#[test]
+fn should_clear_a_confirmed_tree_search_when_search_cancel_is_pressed() {
+    let report = report_with_one_symbol();
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .confirm(&["foo".to_string()], 0);
+    let app = App::new(&report).with_search(search);
+    assert!(app.search().query().is_some());
+
+    let actual = app.handle_key(InputKey::SearchCancel);
+
+    assert_eq!(None, actual.search().query());
+}
+
+#[test]
+fn should_move_the_tree_cursor_when_with_nav_cursor_is_called() {
+    let report = super::report_with_two_directories();
+    let app = App::new(&report);
+    assert_eq!(0, app.nav().cursor());
+
+    let actual = app.with_nav_cursor(3);
+
+    assert_eq!(3, actual.nav().cursor());
 }

--- a/rinkaku-tui/src/app/tests/search.rs
+++ b/rinkaku-tui/src/app/tests/search.rs
@@ -6,12 +6,16 @@
 //! search amendment (ADR 0057 amendment): the same four dispatch keys
 //! (`SearchStart`/`SearchNext`/`SearchPrev`/`SearchCancel`) reaching
 //! `Screen::Entry` + `Focus::Tree` instead, and staying a no-op on
-//! `Focus::Right`. `App::with_nav_cursor` (the tree-search jump primitive)
-//! is also pinned here, alongside the dispatch it backs.
+//! `Focus::Right`, and the search being cancelled by every key that
+//! reshapes the tree's row list or leaves the entry screen (the frozen
+//! row-index invariant `App::handle_key`'s `Select` arm documents).
+//! `App::with_nav_cursor` (the tree-search jump primitive) is also pinned
+//! here, alongside the dispatch it backs.
 
 use super::*;
-use crate::app::Focus;
+use crate::app::{Focus, Screen};
 use crate::search::{SearchMode, SearchState};
+use rstest::rstest;
 
 fn opened_source_screen(report: &Report) -> App {
     App::new(report)
@@ -268,6 +272,89 @@ fn should_clear_a_confirmed_tree_search_when_search_cancel_is_pressed() {
     let actual = app.handle_key(InputKey::SearchCancel);
 
     assert_eq!(None, actual.search().query());
+}
+
+fn tree_search_confirmed_on_two_directories(report: &Report) -> App {
+    let texts = vec![
+        "a".to_string(),
+        "a/one.rs".to_string(),
+        "foo".to_string(),
+        "b".to_string(),
+        "b/two.rs".to_string(),
+        "bar".to_string(),
+    ];
+    let search = SearchState::default()
+        .start()
+        .push_char('o')
+        .confirm(&texts, 0);
+    App::new(report).with_search(search)
+}
+
+#[rstest]
+#[case::expand_all(InputKey::ExpandAll)]
+#[case::collapse_all(InputKey::CollapseAll)]
+#[case::toggle_order(InputKey::ToggleOrder)]
+#[case::toggle_expand(InputKey::Select)]
+fn should_clear_a_confirmed_tree_search_when_the_row_list_is_reshaped(#[case] key: InputKey) {
+    let report = super::report_with_two_directories();
+    let app = tree_search_confirmed_on_two_directories(&report);
+    assert_eq!(Some("o"), app.search().query());
+
+    let actual = app.handle_key(key);
+
+    assert_eq!(&SearchState::default(), actual.search());
+}
+
+#[test]
+fn should_clear_a_confirmed_tree_search_when_open_expands_a_directory_row() {
+    let report = super::report_with_two_directories();
+    let app = tree_search_confirmed_on_two_directories(&report);
+    assert_eq!(Focus::Tree, app.focus());
+
+    let actual = app.handle_key(InputKey::Open);
+
+    assert_eq!(&SearchState::default(), actual.search());
+}
+
+#[test]
+fn should_clear_a_confirmed_tree_search_when_entering_the_source_screen() {
+    let report = report_with_one_symbol();
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .confirm(&["lib.rs".to_string(), "foo".to_string()], 0);
+    let app = App::new(&report)
+        .with_search(search)
+        .handle_key(InputKey::Down);
+
+    let actual = app.handle_key(InputKey::Source);
+
+    assert_eq!(
+        &Screen::Source {
+            symbol_id: "lib.rs::foo".to_string(),
+            scroll_top: 0,
+        },
+        actual.screen()
+    );
+    assert_eq!(&SearchState::default(), actual.search());
+}
+
+#[test]
+fn should_keep_a_confirmed_tree_search_when_source_is_pressed_on_a_non_symbol_row() {
+    let report = report_with_one_symbol();
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .confirm(&["lib.rs".to_string(), "foo".to_string()], 0);
+    let expected = search.clone();
+    // Row 0 of `report_with_one_symbol` is the `lib.rs` File row, which
+    // `InputKey::Source`'s guard refuses to open.
+    let app = App::new(&report).with_search(search);
+
+    let actual = app.handle_key(InputKey::Source);
+
+    assert_eq!(&Screen::Entry, actual.screen());
+    assert_eq!(&expected, actual.search());
 }
 
 #[test]

--- a/rinkaku-tui/src/app/tests/source_screen.rs
+++ b/rinkaku-tui/src/app/tests/source_screen.rs
@@ -1,6 +1,7 @@
 use super::report_with_one_symbol;
 use crate::app::{App, Focus, InputKey, Screen};
 use pretty_assertions::assert_eq;
+use rstest::rstest;
 
 #[test]
 fn should_open_source_screen_when_source_key_is_pressed_on_a_symbol_row() {
@@ -277,6 +278,21 @@ fn should_clamp_tree_cursor_to_last_row_when_focus_tree_scroll_half_page_down_ov
     let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, 100);
 
     assert_eq!(5, app.nav().cursor());
+}
+
+#[rstest]
+#[case::zero_row_viewport(0)]
+#[case::one_row_viewport(1)]
+fn should_move_tree_cursor_by_one_row_when_viewport_is_too_short_for_a_half_page(
+    #[case] viewport_height: usize,
+) {
+    let report = super::report_with_two_directories();
+    let app = App::new(&report);
+    assert_eq!(0, app.nav().cursor());
+
+    let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, viewport_height);
+
+    assert_eq!(1, app.nav().cursor());
 }
 
 #[test]

--- a/rinkaku-tui/src/app/tests/source_screen.rs
+++ b/rinkaku-tui/src/app/tests/source_screen.rs
@@ -234,10 +234,10 @@ fn should_add_half_viewport_to_right_pane_scroll_when_focus_right_scroll_half_pa
 
 #[test]
 fn should_leave_right_pane_scroll_untouched_when_focus_tree_and_scroll_half_page_down() {
-    // Tree focus is the entry view's default; `handle_scroll_key` must
-    // no-op there (ADR 0026's decision 3), leaving `right_pane_scroll`
-    // at 0 rather than scrolling a pane the reviewer is not looking
-    // at.
+    // Tree focus is the entry view's default; `handle_scroll_key` moves
+    // the tree cursor there (ADR 0026 amendment, see the
+    // `should_move_tree_cursor_*` tests below), not `right_pane_scroll`
+    // — that field must stay untouched since no pane is being scrolled.
     let report = report_with_one_symbol();
     let app = App::new(&report);
     assert_eq!(Focus::Tree, app.focus());
@@ -245,6 +245,72 @@ fn should_leave_right_pane_scroll_untouched_when_focus_tree_and_scroll_half_page
     let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, 30);
 
     assert_eq!(0, app.right_pane_scroll());
+}
+
+// ADR 0026 amendment: `Focus::Tree` on the entry view has no pane of its
+// own to scroll (`crate::ui::entry::draw_tree_pane` windows around the
+// cursor at draw time instead), so these four variants move the tree
+// cursor — `Nav::Action::CursorPageDown`/`CursorPageUp`/`CursorTop`/
+// `CursorBottom` — rather than any scroll offset. Uses
+// `report_with_two_directories` (6 rows: a(0), a/one.rs(1), foo(2), b(3),
+// b/two.rs(4), bar(5)) so half-page motion has more than one row of
+// headroom to exercise.
+
+#[test]
+fn should_move_tree_cursor_down_by_half_viewport_when_focus_tree_scroll_half_page_down() {
+    let report = super::report_with_two_directories();
+    let app = App::new(&report);
+    assert_eq!(Focus::Tree, app.focus());
+    assert_eq!(0, app.nav().cursor());
+
+    // Viewport height 4 -> step size 2.
+    let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, 4);
+
+    assert_eq!(2, app.nav().cursor());
+}
+
+#[test]
+fn should_clamp_tree_cursor_to_last_row_when_focus_tree_scroll_half_page_down_overshoots() {
+    let report = super::report_with_two_directories();
+    let app = App::new(&report);
+
+    let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, 100);
+
+    assert_eq!(5, app.nav().cursor());
+}
+
+#[test]
+fn should_move_tree_cursor_up_by_half_viewport_when_focus_tree_scroll_half_page_up() {
+    let report = super::report_with_two_directories();
+    let app = App::new(&report).handle_scroll_key(InputKey::ScrollToBottom, 4);
+    assert_eq!(5, app.nav().cursor());
+
+    // Viewport height 4 -> step size 2.
+    let app = app.handle_scroll_key(InputKey::ScrollHalfPageUp, 4);
+
+    assert_eq!(3, app.nav().cursor());
+}
+
+#[test]
+fn should_move_tree_cursor_to_first_row_when_focus_tree_scroll_to_top() {
+    let report = super::report_with_two_directories();
+    let app = App::new(&report).handle_scroll_key(InputKey::ScrollToBottom, 4);
+    assert_eq!(5, app.nav().cursor());
+
+    let app = app.handle_scroll_key(InputKey::ScrollToTop, 4);
+
+    assert_eq!(0, app.nav().cursor());
+}
+
+#[test]
+fn should_move_tree_cursor_to_last_row_when_focus_tree_scroll_to_bottom() {
+    let report = super::report_with_two_directories();
+    let app = App::new(&report);
+    assert_eq!(0, app.nav().cursor());
+
+    let app = app.handle_scroll_key(InputKey::ScrollToBottom, 4);
+
+    assert_eq!(5, app.nav().cursor());
 }
 
 #[test]

--- a/rinkaku-tui/src/event_loop/mod.rs
+++ b/rinkaku-tui/src/event_loop/mod.rs
@@ -11,7 +11,7 @@
 mod goto;
 mod scroll_sync;
 
-use crate::app::{App, BlastRadiusSelection, InputKey, Screen};
+use crate::app::{App, BlastRadiusSelection, Focus, InputKey, Screen};
 use crate::locale::Locale;
 use crate::review::PrContext;
 use crate::review::ports::{BrowserOpener, ClipboardSink, ReviewSubmitter};
@@ -169,6 +169,16 @@ pub(crate) fn run_app(
     // near-impossible edge case, but guarded rather than defaulting to a
     // zero step) falls back to [`DEFAULT_SCROLL_VIEWPORT_HEIGHT`].
     let mut last_scroll_viewport_height: Option<usize> = None;
+    // The tree pane's own last-drawn inner height
+    // (`ui::DrawOutcome::tree_viewport_height`), tracked separately from
+    // `last_scroll_viewport_height` above for the same reason
+    // `last_help_scroll_viewport_height` is (ADR 0026 amendment): the tree
+    // pane is a different box than the right pane/source pane, and the two
+    // are never the active `Ctrl-d`/`Ctrl-u`/`gg`/`G` target in the same
+    // frame (gated on opposite arms of `Focus`), but sizing a tree-focused
+    // press against a stale right-pane height would silently move the
+    // cursor the wrong distance.
+    let mut last_tree_viewport_height: Option<usize> = None;
     // The `?` help overlay's own last-drawn inner height, tracked
     // separately from `last_scroll_viewport_height` above: the overlay can
     // be open on top of either screen, and its box is a different size
@@ -224,6 +234,9 @@ pub(crate) fn run_app(
         app = clamp_right_pane_scroll_after_draw(app, outcome.clamped_right_pane_scroll);
         if outcome.scroll_viewport_height.is_some() {
             last_scroll_viewport_height = outcome.scroll_viewport_height;
+        }
+        if outcome.tree_viewport_height.is_some() {
+            last_tree_viewport_height = outcome.tree_viewport_height;
         }
         app = clamp_help_scroll_after_draw(app, outcome.clamped_help_scroll);
         if outcome.help_scroll_viewport_height.is_some() {
@@ -401,9 +414,17 @@ pub(crate) fn run_app(
                 // `App::handle_scroll_key`'s own `help_open` branches) —
                 // `last_help_scroll_viewport_height` is this loop's mirror
                 // of `last_scroll_viewport_height` for that surface.
+                //
+                // ADR 0026 amendment: `Focus::Tree` on `Screen::Entry` sizes
+                // against `last_tree_viewport_height` instead — the tree
+                // pane `App::handle_scroll_key` now moves the cursor in
+                // (ADR 0026's own right-pane/source-pane cases fall through
+                // to `last_scroll_viewport_height` unchanged).
                 app = app.handle_key(input_key);
                 let viewport_height = if app.help_open() {
                     last_help_scroll_viewport_height.unwrap_or(DEFAULT_SCROLL_VIEWPORT_HEIGHT)
+                } else if matches!(app.screen(), Screen::Entry) && app.focus() == Focus::Tree {
+                    last_tree_viewport_height.unwrap_or(DEFAULT_SCROLL_VIEWPORT_HEIGHT)
                 } else {
                     last_scroll_viewport_height.unwrap_or(DEFAULT_SCROLL_VIEWPORT_HEIGHT)
                 };

--- a/rinkaku-tui/src/event_loop/mod.rs
+++ b/rinkaku-tui/src/event_loop/mod.rs
@@ -13,6 +13,7 @@ mod scroll_sync;
 
 use crate::app::{App, BlastRadiusSelection, Focus, InputKey, Screen};
 use crate::locale::Locale;
+use crate::nav::row_search_texts;
 use crate::review::PrContext;
 use crate::review::ports::{BrowserOpener, ClipboardSink, ReviewSubmitter};
 use crate::review_flow::{
@@ -327,15 +328,16 @@ pub(crate) fn run_app(
                 // gated on load success.
                 app = dispatch_search_confirm(app, source_content.as_ref());
             } else if matches!(input_key, InputKey::SearchNext | InputKey::SearchPrev) {
-                // ADR 0057: `App::handle_key` already advances/retreats
-                // `SearchState`'s current match (no external data needed
-                // for that step); this loop's own job is folding the
-                // resulting match line into `Screen::Source::scroll_top`,
-                // the same split `InputKey::Source`'s own back-fill above
-                // uses between "what changed" (`App`) and "how that maps
-                // onto the viewport" (`run_app`).
+                // ADR 0057 (tree search by amendment): `App::handle_key`
+                // already advances/retreats `SearchState`'s current match
+                // (no external data needed for that step); this loop's own
+                // job is folding the resulting match into
+                // `Screen::Source::scroll_top` or the tree cursor, the same
+                // split `InputKey::Source`'s own back-fill above uses
+                // between "what changed" (`App`) and "how that maps onto
+                // the viewport" (`run_app`).
                 app = app.handle_key(input_key);
-                app = jump_source_scroll_to_current_match(app);
+                app = jump_search_match_into_view(app);
             } else if let InputKey::OpenPrInBrowser = input_key {
                 // ADR 0050: needs `review_ports.pr_context`/`.browser`,
                 // neither of which `App::handle_key` has access to (mirrors
@@ -624,43 +626,75 @@ fn should_recompute_diff_pane_content(app: &App) -> bool {
 /// [`App::with_source_scroll_top`] (already a no-op on [`Screen::Entry`],
 /// per that method's own doc comment) rather than inlined at each of this
 /// module's three call sites (`SearchConfirm`, `SearchNext`, `SearchPrev`)
-/// sharing the exact same "match line -> scroll target" mapping.
-fn jump_source_scroll_to_current_match(app: App) -> App {
-    match app.search().current_match() {
-        Some(line) => app.with_source_scroll_top(line),
-        None => app,
+/// sharing the exact same "match line/row -> jump target" mapping.
+///
+/// ADR 0057 amendment (tree search): on [`Screen::Entry`], the "jump
+/// target" is the tree cursor ([`App::with_nav_cursor`]) rather than a
+/// scroll offset — the two screens can never both be active at once, so
+/// branching on `app.screen()` here is one function covering both, not two
+/// parallel ones.
+fn jump_search_match_into_view(app: App) -> App {
+    match app.screen() {
+        Screen::Source { .. } => match app.search().current_match() {
+            Some(line) => app.with_source_scroll_top(line),
+            None => app,
+        },
+        Screen::Entry => match app.search().current_match() {
+            Some(index) => app.with_nav_cursor(index),
+            None => app,
+        },
     }
 }
 
-/// Applies [`InputKey::SearchConfirm`] against `source_content` — extracted
-/// from `run_app`'s inline dispatch so this branch is unit-testable without
-/// a live terminal (mirrors `jump_source_scroll_to_current_match`'s own
-/// "small wrapper, pulled out for the shared/testable step" precedent).
+/// Applies [`InputKey::SearchConfirm`] — extracted from `run_app`'s inline
+/// dispatch so this branch is unit-testable without a live terminal
+/// (mirrors [`jump_search_match_into_view`]'s own "small wrapper, pulled
+/// out for the shared/testable step" precedent).
 ///
-/// When `source_content` is not a loaded `Ok` view (the Source screen open
+/// On [`Screen::Source`]: confirms against `source_content`'s lines. When
+/// `source_content` is not a loaded `Ok` view (the Source screen open
 /// against a file that failed to read — e.g. deleted mid-review, or a
 /// permission error), confirming cancels the search instead of leaving it
 /// composing: `App::handle_key`'s own `SearchConfirm` arm is a documented
 /// no-op (it has no lines to match against), and letting Enter do nothing
 /// here trapped the reviewer in the minibuffer with no way out except Esc.
+///
+/// On [`Screen::Entry`] (ADR 0057 amendment, tree search): confirms
+/// against [`row_search_texts`] of the tree's *currently visible* rows
+/// (`App::nav`/`App::tree`, no external content needed — unlike the Source
+/// branch, everything this needs already lives on `App`) — a match under a
+/// collapsed ancestor (e.g. a `TestGroup`, collapsed by default per
+/// `Nav::new_collapsing_test_groups`) is not found; expanding into
+/// collapsed subtrees on a match is explicit future work, mirroring how
+/// ADR 0057 itself deferred Diff-pane search rather than trying to solve
+/// every case in one pass.
 fn dispatch_search_confirm(
     app: App,
     source_content: Option<&Result<source::HighlightedSourceView, String>>,
 ) -> App {
-    if let Some(Ok(highlighted)) = source_content {
-        let from_line = match app.screen() {
-            Screen::Source { scroll_top, .. } => *scroll_top,
-            Screen::Entry => 0,
-        };
-        let search = app
-            .search()
-            .clone()
-            .confirm(&highlighted.view.lines, from_line);
-        let app = app.with_search(search);
-        jump_source_scroll_to_current_match(app)
-    } else {
-        let search = app.search().clone().cancel();
-        app.with_search(search)
+    match app.screen() {
+        Screen::Source { scroll_top, .. } => {
+            if let Some(Ok(highlighted)) = source_content {
+                let from_line = *scroll_top;
+                let search = app
+                    .search()
+                    .clone()
+                    .confirm(&highlighted.view.lines, from_line);
+                let app = app.with_search(search);
+                jump_search_match_into_view(app)
+            } else {
+                let search = app.search().clone().cancel();
+                app.with_search(search)
+            }
+        }
+        Screen::Entry => {
+            let rows = app.nav().rows(app.tree());
+            let texts = row_search_texts(&rows);
+            let from_index = app.nav().cursor();
+            let search = app.search().clone().confirm(&texts, from_index);
+            let app = app.with_search(search);
+            jump_search_match_into_view(app)
+        }
     }
 }
 

--- a/rinkaku-tui/src/event_loop/tests.rs
+++ b/rinkaku-tui/src/event_loop/tests.rs
@@ -649,3 +649,43 @@ fn should_cancel_the_search_when_source_content_is_absent() {
     assert_eq!(&crate::search::SearchMode::Inactive, actual.search().mode());
     assert_eq!(None, actual.search().query());
 }
+
+// ADR 0057 amendment: `dispatch_search_confirm`'s `Screen::Entry` branch
+// (tree search) — needs no `source_content` at all, unlike the
+// `Screen::Source` branch above, since the tree's rows are already on
+// `App` itself.
+
+#[test]
+fn should_confirm_and_jump_the_tree_cursor_to_first_match_on_entry_screen() {
+    let report = report_with_one_symbol();
+    // report_with_one_symbol()'s expanded row order: lib.rs(0, File),
+    // foo(1, Symbol).
+    let app = App::new(&report)
+        .handle_key(InputKey::SearchStart)
+        .handle_key(InputKey::SearchChar('f'))
+        .handle_key(InputKey::SearchChar('o'))
+        .handle_key(InputKey::SearchChar('o'));
+
+    let actual = dispatch_search_confirm(app, None);
+
+    assert_eq!(
+        Some("foo".to_string()),
+        actual.search().query().map(str::to_string)
+    );
+    assert_eq!(&[1], actual.search().matches());
+    assert_eq!(1, actual.nav().cursor());
+}
+
+#[test]
+fn should_leave_the_tree_cursor_untouched_when_confirming_a_tree_search_with_no_matches() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report)
+        .handle_key(InputKey::SearchStart)
+        .handle_key(InputKey::SearchChar('z'))
+        .handle_key(InputKey::SearchChar('z'));
+    assert_eq!(0, app.nav().cursor());
+
+    let actual = dispatch_search_confirm(app, None);
+
+    assert_eq!(0, actual.nav().cursor());
+}

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -109,6 +109,18 @@ fn tree_focus_bindings(locale: Locale) -> Vec<KeyBinding> {
             description: rust_i18n::t!("help.binding.jump_tree_top_bottom", locale = tag)
                 .into_owned(),
         },
+        // ADR 0057 amendment: tree search reuses Source view's own `/`/
+        // `n`/`N` bindings and descriptions (`source_screen_bindings`
+        // below) — same gesture, different search target.
+        KeyBinding {
+            keys: "/",
+            description: rust_i18n::t!("help.binding.start_search", locale = tag).into_owned(),
+        },
+        KeyBinding {
+            keys: "n / N",
+            description: rust_i18n::t!("help.binding.jump_next_prev_match", locale = tag)
+                .into_owned(),
+        },
         KeyBinding {
             keys: "enter",
             description: rust_i18n::t!("help.binding.expand_collapse_open", locale = tag)

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -94,6 +94,21 @@ fn tree_focus_bindings(locale: Locale) -> Vec<KeyBinding> {
             keys: "j / k / ↓ / ↑",
             description: rust_i18n::t!("help.binding.move_cursor", locale = tag).into_owned(),
         },
+        // ADR 0026 amendment: `Ctrl-d`/`Ctrl-u`/`gg`/`G` move the tree
+        // cursor the same way they scroll the right pane/source pane
+        // (`right_focus_bindings`/`source_screen_bindings` below) — the
+        // tree pane just has no separate scroll offset of its own to move
+        // (`App::handle_scroll_key`'s own doc comment).
+        KeyBinding {
+            keys: "ctrl-d / ctrl-u",
+            description: rust_i18n::t!("help.binding.scroll_tree_half_page", locale = tag)
+                .into_owned(),
+        },
+        KeyBinding {
+            keys: "gg / G",
+            description: rust_i18n::t!("help.binding.jump_tree_top_bottom", locale = tag)
+                .into_owned(),
+        },
         KeyBinding {
             keys: "enter",
             description: rust_i18n::t!("help.binding.expand_collapse_open", locale = tag)

--- a/rinkaku-tui/src/input_translate.rs
+++ b/rinkaku-tui/src/input_translate.rs
@@ -81,18 +81,25 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         review::ReviewMode::Idle => {}
     }
 
-    // Search composing (ADR 0057) is checked next, mirroring the review
-    // overlay's own early-return shape just above: while composing a
-    // query, every printable character (including keys that would
-    // otherwise mean something else, like `?`) must land in the query
-    // buffer. Only reachable on `Screen::Source` — `InputKey::SearchStart`
-    // is likewise only ever emitted there (below), so this branch is
-    // unreachable on `Screen::Entry` in practice, but gated on
-    // `on_source_screen` defensively rather than relying on that
-    // invariant, the same defensive style `FocusLeft`'s Esc arm below
-    // already uses.
+    // Search composing (ADR 0057, extended to tree search by amendment) is
+    // checked next, mirroring the review overlay's own early-return shape
+    // just above: while composing a query, every printable character
+    // (including keys that would otherwise mean something else, like `?`)
+    // must land in the query buffer. Only reachable on `Screen::Source` or
+    // `Screen::Entry` + `Focus::Tree` — `InputKey::SearchStart` is likewise
+    // only ever emitted in those two contexts (below), so this branch is
+    // unreachable elsewhere in practice, but gated on
+    // `on_source_screen`/`tree_focused_entry` defensively rather than
+    // relying on that invariant, the same defensive style `FocusLeft`'s Esc
+    // arm below already uses. `tree_focused_entry` cannot go stale mid-
+    // compose: composing swallows every key (this very branch), so nothing
+    // can change `app.focus()` while it is active.
     let on_source_screen = matches!(app.screen(), Screen::Source { .. });
-    if on_source_screen && matches!(app.search().mode(), SearchMode::Composing { .. }) {
+    let tree_focused_entry =
+        matches!(app.screen(), Screen::Entry) && app.focus() == app::Focus::Tree;
+    if (on_source_screen || tree_focused_entry)
+        && matches!(app.search().mode(), SearchMode::Composing { .. })
+    {
         return match code {
             KeyCode::Enter => Some(InputKey::SearchConfirm),
             KeyCode::Esc => Some(InputKey::SearchCancel),
@@ -246,17 +253,20 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         KeyCode::Char(']') => Some(InputKey::NextHunk),
         KeyCode::Char('[') => Some(InputKey::PrevHunk),
         KeyCode::Char('s') => Some(InputKey::Source),
-        // `/` (ADR 0057): starts composing a Source-view search query.
-        // Source-screen-only — unbound on the entry screen, where a diff
-        // pane search is future work (ADR 0057's own Alternatives).
-        KeyCode::Char('/') if on_source_screen => Some(InputKey::SearchStart),
-        // `n`/`N` (ADR 0057): jump to the next/previous search match.
-        // Source-screen-only — ADR 0058 freed these on the entry screen
-        // (moving the annotation bindings below to `a`/`A`) precisely so
-        // a future Entry-screen search can reuse them without colliding
-        // with anything.
-        KeyCode::Char('n') if on_source_screen => Some(InputKey::SearchNext),
-        KeyCode::Char('N') if on_source_screen => Some(InputKey::SearchPrev),
+        // `/` (ADR 0057, extended to tree search by amendment): starts
+        // composing a search query. Valid on `Screen::Source` (searches its
+        // lines) or `Screen::Entry` + `Focus::Tree` (searches the tree's
+        // file/symbol names) — unbound on `Focus::Right`, where a Diff/
+        // Detail pane search is still future work (ADR 0057's own
+        // Alternatives).
+        KeyCode::Char('/') if on_source_screen || tree_focused_entry => Some(InputKey::SearchStart),
+        // `n`/`N` (ADR 0057, extended to tree search by amendment): jump to
+        // the next/previous search match. ADR 0058 freed these on the
+        // entry screen (moving the annotation bindings below to `a`/`A`)
+        // precisely so this tree search could reuse them — still unbound
+        // while `Focus::Right`, mirroring `/`'s own scoping just above.
+        KeyCode::Char('n') if on_source_screen || tree_focused_entry => Some(InputKey::SearchNext),
+        KeyCode::Char('N') if on_source_screen || tree_focused_entry => Some(InputKey::SearchPrev),
         // `a` (ADR 0048, rebound from `n` by ADR 0058): opens the review
         // annotation compose overlay over the row under the cursor. `A`
         // (rebound from `N`): opens the review annotations list overlay.
@@ -281,13 +291,19 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
         // sets `pending_prefix` from this variant unconditionally.
         KeyCode::Char('g') => Some(InputKey::PendingGoto),
         KeyCode::Char('?') => Some(InputKey::ToggleHelp),
-        // ADR 0057: Esc's first press clears an active confirmed search
-        // (matching vim's own `/`-then-Esc convention of dismissing the
-        // highlight before leaving) rather than immediately returning to
-        // the entry view — checked ahead of the plain `Back` arm just
-        // below so a reviewer backing out of a search does not also lose
-        // their place in the file.
-        KeyCode::Esc if on_source_screen && app.search().query().is_some() => {
+        // ADR 0057 (extended to tree search by amendment): Esc's first
+        // press clears an active confirmed search (matching vim's own
+        // `/`-then-Esc convention of dismissing the highlight before
+        // leaving) rather than immediately returning to the entry view —
+        // checked ahead of the plain `Back` arm just below so a reviewer
+        // backing out of a search does not also lose their place in the
+        // file/tree. `tree_focused_entry`'s Esc has no `Back`/`FocusLeft`
+        // meaning of its own to preempt (there is nowhere to "go back" to
+        // from the tree), so widening this guard only adds behavior, never
+        // shadows an existing one.
+        KeyCode::Esc
+            if (on_source_screen || tree_focused_entry) && app.search().query().is_some() =>
+        {
             Some(InputKey::SearchCancel)
         }
         KeyCode::Esc if on_source_screen => Some(InputKey::Back),

--- a/rinkaku-tui/src/input_translate.rs
+++ b/rinkaku-tui/src/input_translate.rs
@@ -206,14 +206,15 @@ pub(crate) fn translate_key(code: KeyCode, modifiers: KeyModifiers, app: &App) -
             Some(InputKey::JumpForward)
         }
         KeyCode::Char('o') => Some(InputKey::ToggleOrder),
-        // `Ctrl-d`/`Ctrl-u` (ADR 0026): half-page scroll on the reading
-        // pane (`Screen::Source`, or `Screen::Entry` + `Focus::Right`).
-        // Must come *before* the plain `Char('d')`/`Char('u')` arms —
-        // otherwise a `Ctrl-d` press would match `ToggleDiff` first and
-        // the modifier would be ignored, silently rebinding "half-page
-        // down" to "toggle diff pane". Emitted regardless of screen/
-        // focus; `App::handle_scroll_key` no-ops on `Focus::Tree` in the
-        // entry view (ADR 0026 decision 3's Tree-focus rule).
+        // `Ctrl-d`/`Ctrl-u` (ADR 0026, tree support added by amendment):
+        // half-page motion on the reading pane (`Screen::Source`, or
+        // `Screen::Entry` + `Focus::Right`) or the tree cursor
+        // (`Screen::Entry` + `Focus::Tree`). Must come *before* the plain
+        // `Char('d')`/`Char('u')` arms — otherwise a `Ctrl-d` press would
+        // match `ToggleDiff` first and the modifier would be ignored,
+        // silently rebinding "half-page down" to "toggle diff pane".
+        // Emitted regardless of screen/focus; `App::handle_scroll_key`
+        // picks the right target from `self.screen`/`self.focus`.
         KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
             Some(InputKey::ScrollHalfPageDown)
         }

--- a/rinkaku-tui/src/input_translate_tests/search.rs
+++ b/rinkaku-tui/src/input_translate_tests/search.rs
@@ -1,11 +1,13 @@
 //! `translate_key` tests for ADR 0057's Source-view search bindings: `/`
-//! starting a query, the composing-mode early return, `n`/`N` being
-//! Source-screen-only (freed entirely on the entry screen by ADR 0058,
-//! which moved the review-annotation bindings to `a`/`A`), and Esc's dual
-//! "cancel search" / "back" meaning.
+//! starting a query, the composing-mode early return, `n`/`N`, and Esc's
+//! dual "cancel search" / "back" meaning — plus the ADR 0057 amendment's
+//! tree search, which reuses the exact same bindings on `Screen::Entry` +
+//! `Focus::Tree` (ADR 0058 having freed `n`/`N` there in anticipation of
+//! exactly this) while leaving `Focus::Right` untranslated, reserved for a
+//! possible future Diff-pane search.
 
 use super::{empty_report, report_with_one_symbol};
-use crate::app::{App, InputKey};
+use crate::app::{App, Focus, InputKey};
 use crate::input_translate::translate_key;
 use crate::search::SearchState;
 use ratatui::crossterm::event::{KeyCode, KeyModifiers};
@@ -27,12 +29,25 @@ fn should_translate_slash_to_search_start_on_source_screen() {
 }
 
 #[test]
-fn should_not_translate_slash_at_all_on_entry_screen() {
-    // ADR 0057: search is Source-screen-only — `/` has no meaning on the
-    // entry screen (diff-pane search is explicit future work, not this
-    // ADR's scope).
+fn should_translate_slash_to_search_start_on_entry_screen_while_focus_tree() {
+    // ADR 0057 amendment: tree search reuses `/` on `Screen::Entry` +
+    // `Focus::Tree` (the entry view's default focus).
     let report = empty_report();
     let app = App::new(&report);
+    assert_eq!(Focus::Tree, app.focus());
+
+    let actual = translate_key(KeyCode::Char('/'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchStart), actual);
+}
+
+#[test]
+fn should_not_translate_slash_at_all_on_entry_screen_while_focus_right() {
+    // Diff/Detail pane search is still explicit future work (ADR 0057's own
+    // Alternatives) — `/` stays reserved, untranslated, while `Focus::Right`.
+    let report = report_with_one_symbol();
+    let app = App::new(&report).handle_key(InputKey::Open);
+    assert_eq!(Focus::Right, app.focus());
 
     let actual = translate_key(KeyCode::Char('/'), KeyModifiers::NONE, &app);
 
@@ -60,12 +75,35 @@ fn should_translate_uppercase_n_to_search_prev_on_source_screen() {
 }
 
 #[test]
-fn should_translate_n_to_none_on_entry_screen() {
-    // ADR 0058: `n`/`N` are freed entirely on the entry screen (moved to
-    // `a`/`A`), reserved for a future Entry-screen search reusing the same
-    // next/prev idiom Source view already has.
+fn should_translate_n_to_search_next_on_entry_screen_while_focus_tree() {
+    // ADR 0058 freed `n`/`N` on the entry screen precisely so the ADR 0057
+    // amendment's tree search could reuse them without colliding with
+    // anything (they used to be the review-annotation bindings, moved to
+    // `a`/`A`).
     let report = empty_report();
     let app = App::new(&report);
+    assert_eq!(Focus::Tree, app.focus());
+
+    let actual = translate_key(KeyCode::Char('n'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchNext), actual);
+}
+
+#[test]
+fn should_translate_uppercase_n_to_search_prev_on_entry_screen_while_focus_tree() {
+    let report = empty_report();
+    let app = App::new(&report);
+
+    let actual = translate_key(KeyCode::Char('N'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchPrev), actual);
+}
+
+#[test]
+fn should_translate_n_to_none_on_entry_screen_while_focus_right() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report).handle_key(InputKey::Open);
+    assert_eq!(Focus::Right, app.focus());
 
     let actual = translate_key(KeyCode::Char('n'), KeyModifiers::NONE, &app);
 
@@ -73,9 +111,9 @@ fn should_translate_n_to_none_on_entry_screen() {
 }
 
 #[test]
-fn should_translate_uppercase_n_to_none_on_entry_screen() {
-    let report = empty_report();
-    let app = App::new(&report);
+fn should_translate_uppercase_n_to_none_on_entry_screen_while_focus_right() {
+    let report = report_with_one_symbol();
+    let app = App::new(&report).handle_key(InputKey::Open);
 
     let actual = translate_key(KeyCode::Char('N'), KeyModifiers::NONE, &app);
 
@@ -194,4 +232,43 @@ fn should_translate_esc_to_back_when_no_search_is_active_on_source_screen() {
     let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
 
     assert_eq!(Some(InputKey::Back), actual);
+}
+
+// ADR 0057 amendment: tree search composing on `Screen::Entry` +
+// `Focus::Tree` mirrors the Source-view composing tests above exactly —
+// the composing-mode early return in `translate_key` is screen-agnostic
+// once entered (its own doc comment).
+
+#[test]
+fn should_translate_printable_char_to_search_char_while_composing_on_entry_screen() {
+    let report = empty_report();
+    let app = App::new(&report).with_search(SearchState::default().start());
+
+    let actual = translate_key(KeyCode::Char('f'), KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchChar('f')), actual);
+}
+
+#[test]
+fn should_translate_enter_to_search_confirm_while_composing_on_entry_screen() {
+    let report = empty_report();
+    let app = App::new(&report).with_search(SearchState::default().start());
+
+    let actual = translate_key(KeyCode::Enter, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchConfirm), actual);
+}
+
+#[test]
+fn should_translate_esc_to_search_cancel_when_a_confirmed_tree_search_is_active() {
+    let search = SearchState::default()
+        .start()
+        .push_char('f')
+        .confirm(&["foo".to_string()], 0);
+    let report = empty_report();
+    let app = App::new(&report).with_search(search);
+
+    let actual = translate_key(KeyCode::Esc, KeyModifiers::NONE, &app);
+
+    assert_eq!(Some(InputKey::SearchCancel), actual);
 }

--- a/rinkaku-tui/src/nav.rs
+++ b/rinkaku-tui/src/nav.rs
@@ -37,6 +37,12 @@ pub enum Action {
     /// [`Self::CursorPageDown`]'s doc comment for why this moves the cursor
     /// rather than a scroll offset.
     CursorPageUp(usize),
+    /// Jumps the cursor directly to visible-row index `usize`, clamped to
+    /// the last visible row — used to land on a confirmed tree search's
+    /// current match (`crate::nav::row_search_texts`' own doc comment),
+    /// which already knows the exact row index it wants rather than a
+    /// relative step.
+    CursorTo(usize),
     /// Toggles the node under the cursor between expanded and collapsed.
     /// A no-op on a [`NodeKind::Symbol`] row (symbols are leaves — see
     /// this module's doc comment) or when there are no visible rows at
@@ -246,7 +252,7 @@ impl Nav {
     /// later that shrinks the row list in some other way.
     ///
     /// `CursorUp`/`CursorDown`/`CursorTop`/`CursorBottom`/`CursorPageDown`/
-    /// `CursorPageUp` are the exceptions: they `return self` directly from
+    /// `CursorPageUp`/`CursorTo` are the exceptions: they `return self` directly from
     /// inside the `match`, bypassing `retarget_cursor` entirely. This is
     /// safe rather than an oversight — moving the cursor is the action that
     /// *sets* the cursor's new target, so there is nothing to re-target it
@@ -285,6 +291,13 @@ impl Nav {
             }
             Action::CursorPageUp(step) => {
                 self.cursor = self.cursor.saturating_sub(step);
+                return self;
+            }
+            Action::CursorTo(index) => {
+                let row_count = self.rows(tree).len();
+                if row_count > 0 {
+                    self.cursor = index.min(row_count - 1);
+                }
                 return self;
             }
             Action::ToggleExpand => {
@@ -377,6 +390,34 @@ impl Nav {
 
         self.cursor = rows.len().saturating_sub(1);
     }
+}
+
+/// The searchable text for one row (ADR 0057 amendment, tree search): a
+/// [`NodeKind::Symbol`] row's own name (matching what
+/// `crate::row_view::entry_row_line` actually displays for that row — its
+/// `node.path` is its *containing file's* path, not a name of its own, per
+/// [`Row`]'s own doc comment), or `node.path` for every other row kind
+/// (`Dir`/`File`/`Section`/`TestGroup`), which is unique per row and gives a
+/// reviewer more to match against than the truncated relative label
+/// `crate::row_view::relative_labels` computes purely for on-screen display.
+fn row_search_text(row: &Row<'_>) -> String {
+    match &row.node.kind {
+        NodeKind::Symbol(symbol_ref) => symbol_ref.name.clone(),
+        _ => row.node.path.clone(),
+    }
+}
+
+/// [`row_search_text`] applied to every row in `rows`, in the same order —
+/// the flat `Vec<String>` [`crate::search::find_matches`] searches over for
+/// tree search, the `Nav::rows`-index-space counterpart of `Screen::Source`'s
+/// own `Vec<String>` of file lines. A match's position in this vec is a
+/// valid [`Action::CursorTo`] index into the *same* `rows` list it was
+/// computed from — the caller must recompute `rows`/`row_search_texts`
+/// together (from the same `Nav`/`Tree` pair) rather than reusing a stale
+/// pair, the same "recomputed together, not cached across a fold state
+/// change" discipline [`Nav::rows`]'s own doc comment already establishes.
+pub fn row_search_texts(rows: &[Row<'_>]) -> Vec<String> {
+    rows.iter().map(row_search_text).collect()
 }
 
 /// Every path in `tree` that has at least one child — i.e. every

--- a/rinkaku-tui/src/nav.rs
+++ b/rinkaku-tui/src/nav.rs
@@ -15,6 +15,28 @@ use std::collections::HashSet;
 pub enum Action {
     CursorUp,
     CursorDown,
+    /// Jumps the cursor to the first visible row (ADR 0026 amendment: `gg`
+    /// on the tree, the [`Focus::Tree`](crate::app::Focus::Tree) counterpart
+    /// of `Screen::Source`/`Focus::Right`'s own `ScrollToTop`). A no-op when
+    /// there are no visible rows.
+    CursorTop,
+    /// Jumps the cursor to the last visible row (ADR 0026 amendment: `G` on
+    /// the tree). A no-op when there are no visible rows.
+    CursorBottom,
+    /// Moves the cursor down by up to `usize` rows, clamped to the last
+    /// visible row — the tree's `Ctrl-d` (ADR 0026 amendment): since the
+    /// tree pane has no separate scroll-offset state (it windows around the
+    /// cursor at draw time, `crate::ui::entry::draw_tree_pane`'s own doc
+    /// comment), "half-page down" here means "move the cursor" rather than
+    /// "move a scroll offset" the way it does on `Screen::Source`/
+    /// `Focus::Right`. The caller (`App::handle_scroll_key`) is responsible
+    /// for turning a viewport height into this step count.
+    CursorPageDown(usize),
+    /// Moves the cursor up by up to `usize` rows, clamped to the first
+    /// visible row — the tree's `Ctrl-u` (ADR 0026 amendment). See
+    /// [`Self::CursorPageDown`]'s doc comment for why this moves the cursor
+    /// rather than a scroll offset.
+    CursorPageUp(usize),
     /// Toggles the node under the cursor between expanded and collapsed.
     /// A no-op on a [`NodeKind::Symbol`] row (symbols are leaves — see
     /// this module's doc comment) or when there are no visible rows at
@@ -223,12 +245,13 @@ impl Nav {
     /// this also future-proofs against a new `Action` variant added there
     /// later that shrinks the row list in some other way.
     ///
-    /// `CursorUp`/`CursorDown` are the two exceptions: they `return self`
-    /// directly from inside the `match`, bypassing `retarget_cursor`
-    /// entirely. This is safe rather than an oversight — moving the cursor
-    /// is the action that *sets* the cursor's new target, so there is
-    /// nothing to re-target it against; both arms already do their own
-    /// bounds clamping against the current `rows(tree).len()` inline.
+    /// `CursorUp`/`CursorDown`/`CursorTop`/`CursorBottom`/`CursorPageDown`/
+    /// `CursorPageUp` are the exceptions: they `return self` directly from
+    /// inside the `match`, bypassing `retarget_cursor` entirely. This is
+    /// safe rather than an oversight — moving the cursor is the action that
+    /// *sets* the cursor's new target, so there is nothing to re-target it
+    /// against; every arm already does its own bounds clamping against the
+    /// current `rows(tree).len()` inline.
     pub fn handle(mut self, action: Action, tree: &Tree) -> Self {
         let cursor_path_chain = self.cursor_path_chain(tree);
 
@@ -242,6 +265,26 @@ impl Nav {
                 if row_count > 0 {
                     self.cursor = (self.cursor + 1).min(row_count - 1);
                 }
+                return self;
+            }
+            Action::CursorTop => {
+                self.cursor = 0;
+                return self;
+            }
+            Action::CursorBottom => {
+                let row_count = self.rows(tree).len();
+                self.cursor = row_count.saturating_sub(1);
+                return self;
+            }
+            Action::CursorPageDown(step) => {
+                let row_count = self.rows(tree).len();
+                if row_count > 0 {
+                    self.cursor = (self.cursor + step).min(row_count - 1);
+                }
+                return self;
+            }
+            Action::CursorPageUp(step) => {
+                self.cursor = self.cursor.saturating_sub(step);
                 return self;
             }
             Action::ToggleExpand => {

--- a/rinkaku-tui/src/nav_tests/cursor_jump.rs
+++ b/rinkaku-tui/src/nav_tests/cursor_jump.rs
@@ -1,0 +1,68 @@
+use super::*;
+use pretty_assertions::assert_eq;
+
+// `deep_tree()`'s expanded row order: src(0), src/pkg(1), src/pkg/lib.rs(2),
+// foo(3), bar(4) — 5 rows total, used throughout so `CursorPageDown`/
+// `CursorPageUp`'s clamping has more than one row of headroom to exercise.
+
+#[test]
+fn should_move_cursor_to_last_row_when_cursor_bottom() {
+    let tree = deep_tree();
+    let nav = Nav::new().handle(Action::CursorBottom, &tree);
+
+    assert_eq!(4, nav.cursor());
+}
+
+#[test]
+fn should_move_cursor_to_first_row_when_cursor_top() {
+    let tree = deep_tree();
+    let nav = Nav::new()
+        .handle(Action::CursorBottom, &tree)
+        .handle(Action::CursorTop, &tree);
+
+    assert_eq!(0, nav.cursor());
+}
+
+#[test]
+fn should_keep_cursor_at_first_row_when_cursor_top_and_already_at_top() {
+    let tree = deep_tree();
+    let nav = Nav::new().handle(Action::CursorTop, &tree);
+
+    assert_eq!(0, nav.cursor());
+}
+
+#[test]
+fn should_move_cursor_down_by_step_when_cursor_page_down() {
+    let tree = deep_tree();
+    let nav = Nav::new().handle(Action::CursorPageDown(2), &tree);
+
+    assert_eq!(2, nav.cursor());
+}
+
+#[test]
+fn should_clamp_cursor_to_last_row_when_cursor_page_down_overshoots() {
+    let tree = deep_tree();
+    let nav = Nav::new().handle(Action::CursorPageDown(100), &tree);
+
+    assert_eq!(4, nav.cursor());
+}
+
+#[test]
+fn should_move_cursor_up_by_step_when_cursor_page_up() {
+    let tree = deep_tree();
+    let nav = Nav::new()
+        .handle(Action::CursorBottom, &tree)
+        .handle(Action::CursorPageUp(2), &tree);
+
+    assert_eq!(2, nav.cursor());
+}
+
+#[test]
+fn should_clamp_cursor_to_first_row_when_cursor_page_up_undershoots() {
+    let tree = deep_tree();
+    let nav = Nav::new()
+        .handle(Action::CursorBottom, &tree)
+        .handle(Action::CursorPageUp(100), &tree);
+
+    assert_eq!(0, nav.cursor());
+}

--- a/rinkaku-tui/src/nav_tests/cursor_jump.rs
+++ b/rinkaku-tui/src/nav_tests/cursor_jump.rs
@@ -66,3 +66,19 @@ fn should_clamp_cursor_to_first_row_when_cursor_page_up_undershoots() {
 
     assert_eq!(0, nav.cursor());
 }
+
+#[test]
+fn should_move_cursor_to_the_given_index_when_cursor_to() {
+    let tree = deep_tree();
+    let nav = Nav::new().handle(Action::CursorTo(3), &tree);
+
+    assert_eq!(3, nav.cursor());
+}
+
+#[test]
+fn should_clamp_cursor_to_last_row_when_cursor_to_index_is_out_of_bounds() {
+    let tree = deep_tree();
+    let nav = Nav::new().handle(Action::CursorTo(100), &tree);
+
+    assert_eq!(4, nav.cursor());
+}

--- a/rinkaku-tui/src/nav_tests/mod.rs
+++ b/rinkaku-tui/src/nav_tests/mod.rs
@@ -4,8 +4,11 @@
 //! - `move_cursor` — `move_cursor_to_path`/`move_cursor_to_symbol`:
 //!   directory/file/symbol targeting, collapsed-ancestor handling
 //! - `cursor_jump` — `CursorTop`/`CursorBottom`/`CursorPageDown`/
-//!   `CursorPageUp`: jump-to-edge and step-clamped paging (ADR 0026
-//!   amendment: `gg`/`G`/`Ctrl-d`/`Ctrl-u` on the tree)
+//!   `CursorPageUp`/`CursorTo`: jump-to-edge, step-clamped paging, and
+//!   direct index jumps (ADR 0026 amendment: `gg`/`G`/`Ctrl-d`/`Ctrl-u`
+//!   on the tree; `CursorTo` also backs ADR 0057's tree search amendment)
+//! - `search_text` — `row_search_texts`: per-row search text (ADR 0057
+//!   amendment, tree search)
 //! - `expand_collapse` — `ToggleExpand`/`ExpandAll`/`CollapseAll`, cursor
 //!   clamping, collapse-state stability across a tree rebuild
 //! - `retarget_cursor` — the CRITICAL regressions: cursor re-targeting
@@ -25,6 +28,7 @@ mod default_collapse;
 mod expand_collapse;
 mod move_cursor;
 mod retarget_cursor;
+mod search_text;
 mod section_crossing;
 
 pub(super) fn symbol_node(path: &str, name: &str) -> TreeNode {

--- a/rinkaku-tui/src/nav_tests/mod.rs
+++ b/rinkaku-tui/src/nav_tests/mod.rs
@@ -3,6 +3,9 @@
 //!
 //! - `move_cursor` — `move_cursor_to_path`/`move_cursor_to_symbol`:
 //!   directory/file/symbol targeting, collapsed-ancestor handling
+//! - `cursor_jump` — `CursorTop`/`CursorBottom`/`CursorPageDown`/
+//!   `CursorPageUp`: jump-to-edge and step-clamped paging (ADR 0026
+//!   amendment: `gg`/`G`/`Ctrl-d`/`Ctrl-u` on the tree)
 //! - `expand_collapse` — `ToggleExpand`/`ExpandAll`/`CollapseAll`, cursor
 //!   clamping, collapse-state stability across a tree rebuild
 //! - `retarget_cursor` — the CRITICAL regressions: cursor re-targeting
@@ -17,6 +20,7 @@
 use super::*;
 use crate::tree::Badges;
 
+mod cursor_jump;
 mod default_collapse;
 mod expand_collapse;
 mod move_cursor;

--- a/rinkaku-tui/src/nav_tests/search_text.rs
+++ b/rinkaku-tui/src/nav_tests/search_text.rs
@@ -1,0 +1,39 @@
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn should_use_the_node_path_as_search_text_for_dir_and_file_rows() {
+    let tree = sample_tree();
+    let nav = Nav::new();
+    let rows = nav.rows(&tree);
+
+    let texts = row_search_texts(&rows);
+
+    // sample_tree()'s expanded row order: src(0, Dir), src/lib.rs(1, File),
+    // foo(2, Symbol), bar(3, Symbol).
+    assert_eq!("src", texts[0]);
+    assert_eq!("src/lib.rs", texts[1]);
+}
+
+#[test]
+fn should_use_the_symbol_name_as_search_text_for_symbol_rows() {
+    let tree = sample_tree();
+    let nav = Nav::new();
+    let rows = nav.rows(&tree);
+
+    let texts = row_search_texts(&rows);
+
+    assert_eq!("foo", texts[2]);
+    assert_eq!("bar", texts[3]);
+}
+
+#[test]
+fn should_return_one_text_per_row_in_the_same_order() {
+    let tree = sample_tree();
+    let nav = Nav::new();
+    let rows = nav.rows(&tree);
+
+    let texts = row_search_texts(&rows);
+
+    assert_eq!(rows.len(), texts.len());
+}

--- a/rinkaku-tui/src/ui/mod.rs
+++ b/rinkaku-tui/src/ui/mod.rs
@@ -68,12 +68,26 @@ pub struct DrawOutcome {
     /// The inner height (borders excluded) of whichever pane is currently
     /// scrollable — the source pane on [`Screen::Source`], the right pane
     /// on [`Screen::Entry`] + [`crate::app::Focus::Right`], and `None`
-    /// otherwise (Tree-focused on the entry view has no scrollable pane
-    /// receiving motion). `crate::run_app` remembers this between frames
-    /// and passes it into [`crate::app::App::handle_scroll_key`] when a
-    /// half-page (ADR 0026) key arrives, so the step size scales with
-    /// the actual pane rather than a magic constant.
+    /// otherwise ([`Self::tree_viewport_height`] covers the
+    /// [`crate::app::Focus::Tree`] case instead). `crate::run_app` remembers
+    /// this between frames and passes it into
+    /// [`crate::app::App::handle_scroll_key`] when a half-page (ADR 0026)
+    /// key arrives, so the step size scales with the actual pane rather
+    /// than a magic constant.
     pub scroll_viewport_height: Option<usize>,
+    /// The tree pane's inner height (borders excluded), reported only while
+    /// [`crate::app::Focus::Tree`] (ADR 0026 amendment: `gg`/`G`/`Ctrl-d`/
+    /// `Ctrl-u` moving the tree cursor rather than any scroll offset — the
+    /// tree pane has none of its own, see
+    /// `crate::ui::entry::draw_tree_pane`'s own doc comment). Kept as a
+    /// separate field from [`Self::scroll_viewport_height`] rather than
+    /// reusing it, mirroring [`Self::clamped_help_scroll`]'s own "one more
+    /// field on the same seam" reasoning: the two panes can never be the
+    /// active motion target in the same frame (they are gated on opposite
+    /// arms of the same `Focus`), but giving each its own field means a
+    /// future frame where that stops being true would not need one field to
+    /// silently pick a winner.
+    pub tree_viewport_height: Option<usize>,
     /// The `?` help overlay's own scroll offset as actually clamped and
     /// rendered this frame (`None` while the overlay is closed) — kept
     /// separate from [`Self::clamped_right_pane_scroll`] rather than reusing
@@ -197,6 +211,11 @@ pub fn draw(
             } else {
                 None
             };
+            let tree_viewport_height = if app.focus() == crate::app::Focus::Tree {
+                Some(tree_pane_viewport_height(body))
+            } else {
+                None
+            };
             let effective_diff_view_mode = if app.right_pane() == crate::app::RightPane::Diff {
                 Some(effective_diff_view_mode_for_body(
                     body,
@@ -208,6 +227,7 @@ pub fn draw(
             DrawOutcome {
                 clamped_right_pane_scroll: clamped,
                 scroll_viewport_height,
+                tree_viewport_height,
                 clamped_help_scroll: None,
                 help_scroll_viewport_height: None,
                 effective_diff_view_mode,
@@ -232,6 +252,7 @@ pub fn draw(
             DrawOutcome {
                 clamped_right_pane_scroll: None,
                 scroll_viewport_height: Some(inner_height),
+                tree_viewport_height: None,
                 clamped_help_scroll: None,
                 help_scroll_viewport_height: None,
                 effective_diff_view_mode: None,
@@ -288,6 +309,23 @@ fn right_pane_viewport_height(body: Rect) -> usize {
     right.height.saturating_sub(2) as usize
 }
 
+/// The tree pane's inner height (borders excluded), computed from `body`
+/// the same way [`right_pane_viewport_height`] computes the right pane's —
+/// same split, same `saturating_sub(2)` border deduction, just the other
+/// half of the [`Layout::horizontal`] array. Extracted for the identical
+/// reason: [`DrawOutcome::tree_viewport_height`] must reflect the exact
+/// viewport a reviewer just saw, without `draw_entry_screen`/
+/// `entry::draw_tree_pane` having to plumb their own inner-height
+/// computation back out through a return value.
+fn tree_pane_viewport_height(body: Rect) -> usize {
+    let [tree, _] = Layout::horizontal([
+        Constraint::Percentage(ENTRY_TREE_WIDTH_PERCENT),
+        Constraint::Percentage(ENTRY_RIGHT_WIDTH_PERCENT),
+    ])
+    .areas(body);
+    tree.height.saturating_sub(2) as usize
+}
+
 /// The diff pane's effective view mode given `body` and the requested
 /// mode — mirrors [`crate::ui::diff_pane::draw_diff_pane`]'s own
 /// `split_requested && split_fits` gate so `DrawOutcome` can report the
@@ -316,8 +354,9 @@ fn effective_diff_view_mode_for_body(
 
 /// Tree-pane / right-pane horizontal split percentages for [`Screen::Entry`],
 /// shared between [`draw_entry_screen`]'s actual layout and
-/// [`right_pane_viewport_height`]'s report of that layout to
-/// [`DrawOutcome::scroll_viewport_height`] (ADR 0026) so the two cannot
+/// [`right_pane_viewport_height`]/[`tree_pane_viewport_height`]'s report of
+/// that layout to [`DrawOutcome::scroll_viewport_height`]/
+/// [`DrawOutcome::tree_viewport_height`] (ADR 0026) so the two cannot
 /// drift.
 pub(crate) const ENTRY_TREE_WIDTH_PERCENT: u16 = 40;
 pub(crate) const ENTRY_RIGHT_WIDTH_PERCENT: u16 = 60;

--- a/rinkaku-tui/src/ui/source_screen_tests/error_handling.rs
+++ b/rinkaku-tui/src/ui/source_screen_tests/error_handling.rs
@@ -113,6 +113,7 @@ fn should_report_none_clamped_scroll_but_source_viewport_height_when_source_scre
     let mut actual = DrawOutcome {
         clamped_right_pane_scroll: Some(999),
         scroll_viewport_height: None,
+        tree_viewport_height: None,
         clamped_help_scroll: None,
         help_scroll_viewport_height: None,
         effective_diff_view_mode: None,

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -81,7 +81,7 @@ pub(crate) fn status_line_text(app: &App, report: &Report) -> String {
             };
             let keys = match app.focus() {
                 crate::app::Focus::Tree => {
-                    "j/k: move  ctrl-d/u: half  gg/G: top/bot  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
+                    "j/k: move  ctrl-d/u: half  gg/G: top/bot  /: search  n/N: next/prev match  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
                 }
                 crate::app::Focus::Right if app.right_pane() == crate::app::RightPane::Diff => {
                     "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  ]/[: next/prev hunk  v: split  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
@@ -256,10 +256,10 @@ mod tests {
         let app = App::new(&report);
         // Wider than the default 80 columns used elsewhere in this test
         // module: the full help text (order mode + Tree-focus key hints,
-        // ADR 0020/0022/0026 amendment) is ~191 columns and would
-        // otherwise be truncated (the status line intentionally does not
-        // wrap), hiding the "quit" fragment this test checks for.
-        let mut terminal = Terminal::new(TestBackend::new(200, 20)).expect("terminal");
+        // ADR 0020/0022/0026 amendment/0057 amendment) is ~224 columns and
+        // would otherwise be truncated (the status line intentionally does
+        // not wrap), hiding the "quit" fragment this test checks for.
+        let mut terminal = Terminal::new(TestBackend::new(230, 20)).expect("terminal");
 
         terminal
             .draw(|frame| {
@@ -293,7 +293,7 @@ mod tests {
         let actual = status_line_text(&app, &report);
 
         assert_eq!(
-            "order: topological  |  j/k: move  ctrl-d/u: half  gg/G: top/bot  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
+            "order: topological  |  j/k: move  ctrl-d/u: half  gg/G: top/bot  /: search  n/N: next/prev match  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
                 .to_string(),
             actual
         );

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -81,7 +81,7 @@ pub(crate) fn status_line_text(app: &App, report: &Report) -> String {
             };
             let keys = match app.focus() {
                 crate::app::Focus::Tree => {
-                    "j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
+                    "j/k: move  ctrl-d/u: half  gg/G: top/bot  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
                 }
                 crate::app::Focus::Right if app.right_pane() == crate::app::RightPane::Diff => {
                     "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  ]/[: next/prev hunk  v: split  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
@@ -256,10 +256,10 @@ mod tests {
         let app = App::new(&report);
         // Wider than the default 80 columns used elsewhere in this test
         // module: the full help text (order mode + Tree-focus key hints,
-        // ADR 0020/0022) is ~155 columns and would otherwise be truncated
-        // (the status line intentionally does not wrap), hiding the "quit"
-        // fragment this test checks for.
-        let mut terminal = Terminal::new(TestBackend::new(170, 20)).expect("terminal");
+        // ADR 0020/0022/0026 amendment) is ~191 columns and would
+        // otherwise be truncated (the status line intentionally does not
+        // wrap), hiding the "quit" fragment this test checks for.
+        let mut terminal = Terminal::new(TestBackend::new(200, 20)).expect("terminal");
 
         terminal
             .draw(|frame| {
@@ -293,7 +293,7 @@ mod tests {
         let actual = status_line_text(&app, &report);
 
         assert_eq!(
-            "order: topological  |  j/k: move  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
+            "order: topological  |  j/k: move  ctrl-d/u: half  gg/G: top/bot  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
                 .to_string(),
             actual
         );


### PR DESCRIPTION
## Summary

Two related vim-idiom gaps on the entry screen's tree (`Focus::Tree`),
found while dogfooding: `gg`/`G`/`Ctrl-d`/`Ctrl-u` and `/` search all
worked on the Source view / right pane already (ADR 0026, ADR 0057),
but were deliberately scoped away from the tree pane. Both ADRs
explicitly called out the tree as future work at the time, for good
reasons that no longer fully applied once actually tried against the
default focus.

- **Tree cursor motion (ADR 0026 amendment).** `Ctrl-d`/`Ctrl-u` move
  the tree cursor by half the pane's viewport height; `gg`/`G` jump to
  the first/last row. The tree pane has no scroll offset of its own
  (it windows around the cursor at draw time), so these move
  `Nav`'s cursor directly rather than a scroll offset — new
  `Nav::Action::CursorTop`/`CursorBottom`/`CursorPageDown`/
  `CursorPageUp`, with the tree pane's inner height plumbed through
  `DrawOutcome` the same way the right pane's already is.
- **Entry-screen tree search (ADR 0057 amendment).** `/`, `n`, `N`,
  and Esc-cancel now also work on `Screen::Entry` + `Focus::Tree`,
  searching each row's symbol name or file/dir path. Reuses
  `crate::search::SearchState`/`find_matches` unchanged — the tree's
  flattened row list is the same `Vec<String>`-shaped search space
  Source view already searches, just a different meaning for the same
  match-index coordinate. `Focus::Right` stays untranslated, leaving
  the Diff/Detail pane search ADR 0057 already deferred exactly as
  undesigned as before. A match hidden under a collapsed ancestor
  (e.g. a default-collapsed `TestGroup`) isn't found yet — expanding
  into collapsed subtrees on a match is left as explicit future work.

Both are recorded as amendments to their respective ADRs
(`docs/adr/0026-...md`, `docs/adr/0057-...md`) rather than new ADRs,
since each fills in a gap the original ADR's own Context/Alternatives
already scoped out.

## Note on file size

`rinkaku-tui/src/app/mod.rs` was already over the 1000-line "warn"
threshold on `main` (1011 lines) before this PR; the new
`with_nav_cursor` wither pushes it to 1025. Splitting this file is a
separate, unrelated refactor — left out of this PR's scope, flagged
here per the file-size discipline's "justify in the PR body" allowance
rather than silently ignored.

## Test plan

- [x] `make test` (1027 tests) and `make lint` pass
- [x] Manually verified in a live TUI (tmux): `gg`/`G`/`Ctrl-d`/`Ctrl-u`
      move the tree cursor and the right pane follows; `/nav` finds 6
      matches, `n`/`N` step through them, Esc clears the query; `/` is
      inert while `Focus::Right`; the `?` help overlay and status line
      show the new bindings correctly (English and Japanese locales)