### PR TITLE
feat(tui): stop dimming unsupported-language file rows

### DIFF
--- a/rinkaku-tui/src/row_view.rs
+++ b/rinkaku-tui/src/row_view.rs
@@ -410,19 +410,30 @@ pub(crate) fn band_style(band: FileSizeBand) -> Style {
     }
 }
 
-/// A `File` row's label style: dimmed for a skipped file (nothing was
-/// extracted from it, so it reads visually as "less relevant" than an
-/// analyzed file, same intent as `symbol_name_style`'s dimming of a removed
-/// symbol), plain otherwise — including a whole-test-file row, which is
-/// still an ordinarily-styled label with its own `[test]` badge rendered
-/// separately (see `test_badge_span`) rather than dimmed, since a test file
-/// is not "uninteresting", just excluded from the default symbol-level view
-/// (ADR 0009).
+/// A `File` row's label style. A whole-test-file row stays undimmed and
+/// carries its own `[test]` badge (see `test_badge_span`) instead, since a
+/// test file is not "uninteresting", just excluded from the default
+/// symbol-level view (ADR 0009).
 fn file_label_style(node: &crate::tree::TreeNode) -> Style {
-    if node.skip_reason.is_some() {
-        Style::default().fg(Color::DarkGray)
-    } else {
-        Style::default()
+    match node.skip_reason {
+        Some(reason) if has_no_readable_content(reason) => Style::default().fg(Color::DarkGray),
+        _ => Style::default(),
+    }
+}
+
+/// Whether a skipped file has nothing left for a reviewer to read — what
+/// ADR 0043's "read bright rows, skim dimmed ones" protocol encodes as
+/// dimming. `UnsupportedLanguage` is excluded: lacking a grammar says
+/// nothing about a file's review importance, and dimming it would steer
+/// the reviewer away from the one case rinkaku cannot help with.
+///
+/// `pub(crate)`: `crate::ui::detail_pane` splits on the same distinction.
+pub(crate) fn has_no_readable_content(reason: rinkaku_core::render::SkipReason) -> bool {
+    match reason {
+        rinkaku_core::render::SkipReason::UnsupportedLanguage => false,
+        rinkaku_core::render::SkipReason::Binary
+        | rinkaku_core::render::SkipReason::Deleted
+        | rinkaku_core::render::SkipReason::Generated => true,
     }
 }
 

--- a/rinkaku-tui/src/row_view_tests/entry_row_line.rs
+++ b/rinkaku-tui/src/row_view_tests/entry_row_line.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rstest::rstest;
 
 #[test]
 fn should_render_plain_text_for_zero_badges_and_no_classification() {
@@ -100,9 +101,14 @@ fn should_append_skip_reason_for_a_skipped_file_row() {
     assert_eq!("  assets/logo.png  (skipped: binary)", line_text(&line));
 }
 
-#[test]
-fn should_dim_label_for_a_skipped_file_row() {
-    let node = skipped_file_node("assets/logo.png", rinkaku_core::render::SkipReason::Binary);
+#[rstest]
+#[case::binary(rinkaku_core::render::SkipReason::Binary)]
+#[case::deleted(rinkaku_core::render::SkipReason::Deleted)]
+#[case::generated(rinkaku_core::render::SkipReason::Generated)]
+fn should_dim_label_for_a_skipped_file_row_when_the_file_has_no_readable_content(
+    #[case] reason: rinkaku_core::render::SkipReason,
+) {
+    let node = skipped_file_node("assets/logo.png", reason);
     let row = Row {
         node: &node,
         depth: 0,
@@ -117,8 +123,66 @@ fn should_dim_label_for_a_skipped_file_row() {
         false,
     );
 
-    // The label span is the third span: indent, expand marker, label.
-    assert_eq!(Some(Color::DarkGray), line.spans[2].style.fg);
+    assert_eq!(
+        Some(Color::DarkGray),
+        fg_of_span_with_content(&line, "assets/logo.png")
+    );
+}
+
+#[test]
+fn should_not_dim_label_for_a_skipped_file_row_when_the_language_is_unsupported() {
+    let node = skipped_file_node(
+        "deploy/values.yaml",
+        rinkaku_core::render::SkipReason::UnsupportedLanguage,
+    );
+    let row = Row {
+        node: &node,
+        depth: 0,
+        expanded: false,
+    };
+
+    let line = entry_row_line(
+        &row,
+        "deploy/values.yaml",
+        &HashMap::new(),
+        &crate::annotation_markers::AnnotationMarkers::default(),
+        false,
+    );
+
+    assert_eq!(None, fg_of_span_with_content(&line, "deploy/values.yaml"));
+}
+
+#[rstest]
+#[case::unsupported_language(
+    rinkaku_core::render::SkipReason::UnsupportedLanguage,
+    "(skipped: unsupported language)"
+)]
+#[case::binary(rinkaku_core::render::SkipReason::Binary, "(skipped: binary)")]
+#[case::deleted(rinkaku_core::render::SkipReason::Deleted, "(skipped: deleted)")]
+#[case::generated(rinkaku_core::render::SkipReason::Generated, "(skipped: generated)")]
+fn should_dim_skip_reason_annotation_when_a_file_row_is_skipped_for_any_reason(
+    #[case] reason: rinkaku_core::render::SkipReason,
+    #[case] annotation: &str,
+) {
+    let node = skipped_file_node("assets/logo.png", reason);
+    let row = Row {
+        node: &node,
+        depth: 0,
+        expanded: false,
+    };
+
+    let line = entry_row_line(
+        &row,
+        "assets/logo.png",
+        &HashMap::new(),
+        &crate::annotation_markers::AnnotationMarkers::default(),
+        false,
+    );
+
+    assert_eq!(
+        Some(Color::DarkGray),
+        fg_of_span_with_content(&line, annotation)
+    );
 }
 
 #[test]

--- a/rinkaku-tui/src/ui/detail_pane.rs
+++ b/rinkaku-tui/src/ui/detail_pane.rs
@@ -156,7 +156,7 @@ pub(crate) fn file_detail_lines(detail: &FileDetail) -> Vec<Line<'static>> {
             ),
             Style::default().fg(Color::DarkGray),
         ));
-        lines.push(Line::raw("rinkaku did not extract symbols from this file."));
+        lines.push(Line::raw(skip_explanation(reason)));
         return lines;
     }
 
@@ -249,6 +249,17 @@ fn file_size_warning_line(warning: &rinkaku_core::file_size::FileSizeWarning) ->
             "Split: {} lines \u{2014} over the {SPLIT_LINE_THRESHOLD}-line split threshold",
             warning.line_count,
         ),
+    }
+}
+
+/// The sentence under a skipped file's `Skipped: <reason>` line, split on
+/// [`crate::row_view::has_no_readable_content`] so the pane never tells a
+/// reviewer to move on from a file the entry tree still shows undimmed.
+fn skip_explanation(reason: rinkaku_core::render::SkipReason) -> &'static str {
+    if crate::row_view::has_no_readable_content(reason) {
+        "rinkaku did not extract symbols from this file."
+    } else {
+        "rinkaku has no parser for this file type, so review its diff directly."
     }
 }
 

--- a/rinkaku-tui/src/ui/detail_pane_tests/mod.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/mod.rs
@@ -16,6 +16,8 @@
 //! - `signature_view` — ADR 0060: `detail_lines`'s `SignatureView`
 //!   rendering pushes one `Line` per source line for a multi-line
 //!   signature, instead of one `Line` with an embedded `\n`
+//! - `skip_reason` — the skipped-file arm's explanation line, split on
+//!   `row_view::has_no_readable_content` like the entry tree's dimming
 
 use super::file_detail_lines;
 use crate::app::{App, BlastRadiusSelection};
@@ -33,6 +35,7 @@ mod content_by_row_kind;
 mod scroll_behavior;
 mod signature_view;
 mod size_warning;
+mod skip_reason;
 mod wrap_reachability;
 
 pub(super) fn symbol(id: &str, name: &str) -> ExtractedSymbol {

--- a/rinkaku-tui/src/ui/detail_pane_tests/skip_reason.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/skip_reason.rs
@@ -1,0 +1,81 @@
+use super::*;
+use pretty_assertions::assert_eq;
+use rstest::rstest;
+
+fn skipped_detail(path: &str, reason: rinkaku_core::render::SkipReason) -> FileDetail {
+    FileDetail {
+        path: path.to_string(),
+        symbols: vec![],
+        skip_reason: Some(reason),
+        test_symbol_count: None,
+        size_warning: None,
+    }
+}
+
+fn rendered(
+    lines: &[ratatui::text::Line<'static>],
+) -> Vec<(String, Option<ratatui::style::Color>)> {
+    lines
+        .iter()
+        .map(|line| {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            (text, line.style.fg)
+        })
+        .collect()
+}
+
+#[rstest]
+#[case::binary(rinkaku_core::render::SkipReason::Binary, "binary")]
+#[case::deleted(rinkaku_core::render::SkipReason::Deleted, "deleted")]
+#[case::generated(rinkaku_core::render::SkipReason::Generated, "generated")]
+fn should_say_no_symbols_were_extracted_when_the_file_has_no_readable_content(
+    #[case] reason: rinkaku_core::render::SkipReason,
+    #[case] label: &str,
+) {
+    let lines = file_detail_lines(&skipped_detail("assets/logo.png", reason));
+
+    assert_eq!(
+        vec![
+            ("File assets/logo.png".to_string(), None),
+            (String::new(), None),
+            (
+                format!("Skipped: {label}"),
+                Some(ratatui::style::Color::DarkGray)
+            ),
+            (
+                "rinkaku did not extract symbols from this file.".to_string(),
+                None
+            ),
+        ],
+        rendered(&lines)
+    );
+}
+
+#[test]
+fn should_point_the_reviewer_at_the_diff_when_the_language_is_unsupported() {
+    let lines = file_detail_lines(&skipped_detail(
+        "deploy/values.yaml",
+        rinkaku_core::render::SkipReason::UnsupportedLanguage,
+    ));
+
+    assert_eq!(
+        vec![
+            ("File deploy/values.yaml".to_string(), None),
+            (String::new(), None),
+            (
+                "Skipped: unsupported language".to_string(),
+                Some(ratatui::style::Color::DarkGray)
+            ),
+            (
+                "rinkaku has no parser for this file type, so review its diff directly."
+                    .to_string(),
+                None
+            ),
+        ],
+        rendered(&lines)
+    );
+}


### PR DESCRIPTION
## Why

The entry tree dimmed a file label whenever `TreeNode::skip_reason` was `Some`, without looking at *which* `SkipReason` it was. ADR 0043 established the reading protocol as **read bright/marked rows, skim dimmed ones** — so a uniform dim was actively telling reviewers to skim every `UnsupportedLanguage` file.

That is the wrong signal. "rinkaku has no tree-sitter grammar for this extension" is a fact about *rinkaku's* coverage, not about the change's review importance. TOML config changes, YAML CI changes, SQL migrations, and shell scripts all land in this bucket, and they have full content a reviewer needs to read. Worse, they are precisely the files where rinkaku offers **no signature summary to read instead** — the reviewer has to read the raw diff unassisted. Steering attention away from them inverts the intent.

`Binary` and `Deleted` are genuinely different: there is no new-side content to read at all, so dimming stays correct. (`Generated` never reaches the TUI — `tree/mod.rs` filters it during tree construction — but it is classified with the no-content group for match exhaustiveness.)

## What changed

`file_label_style` now branches on a new `pub(crate) has_no_readable_content(SkipReason) -> bool`:

| variant | label |
| --- | --- |
| `UnsupportedLanguage` | normal style |
| `Binary` / `Deleted` / `Generated` | `DarkGray` (unchanged) |

The `(skipped: <reason>)` annotation span stays `DarkGray` for **every** variant. It explains why no symbols are listed; it is not a ranking of the file, so it keeps its role as secondary text regardless of the label beside it.

## Detail pane: how it was aligned

The instruction was to apply the same judgment in `file_detail_lines`, distinguishing the "label-like" part from the "annotation-like" part. Reading the actual structure, the split is:

- `File <path>` (bold header) — this is the **label** counterpart of the entry-tree row. It was never dimmed for any skip reason, so there is nothing to change.
- `Skipped: <reason>` (DarkGray) — this is the **annotation** counterpart of `skip_reason_span`. Per the rule above, annotations stay `DarkGray` for all variants, so this is unchanged too.

So the pane had no dim/no-dim decision left to flip. What it *did* have was a misleading sentence: every skipped file, regardless of reason, printed `"rinkaku did not extract symbols from this file."` — accurate but read as "nothing here for you". That line now splits on the same `has_no_readable_content` predicate, so an unsupported-language file gets `"rinkaku has no parser for this file type, so review its diff directly."` instead. Sharing the predicate is what keeps the two views from drifting: the pane can never tell a reviewer to move on from a file the entry tree still shows undimmed.

## Tests

`rinkaku-tui/src/row_view_tests/entry_row_line.rs` — the old single-case `should_dim_label_for_a_skipped_file_row` (Binary only) is replaced by:

- `should_dim_label_for_a_skipped_file_row_when_the_file_has_no_readable_content` — rstest cases for `Binary` / `Deleted` / `Generated`
- `should_not_dim_label_for_a_skipped_file_row_when_the_language_is_unsupported`
- `should_dim_skip_reason_annotation_when_a_file_row_is_skipped_for_any_reason` — all four variants, pinning that the annotation is unaffected

The replaced test also indexed `line.spans[2]` positionally; the new ones use the existing `fg_of_span_with_content` helper, so they no longer break when span layout shifts.

New `rinkaku-tui/src/ui/detail_pane_tests/skip_reason.rs` compares the **whole `Vec` of rendered lines** (text + fg) for a skipped `FileDetail`, which the early-return arm makes feasible without a partial assert.

Red was verified by inverting `has_no_readable_content`'s `UnsupportedLanguage` arm: exactly the two new behavioral tests fail, the rest stay green.

## Verification

- `make test` — 1630 passed, 0 failed (195 + 423 + 1012 across crates)
- `make lint` — clean

No ADR: the uniform dim had no ADR of its own, only the `file_label_style` doc comment, which is updated here.