### PR TITLE
docs: record experiment 0001 round 39

### DIFF
--- a/docs/experiments/0001-map-assisted-llm-review/rounds/039.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/039.md
@@ -1,0 +1,59 @@
+# Round 39
+
+- Subject: PR #190 — expand tabs when rendering diff and source lines
+  (ADR 0061): adds `expand_tabs` in `ui::style`, expanding to width-4
+  true tab stops while remapping `TokenSpan` byte offsets, and routes
+  the diff pane (highlighted and plain), the source screen (unified
+  and split), and `removed_line` through it.
+- Protocol: three agents in parallel — map-assisted static review,
+  independent static review (no map), dynamic verification — then a
+  single fix agent for the surviving findings.
+- **Map delivery**: `rinkaku --base main`, built from a trusted `main`
+  checkout at `2ca8589`, handed to the map-assisted reviewer only.
+- **Map hit (indirect, and the round's only real bug)**: tab expansion
+  was missing in the detail pane, where Go multi-line signatures (the
+  ADR 0060 feature) keep real tabs on continuation lines, so the exact
+  bug this PR fixed elsewhere survived there. The map never pointed at
+  `detail_pane.rs` — the PR does not touch it, so it appears in
+  neither the change graph nor the definitions. What the map did was
+  enumerate `expand_tabs_text — used by 3` in high fan-in, which
+  prompted "are those all the paths that build a `Span`?" and sent the
+  reviewer grepping outside the map. The finding came from the
+  question the map provoked, not from anything the map displayed.
+- **Map value, inverted**: the map's clearest direct contribution was
+  *suppressing* a false positive, not producing a finding. Seeing
+  `section_anchor_lines` format `contract.previous_signature` in
+  Definitions raised "can tabs reach the contract header?", and
+  reading `diff_shape.rs` showed `collapse_to_single_line`'s
+  `split_whitespace().join(" ")` already destroys them. Without the
+  map that path is either missed or wrongly flagged. This round the
+  map reduced wasted deep reading more than it added coverage.
+- **Cross-pass factual contradiction**: the independent and dynamic
+  passes both reported that width-4 expansion breaks `gofmt`'s
+  mid-line alignment; the map-assisted pass reported that `gofmt`
+  aligns with **spaces** and emits tabs only for leading indent, and
+  showed `od -c` output. The map-assisted pass was right
+  (`text/tabwriter`'s default padchar is a space) — reconfirmed
+  independently before deciding. The two wrong passes had inherited
+  the false premise from the orchestrator's own task framing, and the
+  dynamic pass "measured" it on a hand-written file that had never
+  been through `gofmt`. Both the ADR and the PR body carried the same
+  error and were corrected.
+- Severity summary: 1 medium (detail-pane tab expansion missing),
+  2 low (stale coordinate-system contract on
+  `styled_content_spans`; undocumented `unwrap_or(0)` diverging from
+  `scroll.rs`'s `unwrap_or(1)`), plus the ADR/PR factual correction.
+  Two findings were rejected on inspection: "width 4 breaks gofmt
+  alignment" (false premise) and "expansion should start at the
+  display-row origin" — content-origin is correct, since a
+  marker/gutter origin would render the same source line at different
+  indents in the diff pane (2 columns) and the source screen (8).
+  Fixed in `45069b4`..`66f782b`.
+- Takeaway: a reviewer's own framing is an error source that
+  propagates into every pass it touches — two of three passes
+  inherited a false claim about an external tool and one manufactured
+  supporting "measurements" for it. Only the pass that treated the
+  claim as checkable and ran `od -c` caught it. Verifying an external
+  tool's real behavior is structurally outside what a signature map
+  can support, and disagreement between passes was the signal that
+  something needed a primary source.


### PR DESCRIPTION
Records round 39 of experiment 0001, covering the review of PR #190
(tab expansion in TUI rendering).

Adds `rounds/039.md` only — per the README's own rule, a round PR
never touches the README table, so rounds stay conflict-free.

## Why this round was worth recording

Two properties that no earlier round has:

**The map's value was inverted.** Its only direct contribution was
*suppressing* a false positive (the contract header, where
`collapse_to_single_line` already destroys tabs). The round's one real
bug — missing tab expansion in the detail pane — was structurally
outside the map: the PR does not touch `detail_pane.rs`, so it appears
in neither the change graph nor the definitions. The map reached it
only indirectly, by enumerating `expand_tabs_text — used by 3` in high
fan-in, which prompted "are those all the paths?" and sent the reviewer
grepping beyond the map.

**Passes contradicted each other on an external fact.** Two of three
passes reported that width-4 expansion breaks `gofmt`'s mid-line
alignment; the third showed `od -c` output proving `gofmt` aligns with
spaces and emits tabs only for leading indent. The third was right.
The false premise originated in the orchestrator's own task framing and
propagated into every pass it touched — and the dynamic pass
manufactured supporting "measurements" from a file that had never been
through `gofmt`. The same error had reached ADR 0061 and the PR #190
body; both were corrected before merge.

The takeaway recorded is that reviewer framing is itself an error
source, that verifying an external tool's behavior is outside what a
signature map can support, and that disagreement between passes was the
signal to go to a primary source.