### PR TITLE
fix(tui): expand tabs when rendering diff and source lines

### DIFF
--- a/docs/adr/0061-expand-tabs-in-tui-rendering.md
+++ b/docs/adr/0061-expand-tabs-in-tui-rendering.md
@@ -69,12 +69,9 @@ width, and that width matches what the terminal will draw.
 ### Why true tab stops, and why 4
 
 A tab is a *move to the next tab stop*, not an *insert N spaces*. Column
-position determines how far it advances. Honoring that matters here
-beyond pedantry: `gofmt` uses tabs **mid-line** — to align struct field
-types and trailing comments into columns — not only for leading
-indentation. Expanding each tab to a fixed run of spaces would break
-exactly the alignment the author's formatter created, turning tidy
-columns into ragged ones. True tab stops preserve the alignment intent.
+position determines how far it advances, and honoring that is what makes
+the rendered line match how the same file looks in the author's editor —
+which is the whole point of expanding at all.
 
 Width 4 rather than the traditional 8 is driven by the split view.
 `MIN_SPLIT_VIEW_WIDTH` is 100 columns, leaving roughly 49 usable columns
@@ -88,13 +85,11 @@ conventional editor default.
 **Expand only inside `gap_span`.** The minimal change: leave `content`
 and the token offsets untouched, and expand tabs only in the
 uncaptured-byte spans, where leading indentation usually lands. Rejected
-on two counts. First, it is not reliably true that indentation falls in
-a gap — a tree-sitter capture may begin at byte 0 of a line, which pulls
-the leading whitespace inside a token's range where `gap_span` never
-sees it. Second, it cannot handle `gofmt`'s mid-line alignment tabs,
-which sit between tokens whose surrounding capture coverage varies by
-grammar. The premise "indentation is always in a gap" does not hold, so
-the fix would be correct only by coincidence.
+because it is not reliably true that indentation falls in a gap — a
+tree-sitter capture may begin at byte 0 of a line, which pulls the
+leading whitespace inside a token's range where `gap_span` never sees
+it. The premise "indentation is always in a gap" does not hold, so the
+fix would be correct only by coincidence.
 
 **Expand at ingestion, in `crate::source` and the diff parser.**
 Normalizing tabs when file content and hunks are first read would place

--- a/docs/adr/0061-expand-tabs-in-tui-rendering.md
+++ b/docs/adr/0061-expand-tabs-in-tui-rendering.md
@@ -1,0 +1,129 @@
+# 0061. Expand tabs in TUI rendering
+
+- Status: accepted
+- Date: 2026-07-26
+
+## Context
+
+Source lines containing tab characters lose their indentation in the
+TUI's Diff screen and Source screen. A Go file — where `gofmt` mandates
+tab indentation — renders every nested statement flush against the
+gutter, so the block structure a reviewer relies on to read a diff is
+gone.
+
+The cause is a disagreement between two width models that both operate
+on the same string:
+
+- The terminal draws a tab as **zero cells**. `ratatui` passes a
+  `Span`'s content through to the backend, which does not translate
+  `\t`; the character simply occupies no column. Measured against
+  `TestBackend`, the input line `" \t\t\tdeep()"` renders as
+  `"│ deep()  …│"` — three levels of indentation erased.
+- rinkaku's own width arithmetic counts a tab as **one cell**.
+  `crate::ui::scroll`'s wrapping, truncation and split-view alignment
+  all measure with `UnicodeWidthChar::width`, which returns `None` for
+  `\t`, and every call site resolves that with `.unwrap_or(1)`.
+
+So wrapping and truncation reserve one column for a glyph that draws
+none. Lines wrap early, truncation markers land in the wrong place, and
+the two split-view columns drift out of alignment — on top of the
+indentation loss itself.
+
+Nothing in `rinkaku-tui` expands tabs anywhere. This is a rendering-layer
+defect and it is language-independent: Go is the loudest victim because
+its formatter guarantees tabs, but Makefiles (where tabs are syntax), C,
+and any TypeScript/JavaScript project configured for tab indentation hit
+the identical bug.
+
+The complicating constraint is syntax highlighting. `crate::highlight`
+produces `TokenSpan { start, end, palette_index }` in **byte offsets
+against the line's own content**. Any transformation of the content
+string invalidates every offset, so a naive `content.replace('\t', "    ")`
+would shift all token coloring out of registration with the text.
+
+## Decision
+
+Expand tabs to spaces, and remap token offsets, in a **pure function at
+the rendering entry point**, so that no tab character ever reaches a
+`Span`.
+
+- Add a pure function in `rinkaku-tui/src/ui/style.rs` that takes
+  `&str` + `&[TokenSpan]` and returns the expanded `String` together
+  with `TokenSpan`s rebased onto the expanded string's coordinates.
+  Every byte offset is mapped through the same expansion walk that
+  produces the text, so token colors stay registered with the
+  characters they describe.
+- Route all four content-rendering paths through it: the highlighted
+  diff path (`styled_content_spans`), the unhighlighted diff path
+  (`plain_diff_line`, which bypasses `styled_content_spans` entirely),
+  and both source-screen paths (unified and split).
+- Expansion uses **tab stops of width 4**: a tab advances to the next
+  column that is a multiple of 4, rather than emitting a fixed four
+  spaces.
+
+Because expansion happens before any `Span` is constructed, the existing
+`unicode_width` arithmetic in `crate::ui::scroll` becomes correct with no
+change — it now measures a string whose every character has a defined
+width, and that width matches what the terminal will draw.
+
+### Why true tab stops, and why 4
+
+A tab is a *move to the next tab stop*, not an *insert N spaces*. Column
+position determines how far it advances. Honoring that matters here
+beyond pedantry: `gofmt` uses tabs **mid-line** — to align struct field
+types and trailing comments into columns — not only for leading
+indentation. Expanding each tab to a fixed run of spaces would break
+exactly the alignment the author's formatter created, turning tidy
+columns into ragged ones. True tab stops preserve the alignment intent.
+
+Width 4 rather than the traditional 8 is driven by the split view.
+`MIN_SPLIT_VIEW_WIDTH` is 100 columns, leaving roughly 49 usable columns
+per side. At width 8, three levels of Go indentation consume 24 of those
+columns and deeply nested code wraps constantly. Width 4 keeps nested
+code readable in the narrower of the two layouts, and remains a
+conventional editor default.
+
+## Alternatives
+
+**Expand only inside `gap_span`.** The minimal change: leave `content`
+and the token offsets untouched, and expand tabs only in the
+uncaptured-byte spans, where leading indentation usually lands. Rejected
+on two counts. First, it is not reliably true that indentation falls in
+a gap — a tree-sitter capture may begin at byte 0 of a line, which pulls
+the leading whitespace inside a token's range where `gap_span` never
+sees it. Second, it cannot handle `gofmt`'s mid-line alignment tabs,
+which sit between tokens whose surrounding capture coverage varies by
+grammar. The premise "indentation is always in a gap" does not hold, so
+the fix would be correct only by coincidence.
+
+**Expand at ingestion, in `crate::source` and the diff parser.**
+Normalizing tabs when file content and hunks are first read would place
+the transformation before highlighting, so token offsets would be
+generated against already-expanded text and no remapping would be
+needed. Rejected because it makes the in-memory content diverge from the
+file on disk: the source screen's search (ADR 0057) matches against
+`source.lines`, annotation anchoring records positions in those lines,
+and any future feature that reports a column or writes text back would
+silently be working in expanded coordinates. Confining the
+transformation to the render boundary keeps a single, honest
+representation of file content in the core and treats tab expansion as
+what it is — a display concern.
+
+**Configurable tab width.** Deferred, not rejected. A fixed 4 covers the
+overwhelmingly common case; a setting can be added later without
+changing the shape of the function, which already takes the column walk
+as its mechanism.
+
+## Consequences
+
+- Tab-indented source renders with correct, visible indentation in both
+  the Diff and Source screens, in unified and split layouts.
+- Wrapping, truncation, and split-column alignment become accurate for
+  tab-containing lines, because the string being measured no longer
+  contains characters whose drawn width disagrees with the measurement.
+- Rendered text is no longer byte-identical to file content. Any future
+  feature that needs to map a screen column back to a file column must
+  invert the expansion rather than assume identity. The expansion
+  function's offset mapping is the place to build that on.
+- Tab width 4 is now a rendering constant; changing it, or making it
+  configurable, is an amendment to this ADR.

--- a/rinkaku-tui/src/ui/detail_pane.rs
+++ b/rinkaku-tui/src/ui/detail_pane.rs
@@ -4,7 +4,7 @@
 //! (`DetailView`, `DirDetail`, `FileDetail`) come from `crate::detail`.
 
 use super::scroll::{Body, render_scrollable_pane};
-use super::style::pane_border_style;
+use super::style::{expand_tabs_text, pane_border_style};
 use crate::app::{App, Focus, SelectedDetail};
 use crate::detail::{DetailView, DirDetail, FileDetail, SignatureView};
 use ratatui::Frame;
@@ -307,19 +307,19 @@ pub(crate) fn detail_lines(detail: &DetailView) -> Vec<Line<'static>> {
             // A multi-line signature (ADR 0060) needs one `Line` per source
             // line — `Line` never splits on an embedded `\n` itself.
             for line in signature.lines() {
-                lines.push(Line::raw(line.to_string()));
+                lines.push(Line::raw(expand_tabs_text(line)));
             }
         }
         SignatureView::Changed { previous, current } => {
             for line in previous.lines() {
                 lines.push(Line::styled(
-                    format!("- {line}"),
+                    format!("- {}", expand_tabs_text(line)),
                     Style::default().fg(Color::Red),
                 ));
             }
             for line in current.lines() {
                 lines.push(Line::styled(
-                    format!("+ {line}"),
+                    format!("+ {}", expand_tabs_text(line)),
                     Style::default().fg(Color::Green),
                 ));
             }

--- a/rinkaku-tui/src/ui/detail_pane_tests/mod.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/mod.rs
@@ -18,6 +18,9 @@
 //!   signature, instead of one `Line` with an embedded `\n`
 //! - `skip_reason` — the skipped-file arm's explanation line, split on
 //!   `row_view::has_no_readable_content` like the entry tree's dimming
+//! - `tab_expansion` — ADR 0061: signature lines reach the buffer with
+//!   their tabs expanded to tab stops, on both the current and the
+//!   changed-signature paths
 
 use super::file_detail_lines;
 use crate::app::{App, BlastRadiusSelection};
@@ -36,6 +39,7 @@ mod scroll_behavior;
 mod signature_view;
 mod size_warning;
 mod skip_reason;
+mod tab_expansion;
 mod wrap_reachability;
 
 pub(super) fn symbol(id: &str, name: &str) -> ExtractedSymbol {

--- a/rinkaku-tui/src/ui/detail_pane_tests/tab_expansion.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/tab_expansion.rs
@@ -1,0 +1,118 @@
+//! ADR 0061 tab expansion for the detail pane's signature lines. A
+//! `gofmt`-formatted multi-line signature (ADR 0060) carries real tab
+//! characters on its continuation lines, and a terminal draws those as
+//! zero cells — so the pane must expand them just as the Diff and Source
+//! screens do.
+
+use super::*;
+use crate::ui::style::TAB_WIDTH;
+use pretty_assertions::assert_eq;
+
+fn draw_detail_for_signature(signature: &str, previous_signature: Option<&str>) -> String {
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "main.go".to_string(),
+            symbols: vec![ExtractedSymbol {
+                signature: signature.to_string(),
+                previous_signature: previous_signature.map(str::to_string),
+                classification: previous_signature
+                    .map(|_| rinkaku_core::extract::Classification::SignatureChanged),
+                ..symbol("main.go::Run", "Run")
+            }],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+    let app = App::new(&report)
+        .handle_key(crate::app::InputKey::Down)
+        .handle_key(crate::app::InputKey::ToggleDiff);
+    let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                None,
+                &[],
+                &crate::annotation_markers::AnnotationMarkers::default(),
+                Locale::English,
+            );
+        })
+        .expect("draw");
+    buffer_text(&terminal)
+}
+
+/// The rendered indentation of the detail pane row carrying `token`,
+/// measured in columns from the pane's own left border rather than from
+/// the buffer's left edge (the entry pane occupies the columns to the
+/// left of it), and after `marker` when the row carries a diff marker.
+fn indent_in_detail_pane(buffer: &str, marker: &str, token: &str) -> usize {
+    let row = buffer
+        .lines()
+        .find(|row| row.contains(token))
+        .unwrap_or_else(|| panic!("expected a rendered row containing {token:?}"))
+        .to_string();
+    let token_offset = row.find(token).expect("token offset");
+    let content_start = row[..token_offset]
+        .rfind('│')
+        .map(|border| border + '│'.len_utf8() + marker.len())
+        .expect("detail pane border left of the token");
+    assert_eq!(
+        marker,
+        &row[content_start - marker.len()..content_start],
+        "rendered buffer:\n{buffer}"
+    );
+    row[content_start..token_offset].chars().count()
+}
+
+#[test]
+fn should_render_tab_indented_signature_lines_at_tab_stop_columns_in_detail_pane() {
+    let buffer = draw_detail_for_signature("func Run(\n\tctx context.Context,\n) error", None);
+
+    assert_eq!(
+        TAB_WIDTH,
+        indent_in_detail_pane(&buffer, "", "ctx context.Context,"),
+        "rendered buffer:\n{buffer}"
+    );
+}
+
+#[test]
+fn should_render_tab_indented_changed_signature_lines_at_tab_stop_columns_in_detail_pane() {
+    let buffer = draw_detail_for_signature(
+        "func Run(\n\tctx context.Context,\n\tcfg Config,\n) error",
+        Some("func Run(\n\tctx context.Context,\n) error"),
+    );
+
+    assert_eq!(
+        (TAB_WIDTH, TAB_WIDTH),
+        (
+            indent_in_detail_pane(&buffer, "- ", "ctx context.Context,"),
+            indent_in_detail_pane(&buffer, "+ ", "cfg Config,"),
+        ),
+        "rendered buffer:\n{buffer}"
+    );
+}
+
+#[test]
+fn should_not_leave_tab_characters_in_the_rendered_buffer_when_signature_is_tab_indented() {
+    let buffer = draw_detail_for_signature("func Run(\n\tctx context.Context,\n) error", None);
+
+    let actual: Vec<char> = buffer.chars().filter(|c| *c == '\t').collect();
+
+    assert_eq!(Vec::<char>::new(), actual);
+}

--- a/rinkaku-tui/src/ui/diff_pane.rs
+++ b/rinkaku-tui/src/ui/diff_pane.rs
@@ -6,7 +6,7 @@
 use super::scroll::{
     Body, render_scrollable_pane, truncate_line_to_width, truncate_to_width_keeping_tail,
 };
-use super::style::{pane_border_style, styled_content_spans};
+use super::style::{expand_tabs_text, pane_border_style, styled_content_spans};
 use crate::app::{App, DiffTarget, DiffViewMode, Focus};
 use crate::diff_shape::DiffSection;
 use crate::diff_view::{DiffLine, DiffLineKind};
@@ -642,16 +642,17 @@ pub(crate) fn diff_line(line: &DiffLine, token_spans: Option<Vec<TokenSpan>>) ->
 /// plus the same `ADDED_BG`/`REMOVED_BG` tint — a context line stays
 /// unstyled since it carries no diff signal either way.
 pub(crate) fn plain_diff_line(line: &DiffLine) -> Line<'static> {
+    let content = expand_tabs_text(&line.content);
     match line.kind {
         DiffLineKind::Added => Line::styled(
-            format!("+{}", line.content),
+            format!("+{content}"),
             added_removed_style(DiffLineKind::Added),
         ),
         DiffLineKind::Removed => Line::styled(
-            format!("-{}", line.content),
+            format!("-{content}"),
             added_removed_style(DiffLineKind::Removed),
         ),
-        DiffLineKind::Context => Line::raw(format!(" {}", line.content)),
+        DiffLineKind::Context => Line::raw(format!(" {content}")),
     }
 }
 

--- a/rinkaku-tui/src/ui/diff_pane_tests/mod.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/mod.rs
@@ -31,6 +31,7 @@ mod header_lines;
 mod row_kinds;
 mod split_view;
 mod styling;
+mod tab_expansion;
 
 pub(super) fn symbol(id: &str, name: &str) -> ExtractedSymbol {
     ExtractedSymbol {

--- a/rinkaku-tui/src/ui/diff_pane_tests/tab_expansion.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/tab_expansion.rs
@@ -1,0 +1,186 @@
+use super::*;
+use crate::ui::style::TAB_WIDTH;
+use pretty_assertions::assert_eq;
+use rinkaku_core::render::FileReport;
+
+fn go_report() -> Report {
+    Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "main.go".to_string(),
+            symbols: vec![symbol("main.go::run", "run")],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    }
+}
+
+fn row_containing(terminal: &Terminal<TestBackend>, needle: &str) -> String {
+    buffer_text(terminal)
+        .lines()
+        .find(|row| row.contains(needle))
+        .unwrap_or_else(|| panic!("expected a rendered row containing {needle:?}"))
+        .to_string()
+}
+
+/// The rendered column at which `token` starts, counted from the `+`/`-`/` `
+/// diff marker glyph that opens the line's content.
+fn column_after_marker(row: &str, marker_and_rest: &str, token: &str) -> usize {
+    let line_start = row
+        .find(marker_and_rest)
+        .unwrap_or_else(|| panic!("expected {marker_and_rest:?} within {row:?}"));
+    let token_offset = row[line_start..]
+        .find(token)
+        .unwrap_or_else(|| panic!("expected {token:?} after {marker_and_rest:?}"));
+    row[line_start..line_start + token_offset].chars().count()
+}
+
+fn draw_go_diff(diff_text: &str) -> Terminal<TestBackend> {
+    let report = go_report();
+    let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+    let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+    let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+    let diff_content = diff_content_for(&report, &diff_files, &app);
+    let mut terminal = Terminal::new(TestBackend::new(100, 24)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &diff_content,
+                &diff_highlights,
+                &BlastRadiusSelection::NotApplicable,
+                None,
+                &[],
+                &crate::annotation_markers::AnnotationMarkers::default(),
+                Locale::English,
+            );
+        })
+        .expect("draw");
+    terminal
+}
+
+#[test]
+fn should_render_tab_indented_go_lines_at_tab_stop_columns_in_diff_pane() {
+    let diff_text = "\
+diff --git a/main.go b/main.go
+index e69de29..4b825dc 100644
+--- a/main.go
++++ b/main.go
+@@ -1,1 +1,4 @@
+ package main
++func run() {
++\tif ok {
++\t\tdeep()
++\t}
+";
+
+    let terminal = draw_go_diff(diff_text);
+    let buffer = buffer_text(&terminal);
+
+    let one_level = row_containing(&terminal, "if ok {");
+    let two_levels = row_containing(&terminal, "deep()");
+
+    assert_eq!(
+        (1 + TAB_WIDTH, 1 + TAB_WIDTH * 2),
+        (
+            column_after_marker(&one_level, "+", "if"),
+            column_after_marker(&two_levels, "+", "deep"),
+        ),
+        "rendered buffer:\n{buffer}"
+    );
+}
+
+#[test]
+fn should_not_leave_tab_characters_in_the_rendered_buffer_when_diff_is_tab_indented() {
+    let diff_text = "\
+diff --git a/main.go b/main.go
+index e69de29..4b825dc 100644
+--- a/main.go
++++ b/main.go
+@@ -1,1 +1,3 @@
+ package main
++func run() {
++\t\tdeep()
+";
+
+    let terminal = draw_go_diff(diff_text);
+
+    let actual: Vec<char> = buffer_text(&terminal)
+        .chars()
+        .filter(|c| *c == '\t')
+        .collect();
+
+    assert_eq!(Vec::<char>::new(), actual);
+}
+
+#[test]
+fn should_expand_tabs_on_the_unhighlighted_path_when_extension_is_unknown() {
+    // A `Makefile` has no bundled grammar, so `highlight_diff_files` yields
+    // no spans and the line renders through `plain_diff_line` — the path
+    // that never reaches `styled_content_spans`.
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "Makefile".to_string(),
+            symbols: vec![symbol("Makefile::build", "build")],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+    let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+    let diff_text = "\
+diff --git a/Makefile b/Makefile
+index e69de29..4b825dc 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,1 +1,2 @@
+ build:
++\tcargo build
+";
+    let diff_files = crate::diff_view::parse_diff_hunks(diff_text);
+    let diff_highlights = crate::highlight::highlight_diff_files(&diff_files);
+    let diff_content = diff_content_for(&report, &diff_files, &app);
+    let mut terminal = Terminal::new(TestBackend::new(100, 24)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &diff_content,
+                &diff_highlights,
+                &BlastRadiusSelection::NotApplicable,
+                None,
+                &[],
+                &crate::annotation_markers::AnnotationMarkers::default(),
+                Locale::English,
+            );
+        })
+        .expect("draw");
+
+    let row = row_containing(&terminal, "cargo build");
+
+    assert_eq!(1 + TAB_WIDTH, column_after_marker(&row, "+", "cargo"));
+}

--- a/rinkaku-tui/src/ui/source_screen.rs
+++ b/rinkaku-tui/src/ui/source_screen.rs
@@ -6,7 +6,7 @@
 
 use super::diff_pane::{ADDED_BG, MIN_SPLIT_VIEW_WIDTH, REMOVED_BG, marker_span};
 use super::scroll::{Body, render_scrollable_pane};
-use super::style::{gap_span, pane_border_style, styled_content_spans};
+use super::style::{expand_tabs_text, gap_span, pane_border_style, styled_content_spans};
 use crate::app::DiffViewMode;
 use crate::diff_view::{DiffLineKind, FileHunks};
 use crate::search::MatchLine;
@@ -376,7 +376,7 @@ fn unchanged_line(
         Some(token_spans) => {
             spans.extend(styled_content_spans(text, &token_spans, bg));
         }
-        None => spans.push(gap_span(text, bg)),
+        None => spans.push(gap_span(&expand_tabs_text(text), bg)),
     }
     Line::from(spans)
 }
@@ -394,7 +394,7 @@ fn removed_line(content: &str) -> Line<'static> {
         gap_span("     ", bg),
         marker_span(DiffLineKind::Removed, bg),
         gap_span("| ", bg),
-        gap_span(content, bg),
+        gap_span(&expand_tabs_text(content), bg),
     ])
 }
 
@@ -490,7 +490,7 @@ fn source_split_side_line(
             .flatten()
     }) {
         Some(token_spans) => spans.extend(styled_content_spans(&cell.content, &token_spans, bg)),
-        None => spans.push(gap_span(&cell.content, bg)),
+        None => spans.push(gap_span(&expand_tabs_text(&cell.content), bg)),
     }
     Line::from(spans)
 }

--- a/rinkaku-tui/src/ui/source_screen_tests/mod.rs
+++ b/rinkaku-tui/src/ui/source_screen_tests/mod.rs
@@ -28,6 +28,7 @@ mod highlighting;
 mod overlay;
 mod search;
 mod split_view;
+mod tab_expansion;
 
 pub(super) fn symbol(id: &str, name: &str) -> ExtractedSymbol {
     ExtractedSymbol {

--- a/rinkaku-tui/src/ui/source_screen_tests/tab_expansion.rs
+++ b/rinkaku-tui/src/ui/source_screen_tests/tab_expansion.rs
@@ -1,0 +1,111 @@
+use super::*;
+use crate::ui::style::TAB_WIDTH;
+use pretty_assertions::assert_eq;
+use rinkaku_core::extract::ExtractedSymbol;
+
+fn draw_source(path: &str, contents: &str) -> Terminal<TestBackend> {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(dir.path().join(path), contents).expect("write file");
+
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: path.to_string(),
+            symbols: vec![ExtractedSymbol {
+                range: LineRange { start: 1, end: 1 },
+                ..symbol(&format!("{path}::run"), "run")
+            }],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+    let app = App::new(&report)
+        .handle_key(crate::app::InputKey::Down)
+        .handle_key(crate::app::InputKey::Source);
+    let source_content = Some(crate::source::load_highlighted_symbol_source(
+        &report,
+        &format!("{path}::run"),
+        dir.path(),
+        &crate::source::WorkingTreeSourceReader,
+    ));
+    let mut terminal = Terminal::new(TestBackend::new(100, 24)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            draw(
+                frame,
+                &app,
+                &report,
+                &crate::diff_shape::DiffPaneContent::Empty,
+                &[],
+                &BlastRadiusSelection::NotApplicable,
+                source_content.as_ref(),
+                &[],
+                &crate::annotation_markers::AnnotationMarkers::default(),
+                Locale::English,
+            );
+        })
+        .expect("draw");
+    terminal
+}
+
+/// The rendered column at which `token` starts, measured from the first
+/// column after the `"{line_number:>5} | "` gutter.
+fn column_after_gutter(terminal: &Terminal<TestBackend>, line_number: usize, token: &str) -> usize {
+    let gutter = format!("{line_number:>5} | ");
+    let row = buffer_text(terminal)
+        .lines()
+        .find(|row| row.contains(&gutter))
+        .unwrap_or_else(|| panic!("expected a rendered row containing {gutter:?}"))
+        .to_string();
+    let gutter_end = row.find(&gutter).expect("gutter offset") + gutter.len();
+    let token_offset = row[gutter_end..]
+        .find(token)
+        .unwrap_or_else(|| panic!("expected {token:?} after the gutter in {row:?}"));
+    row[gutter_end..gutter_end + token_offset].chars().count()
+}
+
+#[test]
+fn should_render_tab_indented_go_lines_at_tab_stop_columns_in_source_screen() {
+    let terminal = draw_source("main.go", "func run() {\n\tif ok {\n\t\tdeep()\n\t}\n}\n");
+    let buffer = buffer_text(&terminal);
+
+    assert_eq!(
+        (TAB_WIDTH, TAB_WIDTH * 2),
+        (
+            column_after_gutter(&terminal, 2, "if"),
+            column_after_gutter(&terminal, 3, "deep"),
+        ),
+        "rendered buffer:\n{buffer}"
+    );
+}
+
+#[test]
+fn should_expand_tabs_on_the_unhighlighted_path_when_extension_is_unknown_in_source_screen() {
+    // A `Makefile` has no bundled grammar, so no token spans exist and the
+    // line renders through `gap_span` rather than `styled_content_spans`.
+    let terminal = draw_source("Makefile", "build:\n\tcargo build\n");
+
+    assert_eq!(TAB_WIDTH, column_after_gutter(&terminal, 2, "cargo"));
+}
+
+#[test]
+fn should_not_leave_tab_characters_in_the_rendered_buffer_when_source_is_tab_indented() {
+    let terminal = draw_source("main.go", "func run() {\n\t\tdeep()\n}\n");
+
+    let actual: Vec<char> = buffer_text(&terminal)
+        .chars()
+        .filter(|c| *c == '\t')
+        .collect();
+
+    assert_eq!(Vec::<char>::new(), actual);
+}

--- a/rinkaku-tui/src/ui/style.rs
+++ b/rinkaku-tui/src/ui/style.rs
@@ -36,6 +36,9 @@ pub(crate) fn expand_tabs(content: &str, spans: &[TokenSpan]) -> (String, Vec<To
             column += padding;
         } else {
             expanded.push(ch);
+            // `unwrap_or(0)`, unlike `crate::ui::scroll`'s `unwrap_or(1)`:
+            // this column count only feeds the next tab stop, which a
+            // zero-width character must not advance.
             column += ch.width().unwrap_or(0);
         }
     }
@@ -68,6 +71,10 @@ pub(crate) fn expand_tabs_text(content: &str) -> String {
 /// the query didn't capture) becomes an unstyled-foreground span with just
 /// `bg` applied, so the line's background tint is always contiguous even
 /// where token coloring has gaps.
+///
+/// Both arguments are in `content`'s pre-expansion coordinates: this
+/// function applies [`expand_tabs`] itself, so the bytes it slices are not
+/// the bytes the caller passed in (ADR 0061).
 pub(crate) fn styled_content_spans(
     content: &str,
     spans: &[TokenSpan],

--- a/rinkaku-tui/src/ui/style.rs
+++ b/rinkaku-tui/src/ui/style.rs
@@ -7,6 +7,58 @@
 use crate::highlight::{PALETTE, TokenSpan};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
+use unicode_width::UnicodeWidthChar;
+
+/// Columns between tab stops when rendering source text (ADR 0061).
+pub(crate) const TAB_WIDTH: usize = 4;
+
+/// Rewrites `content` with every tab replaced by spaces up to the next
+/// [`TAB_WIDTH`] tab stop, returning the expanded text alongside `spans`
+/// rebased onto its byte offsets (ADR 0061) — a terminal draws `\t` as zero
+/// cells while this crate's width arithmetic counts it as one, so no tab may
+/// reach a rendered [`Span`].
+pub(crate) fn expand_tabs(content: &str, spans: &[TokenSpan]) -> (String, Vec<TokenSpan>) {
+    if !content.contains('\t') {
+        return (content.to_string(), spans.to_vec());
+    }
+
+    let mut expanded = String::with_capacity(content.len());
+    let mut column = 0usize;
+    let mut offsets = Vec::with_capacity(content.len() + 1);
+
+    for (byte_index, ch) in content.char_indices() {
+        while offsets.len() <= byte_index {
+            offsets.push(expanded.len());
+        }
+        if ch == '\t' {
+            let padding = TAB_WIDTH - (column % TAB_WIDTH);
+            expanded.extend(std::iter::repeat_n(' ', padding));
+            column += padding;
+        } else {
+            expanded.push(ch);
+            column += ch.width().unwrap_or(0);
+        }
+    }
+    while offsets.len() <= content.len() {
+        offsets.push(expanded.len());
+    }
+
+    let remapped = spans
+        .iter()
+        .map(|span| TokenSpan {
+            start: offsets.get(span.start).copied().unwrap_or(expanded.len()),
+            end: offsets.get(span.end).copied().unwrap_or(expanded.len()),
+            palette_index: span.palette_index,
+        })
+        .collect();
+
+    (expanded, remapped)
+}
+
+/// [`expand_tabs`] for a path with no token spans to remap.
+pub(crate) fn expand_tabs_text(content: &str) -> String {
+    expand_tabs(content, &[]).0
+}
 
 /// Splits `content` into styled spans per `spans` (byte-offset [`TokenSpan`]s
 /// already rebased to `content`'s own coordinates by
@@ -21,10 +73,13 @@ pub(crate) fn styled_content_spans(
     spans: &[TokenSpan],
     bg: Option<Color>,
 ) -> Vec<Span<'static>> {
+    let (content, spans) = expand_tabs(content, spans);
+    let content = content.as_str();
+
     let mut result = Vec::new();
     let mut cursor = 0usize;
 
-    let mut sorted_spans = spans.to_vec();
+    let mut sorted_spans = spans;
     sorted_spans.sort_by_key(|span| span.start);
 
     for span in &sorted_spans {
@@ -116,6 +171,149 @@ pub(crate) fn palette_style(palette_index: usize) -> Style {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::leading_tab("\tx", "    x")]
+    #[case::three_leading_tabs("\t\t\tdeep()", "            deep()")]
+    #[case::tab_after_one_column("a\tb", "a   b")]
+    #[case::tab_after_three_columns("abc\td", "abc d")]
+    #[case::tab_on_stop_boundary("abcd\te", "abcd    e")]
+    #[case::consecutive_mid_line_tabs("ab\t\tc", "ab      c")]
+    #[case::wide_chars_advance_two_columns("あ\tx", "あ  x")]
+    #[case::combining_marks_do_not_advance("a\u{0301}\tb", "a\u{0301}   b")]
+    #[case::no_tabs_unchanged("plain text", "plain text")]
+    #[case::empty_unchanged("", "")]
+    fn should_advance_to_next_tab_stop_when_expanding(
+        #[case] content: &str,
+        #[case] expected: &str,
+    ) {
+        let actual = expand_tabs_text(content);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_shift_span_offsets_when_tabs_precede_tokens() {
+        let content = "\t\tfn name()";
+        let spans = vec![
+            TokenSpan {
+                start: 2,
+                end: 4,
+                palette_index: 0,
+            },
+            TokenSpan {
+                start: 5,
+                end: 9,
+                palette_index: 3,
+            },
+        ];
+
+        let actual = expand_tabs(content, &spans);
+
+        assert_eq!(
+            (
+                "        fn name()".to_string(),
+                vec![
+                    TokenSpan {
+                        start: 8,
+                        end: 10,
+                        palette_index: 0,
+                    },
+                    TokenSpan {
+                        start: 11,
+                        end: 15,
+                        palette_index: 3,
+                    },
+                ]
+            ),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_grow_span_range_when_tab_lies_inside_token() {
+        let content = "a\tb";
+        let spans = vec![TokenSpan {
+            start: 0,
+            end: 3,
+            palette_index: 1,
+        }];
+
+        let actual = expand_tabs(content, &spans);
+
+        assert_eq!(
+            (
+                "a   b".to_string(),
+                vec![TokenSpan {
+                    start: 0,
+                    end: 5,
+                    palette_index: 1,
+                }]
+            ),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_keep_offsets_registered_when_multibyte_chars_precede_tab() {
+        let content = "あ\tx";
+        let spans = vec![TokenSpan {
+            start: 4,
+            end: 5,
+            palette_index: 4,
+        }];
+
+        let actual = expand_tabs(content, &spans);
+
+        assert_eq!(
+            (
+                "あ  x".to_string(),
+                vec![TokenSpan {
+                    start: 5,
+                    end: 6,
+                    palette_index: 4,
+                }]
+            ),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_return_spans_unchanged_when_line_has_no_tab() {
+        let content = "let x = 1;";
+        let spans = vec![TokenSpan {
+            start: 0,
+            end: 3,
+            palette_index: 0,
+        }];
+
+        let actual = expand_tabs(content, &spans);
+
+        assert_eq!(("let x = 1;".to_string(), spans), actual);
+    }
+
+    #[test]
+    fn should_color_tokens_at_expanded_positions_when_content_has_tabs() {
+        let content = "\tif x {";
+        let spans = vec![TokenSpan {
+            start: 1,
+            end: 3,
+            palette_index: 0,
+        }];
+
+        let actual = styled_content_spans(content, &spans, None);
+
+        assert_eq!(
+            vec![
+                Span::styled("    ".to_string(), Style::default()),
+                Span::styled("if".to_string(), Style::default().fg(Color::Magenta)),
+                Span::styled(" x {".to_string(), Style::default()),
+            ],
+            actual
+        );
+    }
 
     #[test]
     fn should_map_every_palette_entry_to_its_pinned_style_when_resolved_by_index() {


### PR DESCRIPTION
## What was broken

Tab-indented source lost its indentation in the TUI's Diff screen, Source
screen, and Detail pane. The cause was a disagreement between two width
models applied to the same string:

- The terminal draws `\t` as **zero cells** — ratatui hands a `Span`'s
  content to the backend untranslated, so the character occupies no
  column.
- rinkaku's own width arithmetic (`ui::scroll`, used for wrapping,
  truncation, and split-column alignment) counted a tab as **one cell**:
  `UnicodeWidthChar::width` returns `None` for `\t` and every call site
  resolved it with `.unwrap_or(1)`.

So indentation vanished on screen, *and* wrapping/truncation reserved a
column for a glyph that drew nothing. Nothing in `rinkaku-tui` expanded
tabs anywhere.

## Why this is a language-independent rendering bug

Go is the loudest victim because `gofmt` mandates tab indentation, but
nothing about the defect is Go-specific: Makefiles (where tabs are
syntax), C, and any TypeScript/JavaScript project configured for tabs hit
it identically. The fix lives in the rendering layer, not in any language
support.

## Approach

Expand tabs to spaces and remap token offsets in a **pure function at the
render entry point**, so no tab ever reaches a `Span`
(`ui::style::expand_tabs`). It takes `&str` + `&[TokenSpan]` and returns
the expanded `String` alongside spans rebased onto the expanded
coordinates — necessary because `TokenSpan` carries **byte offsets** into
the line, so a naive `replace` would shift all syntax coloring out of
registration.

All five content paths are routed through it: the highlighted diff path
(`styled_content_spans`), the unhighlighted diff path (`plain_diff_line`,
which bypasses `styled_content_spans` entirely), both source-screen paths
(unified and split, including the removed-line overlay), and the detail
pane's `SignatureView` lines — a gofmt-formatted multi-line signature
(ADR 0060) carries real tabs on its continuation lines, since
`tidy_signature_lines` does not normalize them.

The contract header is deliberately untouched: `diff_shape`'s
`collapse_to_single_line` already removes tabs via
`split_whitespace().join(" ")`, so none reach it.

Because expansion happens before any `Span` exists, the existing
`unicode_width` arithmetic becomes correct with no change — it now
measures a string whose every character has a defined width matching what
the terminal draws. Verified there is no surviving path: two tests assert
the rendered `TestBackend` buffer contains zero `\t` characters.

**Tab width 4, true tab stops** (advance to the next multiple of 4, not a
fixed 4 spaces). A tab *is* a move to the next stop, so honoring that is
what makes a rendered line match how the same file looks in the author's
editor. Width 4 rather than 8 because `MIN_SPLIT_VIEW_WIDTH` is 100
columns (~49 per side), where 8-wide indentation wraps constantly.

An earlier revision of this PR and of ADR 0061 justified true tab stops
by claiming `gofmt` emits tabs *mid-line* to align struct field types and
trailing comments. That is false — `text/tabwriter` pads with spaces by
default, so gofmt's tabs are leading indentation only and every in-line
alignment column is spaces (verified with `od -c`). Both texts have been
corrected; the decision itself is unchanged.

### Rejected alternatives

- **Expand only inside `gap_span`** (the minimal change). Rejected: a
  tree-sitter capture may begin at byte 0, pulling leading whitespace
  *inside* a token range where `gap_span` never sees it. The premise
  "indentation is always in a gap" does not hold.
- **Expand at ingestion** (in `source`/the diff parser). Rejected: it
  makes in-memory content diverge from the file on disk, so search
  (ADR 0057), annotation anchoring, and any future column-reporting
  feature would silently work in expanded coordinates. Tab expansion is
  a display concern and belongs at the display boundary.
- **Configurable tab width.** Deferred, not rejected.

See [ADR 0061](docs/adr/0061-expand-tabs-in-tui-rendering.md).

## Dynamic verification

Headless `ratatui::TestBackend` rendering with exact column assertions
(no tmux — TestBackend asserts precisely without PTY sizing trouble),
covering the Diff pane, the Source screen, and the Detail pane, on both
the highlighted (`main.go`) and unhighlighted (`Makefile`, no bundled
grammar) paths.

Each new test was confirmed to **fail** against the pre-fix behavior
before being accepted — the pure-function cases and every end-to-end
rendering case, including the two detail-pane regressions, which were
re-run with the detail-pane fix stashed to watch them go red.

Diff pane, tab-indented Go, **before**:

```
│ +func run() {                                            │
│ +if ok {                                                 │
│ +deep()                                                  │
│ +}                                                       │
```

**After**:

```
│ +func run() {                                            │
│ +    if ok {                                             │
│ +        deep()                                          │
│ +    }                                                   │
```

`make test` (1654 tests) and `make lint` both pass.

## Test coverage

Pure function (`ui::style`): leading tabs, mid-line tabs, tabs landing
exactly on a stop boundary, consecutive tabs, wide (CJK) characters
advancing two columns, combining marks advancing none, tab-free lines
returned unchanged, offsets shifted when tabs precede a token, span range
grown when a tab lies *inside* a token, and offsets staying registered
when multibyte characters precede a tab.

End-to-end: tab-stop columns in the Diff pane, the Source screen, and the
Detail pane (on both the `Current` and `Changed` signature arms), the
unhighlighted `plain_diff_line`/`gap_span` fallbacks, and no `\t`
surviving into the rendered buffer.

