### PR TITLE
feat: preserve line structure in displayed signatures

### DIFF
--- a/docs/adr/0060-preserve-line-structure-in-displayed-signatures.md
+++ b/docs/adr/0060-preserve-line-structure-in-displayed-signatures.md
@@ -31,10 +31,20 @@ Split "the string used for classification" from "the string shown to a
 reader":
 
 - `slice_signature` keeps the retained text's original line structure
-  (after comment/body stripping), dedented so the first line's own
-  indentation becomes the baseline. `ExtractedSymbol::signature` is now
-  a multi-line string for any definition whose kept range spans more
-  than one line.
+  (after comment/body stripping), dedented relative to the definition's
+  own starting column in the source (`node.start_position().column`) —
+  not the first line's own indentation as sliced text, which a
+  tree-sitter node never carries: a node's text starts exactly at its
+  first token, so a nested definition's first line always reads as
+  column 0 in the slice regardless of how deep it actually sits in the
+  file. Using the real starting column as the dedent baseline is what
+  lets a nested definition's continuation lines (which do keep their
+  absolute source column) get dedented back down to that depth, while a
+  top-level definition's continuation lines — genuinely indented
+  relative to its own body, not to an enclosing block outside the
+  slice — are left untouched. `ExtractedSymbol::signature` is now a
+  multi-line string for any definition whose kept range spans more than
+  one line.
 - `classify_symbols` normalizes both sides' signatures (collapse
   whitespace, same transform `slice_signature` used to bake in) at
   comparison time only, so a whitespace/line-reflow-only change still

--- a/docs/adr/0060-preserve-line-structure-in-displayed-signatures.md
+++ b/docs/adr/0060-preserve-line-structure-in-displayed-signatures.md
@@ -1,0 +1,93 @@
+# 0060. Preserve line structure in displayed signatures
+
+- Status: accepted
+- Date: 2026-07-25
+
+## Context
+
+`extract::slice_signature` runs every extracted signature through
+`normalize_whitespace` (`split_whitespace().join(" ")`), collapsing it to
+a single line regardless of its original shape. This is fine for a short
+function declaration, but a `struct`/`enum`/`trait`/`interface`/`class`
+signature keeps its full field/variant/method list (ADR 0014's "the
+fields are the contract" decision), and a long argument list or a
+`where` clause can span many lines in the source. Flattened to one line,
+these become a wall of text a reviewer cannot visually parse, and a
+`SignatureChanged` Markdown block becomes one giant `-` line and one
+giant `+` line with no visible indication of which field actually
+changed.
+
+Whitespace normalization exists for a second, independent reason (ADR
+0014): `classify_symbols` compares two signature strings verbatim to
+decide `BodyOnly` vs `SignatureChanged`, and a reformatting-only edit
+(e.g. reflowing a struct's fields onto more/fewer lines, changing
+indentation) must not register as a contract change. Today the same
+normalized string serves both the comparison and the display, so this
+decision only had one lever to pull.
+
+## Decision
+
+Split "the string used for classification" from "the string shown to a
+reader":
+
+- `slice_signature` keeps the retained text's original line structure
+  (after comment/body stripping), dedented so the first line's own
+  indentation becomes the baseline. `ExtractedSymbol::signature` is now
+  a multi-line string for any definition whose kept range spans more
+  than one line.
+- `classify_symbols` normalizes both sides' signatures (collapse
+  whitespace, same transform `slice_signature` used to bake in) at
+  comparison time only, so a whitespace/line-reflow-only change still
+  classifies as `BodyOnly`, unchanged from today.
+- Markdown's `SignatureChanged` block renders a line-based diff (each
+  retained line prefixed `-`/`+`) instead of one `-`/`+` line per whole
+  signature, so a single changed struct field shows up as one changed
+  line, not a full-text replacement. The digest renderer (`digest.rs`)
+  gets the same treatment for consistency between the two Markdown
+  outputs.
+- Every place a signature is used as a single structural line — the
+  "Depends on:" inline code span, the TUI diff-pane section anchor/
+  title, the TUI review agent-packet heading — collapses the signature
+  to one line at that render site instead of carrying multi-line text
+  into a slot that must stay one line.
+- The TUI detail pane and the agent-packet's fenced code block already
+  accept arbitrary text and keep the signature's line breaks as-is.
+
+JSON output's `signature` (and `previous_signature`) fields become
+multi-line strings (embedded `\n`) instead of single-line ones — a
+breaking change to the JSON output format, sanctioned here the same way
+ADR 0014 sanctioned its own comment-stripping output change.
+
+## Alternatives
+
+- **Re-indent/pretty-print the signature at render time** from the
+  flattened single-line string, instead of preserving source structure
+  at extraction time: rejected — a generic pretty-printer would need
+  per-language formatting rules (brace style, wrap width, where-clause
+  placement) to look right, duplicating each language's own formatter
+  and breaking easily on constructs the printer wasn't written for.
+  Keeping the source's own line breaks is free and always matches how
+  the author actually wrote it.
+- **Keep signatures single-line (status quo), rely on the renderer to
+  wrap at display width**: rejected — width-wrapping (ADR 0052) is
+  already a renderer concern for long *single* lines, but it cannot
+  recover the original field-per-line structure of a struct/class once
+  it has been flattened; a wrapped single line still reads as one
+  undifferentiated blob, and a whole-signature diff still can't
+  localize which field changed.
+
+## Consequences
+
+- Struct/enum/trait/interface/class signatures — the cases ADR 0014
+  already calls out as "the fields are the contract" — become readable
+  in Markdown and the TUI detail pane instead of one long line.
+- `SignatureChanged` diff blocks localize to the changed line(s) instead
+  of replacing the whole signature, matching how a reviewer already
+  reads a normal diff hunk.
+- JSON consumers that assumed `signature`/`previous_signature` are
+  single-line strings must be updated to handle embedded newlines — a
+  breaking output-format change.
+- A handful of render sites that need a single line (dependency list
+  entries, TUI diff-pane section titles) now must explicitly collapse
+  multi-line signatures rather than getting a single line for free;
+  each such site is documented at its own collapse call.

--- a/docs/adr/0060-preserve-line-structure-in-displayed-signatures.md
+++ b/docs/adr/0060-preserve-line-structure-in-displayed-signatures.md
@@ -45,10 +45,26 @@ reader":
   slice — are left untouched. `ExtractedSymbol::signature` is now a
   multi-line string for any definition whose kept range spans more than
   one line.
-- `classify_symbols` normalizes both sides' signatures (collapse
-  whitespace, same transform `slice_signature` used to bake in) at
-  comparison time only, so a whitespace/line-reflow-only change still
-  classifies as `BodyOnly`, unchanged from today.
+- `classify_symbols` normalizes both sides' signatures at comparison time
+  only (`normalize_for_comparison`), so a whitespace/line-reflow-only
+  change still classifies as `BodyOnly`. This is a different transform
+  from the old single-line `normalize_whitespace`
+  (`split_whitespace().join(" ")`) it replaces: that transform always
+  inserted a space at every normalized whitespace run, so a reflow that
+  introduced a line break right after a symbol character (e.g. gofmt
+  wrapping a parameter list — a newline right after `(`, a position that
+  had no space in the original) compared unequal to the un-reflowed form,
+  a false `SignatureChanged` purely from where the normalizer chose to
+  put a space back. `normalize_for_comparison` instead collapses a
+  whitespace run to a single space only when both neighboring characters
+  are word characters (alphanumeric or `_`), and drops the run entirely
+  otherwise — a run next to punctuation carries no information the
+  comparison should key on. A whitespace run between two word characters
+  is still preserved as meaningful content (`a b` vs. `ab` continue to
+  compare unequal). This transform is comparison-only; every display
+  render site keeps the old unconditional single-line collapse (e.g.
+  `render::markdown`'s `collapse_to_single_line`) so a struct like `Foo{x:
+  i32}` still reads with a space after `{`.
 - Markdown's `SignatureChanged` block renders a line-based diff (each
   retained line prefixed `-`/`+`) instead of one `-`/`+` line per whole
   signature, so a single changed struct field shows up as one changed
@@ -101,3 +117,12 @@ ADR 0014 sanctioned its own comment-stripping output change.
   entries, TUI diff-pane section titles) now must explicitly collapse
   multi-line signatures rather than getting a single line for free;
   each such site is documented at its own collapse call.
+- Known limitation: a reflow that also adds or removes a trailing comma
+  (e.g. gofmt/rustfmt inserting one when a parameter list wraps onto
+  multiple lines) still classifies as `SignatureChanged`, since
+  `normalize_for_comparison` only touches whitespace runs and a comma is
+  a real token, not whitespace. This is judged correct rather than a gap
+  to close: the comma is an actual textual difference, so treating it as
+  "no contract change" would risk masking a case where a comma is added
+  or removed for a reason that isn't purely cosmetic (e.g. alongside a
+  parameter list edit that the diff hunk happens to also reflow).

--- a/docs/experiments/0001-map-assisted-llm-review/rounds/038.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/038.md
@@ -1,0 +1,51 @@
+# Round 38
+
+- Subject: PR #187 — preserve source line structure in displayed
+  signatures (ADR 0060): replaces the extract-time single-line
+  collapse with `tidy_signature_lines`, moves whitespace
+  normalization to classification-compare time, and renders
+  line-based `-`/`+` signature diffs in Markdown/digest plus
+  multi-line detail-pane lines in the TUI.
+- Protocol: two agents — one map-assisted static-review pass, one
+  dynamic-verification pass — run against the branch in a shared
+  worktree, then a single fix agent for all findings.
+- **Map delivery**: `rinkaku --base main`, built from a trusted
+  `main` checkout at `90544ca`, run before reading the diff.
+- **Map hit**: the high fan-in list flagged the triplicated
+  single-line-collapse helpers (`normalize_whitespace` /
+  `collapse_to_single_line` in core render and TUI), which became a
+  drift-risk nit. `classify_symbols` appearing in Definitions also
+  routed the static reviewer to the comparison-semantics change.
+- **Map miss 1 (blocker)**: `tidy_signature_lines` dedent is a no-op
+  for nested definitions — tree-sitter node text has no leading
+  indent on its first line while continuation lines keep absolute
+  columns, so `min_indent` computed over all lines is always 0. The
+  map never pointed at the function (low fan-in, new symbol); the
+  static reviewer found it via test-matrix gap analysis (no
+  nested × multiline case existed anywhere in the PR) plus in-crate
+  probing of `extract_changed_symbols`.
+- **Map miss 2 (blocker, dynamic-only)**: comparison normalization
+  was asymmetric — `split_whitespace().join(" ")` inserts a space
+  where none existed, so the formatter-standard reflow "break after
+  the opening paren" (gofmt/rustfmt/prettier/black) was misclassified
+  as `signature changed` in all four languages. Zero static
+  footprint; found only by running the binary against synthetic
+  4-language repos with reflow-only commits.
+- Severity summary: 2 blockers (nested dedent no-op;
+  reflow-only misclassification), 2 should-fix (no test pinning the
+  reflow→BodyOnly invariant; partial asserts without NOTE in
+  `signature_view.rs`), 2 nits (collapse-helper triplication;
+  comment-removal blank-line residue). Fix approach: feed the node's
+  real `start_position().column` into the dedent min-indent calc as
+  the first line's indent; a separate `normalize_for_comparison`
+  keeping a space only between word characters, leaving display
+  collapse untouched. All fixed in `f8edf0b`..`6d03cd7`, with the
+  missing nested × multiline and reflow-invariant tests added.
+- Takeaway: both blockers were invisible on the signature surface —
+  one hid in a coordinate-system assumption (node-relative vs
+  absolute columns), the other in a normalization asymmetry only
+  triggered by realistic formatter output. The decisive techniques
+  were test-matrix gap analysis ("which combinations have no test?")
+  and dynamically feeding the binary formatter-realistic edits, not
+  map-guided reading; the map's contribution this round was limited
+  to a duplication nit and target routing.

--- a/rinkaku-core/src/deps_tests/tags_resolver_indexing.rs
+++ b/rinkaku-core/src/deps_tests/tags_resolver_indexing.rs
@@ -43,7 +43,7 @@ fn should_resolve_type_reference_when_type_is_defined_in_repo() {
     );
 
     let expected = vec![ResolvedSymbol {
-        signature: "struct Point { x: i32, }".to_string(),
+        signature: "struct Point {\n    x: i32,\n}".to_string(),
         path: "src/point.rs".to_string(),
     }];
     let actual = resolver.resolve("Point");

--- a/rinkaku-core/src/extract.rs
+++ b/rinkaku-core/src/extract.rs
@@ -262,9 +262,13 @@ pub struct RemovedSymbol {
 /// Pure: takes both sides' already-extracted symbol lists and matches them
 /// in memory, no IO. `lang` is not needed here — `head_symbols` and
 /// `base_symbols` are both already the output of `extract_changed_symbols`/
-/// `extract_all_symbols`, whose signatures are already comment-stripped and
-/// normalized (ADR 0014's first change) — so signature comparison is a
-/// plain string comparison, not a second parse.
+/// `extract_all_symbols`, whose signatures are already comment-stripped
+/// (ADR 0014). Signatures are compared with [`normalize_whitespace`]
+/// applied to both sides (ADR 0060) rather than as plain strings: a
+/// signature now keeps its original line structure for display, so a
+/// reflow-only difference (indentation, line wrapping) must be normalized
+/// away here to avoid a false `SignatureChanged`, same as ADR 0014 already
+/// required before display signatures went multi-line.
 pub fn classify_symbols(
     head_symbols: &mut [ExtractedSymbol],
     base_symbols: &[ExtractedSymbol],
@@ -287,7 +291,9 @@ pub fn classify_symbols(
             }
             Some(base_symbol) => {
                 matched_base_identities.insert(identity);
-                if base_symbol.signature == symbol.signature {
+                if normalize_whitespace(&base_symbol.signature)
+                    == normalize_whitespace(&symbol.signature)
+                {
                     symbol.classification = Some(Classification::BodyOnly);
                 } else {
                     symbol.classification = Some(Classification::SignatureChanged);
@@ -555,7 +561,12 @@ fn definition_name(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
 }
 
 /// Slices a definition's signature: the declaration text with implementation
-/// detail and comment nodes removed, whitespace normalized to single spaces.
+/// detail and comment nodes removed, keeping its original line structure
+/// (dedented — see [`tidy_signature_lines`], ADR 0060) rather than
+/// collapsing it to one line. Contract-impact comparison
+/// ([`classify_symbols`]) normalizes whitespace separately, at comparison
+/// time, so a reflow-only difference between two multi-line signatures
+/// still doesn't register as a contract change.
 ///
 /// - `function_item`, `function_declaration` (Go/TS), `method_declaration`
 ///   (Go), `function_definition` (Python), `method_definition` (TS),
@@ -594,7 +605,7 @@ fn slice_signature(node: tree_sitter::Node, source: &[u8]) -> String {
         let mut removed_ranges: Vec<std::ops::Range<usize>> = Vec::new();
         collect_method_body_ranges(node, &mut removed_ranges);
         collect_comment_ranges(node, &removed_ranges.clone(), &mut removed_ranges);
-        return normalize_whitespace(&text_with_ranges_removed(node, source, removed_ranges));
+        return tidy_signature_lines(&text_with_ranges_removed(node, source, removed_ranges));
     }
 
     // `variable_declarator`'s body (a TS arrow function's `{ ... }`) is
@@ -632,7 +643,7 @@ fn slice_signature(node: tree_sitter::Node, source: &[u8]) -> String {
     }
 
     let raw = text_with_ranges_removed(node, source, removed_ranges);
-    normalize_whitespace(&raw)
+    tidy_signature_lines(&raw)
 }
 
 /// Removes every byte range in `ranges` from `node`'s own text (`node`'s
@@ -738,9 +749,58 @@ fn is_comment_node(node: tree_sitter::Node) -> bool {
 }
 
 /// Collapses runs of whitespace (including newlines/indentation from the
-/// original source) into single spaces, and trims the result.
+/// original source) into single spaces, and trims the result. Used only to
+/// compare two signatures for contract-impact classification
+/// ([`classify_symbols`], ADR 0014/0060) — display uses
+/// [`tidy_signature_lines`] instead, which keeps line structure.
 fn normalize_whitespace(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Shapes a raw, range-stripped declaration slice into the multi-line text
+/// stored on [`ExtractedSymbol::signature`] (ADR 0060): dedents every line
+/// relative to the least-indented non-blank line, trims trailing
+/// whitespace from each line, collapses runs of blank lines left behind by
+/// a stripped comment/body into a single blank line, and trims leading/
+/// trailing blank lines. A single-line input is returned trimmed, same as
+/// before ADR 0060.
+fn tidy_signature_lines(text: &str) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+
+    let min_indent = lines
+        .iter()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    let dedented: Vec<&str> = lines
+        .iter()
+        .map(|line| {
+            if line.trim().is_empty() {
+                ""
+            } else {
+                line.get(min_indent..).unwrap_or(line).trim_end()
+            }
+        })
+        .collect();
+
+    let mut collapsed: Vec<&str> = Vec::with_capacity(dedented.len());
+    for line in dedented {
+        if line.is_empty() && collapsed.last().is_some_and(|last: &&str| last.is_empty()) {
+            continue;
+        }
+        collapsed.push(line);
+    }
+
+    while collapsed.first().is_some_and(|line| line.is_empty()) {
+        collapsed.remove(0);
+    }
+    while collapsed.last().is_some_and(|line| line.is_empty()) {
+        collapsed.pop();
+    }
+
+    collapsed.join("\n")
 }
 
 /// Walks up from `node` to find an enclosing container (Rust

--- a/rinkaku-core/src/extract.rs
+++ b/rinkaku-core/src/extract.rs
@@ -263,7 +263,7 @@ pub struct RemovedSymbol {
 /// in memory, no IO. `lang` is not needed here — `head_symbols` and
 /// `base_symbols` are both already the output of `extract_changed_symbols`/
 /// `extract_all_symbols`, whose signatures are already comment-stripped
-/// (ADR 0014). Signatures are compared with [`normalize_whitespace`]
+/// (ADR 0014). Signatures are compared with [`normalize_for_comparison`]
 /// applied to both sides (ADR 0060) rather than as plain strings: a
 /// signature now keeps its original line structure for display, so a
 /// reflow-only difference (indentation, line wrapping) must be normalized
@@ -291,8 +291,8 @@ pub fn classify_symbols(
             }
             Some(base_symbol) => {
                 matched_base_identities.insert(identity);
-                if normalize_whitespace(&base_symbol.signature)
-                    == normalize_whitespace(&symbol.signature)
+                if normalize_for_comparison(&base_symbol.signature)
+                    == normalize_for_comparison(&symbol.signature)
                 {
                     symbol.classification = Some(Classification::BodyOnly);
                 } else {
@@ -753,13 +753,51 @@ fn is_comment_node(node: tree_sitter::Node) -> bool {
     matches!(node.kind(), "line_comment" | "block_comment" | "comment")
 }
 
-/// Collapses runs of whitespace (including newlines/indentation from the
-/// original source) into single spaces, and trims the result. Used only to
-/// compare two signatures for contract-impact classification
+/// Normalizes a signature for contract-impact comparison only
 /// ([`classify_symbols`], ADR 0014/0060) — display uses
-/// [`tidy_signature_lines`] instead, which keeps line structure.
-fn normalize_whitespace(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
+/// [`tidy_signature_lines`] instead, which keeps line structure, and other
+/// single-line render sites collapse whitespace unconditionally instead
+/// (each documented at its own call, e.g. `render::markdown`'s
+/// `collapse_to_single_line`; that transform is display-only and must stay
+/// unconditional so a struct like `Foo{x: i32}` still reads with a space
+/// after `{`, so it is not reused here).
+///
+/// Every maximal run of whitespace is replaced with a single space when
+/// both the character immediately before and immediately after the run are
+/// word characters (alphanumeric or `_`), and removed entirely otherwise.
+/// A naive `split_whitespace().join(" ")` (this function's predecessor)
+/// always inserts a space at a normalized run regardless of what the
+/// original text had there, so a reflow that introduces a line break right
+/// after a symbol like `(` or `,` — a position that never had a space in
+/// the original — would compare unequal to the un-reflowed form purely
+/// because of where the normalizer chose to put a space back. Restricting
+/// the collapse to word/word boundaries keeps a reflow-only change
+/// (whitespace inserted or moved next to punctuation) invisible to the
+/// comparison while still preserving whitespace that is itself meaningful
+/// content (e.g. the space in `a b` vs. no space in `ab`).
+fn normalize_for_comparison(text: &str) -> String {
+    let is_word_char = |c: char| c.is_alphanumeric() || c == '_';
+    let chars: Vec<char> = text.chars().collect();
+
+    let mut result = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i].is_whitespace() {
+            let run_start = i;
+            while i < chars.len() && chars[i].is_whitespace() {
+                i += 1;
+            }
+            let before = chars[..run_start].last().copied();
+            let after = chars.get(i).copied();
+            if before.is_some_and(is_word_char) && after.is_some_and(is_word_char) {
+                result.push(' ');
+            }
+        } else {
+            result.push(chars[i]);
+            i += 1;
+        }
+    }
+    result
 }
 
 /// Shapes a raw, range-stripped declaration slice into the multi-line text

--- a/rinkaku-core/src/extract.rs
+++ b/rinkaku-core/src/extract.rs
@@ -598,6 +598,8 @@ fn definition_name(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
 /// change sanctioned by the ADR — some previously-reported signature strings
 /// that contained inline comments now omit them.
 fn slice_signature(node: tree_sitter::Node, source: &[u8]) -> String {
+    let first_line_column = node.start_position().column;
+
     if matches!(
         node.kind(),
         "class_definition" | "class_declaration" | "abstract_class_declaration"
@@ -605,7 +607,10 @@ fn slice_signature(node: tree_sitter::Node, source: &[u8]) -> String {
         let mut removed_ranges: Vec<std::ops::Range<usize>> = Vec::new();
         collect_method_body_ranges(node, &mut removed_ranges);
         collect_comment_ranges(node, &removed_ranges.clone(), &mut removed_ranges);
-        return tidy_signature_lines(&text_with_ranges_removed(node, source, removed_ranges));
+        return tidy_signature_lines(
+            &text_with_ranges_removed(node, source, removed_ranges),
+            first_line_column,
+        );
     }
 
     // `variable_declarator`'s body (a TS arrow function's `{ ... }`) is
@@ -643,7 +648,7 @@ fn slice_signature(node: tree_sitter::Node, source: &[u8]) -> String {
     }
 
     let raw = text_with_ranges_removed(node, source, removed_ranges);
-    tidy_signature_lines(&raw)
+    tidy_signature_lines(&raw, first_line_column)
 }
 
 /// Removes every byte range in `ranges` from `node`'s own text (`node`'s
@@ -758,27 +763,54 @@ fn normalize_whitespace(text: &str) -> String {
 }
 
 /// Shapes a raw, range-stripped declaration slice into the multi-line text
-/// stored on [`ExtractedSymbol::signature`] (ADR 0060): dedents every line
-/// relative to the least-indented non-blank line, trims trailing
-/// whitespace from each line, collapses runs of blank lines left behind by
-/// a stripped comment/body into a single blank line, and trims leading/
-/// trailing blank lines. A single-line input is returned trimmed, same as
-/// before ADR 0060.
-fn tidy_signature_lines(text: &str) -> String {
+/// stored on [`ExtractedSymbol::signature`] (ADR 0060): dedents every
+/// continuation line relative to the least-indented non-blank line
+/// (`first_line_column` standing in for the first line's own indentation,
+/// see below), trims trailing whitespace from each line, collapses runs
+/// of blank lines left behind by a stripped comment/body into a single
+/// blank line, and trims leading/trailing blank lines. A single-line
+/// input is returned trimmed, same as before ADR 0060.
+///
+/// `first_line_column` is the node's `start_position().column` in the
+/// original source — the column the declaration keyword (`fn`/`class`/...)
+/// actually starts at, which is *not* recoverable from the text alone: a
+/// tree-sitter node's text only ever contains that node's own span, so the
+/// first line of the sliced text never carries the leading whitespace
+/// before it, whether or not the definition is nested. Folding this column
+/// into the dedent-baseline calculation (as a stand-in for "line 0's own
+/// indent") is what tells a nested definition (`first_line_column` > 0,
+/// e.g. 4 inside an `impl` block) apart from a top-level one
+/// (`first_line_column` == 0): a nested method's continuation lines carry
+/// their real absolute column and must be dedented back down to
+/// `first_line_column`'s depth, while a top-level struct/class's
+/// continuation lines are indented *relative to that definition's own
+/// body* and must be left alone.
+fn tidy_signature_lines(text: &str, first_line_column: usize) -> String {
     let lines: Vec<&str> = text.lines().collect();
 
     let min_indent = lines
         .iter()
-        .filter(|line| !line.trim().is_empty())
-        .map(|line| line.len() - line.trim_start().len())
+        .enumerate()
+        .filter(|(_, line)| !line.trim().is_empty())
+        .map(|(index, line)| {
+            if index == 0 {
+                first_line_column
+            } else {
+                line.len() - line.trim_start().len()
+            }
+        })
         .min()
         .unwrap_or(0);
 
     let dedented: Vec<&str> = lines
         .iter()
-        .map(|line| {
+        .enumerate()
+        .map(|(index, line)| {
             if line.trim().is_empty() {
                 ""
+            } else if index == 0 {
+                // Never dedented: see `first_line_column`'s doc comment.
+                line.trim_end()
             } else {
                 line.get(min_indent..).unwrap_or(line).trim_end()
             }

--- a/rinkaku-core/src/extract_tests/classification.rs
+++ b/rinkaku-core/src/extract_tests/classification.rs
@@ -62,6 +62,133 @@ fn should_classify_as_added_when_no_base_side_match_exists() {
     assert_eq!(expected_removed, removed);
 }
 
+// Regression: a reflow-only edit that inserts a newline right after an
+// opening `(` — no space in the original text at that position, e.g.
+// gofmt wrapping a long parameter list — must not register as a contract
+// change. `normalize_whitespace`'s old `split_whitespace().join(" ")`
+// always inserts a space at a normalized whitespace run regardless of
+// whether the original had one, so it disagreed on this exact case
+// (`...F(alpha,...` vs `...F( alpha,...`) even though nothing in the
+// contract changed. No trailing comma before the closing `)` here — that
+// is a separate, real token difference (see the trailing-comma test
+// below), not reflow, so it is deliberately excluded from this case.
+#[test]
+fn should_classify_as_body_only_when_reflow_inserts_newline_right_after_opening_paren() {
+    let mut head = vec![symbol(
+        "LongArgs",
+        None,
+        "func LongArgs(\n\talpha, beta, gamma, delta string\n) string",
+        LineRange { start: 1, end: 3 },
+    )];
+    let base = vec![symbol(
+        "LongArgs",
+        None,
+        "func LongArgs(alpha, beta, gamma, delta string) string",
+        LineRange { start: 1, end: 1 },
+    )];
+
+    let removed = classify_symbols(&mut head, &base, &[], "src/lib.go");
+
+    let mut expected = head.clone();
+    expected[0].classification = Some(Classification::BodyOnly);
+    let expected_removed: Vec<RemovedSymbol> = Vec::new();
+
+    assert_eq!(expected, head);
+    assert_eq!(expected_removed, removed);
+}
+
+// Companion to the test above: a reflow that moves a line break right
+// after a comma (rather than an opening paren) must also stay `BodyOnly`
+// — this is the shape the un-normalized comparison already handled
+// correctly before ADR 0060's multi-line signatures existed, and must
+// keep handling correctly now.
+#[test]
+fn should_classify_as_body_only_when_reflow_inserts_newline_right_after_comma() {
+    let mut head = vec![symbol(
+        "foo",
+        None,
+        "fn foo(\n    a: i32,\n    b: i32\n) -> i32",
+        LineRange { start: 1, end: 4 },
+    )];
+    let base = vec![symbol(
+        "foo",
+        None,
+        "fn foo(a: i32, b: i32) -> i32",
+        LineRange { start: 1, end: 1 },
+    )];
+
+    let removed = classify_symbols(&mut head, &base, &[], "src/lib.rs");
+
+    let mut expected = head.clone();
+    expected[0].classification = Some(Classification::BodyOnly);
+    let expected_removed: Vec<RemovedSymbol> = Vec::new();
+
+    assert_eq!(expected, head);
+    assert_eq!(expected_removed, removed);
+}
+
+// Scope note (task spec): a trailing comma introduced by reflow (e.g.
+// gofmt/rustfmt adding one when wrapping a parameter list onto multiple
+// lines) is a real extra token, not a whitespace-only difference —
+// `normalize_for_comparison` only touches whitespace runs, so this
+// legitimately still classifies as `SignatureChanged`, not a false
+// negative to fix.
+#[test]
+fn should_classify_as_signature_changed_when_reflow_adds_a_trailing_comma() {
+    let mut head = vec![symbol(
+        "foo",
+        None,
+        "fn foo(\n    a: i32,\n    b: i32,\n) -> i32",
+        LineRange { start: 1, end: 4 },
+    )];
+    let base = vec![symbol(
+        "foo",
+        None,
+        "fn foo(a: i32, b: i32) -> i32",
+        LineRange { start: 1, end: 1 },
+    )];
+
+    let removed = classify_symbols(&mut head, &base, &[], "src/lib.rs");
+
+    let mut expected = head.clone();
+    expected[0].classification = Some(Classification::SignatureChanged);
+    expected[0].previous_signature = Some("fn foo(a: i32, b: i32) -> i32".to_string());
+    let expected_removed: Vec<RemovedSymbol> = Vec::new();
+
+    assert_eq!(expected, head);
+    assert_eq!(expected_removed, removed);
+}
+
+// Guards against over-normalizing: removing whitespace runs unconditionally
+// (rather than only when adjacent to a non-word character) would make
+// `F(a b string)` and `F(ab string)` compare equal, hiding a genuine
+// signature change.
+#[test]
+fn should_classify_as_signature_changed_when_signatures_differ_only_by_a_word_boundary_space() {
+    let mut head = vec![symbol(
+        "F",
+        None,
+        "func F(ab string)",
+        LineRange { start: 1, end: 1 },
+    )];
+    let base = vec![symbol(
+        "F",
+        None,
+        "func F(a b string)",
+        LineRange { start: 1, end: 1 },
+    )];
+
+    let removed = classify_symbols(&mut head, &base, &[], "src/lib.go");
+
+    let mut expected = head.clone();
+    expected[0].classification = Some(Classification::SignatureChanged);
+    expected[0].previous_signature = Some("func F(a b string)".to_string());
+    let expected_removed: Vec<RemovedSymbol> = Vec::new();
+
+    assert_eq!(expected, head);
+    assert_eq!(expected_removed, removed);
+}
+
 #[test]
 fn should_classify_as_signature_changed_when_base_signature_differs() {
     let mut head = vec![symbol(

--- a/rinkaku-core/src/extract_tests/go.rs
+++ b/rinkaku-core/src/extract_tests/go.rs
@@ -96,7 +96,7 @@ type Repo struct {
         id: String::new(),
         name: "Repo".to_string(),
         kind: SymbolKind::Struct,
-        signature: "Repo struct { Name string Size int }".to_string(),
+        signature: "Repo struct {\n\tName string\n\tSize int\n}".to_string(),
         range: LineRange { start: 3, end: 6 },
         container: None,
         // "Repo" is the struct's own name (self-reference,
@@ -136,7 +136,7 @@ type Repo struct {
         id: String::new(),
         name: "Repo".to_string(),
         kind: SymbolKind::Struct,
-        signature: "Repo struct { Name string Size int }".to_string(),
+        signature: "Repo struct {\n\n\tName string\n\tSize int\n}".to_string(),
         range: LineRange { start: 3, end: 7 },
         container: None,
         referenced_names: vec!["Repo".to_string(), "int".to_string(), "string".to_string()],
@@ -167,7 +167,7 @@ type Fetcher interface {
         id: String::new(),
         name: "Fetcher".to_string(),
         kind: SymbolKind::Interface,
-        signature: "Fetcher interface { Fetch(id string) (string, error) }".to_string(),
+        signature: "Fetcher interface {\n\tFetch(id string) (string, error)\n}".to_string(),
         range: LineRange { start: 3, end: 5 },
         container: None,
         // "Fetch" is the interface's own method spec name (ADR
@@ -207,7 +207,8 @@ type Repo interface {
         id: String::new(),
         name: "Repo".to_string(),
         kind: SymbolKind::Interface,
-        signature: "Repo interface { Save(id string) error Delete(id string) error }".to_string(),
+        signature: "Repo interface {\n\tSave(id string) error\n\tDelete(id string) error\n}"
+            .to_string(),
         range: LineRange { start: 3, end: 6 },
         container: None,
         referenced_names: vec![

--- a/rinkaku-core/src/extract_tests/mod.rs
+++ b/rinkaku-core/src/extract_tests/mod.rs
@@ -23,6 +23,9 @@
 //! - [`tidy_lines`] — `tidy_signature_lines`: dedenting, trailing-
 //!   whitespace trimming, and blank-line collapsing applied to a
 //!   multi-line signature slice (ADR 0060).
+//! - [`normalize_for_comparison`] — the whitespace-run normalization
+//!   `classify_symbols` uses to compare two signatures without false
+//!   positives from a reflow-only edit (ADR 0060).
 
 // Re-export `crate::extract`'s items so each topic submodule can pull them
 // in with the customary `use super::*;`, mirroring what the original
@@ -35,6 +38,7 @@ pub(crate) use super::*;
 
 mod classification;
 mod go;
+mod normalize_for_comparison;
 mod python;
 mod rust;
 mod tidy_lines;

--- a/rinkaku-core/src/extract_tests/mod.rs
+++ b/rinkaku-core/src/extract_tests/mod.rs
@@ -20,6 +20,9 @@
 //! - [`classification`] — `classify_symbols`: `Added` /
 //!   `SignatureChanged` / `BodyOnly` classification and `RemovedSymbol`
 //!   reporting (ADR 0014), matched by `(name, container)` identity.
+//! - [`tidy_lines`] — `tidy_signature_lines`: dedenting, trailing-
+//!   whitespace trimming, and blank-line collapsing applied to a
+//!   multi-line signature slice (ADR 0060).
 
 // Re-export `crate::extract`'s items so each topic submodule can pull them
 // in with the customary `use super::*;`, mirroring what the original
@@ -34,4 +37,5 @@ mod classification;
 mod go;
 mod python;
 mod rust;
+mod tidy_lines;
 mod typescript;

--- a/rinkaku-core/src/extract_tests/normalize_for_comparison.rs
+++ b/rinkaku-core/src/extract_tests/normalize_for_comparison.rs
@@ -1,0 +1,54 @@
+//! Tests pinning [`super::normalize_for_comparison`]: the whitespace
+//! normalization `classify_symbols` uses to compare two signatures (ADR
+//! 0014/0060). Unlike the unconditional single-line collapsing used at
+//! display sites (`render::markdown`'s `collapse_to_single_line` and its
+//! `rinkaku-tui` counterpart, both unaffected by this change), this
+//! variant must not introduce a space at a position the source never had
+//! one: a reflow that inserts a newline right after an opening `(` (no
+//! space in the original) must normalize identically to the un-reflowed
+//! source, or `classify_symbols` reports a false `SignatureChanged`.
+
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn should_drop_whitespace_run_when_adjacent_to_a_symbol_character() {
+    let actual = normalize_for_comparison("func F(\n\talpha string,\n) string");
+
+    assert_eq!("func F(alpha string,)string", actual);
+}
+
+#[test]
+fn should_collapse_whitespace_run_to_single_space_when_both_sides_are_word_characters() {
+    let actual = normalize_for_comparison("a\n   b");
+
+    assert_eq!("a b", actual);
+}
+
+#[test]
+fn should_treat_underscore_as_a_word_character() {
+    let actual = normalize_for_comparison("foo_bar\nbaz_qux");
+
+    assert_eq!("foo_bar baz_qux", actual);
+}
+
+#[test]
+fn should_normalize_identically_when_reflow_only_moves_a_comma_onto_its_own_line() {
+    let with_trailing_comma_on_own_line = normalize_for_comparison("a,\nb");
+    let on_one_line = normalize_for_comparison("a, b");
+
+    assert_eq!(with_trailing_comma_on_own_line, on_one_line);
+}
+
+#[test]
+fn should_distinguish_signatures_that_differ_only_by_a_word_boundary_space() {
+    // `F(a b string)` and `F(ab string)` must never normalize to the same
+    // string — the space between `a` and `b` is meaningful content, not
+    // reflow, so collapsing/removing it here would hide an actual
+    // signature change from `classify_symbols`.
+    let with_space = normalize_for_comparison("func F(a b string)");
+    let without_space = normalize_for_comparison("func F(ab string)");
+
+    assert_eq!("func F(a b string)", with_space);
+    assert_eq!("func F(ab string)", without_space);
+}

--- a/rinkaku-core/src/extract_tests/python.rs
+++ b/rinkaku-core/src/extract_tests/python.rs
@@ -288,6 +288,46 @@ class Point:
     assert_eq!(expected, actual);
 }
 
+// Regression for the dedent bug ADR 0060 shipped with: a nested method's
+// node text starts mid-line (no leading indentation on its own first
+// line) while its continuation lines still carry their absolute source
+// column, so computing `min_indent` over every line (including the
+// unindented first one) always floored it at 0 and left continuation
+// lines at their raw source indentation instead of dedented.
+#[test]
+fn should_dedent_continuation_lines_when_multiline_method_signature_is_nested_in_class() {
+    let source = "\
+class Point:
+    def __init__(
+        self,
+        x,
+        y,
+    ):
+        self.x = x
+";
+    let lang = PythonSupport;
+    // Line 7 (`self.x = x`) is inside `__init__`'s body.
+    let changed_ranges = vec![LineRange { start: 7, end: 7 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "__init__".to_string(),
+        kind: SymbolKind::Function,
+        signature: "def __init__(\n    self,\n    x,\n    y,\n):".to_string(),
+        range: LineRange { start: 2, end: 7 },
+        container: Some("class Point".to_string()),
+        referenced_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
 #[test]
 fn should_extract_only_the_touched_method_when_class_has_two_methods() {
     let source = "\

--- a/rinkaku-core/src/extract_tests/python.rs
+++ b/rinkaku-core/src/extract_tests/python.rs
@@ -172,7 +172,8 @@ class Point:
         id: String::new(),
         name: "Point".to_string(),
         kind: SymbolKind::Class,
-        signature: "class Point: x: int y: int def __init__(self, x, y):".to_string(),
+        signature: "class Point:\n    x: int\n    y: int\n\n    def __init__(self, x, y):"
+            .to_string(),
         range: LineRange { start: 1, end: 7 },
         container: None,
         // "int" is the shared field-annotation type of both `x`
@@ -211,7 +212,8 @@ class Point:
         id: String::new(),
         name: "Point".to_string(),
         kind: SymbolKind::Class,
-        signature: "class Point: x: int y: int def __init__(self, x, y):".to_string(),
+        signature: "class Point:\n\n    x: int\n    y: int\n\n    def __init__(self, x, y):"
+            .to_string(),
         range: LineRange { start: 1, end: 8 },
         container: None,
         referenced_names: vec!["int".to_string()],

--- a/rinkaku-core/src/extract_tests/rust.rs
+++ b/rinkaku-core/src/extract_tests/rust.rs
@@ -508,6 +508,49 @@ impl Foo {
     assert_eq!(expected, actual);
 }
 
+// Regression for the dedent bug ADR 0060 shipped with: a nested method's
+// tree-sitter node text starts mid-line (no leading indentation on its
+// own first line) while its continuation lines still carry their
+// absolute source column, so computing `min_indent` over every line
+// (including the unindented first one) always floored it at 0 and left
+// continuation lines at their raw source indentation instead of dedented.
+#[test]
+fn should_dedent_continuation_lines_when_multiline_method_signature_is_nested_in_impl_block() {
+    let source = "\
+struct Foo;
+
+impl Foo {
+    fn bar(
+        &self,
+        extra: i32,
+    ) -> i32 {
+        extra
+    }
+}
+";
+    let lang = RustSupport;
+    // Line 8 (`extra`) is inside `bar`'s body.
+    let changed_ranges = vec![LineRange { start: 8, end: 8 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "bar".to_string(),
+        kind: SymbolKind::Function,
+        signature: "fn bar(\n    &self,\n    extra: i32,\n) -> i32".to_string(),
+        range: LineRange { start: 4, end: 9 },
+        container: Some("impl Foo".to_string()),
+        referenced_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
 #[test]
 fn should_extract_full_enum_signature_when_variant_changed() {
     let source = "\

--- a/rinkaku-core/src/extract_tests/rust.rs
+++ b/rinkaku-core/src/extract_tests/rust.rs
@@ -53,7 +53,7 @@ struct Point {
             id: String::new(),
             name: "Point".to_string(),
             kind: SymbolKind::Struct,
-            signature: "struct Point { x: i32, }".to_string(),
+            signature: "struct Point {\n    x: i32,\n}".to_string(),
             range: LineRange { start: 5, end: 7 },
             container: None,
             referenced_names: vec!["Point".to_string()],
@@ -354,7 +354,7 @@ struct Point {
         id: String::new(),
         name: "Point".to_string(),
         kind: SymbolKind::Struct,
-        signature: "struct Point { x: i32, y: i32, }".to_string(),
+        signature: "struct Point {\n    x: i32,\n    y: i32,\n}".to_string(),
         range: LineRange { start: 1, end: 4 },
         container: None,
         // The struct's own name appears as a `type_identifier` too
@@ -393,7 +393,7 @@ struct Point {
         id: String::new(),
         name: "Point".to_string(),
         kind: SymbolKind::Struct,
-        signature: "struct Point { x: i32, y: i32, }".to_string(),
+        signature: "struct Point {\n\n    x: i32,\n    y: i32,\n}".to_string(),
         range: LineRange { start: 1, end: 5 },
         container: None,
         referenced_names: vec!["Point".to_string()],
@@ -525,7 +525,7 @@ enum Color {
         id: String::new(),
         name: "Color".to_string(),
         kind: SymbolKind::Enum,
-        signature: "enum Color { Red, Green, Blue, }".to_string(),
+        signature: "enum Color {\n    Red,\n    Green,\n    Blue,\n}".to_string(),
         range: LineRange { start: 1, end: 5 },
         container: None,
         // Same self-reference note as the struct case above: the
@@ -591,7 +591,7 @@ trait Greeter {
         id: String::new(),
         name: "Greeter".to_string(),
         kind: SymbolKind::Trait,
-        signature: "trait Greeter { fn greet(&self) -> String; }".to_string(),
+        signature: "trait Greeter {\n    fn greet(&self) -> String;\n}".to_string(),
         range: LineRange { start: 1, end: 3 },
         container: None,
         // The trait's own name, its "greet" method name (ADR 0012
@@ -635,9 +635,8 @@ trait Repo {
         id: String::new(),
         name: "Repo".to_string(),
         kind: SymbolKind::Trait,
-        signature:
-            "trait Repo { fn save(&self, id: &str); fn label(&self) -> String { String::new() } }"
-                .to_string(),
+        signature: "trait Repo {\n    fn save(&self, id: &str);\n\n    fn label(&self) -> String {\n        String::new()\n    }\n}"
+            .to_string(),
         range: LineRange { start: 1, end: 7 },
         container: None,
         // Both the bodiless `save` signature and the default-body

--- a/rinkaku-core/src/extract_tests/tidy_lines.rs
+++ b/rinkaku-core/src/extract_tests/tidy_lines.rs
@@ -1,8 +1,9 @@
 //! Tests pinning [`super::tidy_signature_lines`]: the transform that turns
 //! a raw, range-stripped declaration slice into the multi-line text
 //! actually stored on [`super::ExtractedSymbol::signature`] (ADR 0060) —
-//! dedenting relative to the first line, trimming trailing whitespace per
-//! line, and collapsing the blank-line runs a removed comment/body leaves
+//! dedenting continuation lines relative to the node's real starting
+//! column (`first_line_column`), trimming trailing whitespace per line,
+//! and collapsing the blank-line runs a removed comment/body leaves
 //! behind.
 
 use super::*;
@@ -10,7 +11,7 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn should_return_unchanged_when_text_is_a_single_line() {
-    let actual = tidy_signature_lines("fn foo(a: i32) -> i32");
+    let actual = tidy_signature_lines("fn foo(a: i32) -> i32", 0);
 
     assert_eq!("fn foo(a: i32) -> i32", actual);
 }
@@ -19,7 +20,7 @@ fn should_return_unchanged_when_text_is_a_single_line() {
 fn should_dedent_continuation_lines_relative_to_common_indent() {
     let raw = "struct Point {\n    x: i32,\n    y: i32,\n}";
 
-    let actual = tidy_signature_lines(raw);
+    let actual = tidy_signature_lines(raw, 0);
 
     assert_eq!("struct Point {\n    x: i32,\n    y: i32,\n}", actual);
 }
@@ -31,7 +32,7 @@ fn should_collapse_blank_line_left_by_a_stripped_body() {
     // not appear in the tidied signature.
     let raw = "class Point:\n    x: int\n    y: int\n\n    def __init__(self, x, y):\n";
 
-    let actual = tidy_signature_lines(raw);
+    let actual = tidy_signature_lines(raw, 0);
 
     assert_eq!(
         "class Point:\n    x: int\n    y: int\n\n    def __init__(self, x, y):",
@@ -43,7 +44,7 @@ fn should_collapse_blank_line_left_by_a_stripped_body() {
 fn should_collapse_multiple_consecutive_blank_lines_into_one() {
     let raw = "class Foo:\n    a: int\n\n\n\n    def bar(self):\n";
 
-    let actual = tidy_signature_lines(raw);
+    let actual = tidy_signature_lines(raw, 0);
 
     assert_eq!("class Foo:\n    a: int\n\n    def bar(self):", actual);
 }
@@ -52,7 +53,7 @@ fn should_collapse_multiple_consecutive_blank_lines_into_one() {
 fn should_trim_leading_and_trailing_blank_lines() {
     let raw = "\n\nstruct Foo {\n    a: i32,\n}\n\n";
 
-    let actual = tidy_signature_lines(raw);
+    let actual = tidy_signature_lines(raw, 0);
 
     assert_eq!("struct Foo {\n    a: i32,\n}", actual);
 }
@@ -61,14 +62,47 @@ fn should_trim_leading_and_trailing_blank_lines() {
 fn should_trim_trailing_whitespace_from_each_line() {
     let raw = "struct Foo {   \n    a: i32,  \n}";
 
-    let actual = tidy_signature_lines(raw);
+    let actual = tidy_signature_lines(raw, 0);
 
     assert_eq!("struct Foo {\n    a: i32,\n}", actual);
 }
 
 #[test]
 fn should_return_empty_string_when_text_is_only_whitespace() {
-    let actual = tidy_signature_lines("   \n\n  \n");
+    let actual = tidy_signature_lines("   \n\n  \n", 0);
 
     assert_eq!("", actual);
+}
+
+#[test]
+fn should_dedent_continuation_lines_relative_to_nesting_depth_when_first_line_column_is_nonzero() {
+    // Mirrors what a nested definition's node text actually looks like:
+    // tree-sitter's node span starts mid-line, so the first line (`fn
+    // bar(`) carries none of the source's leading indentation in its own
+    // stored text, while continuation lines still hold their absolute
+    // source column (8 spaces for the params, 4 for the closing paren,
+    // matching `fn`'s own column inside an `impl` block, passed here as
+    // `first_line_column`). Folding that column into the dedent baseline
+    // is what tells this apart from a top-level definition whose
+    // continuation lines must NOT be dedented (see the sibling tests
+    // above, all passing `first_line_column: 0`).
+    let raw = "fn bar(\n        &self,\n        extra: i32,\n    ) -> i32";
+
+    let actual = tidy_signature_lines(raw, 4);
+
+    assert_eq!("fn bar(\n    &self,\n    extra: i32,\n) -> i32", actual);
+}
+
+#[test]
+fn should_not_dedent_top_level_class_body_when_its_last_line_is_still_indented() {
+    // Unlike a brace-delimited struct (whose closing `}` sits back at
+    // column 0), a Python class's last kept line stays indented — every
+    // non-blank continuation line here is at column 4, which must NOT be
+    // read as "this nested definition needs 4 dedented off", since
+    // `first_line_column` (0) already says this definition is top-level.
+    let raw = "class Foo:\n    a: int\n    def bar(self):";
+
+    let actual = tidy_signature_lines(raw, 0);
+
+    assert_eq!("class Foo:\n    a: int\n    def bar(self):", actual);
 }

--- a/rinkaku-core/src/extract_tests/tidy_lines.rs
+++ b/rinkaku-core/src/extract_tests/tidy_lines.rs
@@ -1,0 +1,74 @@
+//! Tests pinning [`super::tidy_signature_lines`]: the transform that turns
+//! a raw, range-stripped declaration slice into the multi-line text
+//! actually stored on [`super::ExtractedSymbol::signature`] (ADR 0060) —
+//! dedenting relative to the first line, trimming trailing whitespace per
+//! line, and collapsing the blank-line runs a removed comment/body leaves
+//! behind.
+
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn should_return_unchanged_when_text_is_a_single_line() {
+    let actual = tidy_signature_lines("fn foo(a: i32) -> i32");
+
+    assert_eq!("fn foo(a: i32) -> i32", actual);
+}
+
+#[test]
+fn should_dedent_continuation_lines_relative_to_common_indent() {
+    let raw = "struct Point {\n    x: i32,\n    y: i32,\n}";
+
+    let actual = tidy_signature_lines(raw);
+
+    assert_eq!("struct Point {\n    x: i32,\n    y: i32,\n}", actual);
+}
+
+#[test]
+fn should_collapse_blank_line_left_by_a_stripped_body() {
+    // The body-removal hole after `def __init__(self, x, y):` leaves a
+    // trailing blank line before the closing dedent — that residue must
+    // not appear in the tidied signature.
+    let raw = "class Point:\n    x: int\n    y: int\n\n    def __init__(self, x, y):\n";
+
+    let actual = tidy_signature_lines(raw);
+
+    assert_eq!(
+        "class Point:\n    x: int\n    y: int\n\n    def __init__(self, x, y):",
+        actual
+    );
+}
+
+#[test]
+fn should_collapse_multiple_consecutive_blank_lines_into_one() {
+    let raw = "class Foo:\n    a: int\n\n\n\n    def bar(self):\n";
+
+    let actual = tidy_signature_lines(raw);
+
+    assert_eq!("class Foo:\n    a: int\n\n    def bar(self):", actual);
+}
+
+#[test]
+fn should_trim_leading_and_trailing_blank_lines() {
+    let raw = "\n\nstruct Foo {\n    a: i32,\n}\n\n";
+
+    let actual = tidy_signature_lines(raw);
+
+    assert_eq!("struct Foo {\n    a: i32,\n}", actual);
+}
+
+#[test]
+fn should_trim_trailing_whitespace_from_each_line() {
+    let raw = "struct Foo {   \n    a: i32,  \n}";
+
+    let actual = tidy_signature_lines(raw);
+
+    assert_eq!("struct Foo {\n    a: i32,\n}", actual);
+}
+
+#[test]
+fn should_return_empty_string_when_text_is_only_whitespace() {
+    let actual = tidy_signature_lines("   \n\n  \n");
+
+    assert_eq!("", actual);
+}

--- a/rinkaku-core/src/extract_tests/typescript.rs
+++ b/rinkaku-core/src/extract_tests/typescript.rs
@@ -134,7 +134,8 @@ interface Shape {
         id: String::new(),
         name: "Shape".to_string(),
         kind: SymbolKind::Interface,
-        signature: "interface Shape { area(): number; perimeter(): number; }".to_string(),
+        signature: "interface Shape {\n    area(): number;\n    perimeter(): number;\n}"
+            .to_string(),
         range: LineRange { start: 1, end: 4 },
         container: None,
         // The interface's own name is a `type_identifier` (self-
@@ -179,7 +180,8 @@ interface Repo {
         id: String::new(),
         name: "Repo".to_string(),
         kind: SymbolKind::Interface,
-        signature: "interface Repo { id: string; save(item: string): void; }".to_string(),
+        signature: "interface Repo {\n    id: string;\n    save(item: string): void;\n}"
+            .to_string(),
         range: LineRange { start: 1, end: 4 },
         container: None,
         // "id" (a `property_signature` name) is deliberately
@@ -213,7 +215,7 @@ type Point = {
         id: String::new(),
         name: "Point".to_string(),
         kind: SymbolKind::TypeAlias,
-        signature: "type Point = { x: number; y: number; };".to_string(),
+        signature: "type Point = {\n    x: number;\n    y: number;\n};".to_string(),
         range: LineRange { start: 1, end: 4 },
         container: None,
         referenced_names: vec!["Point".to_string()],
@@ -245,7 +247,7 @@ enum Color {
         id: String::new(),
         name: "Color".to_string(),
         kind: SymbolKind::Enum,
-        signature: "enum Color { Red, Green, Blue, }".to_string(),
+        signature: "enum Color {\n    Red,\n    Green,\n    Blue,\n}".to_string(),
         range: LineRange { start: 1, end: 5 },
         container: None,
         referenced_names: vec![],
@@ -280,7 +282,7 @@ class Circle {
         id: String::new(),
         name: "Circle".to_string(),
         kind: SymbolKind::Class,
-        signature: "class Circle { radius: number; area(): number }".to_string(),
+        signature: "class Circle {\n    radius: number;\n\n    area(): number\n}".to_string(),
         range: LineRange { start: 1, end: 7 },
         container: None,
         referenced_names: vec!["Circle".to_string()],
@@ -317,7 +319,7 @@ class Circle {
         id: String::new(),
         name: "Circle".to_string(),
         kind: SymbolKind::Class,
-        signature: "class Circle { radius: number; area(): number }".to_string(),
+        signature: "class Circle {\n\n    radius: number;\n\n    area(): number\n}".to_string(),
         range: LineRange { start: 1, end: 8 },
         container: None,
         referenced_names: vec!["Circle".to_string()],
@@ -555,7 +557,7 @@ abstract class Shape {
         name: "Shape".to_string(),
         kind: SymbolKind::Class,
         signature:
-            "abstract class Shape { abstract area(): number; abstract perimeter(): number; }"
+            "abstract class Shape {\n    abstract area(): number;\n    abstract perimeter(): number;\n}"
                 .to_string(),
         range: LineRange { start: 1, end: 4 },
         container: None,
@@ -594,7 +596,8 @@ class Circle {
         id: String::new(),
         name: "Circle".to_string(),
         kind: SymbolKind::Class,
-        signature: "class Circle { radius: number; area = (): number => ; }".to_string(),
+        signature: "class Circle {\n    radius: number;\n\n    area = (): number => ;\n}"
+            .to_string(),
         range: LineRange { start: 1, end: 7 },
         container: None,
         // The reference query runs over the full node (including

--- a/rinkaku-core/src/pipeline_tests/analyze_diff.rs
+++ b/rinkaku-core/src/pipeline_tests/analyze_diff.rs
@@ -506,7 +506,9 @@ func (r *repoImpl) Save(id string) error {
 ### interface Repo (repo.go)
 
 ```
-Repo interface { Save(id string) (err error) }
+Repo interface {
+	Save(id string) (err error)
+}
 ```
 
 ### fn Save (repo.go)

--- a/rinkaku-core/src/pipeline_tests/analyze_repo.rs
+++ b/rinkaku-core/src/pipeline_tests/analyze_repo.rs
@@ -74,7 +74,7 @@ struct Point {
                     id: "src/lib.rs::Point".to_string(),
                     name: "Point".to_string(),
                     kind: SymbolKind::Struct,
-                    signature: "struct Point { x: i32, }".to_string(),
+                    signature: "struct Point {\n    x: i32,\n}".to_string(),
                     range: LineRange { start: 5, end: 7 },
                     container: None,
                     referenced_names: vec!["Point".to_string()],

--- a/rinkaku-core/src/render/digest.rs
+++ b/rinkaku-core/src/render/digest.rs
@@ -81,7 +81,8 @@ fn added_line(path: &str, symbol: &ExtractedSymbol) -> String {
 }
 
 /// Same ` ```diff ` convention `render_markdown`'s "Definitions" section
-/// uses for `SignatureChanged`.
+/// uses for `SignatureChanged`: every base signature line prefixed `-`,
+/// then every head signature line prefixed `+` (ADR 0060).
 ///
 /// `previous_signature` is expected to be `Some` whenever `classification`
 /// is `SignatureChanged` (`extract::classify_symbols`' invariant); falls
@@ -95,8 +96,12 @@ fn signature_changed_line(path: &str, symbol: &ExtractedSymbol) -> String {
         Some(previous_signature) => {
             let fence = fence_for_diff(previous_signature, &symbol.signature);
             writeln!(out, "  {fence}diff").expect("writing to a String cannot fail");
-            writeln!(out, "  -{previous_signature}").expect("writing to a String cannot fail");
-            writeln!(out, "  +{}", symbol.signature).expect("writing to a String cannot fail");
+            for line in previous_signature.lines() {
+                writeln!(out, "  -{line}").expect("writing to a String cannot fail");
+            }
+            for line in symbol.signature.lines() {
+                writeln!(out, "  +{line}").expect("writing to a String cannot fail");
+            }
             writeln!(out, "  {fence}").expect("writing to a String cannot fail");
         }
         None => {
@@ -267,6 +272,44 @@ mod tests {
   ```diff
   -fn foo(a: i32) -> i32
   +fn foo(a: i32, b: i32) -> i32
+  ```
+"
+        .to_string();
+        let actual = render(&report, OutputFormat::Digest).expect("digest render succeeds");
+
+        assert_eq!(expected, actual);
+    }
+
+    // ADR 0060: same line-based diff convention as `render_markdown`'s
+    // "Definitions" section — every base line prefixed `-`, every head
+    // line prefixed `+`.
+    #[test]
+    fn should_render_line_based_diff_block_when_multiline_signature_changed() {
+        let report = empty_report(
+            vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![symbol(
+                    "Point",
+                    "struct Point {\n    x: i32,\n    y: i32,\n}",
+                    Some(Classification::SignatureChanged),
+                    Some("struct Point {\n    x: i32,\n}"),
+                )],
+            }],
+            vec![],
+        );
+
+        let expected = "\
+### API changes
+
+- **Point (src/lib.rs)**
+  ```diff
+  -struct Point {
+  -    x: i32,
+  -}
+  +struct Point {
+  +    x: i32,
+  +    y: i32,
+  +}
   ```
 "
         .to_string();

--- a/rinkaku-core/src/render/markdown.rs
+++ b/rinkaku-core/src/render/markdown.rs
@@ -404,11 +404,14 @@ fn render_tree_node(
 ///
 /// The signature block is a plain fence for every classification except
 /// [`Classification::SignatureChanged`] (or classification not attempted),
-/// which instead gets a ` ```diff ` block showing the base signature as a
-/// `-` line and the head signature as a `+` line — the same before/after
-/// shape a reviewer already reads diffs in, applied to just the signature
-/// rather than the whole file. The container comment line, when present, is
-/// unchanged either way (not part of the diff, since it never differs
+/// which instead gets a ` ```diff ` block: every line of the base
+/// signature prefixed `-`, followed by every line of the head signature
+/// prefixed `+` (ADR 0060) — a whole-signature replacement rather than a
+/// paired line-by-line diff, so a multi-line signature's unchanged lines
+/// still repeat on both sides, but a struct/enum/trait/interface/class
+/// signature's changed field is at least visible on its own line instead of
+/// buried in one flattened line. The container comment line, when present,
+/// is unchanged either way (not part of the diff, since it never differs
 /// between base and head — `find_container`'s output depends only on
 /// enclosing-block structure, not on the signature text being compared).
 fn render_definition(
@@ -431,8 +434,12 @@ fn render_definition(
             if let Some(container_line) = &container_line {
                 writeln!(out, "{container_line}")?;
             }
-            writeln!(out, "-{previous_signature}")?;
-            writeln!(out, "+{}", symbol.signature)?;
+            for line in previous_signature.lines() {
+                writeln!(out, "-{line}")?;
+            }
+            for line in symbol.signature.lines() {
+                writeln!(out, "+{line}")?;
+            }
             writeln!(out, "{fence}")?;
         }
         _ => {
@@ -458,7 +465,14 @@ fn render_definition(
             // to break out of a single backtick span, and this is a
             // cosmetic-only failure mode (unlike the fenced blocks, which
             // without widening could make later content render as code).
-            writeln!(out, "- `{}`: `{}`", dependency.path, dependency.signature)?;
+            // A multi-line dependency signature (ADR 0060) is collapsed to
+            // one line here, since this list's shape is one entry per line.
+            writeln!(
+                out,
+                "- `{}`: `{}`",
+                dependency.path,
+                collapse_to_single_line(&dependency.signature)
+            )?;
         }
         if symbol.omitted_dependency_matches > 0 {
             writeln!(
@@ -732,6 +746,13 @@ fn longest_backtick_run(text: &str) -> Option<usize> {
         .map(str::len)
         .filter(|&len| len > 0)
         .max()
+}
+
+/// Collapses a possibly multi-line signature (ADR 0060) into one line for
+/// a render slot that must stay a single line — e.g. a "Depends on:"
+/// inline code span, which is one list entry per line.
+fn collapse_to_single_line(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 #[cfg(test)]

--- a/rinkaku-core/src/render/markdown_tests/classification_and_removed.rs
+++ b/rinkaku-core/src/render/markdown_tests/classification_and_removed.rs
@@ -111,6 +111,67 @@ fn should_render_diff_block_and_marker_when_symbol_is_signature_changed() {
     assert_eq!(expected, actual);
 }
 
+// ADR 0060: a multi-line signature's diff block prefixes every line of
+// the base/head text with `-`/`+`, so a struct's changed field shows up
+// as one changed line among unchanged ones, not a full-signature
+// replacement.
+#[test]
+fn should_render_line_based_diff_block_when_multiline_signature_changed() {
+    let mut point = symbol(
+        "src/lib.rs::Point",
+        "Point",
+        SymbolKind::Struct,
+        "struct Point {\n    x: i32,\n    y: i32,\n}",
+    );
+    point.classification = Some(Classification::SignatureChanged);
+    point.previous_signature = Some("struct Point {\n    x: i32,\n}".to_string());
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![point],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![node("src/lib.rs::Point", "src/lib.rs", "Point")],
+            edges: vec![],
+            roots: vec!["src/lib.rs::Point".to_string()],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+
+    let expected = "\
+## Change graph
+
+1 changed symbol in 1 file
+
+- struct Point (src/lib.rs) — signature changed
+
+## Definitions
+
+### struct Point (src/lib.rs) — signature changed
+
+```diff
+-struct Point {
+-    x: i32,
+-}
++struct Point {
++    x: i32,
++    y: i32,
++}
+```
+
+"
+    .to_string();
+    let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
 // A signature-changed symbol with a container gets the container
 // comment line rendered unchanged above the diff lines — it is not
 // itself part of the base/head comparison (see `render_definition`'s

--- a/rinkaku-core/src/render/markdown_tests/definition_body.rs
+++ b/rinkaku-core/src/render/markdown_tests/definition_body.rs
@@ -119,6 +119,67 @@ Depends on:
     assert_eq!(expected, actual);
 }
 
+// ADR 0060: `Depends on:` is a one-line-per-dependency inline code span,
+// so a multi-line dependency signature (e.g. a struct with several
+// fields) must collapse to a single line here rather than breaking the
+// list's one-entry-per-line shape.
+#[test]
+fn should_collapse_multiline_dependency_signature_to_one_line() {
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![ExtractedSymbol {
+                dependencies: vec![crate::deps::ResolvedSymbol {
+                    signature: "struct Point {\n    x: i32,\n    y: i32,\n}".to_string(),
+                    path: "src/point.rs".to_string(),
+                }],
+                ..symbol(
+                    "src/lib.rs::foo",
+                    "foo",
+                    SymbolKind::Function,
+                    "fn foo(p: Point) -> i32",
+                )
+            }],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![node("src/lib.rs::foo", "src/lib.rs", "foo")],
+            edges: vec![],
+            roots: vec!["src/lib.rs::foo".to_string()],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+
+    let expected = "\
+## Change graph
+
+1 changed symbol in 1 file
+
+- fn foo (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo(p: Point) -> i32
+```
+
+Depends on:
+- `src/point.rs`: `struct Point { x: i32, y: i32, }`
+
+"
+    .to_string();
+    let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
 #[test]
 fn should_render_multiple_depends_on_entries_when_symbol_has_several_dependencies() {
     let report = Report {

--- a/rinkaku-core/src/render/report.rs
+++ b/rinkaku-core/src/render/report.rs
@@ -467,4 +467,82 @@ mod tests {
 
         assert_eq!(expected, actual);
     }
+
+    // ADR 0060: a multi-line signature serializes as a JSON string with
+    // escaped `\n` sequences, same as any other string field — pins the
+    // output-format change JSON consumers must account for.
+    #[test]
+    fn should_serialize_multiline_signature_with_escaped_newlines_in_json() {
+        let point = symbol(
+            "src/lib.rs::Point",
+            "Point",
+            SymbolKind::Struct,
+            "struct Point {\n    x: i32,\n}",
+        );
+        let report = Report {
+            origin: ReportOrigin::Diff,
+            files: vec![FileReport {
+                path: "src/lib.rs".to_string(),
+                symbols: vec![point],
+            }],
+            skipped: vec![],
+            graph: SymbolGraph {
+                nodes: vec![node("src/lib.rs::Point", "src/lib.rs", "Point")],
+                edges: vec![],
+                roots: vec!["src/lib.rs::Point".to_string()],
+            },
+            tests: vec![],
+            fan_ins: vec![],
+            file_size_warnings: vec![],
+            file_size_bands: vec![],
+            removed: vec![],
+        };
+
+        let expected = "\
+{
+  \"files\": [
+    {
+      \"path\": \"src/lib.rs\",
+      \"symbols\": [
+        {
+          \"id\": \"src/lib.rs::Point\",
+          \"name\": \"Point\",
+          \"kind\": \"Struct\",
+          \"signature\": \"struct Point {\\n    x: i32,\\n}\",
+          \"range\": {
+            \"start\": 1,
+            \"end\": 1
+          },
+          \"container\": null,
+          \"dependencies\": [],
+          \"omitted_matches\": 0
+        }
+      ]
+    }
+  ],
+  \"skipped\": [],
+  \"graph\": {
+    \"nodes\": [
+      {
+        \"id\": \"src/lib.rs::Point\",
+        \"path\": \"src/lib.rs\",
+        \"name\": \"Point\"
+      }
+    ],
+    \"edges\": [],
+    \"roots\": [
+      \"src/lib.rs::Point\"
+    ]
+  },
+  \"tests\": [],
+  \"fan_ins\": [],
+  \"file_size_warnings\": [],
+  \"file_size_bands\": [],
+  \"removed\": []
+}"
+        .to_string();
+        let actual = render(&report, OutputFormat::Json).expect("json render succeeds");
+
+        assert_eq!(expected, actual);
+    }
 }

--- a/rinkaku-tui/src/diff_shape.rs
+++ b/rinkaku-tui/src/diff_shape.rs
@@ -315,7 +315,7 @@ fn build_file_content(report: &Report, diff_files: &[FileHunks], path: &str) -> 
     let mut sections: Vec<DiffSection> = symbols
         .iter()
         .map(|symbol| DiffSection {
-            title: symbol.signature.clone(),
+            title: collapse_to_single_line(&symbol.signature),
             symbol_id: Some(symbol.id.clone()),
             contract_header: contract_header_for_symbol(symbol),
             hunks: Vec::new(),
@@ -391,11 +391,19 @@ fn contract_header_for_symbol(
 ) -> Option<ContractHeader> {
     match (symbol.classification, &symbol.previous_signature) {
         (Some(Classification::SignatureChanged), Some(previous)) => Some(ContractHeader {
-            previous_signature: previous.clone(),
-            signature: symbol.signature.clone(),
+            previous_signature: collapse_to_single_line(previous),
+            signature: collapse_to_single_line(&symbol.signature),
         }),
         _ => None,
     }
+}
+
+/// Collapses a possibly multi-line signature (ADR 0060) into one line for
+/// [`DiffSection::title`]/[`ContractHeader`]'s fields, both of which the
+/// diff pane renders as a single anchor [`ratatui::text::Line`]
+/// (`crate::ui::diff_pane::section_anchor_lines`/`section_anchor_split_row`).
+fn collapse_to_single_line(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// The distinct changed-line ranges across `sections`' hunks, for the

--- a/rinkaku-tui/src/diff_shape_tests/build_diff_pane_content.rs
+++ b/rinkaku-tui/src/diff_shape_tests/build_diff_pane_content.rs
@@ -76,6 +76,52 @@ fn should_group_file_selection_hunks_under_per_symbol_sections() {
     assert_eq!(expected, actual);
 }
 
+// ADR 0060: `DiffSection::title` is a single anchor line, so a symbol
+// whose signature keeps its original multi-line structure (e.g. a
+// struct) must be collapsed to one line here rather than expanding the
+// section header into several lines.
+#[test]
+fn should_collapse_multiline_signature_to_one_line_title() {
+    let report = Report {
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![ExtractedSymbol {
+                signature: "struct Point {\n    x: i32,\n    y: i32,\n}".to_string(),
+                ..symbol("lib.rs::Point", "Point", LineRange { start: 1, end: 4 })
+            }],
+        }],
+        ..empty_report()
+    };
+    let diff_files = vec![FileHunks {
+        path: "lib.rs".to_string(),
+        hunks: vec![hunk(
+            "@@ -1,4 +1,4 @@",
+            Some((1, 4)),
+            vec!["struct Point {", "    x: i32,", "    y: i32,", "}"],
+        )],
+    }];
+    let target = DiffTarget::File {
+        path: "lib.rs".to_string(),
+    };
+
+    let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+    let expected = DiffPaneContent::File(vec![DiffSection {
+        title: "struct Point { x: i32, y: i32, }".to_string(),
+        symbol_id: Some("lib.rs::Point".to_string()),
+        contract_header: None,
+        hunks: vec![attributed(
+            0,
+            hunk(
+                "@@ -1,4 +1,4 @@",
+                Some((1, 4)),
+                vec!["struct Point {", "    x: i32,", "    y: i32,", "}"],
+            ),
+        )],
+    }]);
+    assert_eq!(expected, actual);
+}
+
 #[test]
 fn should_attribute_pure_deletion_hunk_to_owning_symbol_instead_of_module_level() {
     // Finding-2 regression: `hunk_intersects` always returning `false`
@@ -472,6 +518,57 @@ fn should_include_contract_header_on_the_owning_section_in_a_file_selection() {
         hunks: vec![attributed(
             0,
             hunk("@@ -1,1 +1,2 @@", Some((1, 2)), vec!["fn foo(a, b) {}"]),
+        )],
+    }]);
+    assert_eq!(expected, actual);
+}
+
+// ADR 0060: `ContractHeader`'s two fields are each a single anchor line
+// (`section_anchor_lines`/`section_anchor_split_row` render them as one
+// `Line` apiece), so a multi-line struct/class signature change must
+// collapse both sides to one line here too, not just `title`.
+#[test]
+fn should_collapse_multiline_contract_header_signatures_to_one_line_each() {
+    let report = Report {
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![ExtractedSymbol {
+                classification: Some(Classification::SignatureChanged),
+                previous_signature: Some("struct Point {\n    x: i32,\n}".to_string()),
+                signature: "struct Point {\n    x: i32,\n    y: i32,\n}".to_string(),
+                ..symbol("lib.rs::Point", "Point", LineRange { start: 1, end: 4 })
+            }],
+        }],
+        ..empty_report()
+    };
+    let diff_files = vec![FileHunks {
+        path: "lib.rs".to_string(),
+        hunks: vec![hunk(
+            "@@ -1,3 +1,4 @@",
+            Some((1, 4)),
+            vec!["struct Point {", "    x: i32,", "    y: i32,", "}"],
+        )],
+    }];
+    let target = DiffTarget::File {
+        path: "lib.rs".to_string(),
+    };
+
+    let actual = build_diff_pane_content(&report, &diff_files, Some(&target));
+
+    let expected = DiffPaneContent::File(vec![DiffSection {
+        title: "struct Point { x: i32, y: i32, }".to_string(),
+        symbol_id: Some("lib.rs::Point".to_string()),
+        contract_header: Some(ContractHeader {
+            previous_signature: "struct Point { x: i32, }".to_string(),
+            signature: "struct Point { x: i32, y: i32, }".to_string(),
+        }),
+        hunks: vec![attributed(
+            0,
+            hunk(
+                "@@ -1,3 +1,4 @@",
+                Some((1, 4)),
+                vec!["struct Point {", "    x: i32,", "    y: i32,", "}"],
+            ),
         )],
     }]);
     assert_eq!(expected, actual);

--- a/rinkaku-tui/src/ui/detail_pane.rs
+++ b/rinkaku-tui/src/ui/detail_pane.rs
@@ -293,17 +293,25 @@ pub(crate) fn detail_lines(detail: &DetailView) -> Vec<Line<'static>> {
     lines.push(Line::raw(""));
     match &detail.signature {
         SignatureView::Current(signature) => {
-            lines.push(Line::raw(signature.clone()));
+            // A multi-line signature (ADR 0060) needs one `Line` per source
+            // line — `Line` never splits on an embedded `\n` itself.
+            for line in signature.lines() {
+                lines.push(Line::raw(line.to_string()));
+            }
         }
         SignatureView::Changed { previous, current } => {
-            lines.push(Line::styled(
-                format!("- {previous}"),
-                Style::default().fg(Color::Red),
-            ));
-            lines.push(Line::styled(
-                format!("+ {current}"),
-                Style::default().fg(Color::Green),
-            ));
+            for line in previous.lines() {
+                lines.push(Line::styled(
+                    format!("- {line}"),
+                    Style::default().fg(Color::Red),
+                ));
+            }
+            for line in current.lines() {
+                lines.push(Line::styled(
+                    format!("+ {line}"),
+                    Style::default().fg(Color::Green),
+                ));
+            }
         }
     }
 

--- a/rinkaku-tui/src/ui/detail_pane_tests/mod.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/mod.rs
@@ -13,6 +13,9 @@
 //!   total
 //! - `size_warning` — ADR 0028 `file_detail_lines` size-warning line
 //!   rendering (Warn vs Split label / trailing hint)
+//! - `signature_view` — ADR 0060: `detail_lines`'s `SignatureView`
+//!   rendering pushes one `Line` per source line for a multi-line
+//!   signature, instead of one `Line` with an embedded `\n`
 
 use super::file_detail_lines;
 use crate::app::{App, BlastRadiusSelection};
@@ -28,6 +31,7 @@ use rinkaku_core::render::{FileReport, Report};
 
 mod content_by_row_kind;
 mod scroll_behavior;
+mod signature_view;
 mod size_warning;
 mod wrap_reachability;
 

--- a/rinkaku-tui/src/ui/detail_pane_tests/signature_view.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/signature_view.rs
@@ -7,6 +7,7 @@
 use crate::detail::{DetailView, SignatureView};
 use crate::ui::detail_pane::detail_lines;
 
+use pretty_assertions::assert_eq;
 use rinkaku_core::extract::SymbolKind;
 
 fn detail_view(signature: SignatureView) -> DetailView {
@@ -24,22 +25,41 @@ fn detail_view(signature: SignatureView) -> DetailView {
     }
 }
 
+/// Renders `detail_lines`'s output down to its text content, one `String`
+/// per `Line` — styling (bold headings, red/green diff coloring) is
+/// covered by the render code's own visual intent rather than pinned
+/// here, since this suite's concern is which lines get pushed and in what
+/// order.
+fn rendered_text(detail: &DetailView) -> Vec<String> {
+    detail_lines(detail)
+        .iter()
+        .map(|line| line.to_string())
+        .collect()
+}
+
 #[test]
 fn should_push_one_line_per_source_line_for_current_multiline_signature() {
     let detail = detail_view(SignatureView::Current(
         "struct Point {\n    x: i32,\n    y: i32,\n}".to_string(),
     ));
 
-    let lines = detail_lines(&detail);
-    let rendered: Vec<String> = lines.iter().map(|line| line.to_string()).collect();
+    let actual = rendered_text(&detail);
 
-    assert!(rendered.contains(&"struct Point {".to_string()));
-    assert!(rendered.contains(&"    x: i32,".to_string()));
-    assert!(rendered.contains(&"    y: i32,".to_string()));
-    assert!(rendered.contains(&"}".to_string()));
-    // No line should carry an embedded newline — each source line is its
-    // own `Line`, not one `Line` with `\n` baked into its text.
-    assert!(rendered.iter().all(|line| !line.contains('\n')));
+    let expected = vec![
+        "Struct Point".to_string(),
+        "lib.rs".to_string(),
+        "".to_string(),
+        "".to_string(),
+        "struct Point {".to_string(),
+        "    x: i32,".to_string(),
+        "    y: i32,".to_string(),
+        "}".to_string(),
+        "".to_string(),
+        "Used by (0)".to_string(),
+        "".to_string(),
+        "Callees (0)".to_string(),
+    ];
+    assert_eq!(expected, actual);
 }
 
 #[test]
@@ -49,15 +69,24 @@ fn should_push_one_line_per_source_line_for_each_side_of_a_changed_multiline_sig
         current: "struct Point {\n    x: i32,\n    y: i32,\n}".to_string(),
     });
 
-    let lines = detail_lines(&detail);
-    let rendered: Vec<String> = lines.iter().map(|line| line.to_string()).collect();
+    let actual = rendered_text(&detail);
 
-    assert!(rendered.contains(&"- struct Point {".to_string()));
-    assert!(rendered.contains(&"-     x: i32,".to_string()));
-    assert!(rendered.contains(&"- }".to_string()));
-    assert!(rendered.contains(&"+ struct Point {".to_string()));
-    assert!(rendered.contains(&"+     x: i32,".to_string()));
-    assert!(rendered.contains(&"+     y: i32,".to_string()));
-    assert!(rendered.contains(&"+ }".to_string()));
-    assert!(rendered.iter().all(|line| !line.contains('\n')));
+    let expected = vec![
+        "Struct Point".to_string(),
+        "lib.rs".to_string(),
+        "".to_string(),
+        "".to_string(),
+        "- struct Point {".to_string(),
+        "-     x: i32,".to_string(),
+        "- }".to_string(),
+        "+ struct Point {".to_string(),
+        "+     x: i32,".to_string(),
+        "+     y: i32,".to_string(),
+        "+ }".to_string(),
+        "".to_string(),
+        "Used by (0)".to_string(),
+        "".to_string(),
+        "Callees (0)".to_string(),
+    ];
+    assert_eq!(expected, actual);
 }

--- a/rinkaku-tui/src/ui/detail_pane_tests/signature_view.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/signature_view.rs
@@ -1,0 +1,63 @@
+//! `detail_lines`'s `SignatureView` rendering (ADR 0060): a multi-line
+//! signature must produce one `Line` per source line rather than a
+//! single `Line` whose text contains a literal embedded `\n` — `Line`
+//! itself never splits on `\n` (it renders as one row), so this behavior
+//! has to be built by pushing multiple `Line`s, not left to ratatui.
+
+use crate::detail::{DetailView, SignatureView};
+use crate::ui::detail_pane::detail_lines;
+
+use rinkaku_core::extract::SymbolKind;
+
+fn detail_view(signature: SignatureView) -> DetailView {
+    DetailView {
+        id: "lib.rs::Point".to_string(),
+        name: "Point".to_string(),
+        kind: SymbolKind::Struct,
+        path: "lib.rs".to_string(),
+        container: None,
+        signature,
+        classification: None,
+        used_by: vec![],
+        callees: vec![],
+        callers: vec![],
+    }
+}
+
+#[test]
+fn should_push_one_line_per_source_line_for_current_multiline_signature() {
+    let detail = detail_view(SignatureView::Current(
+        "struct Point {\n    x: i32,\n    y: i32,\n}".to_string(),
+    ));
+
+    let lines = detail_lines(&detail);
+    let rendered: Vec<String> = lines.iter().map(|line| line.to_string()).collect();
+
+    assert!(rendered.contains(&"struct Point {".to_string()));
+    assert!(rendered.contains(&"    x: i32,".to_string()));
+    assert!(rendered.contains(&"    y: i32,".to_string()));
+    assert!(rendered.contains(&"}".to_string()));
+    // No line should carry an embedded newline — each source line is its
+    // own `Line`, not one `Line` with `\n` baked into its text.
+    assert!(rendered.iter().all(|line| !line.contains('\n')));
+}
+
+#[test]
+fn should_push_one_line_per_source_line_for_each_side_of_a_changed_multiline_signature() {
+    let detail = detail_view(SignatureView::Changed {
+        previous: "struct Point {\n    x: i32,\n}".to_string(),
+        current: "struct Point {\n    x: i32,\n    y: i32,\n}".to_string(),
+    });
+
+    let lines = detail_lines(&detail);
+    let rendered: Vec<String> = lines.iter().map(|line| line.to_string()).collect();
+
+    assert!(rendered.contains(&"- struct Point {".to_string()));
+    assert!(rendered.contains(&"-     x: i32,".to_string()));
+    assert!(rendered.contains(&"- }".to_string()));
+    assert!(rendered.contains(&"+ struct Point {".to_string()));
+    assert!(rendered.contains(&"+     x: i32,".to_string()));
+    assert!(rendered.contains(&"+     y: i32,".to_string()));
+    assert!(rendered.contains(&"+ }".to_string()));
+    assert!(rendered.iter().all(|line| !line.contains('\n')));
+}


### PR DESCRIPTION
## Summary

Signatures now keep their original multi-line shape instead of being
flattened by `normalize_whitespace` — a struct/enum/trait/interface/class
signature (whose full body is the reported contract, per ADR 0014) reads
as its original layout instead of one long line.

- `extract::slice_signature` dedents and cleans up the range-stripped
  declaration text (`tidy_signature_lines`) instead of collapsing
  whitespace to single spaces.
- `classify_symbols` normalizes both sides' signatures at comparison
  time instead, so a reflow-only edit still classifies as `body_only`
  (contract-impact classification behavior is unchanged).
- Markdown's `SignatureChanged` block and the digest renderer's
  equivalent now emit a line-based diff (`-`/`+` per source line)
  instead of one giant `-` line and one giant `+` line.
- Render sites that must stay a single line collapse the signature back
  to one line at that boundary: the "Depends on:" inline code span, and
  the TUI diff-pane's section title / contract header.
- The TUI detail pane pushes one `ratatui::text::Line` per source line
  for a multi-line signature (it previously pushed one `Line` with an
  embedded `\n`, which `Line` does not split on).

See `docs/adr/0060-preserve-line-structure-in-displayed-signatures.md`.

## Breaking change

JSON output's `signature`/`previous_signature` fields can now contain
embedded `\n` (serialized as `\n` in the JSON string) instead of always
being single-line. Consumers that assumed single-line signatures need
updating.

## QA

- `make test` (`cargo test --all-features`): all green — 195
  (`rinkaku`) + 410 (`rinkaku-core`) + 1001 (`rinkaku-tui`) tests.
- `make lint` (`cargo fmt --all --check` + `cargo clippy --all-targets
  --all-features -- -D warnings`): clean.
- Built the release binary and ran it against a real 2-commit git repo
  with a struct field added (`x: i32` → `x: i32, y: i32`):
  - Default Markdown output shows the struct's `SignatureChanged`
    block as a line-based diff, localizing the added field instead of
    replacing the whole signature text.
  - `--format json` confirms `signature`/`previous_signature` contain
    escaped `\n` sequences.
  - `--format digest` shows the same line-based diff convention.
  - A body-only follow-up commit (helper referencing `Point`) confirms
    `Depends on:` collapses the multi-line `Point` signature back to a
    single inline-code-span line.
  - Piped-diff (non-`--base`) mode and empty-stdin both still behave
    as before (no regression).
  - A `TestBackend` (headless ratatui) draw of the Detail pane against
    a multi-line struct signature confirmed the signature renders
    across multiple visible rows with no panic.

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] Manual CLI run against a real git repo (Markdown/JSON/digest)
- [x] Headless TUI (`TestBackend`) detail-pane render check

## Review fixes

Addressed three findings from review of this PR:

- **fix: dedent nested multiline signatures relative to real source
  column** — `tidy_signature_lines` computed its dedent baseline from
  every line's own text, but a tree-sitter node's text never includes
  the leading whitespace before it, so a nested definition's first line
  always read as column 0 regardless of actual depth. This floored the
  computed indent at 0 and left continuation lines (e.g. a multi-line
  method signature inside an `impl`/class body) at their raw,
  un-dedented source column. Fixed by passing the node's real starting
  column (`node.start_position().column`) into the dedent calculation
  as a stand-in for "line 0's own indent". ADR 0060 updated to describe
  the new baseline.
- **fix: whitespace-insensitive signature comparison for line-reflow**
  — `classify_symbols` compared signatures with `normalize_whitespace`
  (`split_whitespace().join(" ")`), which always inserts a space at a
  normalized whitespace run regardless of what the original had there.
  A reflow that introduces a line break right after a symbol character
  (e.g. gofmt wrapping a parameter list — a newline right after `(`)
  therefore compared unequal to the un-reflowed form, a false
  `SignatureChanged` even though nothing in the contract changed.
  Replaced with `normalize_for_comparison`, which only collapses a
  whitespace run to a single space when both neighbors are word
  characters, and drops it entirely otherwise — reflow next to
  punctuation becomes invisible to the comparison while whitespace that
  is itself meaningful content (`a b` vs `ab`) is still preserved.
  Display-site collapsing is unchanged. A reflow that also adds/removes
  a trailing comma is a real token difference and is documented in ADR
  0060 as an intentional, out-of-scope limitation.
- **test: assert full rendered line vec instead of partial contains
  checks** — `detail_pane_tests/signature_view.rs` used
  `assert!(rendered.contains(...))` per expected line, which pins
  membership but not order, count, or unexpected extra lines. Since the
  `detail_lines` output for these fixtures is fully enumerable, switched
  to a full `Vec<String>` comparison with `pretty_assertions::assert_eq!`.
