### PR TITLE
feat: confirm the update before analysis and re-exec after it

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ Press `w` from anywhere to open the PR's page in your web browser
 | From source | `cargo install rinkaku` |
 | Manual | Grab a tarball from the [latest release](https://github.com/hiro-o918/rinkaku/releases/latest) and put `rinkaku` on your `PATH`. Targets: `{x86_64,aarch64}-{unknown-linux-musl,unknown-linux-gnu,apple-darwin}` (Linux tooling picks the statically linked musl build). |
 
-Update with `rinkaku self-update`, or press `U` in `--tui` once it
-notices a newer release (see
+Update with `rinkaku self-update`. `--tui` also offers it for you: when
+its startup check finds a newer release, it asks before analysis starts
+and re-runs your command with the updated binary, falling back to a
+status-line hint and the `U` key if the check answers too late (see
 [`docs/cli.md#self-update`](docs/cli.md#self-update) for the
 interactive / `--yes` / non-TTY behavior).
 

--- a/docs/adr/0054-tui-update-available-prompt.md
+++ b/docs/adr/0054-tui-update-available-prompt.md
@@ -1,6 +1,10 @@
 # 0054. TUI: prompt to self-update when a newer release is available
 
-- Status: Accepted
+- Status: partly superseded by
+  [ADR 0062](0062-update-prompt-before-analysis.md) (the confirmation is now
+  offered on the ordinary terminal before analysis, and a successful update
+  re-execs the same command; the background check, the status-line hint, the
+  `u` key, and the post-teardown `run_self_update(true)` call are unchanged)
 - Date: 2026-07-15
 
 ## Context

--- a/docs/adr/0056-tui-update-prompt-auto-open-and-freeze-fix.md
+++ b/docs/adr/0056-tui-update-prompt-auto-open-and-freeze-fix.md
@@ -1,6 +1,10 @@
 # 0056. TUI: auto-open the update prompt at startup, fix its dead keys, and stop the silent self-update stall
 
-- Status: Accepted
+- Status: partly superseded by
+  [ADR 0062](0062-update-prompt-before-analysis.md) (the auto-open decision
+  is reverted — the confirmation moved ahead of analysis, onto the ordinary
+  terminal; the `translate_key` short-circuit and the `Spinner` around
+  `updater.update()` are unchanged)
 - Date: 2026-07-16
 
 ## Context

--- a/docs/adr/0062-update-prompt-before-analysis.md
+++ b/docs/adr/0062-update-prompt-before-analysis.md
@@ -1,0 +1,164 @@
+# 0062. Confirm the update on the terminal before analysis, then re-exec
+
+- Status: accepted
+- Date: 2026-07-26
+- Supersedes: parts of [ADR 0054](0054-tui-update-available-prompt.md) and
+  [ADR 0056](0056-tui-update-prompt-auto-open-and-freeze-fix.md) (where and
+  when the update is confirmed; the background check itself, the status-line
+  hint, the `u` key, and the post-teardown `run_self_update(true)` call are
+  unchanged)
+
+## Context
+
+ADR 0054 introduced a background version check spawned before analysis
+and a `u`-triggered confirmation popup inside the TUI; ADR 0056 made
+that popup auto-open the first time the check reports a newer release.
+Both decisions put the confirmation *after* analysis, because that is
+where the TUI lives.
+
+Two measurements taken on this repository make that placement look
+wrong:
+
+- `run_analysis` on a typical `--base main` run takes roughly **1.9
+  seconds**.
+- `self_update::check_update_available` — one GitHub `/releases/latest`
+  call plus a semver comparison — completes in roughly **0.07
+  seconds**. Repeated sampling shows that is the typical case, not the
+  worst: an occasional call takes ~0.3s (cold DNS/TLS) or even ~1.1s.
+  The fallback path below exists precisely for those.
+
+So the answer is already known before the analysis is a tenth of the
+way through, and the reviewer is nevertheless made to wait ~1.9s and
+then have a modal thrown over the entry screen. Worse, the two
+decisions compound: choosing to update quits the TUI and discards the
+analysis that was just paid for, and the reviewer has to re-run
+`rinkaku` by hand afterwards to get back to where they were. The
+expensive work is done first and then deliberately thrown away.
+
+The confirmation is also drawn as a TUI popup only because of where it
+sits in the sequence. Before `TuiSession::init` there is an ordinary
+terminal available, and `run_self_update` already owns a perfectly good
+y/N prompt for exactly this question.
+
+## Decision
+
+**Confirm the update on the ordinary terminal, before analysis starts,
+and re-exec after a successful update.**
+
+**Wait at most 300ms for the check.** The background thread and its
+`mpsc` channel from ADR 0054 stay exactly as they are. Immediately
+after spawning it, `main` does a single `recv_timeout(300ms)` on the
+receiver. If a version arrives in time, the confirmation is offered
+right there, on the terminal, before `TuiSession::init` is called. If
+it does not, nothing is printed and the run proceeds straight to
+analysis — the missed result is **deliberately tolerated**. The check
+takes ~0.07s in the ordinary case, so 300ms is a ~4x margin over the
+measured cost while still being short enough that a slow or flaky
+network cannot make startup feel worse than it is today. Blocking
+startup on a network call is precisely what ADR 0054's "never blocks
+TUI startup" contract set out to avoid, and a bounded wait is the
+smallest possible relaxation of it.
+
+**The `u` key and the status-line hint remain the receiver for the
+missed case.** The `Receiver` is still threaded into `TuiSession::run`,
+so a check that lands after the 300ms window still reaches
+`App::notify_update_available` on the event loop's poll tick, still
+lights up the status-line hint, and is still reachable via `u`. This is
+what makes tolerating the timeout acceptable rather than merely
+lossy. When the confirmation *was* offered before analysis, the
+receiver is not passed on (it has already been drained and answered),
+so the TUI cannot ask the same question twice in one run.
+
+**The TUI's auto-open is removed.** `should_auto_open_update_prompt`
+and `App::update_prompt_dismissed` are deleted, and
+`App::notify_update_available` goes back to only recording the version
+(ADR 0054's original behavior). With the confirmation now offered
+before the TUI exists, an auto-opening modal has nothing left to
+justify it: ADR 0056's motivation was that the status-line hint was
+missed for weeks, and a pre-analysis terminal prompt cannot be missed.
+`update_prompt_open`, `update_requested`, and the popup's
+`PopupConfirm`/`PopupCancel` handling all stay — the popup is still
+reachable via `u`.
+
+**A successful update re-execs the same command.** After
+`run_self_update` reports success, `main` replaces the current process
+image with the freshly installed binary, passing `std::env::args_os()`
+through unchanged, so the reviewer gets the analysis they asked for
+instead of a "please run it again" message. On Unix this is
+`std::os::unix::process::CommandExt::exec`, which never returns on
+success and therefore cannot loop: the new image starts from `main`
+with a *newer* version, so its own check finds nothing newer and no
+second prompt is possible. On non-Unix targets (none are built today —
+see `build-and-publish.yaml`'s target list) the `#[cfg(not(unix))]`
+fallback prints the same "updated, re-run rinkaku" message the old flow
+effectively produced.
+
+**stdin-piped input can never reach the re-exec.** `gh pr diff 123 |
+rinkaku` consumes stdin on the way in; a re-exec'd process would find
+that pipe already at EOF and analyze nothing. The guard is the same
+`confirm_mode` rule ADR 0054's `self-update` subcommand already uses:
+the pre-analysis confirmation is only offered when stdin is a TTY.
+Piped input means stdin is not a TTY, so no confirmation is offered, so
+no update runs, so no re-exec happens — the dangerous case is
+structurally unreachable rather than specially cased. The decision
+function `decide_pre_analysis_prompt` makes this explicit by taking
+`stdin_is_tty` and returning `Skip` when it is false, and it is
+unit-tested for exactly that. `RINKAKU_UPDATE_CHECK=0` continues to
+skip the check (and therefore this whole path) entirely.
+
+## Alternatives
+
+- **Wait for the check to finish, however long it takes.** Rejected:
+  makes every startup hostage to GitHub's latency and the user's
+  connection. Today's design pays zero startup cost for the check; an
+  unbounded wait would turn a best-effort hint into a hard dependency,
+  and a 5-second stall before anything is drawn is a far worse regression
+  than occasionally falling back to the status-line hint.
+- **Just remove ADR 0056's auto-open, keep the confirmation in the
+  TUI.** Rejected: it fixes the interruption but not the waste. The
+  reviewer still spends ~1.9s on an analysis that confirming the update
+  discards, and still has to re-run by hand. The auto-open is a symptom
+  of the confirmation being in the wrong place, not the disease.
+- **Keep the confirmation after analysis but re-exec instead of
+  exiting.** Rejected: it removes the manual re-run but doubles the
+  analysis cost — the discarded ~1.9s is still paid, and then paid
+  again by the re-exec'd process.
+- **Prompt before analysis but skip the re-exec, printing "updated,
+  re-run rinkaku".** Rejected: this is what the `#[cfg(not(unix))]`
+  fallback does, and it is strictly worse on the platforms that can do
+  better. The reviewer's intent (analyze this diff) is fully known at
+  that point, and `args_os()` is exactly the information needed to
+  honour it.
+- **Prompt even when stdin is not a TTY, reading the answer from
+  somewhere else.** Rejected: there is nobody to answer, and the stdin
+  pipe is very likely carrying the diff itself. Refusing to prompt is
+  both the safe default and, as noted above, the mechanism that makes
+  the re-exec's stdin problem unreachable.
+
+## Consequences
+
+- `rinkaku/src/update_prompt.rs` is a new module holding the pure
+  decision (`decide_pre_analysis_prompt`) and the re-exec's argument
+  handling; the IO around it (channel receive, terminal read,
+  `exec`) stays in that module's thin boundary functions and `main.rs`.
+- `main.rs`'s `DisplayMode::Tui` branch gains a pre-analysis block
+  between spawning the check and `TuiSession::init`; the
+  `update_check` receiver it passes to `session.run` becomes `None`
+  when the question has already been answered.
+- `App` loses one field (`update_prompt_dismissed`) and the crate loses
+  one free function (`should_auto_open_update_prompt`);
+  `notify_update_available` reverts to a plain setter. Tests asserting
+  the auto-open behavior are rewritten to assert the popup stays
+  closed, which is what ADR 0054's original tests asserted.
+- `run_self_update`'s own confirmation is untouched — the pre-analysis
+  prompt is a separate, differently-worded question asked at a
+  different time, and the subsequent `run_self_update(true)` call still
+  skips the redundant second prompt exactly as ADR 0054 arranged.
+- No output format changed. `docs/tui.md`, `docs/cli.md`, and
+  `README.md` are updated to describe the new confirmation point; the
+  `?` help overlay's `U` row is unchanged, since the key still does the
+  same thing.
+- A user on a slow connection sees the pre-analysis prompt less often
+  and the status-line hint more often. That is the accepted trade, and
+  the 300ms number is the knob to revisit if it turns out to be too
+  tight in practice.

--- a/docs/adr/0062-update-prompt-before-analysis.md
+++ b/docs/adr/0062-update-prompt-before-analysis.md
@@ -80,18 +80,40 @@ missed for weeks, and a pre-analysis terminal prompt cannot be missed.
 `PopupConfirm`/`PopupCancel` handling all stay — the popup is still
 reachable via `u`.
 
-**A successful update re-execs the same command.** After
-`run_self_update` reports success, `main` replaces the current process
-image with the freshly installed binary, passing `std::env::args_os()`
-through unchanged, so the reviewer gets the analysis they asked for
-instead of a "please run it again" message. On Unix this is
-`std::os::unix::process::CommandExt::exec`, which never returns on
-success and therefore cannot loop: the new image starts from `main`
-with a *newer* version, so its own check finds nothing newer and no
-second prompt is possible. On non-Unix targets (none are built today —
-see `build-and-publish.yaml`'s target list) the `#[cfg(not(unix))]`
-fallback prints the same "updated, re-run rinkaku" message the old flow
-effectively produced.
+**An update that actually replaced the binary re-execs the same
+command.** `main` replaces the current process image with the freshly
+installed binary, passing `std::env::args_os()` through unchanged, so
+the reviewer gets the analysis they asked for instead of a "please run
+it again" message. On Unix this is
+`std::os::unix::process::CommandExt::exec`; on non-Unix targets (none
+are built today — see `build-and-publish.yaml`'s target list) the
+`#[cfg(not(unix))]` fallback prints the same "updated, re-run rinkaku"
+message the old flow effectively produced.
+
+The re-exec is gated on the update having *happened*, not on
+`run_self_update` merely having succeeded. `run_self_update` returns
+`Ok` without updating on three paths (the version comparison finds
+nothing newer, the confirmation is cancelled, and `updater.update()`
+reports `updated() == false`), and re-execing on any of them would put
+the *same* version back at `main`, where it would find the same release
+newer and ask the same question again — a loop for as long as the user
+keeps answering `y`. So `run_self_update` returns an `UpdateOutcome`
+(`Updated` / `NotUpdated`) rather than `()`, and only `Updated` reaches
+the `exec`; `NotUpdated` falls through to analysis exactly like a
+declined prompt. The mapping is the pure `decide_after_update`, unit
+tested for both outcomes.
+
+**`exec` runs no destructors, so the deferred log sink is drained
+explicitly before it.** ADR 0033's `--tui` branch buffers `log::`
+records in a `DeferredLogSink` and relies on a `ReleaseGuard`'s `Drop`
+as its safety net for abrupt exits. Replacing the process image skips
+every `Drop` in the stack, that guard included, so anything buffered
+during the pre-analysis check (`run_self_update` does network IO, and
+its dependencies may log) would vanish silently. `main` therefore hands
+`offer_pre_analysis_update` a `before_reexec` callback that releases
+the sink, invoked on the accept-and-updated path only — the paths that
+continue into the TUI must keep deferring until the alternate screen is
+gone.
 
 **stdin-piped input can never reach the re-exec.** `gh pr diff 123 |
 rinkaku` consumes stdin on the way in; a re-exec'd process would find
@@ -152,8 +174,17 @@ skip the check (and therefore this whole path) entirely.
   closed, which is what ADR 0054's original tests asserted.
 - `run_self_update`'s own confirmation is untouched — the pre-analysis
   prompt is a separate, differently-worded question asked at a
-  different time, and the subsequent `run_self_update(true)` call still
-  skips the redundant second prompt exactly as ADR 0054 arranged.
+  different time, and the subsequent `run_self_update(true, ..)` call
+  still skips the redundant second prompt exactly as ADR 0054 arranged.
+  Its signature does change: it takes an `Announcement` (so the
+  pre-analysis caller, which already printed the version, can suppress
+  the duplicate "New release found" line) and returns `UpdateOutcome`.
+  The `self-update` subcommand and the TUI's `u` path both pass
+  `Announcement::Print` and ignore the outcome, keeping their output
+  and behavior identical.
+- `is_affirmative` is shared rather than duplicated: `update_prompt`
+  calls `self_update`'s, so there is one rule for what counts as
+  consent to replace the running binary.
 - No output format changed. `docs/tui.md`, `docs/cli.md`, and
   `README.md` are updated to describe the new confirmation point; the
   `?` help overlay's `U` row is unchanged, since the key still does the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -196,11 +196,22 @@ terminal and `--yes` is not given, `self-update` refuses to run rather
 than silently proceeding.
 
 `--tui` also checks for a newer release in the background on startup.
-When one is found, the status line shows an `update vX.Y.Z: U` hint;
-press `U` to open a confirmation popup, and `Enter` to update and quit
-(the update itself runs after the TUI has exited, reusing the same
-`self-update` path). The check is silent on any failure and never
-blocks TUI startup. Set `RINKAKU_UPDATE_CHECK=0` to skip it entirely.
+The check gets up to 300ms to answer before analysis begins; if it
+finds a newer release in that window and stdin is a terminal, `rinkaku`
+asks on the terminal whether to update, and answering `y` installs the
+release and re-runs the same command with the updated binary. Piped
+input (`gh pr diff 123 | rinkaku --tui`) is never asked, since a re-run
+could not read the already-consumed diff.
+
+If the check answers too late for that window, nothing is printed and
+analysis proceeds; the result still reaches the TUI, where the status
+line shows an `update vX.Y.Z: U` hint. Press `U` to open a
+confirmation popup and `Enter` to update and quit (the update runs
+after the TUI has exited, and does not re-run the analysis).
+
+The check is silent on any failure and never blocks TUI startup for
+longer than the 300ms window. Set `RINKAKU_UPDATE_CHECK=0` to skip it
+entirely.
 
 ## Known limitations
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -107,7 +107,7 @@ Press `?` in the TUI for the always-up-to-date table.
 | `ctrl-o` / `ctrl-i` | Jump back / forward through the jumplist |
 | `n` / `N` | Compose a review note / open the notes list ([ADR 0048](adr/0048-tui-review-actions.md)) |
 | `w` / `W` | Open the current PR's page in a web browser, `--pr` mode only ([ADR 0050](adr/0050-tui-open-pr-in-browser.md)) |
-| `U` | Prompt to self-update; opens automatically once a newer release is found, or reopens it after a dismissal ([ADR 0054](adr/0054-tui-update-available-prompt.md), [ADR 0056](adr/0056-tui-update-prompt-auto-open-and-freeze-fix.md)) |
+| `U` | Prompt to self-update, once the background check has found a newer release ([ADR 0054](adr/0054-tui-update-available-prompt.md), [ADR 0062](adr/0062-update-prompt-before-analysis.md)) |
 | `?` | Toggle the help overlay |
 | `q` / `ctrl-c` | Quit (from the entry view); `esc`/`q` also returns from the source view |
 

--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -179,7 +179,6 @@ impl App {
                 }
                 InputKey::PopupCancel => {
                     self.update_prompt_open = false;
-                    self.update_prompt_dismissed = true;
                 }
                 _ => {}
             }

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -368,18 +368,11 @@ pub struct App {
     /// hint and whether `u` opens [`Self::update_prompt_open`] at all.
     update_available: Option<String>,
     /// Whether the update confirmation popup is currently open — reachable
-    /// via `u` (once [`Self::update_available`] is `Some`) or auto-opened by
-    /// [`Self::notify_update_available`] (ADR 0056). Mirrors
+    /// via `u`, once [`Self::update_available`] is `Some`. Mirrors
     /// [`Self::jump_popup`]'s flag-not-`Screen` shape for the same reason:
     /// it sits on top of whatever was already showing and must not disturb
     /// that state.
     update_prompt_open: bool,
-    /// Whether the reviewer has already closed the update prompt once this
-    /// session (`PopupCancel` while it was open) — kept separate from
-    /// [`Self::update_prompt_open`] so [`should_auto_open_update_prompt`]
-    /// can tell "never shown yet" from "shown and dismissed" and not
-    /// reopen the popup out from under a reviewer who just closed it.
-    update_prompt_dismissed: bool,
     /// Whether the reviewer confirmed the update popup — `run_app`/
     /// `TuiSession::run` read this once [`Self::should_quit`] is set to
     /// decide whether to run `self-update` after the terminal is restored.
@@ -424,7 +417,6 @@ impl App {
             review_sink_a_available: false,
             update_available: None,
             update_prompt_open: false,
-            update_prompt_dismissed: false,
             update_requested: false,
         }
     }
@@ -625,24 +617,12 @@ impl App {
     /// version-check thread's `mpsc::Receiver` yields a version string
     /// (`main.rs`'s composition root spawns that thread; this method is
     /// the only seam through which its result reaches `App`, keeping this
-    /// module free of the thread/channel itself). Auto-opens
-    /// [`Self::update_prompt_open`] via [`should_auto_open_update_prompt`]
-    /// (ADR 0056, superseding ADR 0054's original "never auto-opens"
-    /// decision) unless the reviewer already dismissed the prompt once
-    /// this session, or another modal (help overlay, jump popup) is
-    /// currently on screen — the renderer draws the update prompt on top
-    /// of everything else, but key routing checks those modals first, so
-    /// auto-opening over one of them would show the prompt while still
-    /// routing keys to the hidden modal underneath.
+    /// module free of the thread/channel itself). The popup is never
+    /// opened from here: ADR 0062 moved the confirmation ahead of
+    /// analysis, onto the ordinary terminal, so reaching the TUI at all
+    /// means the reviewer was not asked and `u` is the only way in.
     pub fn notify_update_available(&mut self, version: impl Into<String>) {
         self.update_available = Some(version.into());
-        if should_auto_open_update_prompt(
-            self.update_available.is_some(),
-            self.update_prompt_dismissed,
-            !self.help_open && self.jump_popup.is_none(),
-        ) {
-            self.update_prompt_open = true;
-        }
     }
 
     /// The detail-pane content for the row currently under the cursor
@@ -994,18 +974,4 @@ impl App {
         }
         self
     }
-}
-
-/// Whether the update prompt should auto-open now that an update is known
-/// to be available, given whether the reviewer has already dismissed it
-/// once this session and whether no other modal is currently active.
-/// Extracted as a free function (rather than inlined in
-/// [`App::notify_update_available`]) so a future startup splash screen can
-/// reuse this exact decision without depending on `App`'s internals.
-fn should_auto_open_update_prompt(
-    update_available: bool,
-    update_prompt_dismissed: bool,
-    no_other_modal_active: bool,
-) -> bool {
-    update_available && !update_prompt_dismissed && no_other_modal_active
 }

--- a/rinkaku-tui/src/app/tests/update_prompt.rs
+++ b/rinkaku-tui/src/app/tests/update_prompt.rs
@@ -1,26 +1,25 @@
 use super::empty_report;
 use crate::app::{App, InputKey, JumpCandidate};
 use pretty_assertions::assert_eq;
-use rstest::rstest;
 
-// Update-available prompt tests (ADR 0054, amended to auto-open at
-// startup): `notify_update_available`, `OpenUpdatePrompt`'s gating on
-// `update_available`, and the popup's own `PopupConfirm`/`PopupCancel`
+// Update-available prompt tests (ADR 0054, amended by ADR 0062 to drop
+// the auto-open): `notify_update_available`, `OpenUpdatePrompt`'s gating
+// on `update_available`, and the popup's own `PopupConfirm`/`PopupCancel`
 // handling.
 
 #[test]
-fn should_set_update_available_and_auto_open_prompt_when_notified() {
+fn should_set_update_available_without_opening_prompt_when_notified() {
     let report = empty_report();
     let mut app = App::new(&report);
 
     app.notify_update_available("1.2.3");
 
     assert_eq!(Some("1.2.3"), app.update_available());
-    assert_eq!(true, app.update_prompt_open());
+    assert_eq!(false, app.update_prompt_open());
 }
 
 #[test]
-fn should_not_auto_open_prompt_when_notified_while_help_overlay_is_open() {
+fn should_leave_help_overlay_untouched_when_notified_while_it_is_open() {
     let report = empty_report();
     let mut app = App::new(&report).handle_key(InputKey::ToggleHelp);
 
@@ -32,7 +31,7 @@ fn should_not_auto_open_prompt_when_notified_while_help_overlay_is_open() {
 }
 
 #[test]
-fn should_not_auto_open_prompt_when_notified_while_jump_popup_is_open() {
+fn should_leave_jump_popup_untouched_when_notified_while_it_is_open() {
     let report = empty_report();
     let mut app = App::new(&report).open_jump_popup(vec![JumpCandidate {
         id: "lib.rs::foo".to_string(),
@@ -48,11 +47,10 @@ fn should_not_auto_open_prompt_when_notified_while_jump_popup_is_open() {
 }
 
 #[test]
-fn should_not_reopen_prompt_when_notified_again_after_dismissal() {
+fn should_replace_the_version_without_opening_prompt_when_notified_again() {
     let report = empty_report();
     let mut app = App::new(&report);
     app.notify_update_available("1.2.3");
-    let mut app = app.handle_key(InputKey::PopupCancel);
 
     app.notify_update_available("1.2.4");
 
@@ -75,7 +73,9 @@ fn should_reopen_update_prompt_when_open_update_prompt_is_pressed_after_dismissa
     let report = empty_report();
     let mut app = App::new(&report);
     app.notify_update_available("1.2.3");
-    let app = app.handle_key(InputKey::PopupCancel);
+    let app = app
+        .handle_key(InputKey::OpenUpdatePrompt)
+        .handle_key(InputKey::PopupCancel);
 
     let app = app.handle_key(InputKey::OpenUpdatePrompt);
 
@@ -127,25 +127,4 @@ fn should_ignore_other_keys_while_update_prompt_is_open() {
 
     assert_eq!(true, app.update_prompt_open());
     assert_eq!(false, app.should_quit());
-}
-
-#[rstest]
-#[case::should_open_when_available_and_not_dismissed_and_no_other_modal(true, false, true, true)]
-#[case::should_not_open_when_unavailable(false, false, true, false)]
-#[case::should_not_reopen_when_already_dismissed(true, true, true, false)]
-#[case::should_not_open_when_unavailable_and_dismissed(false, true, true, false)]
-#[case::should_not_open_when_other_modal_active(true, false, false, false)]
-fn should_decide_auto_open_from_availability_dismissal_and_other_modal(
-    #[case] update_available: bool,
-    #[case] update_prompt_dismissed: bool,
-    #[case] no_other_modal_active: bool,
-    #[case] expected: bool,
-) {
-    let actual = super::super::should_auto_open_update_prompt(
-        update_available,
-        update_prompt_dismissed,
-        no_other_modal_active,
-    );
-
-    assert_eq!(expected, actual);
 }

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -379,14 +379,11 @@ mod tests {
     }
 
     #[test]
-    fn should_draw_update_prompt_with_version_as_soon_as_notified() {
-        // No `OpenUpdatePrompt` key press here — this pins the
-        // auto-open-at-startup behavior: `notify_update_available` alone
-        // must be enough for the prompt to already be on screen the very
-        // next frame, not only after an explicit `u` press.
+    fn should_draw_update_prompt_with_version_when_opened() {
         let report = report_with_one_symbol();
         let mut app = App::new(&report);
         app.notify_update_available("1.2.3");
+        let app = app.handle_key(crate::app::InputKey::OpenUpdatePrompt);
         let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
 
         terminal
@@ -417,9 +414,6 @@ mod tests {
         let report = report_with_one_symbol();
         let mut app = App::new(&report);
         app.notify_update_available("1.2.3");
-        // `notify_update_available` auto-opens the prompt; dismiss it here
-        // to reach the "notified but closed" state this test covers.
-        let app = app.handle_key(crate::app::InputKey::PopupCancel);
         let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");
 
         terminal
@@ -449,6 +443,7 @@ mod tests {
         let mut app = App::new(&report);
         app.notify_update_available("1.2.3");
         let app = app
+            .handle_key(crate::app::InputKey::OpenUpdatePrompt)
             .handle_key(crate::app::InputKey::PopupCancel)
             .handle_key(crate::app::InputKey::OpenUpdatePrompt);
         let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("terminal");

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -113,7 +113,7 @@ fn main() -> anyhow::Result<()> {
         // Non-TUI: logs straight to stderr like every other subcommand did
         // before display-mode resolution was moved ahead of logger init.
         logger_builder().init();
-        return self_update::run_self_update(yes);
+        return self_update::run_self_update(yes, self_update::Announcement::Print).map(|_| ());
     }
 
     // ADR 0033: the display mode is decided *before* analysis runs, not
@@ -178,12 +178,18 @@ fn main() -> anyhow::Result<()> {
             // ADR 0062: the confirmation is offered here — on the ordinary
             // terminal, before the alternate screen opens and before the
             // ~1.9s analysis an accepted update would otherwise discard.
-            // Accepting never returns from this call (the process re-execs
-            // itself with the updated binary).
-            let update_check = match update_prompt::offer_pre_analysis_update(update_check)? {
-                update_prompt::PreAnalysisOutcome::NotAsked(receiver) => receiver,
-                update_prompt::PreAnalysisOutcome::Declined => None,
-            };
+            //
+            // The callback drains buffered logs on the one path that
+            // `exec`s: replacing the process image runs no `Drop`, so
+            // `_log_sink_guard` cannot cover it. It is not called on the
+            // paths that continue into the TUI, which still need the sink
+            // deferring until the alternate screen is gone (ADR 0033).
+            let before_reexec = || release_log_sink(&log_sink);
+            let update_check =
+                match update_prompt::offer_pre_analysis_update(update_check, before_reexec)? {
+                    update_prompt::PreAnalysisOutcome::NotAsked(receiver) => receiver,
+                    update_prompt::PreAnalysisOutcome::Declined => None,
+                };
 
             // No stderr spinner in this branch (ADR 0033 decision 1): the
             // splash screen drawn on the alternate screen is this run's
@@ -308,7 +314,7 @@ fn main() -> anyhow::Result<()> {
             // `run_self_update` skips straight to downloading rather than
             // prompting a second time on the now-restored terminal.
             if update_requested {
-                self_update::run_self_update(true)
+                self_update::run_self_update(true, self_update::Announcement::Print).map(|_| ())
             } else {
                 Ok(())
             }

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -53,6 +53,7 @@ mod progress;
 mod self_update;
 mod spinner;
 mod splash_progress;
+mod update_prompt;
 
 #[cfg(test)]
 mod test_util;
@@ -174,6 +175,15 @@ fn main() -> anyhow::Result<()> {
             } else {
                 None
             };
+            // ADR 0062: the confirmation is offered here — on the ordinary
+            // terminal, before the alternate screen opens and before the
+            // ~1.9s analysis an accepted update would otherwise discard.
+            // Accepting never returns from this call (the process re-execs
+            // itself with the updated binary).
+            let update_check = match update_prompt::offer_pre_analysis_update(update_check)? {
+                update_prompt::PreAnalysisOutcome::NotAsked(receiver) => receiver,
+                update_prompt::PreAnalysisOutcome::Declined => None,
+            };
 
             // No stderr spinner in this branch (ADR 0033 decision 1): the
             // splash screen drawn on the alternate screen is this run's
@@ -290,8 +300,10 @@ fn main() -> anyhow::Result<()> {
             release_log_sink(&log_sink);
             flush_notes(buffered_notes);
             let update_requested = run_result.map_err(anyhow::Error::from)?;
-            // ADR 0054: the update itself runs only after the block above
-            // has already restored the terminal — `yes: true` since the
+            // ADR 0054: reached only when the pre-analysis prompt did not
+            // run (ADR 0062) and the reviewer opened the popup with `u`
+            // instead. The update runs only after the block above has
+            // already restored the terminal — `yes: true` since the
             // reviewer already confirmed inside the TUI's own popup, so
             // `run_self_update` skips straight to downloading rather than
             // prompting a second time on the now-restored terminal.

--- a/rinkaku/src/self_update.rs
+++ b/rinkaku/src/self_update.rs
@@ -20,6 +20,23 @@ const REPO_OWNER: &str = "hiro-o918";
 const REPO_NAME: &str = "rinkaku";
 const BIN_NAME: &str = "rinkaku";
 
+/// Whether [`run_self_update`] actually replaced the binary on disk. A
+/// plain `Ok(())` cannot say this: the "already up to date", "cancelled",
+/// and "the crate reported no update" paths all succeed without updating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateOutcome {
+    Updated,
+    NotUpdated,
+}
+
+/// Whether [`run_self_update`] should print its own "New release found"
+/// line, or stay quiet because the caller already announced the version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Announcement {
+    Print,
+    AlreadyAnnounced,
+}
+
 /// How the update prompt should behave, decided up front from `--yes` and
 /// whether stdin is a terminal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -64,9 +81,9 @@ fn confirm_mode(yes: bool, stdin_is_tty: bool) -> ConfirmMode {
     }
 }
 
-/// Whether a confirmation answer counts as "yes": trimmed and compared
-/// case-insensitively against `y` / `yes`. Everything else — including an
-/// empty string — is not affirmative.
+/// Whether a confirmation answer counts as "yes". The single rule for
+/// consent across every update prompt in this binary, including
+/// `update_prompt`'s pre-analysis one.
 ///
 /// This is the deliberate opposite of the `self_update` crate's own
 /// `confirm()` helper, which treats an *empty* response as "yes" (see
@@ -74,7 +91,7 @@ fn confirm_mode(yes: bool, stdin_is_tty: bool) -> ConfirmMode {
 /// requiring an explicit `y`/`yes` means a stray newline or a
 /// misunderstood prompt can never be read as consent to replace the
 /// running binary.
-fn is_affirmative(answer: &str) -> bool {
+pub(crate) fn is_affirmative(answer: &str) -> bool {
     matches!(answer.trim().to_lowercase().as_str(), "y" | "yes")
 }
 
@@ -131,7 +148,13 @@ fn build_updater(
 /// `yes` corresponds to the `--yes`/`-y` flag; TTY detection (the other
 /// input to `confirm_mode`) is read here at the composition-root boundary
 /// rather than passed in, since it is itself a form of environment IO.
-pub fn run_self_update(yes: bool) -> Result<()> {
+/// `announcement` lets a caller that has already told the user which
+/// version is available suppress the duplicate line.
+///
+/// Returns [`UpdateOutcome`] rather than `()` because "no error" and "the
+/// binary on disk was replaced" are different facts: `update_prompt`'s
+/// re-exec is only sound for the latter.
+pub fn run_self_update(yes: bool, announcement: Announcement) -> Result<UpdateOutcome> {
     let confirm_mode = confirm_mode(yes, std::io::stdin().is_terminal());
     if confirm_mode == ConfirmMode::RefuseNonInteractive {
         anyhow::bail!("refusing to self-update non-interactively; pass --yes to proceed");
@@ -153,13 +176,15 @@ pub fn run_self_update(yes: bool) -> Result<()> {
         })?;
     if !is_newer {
         println!("{BIN_NAME} is already up to date (v{current_version})");
-        return Ok(());
+        return Ok(UpdateOutcome::NotUpdated);
     }
 
-    println!(
-        "New release found: v{current_version} -> v{}",
-        latest.version
-    );
+    if announcement == Announcement::Print {
+        println!(
+            "New release found: v{current_version} -> v{}",
+            latest.version
+        );
+    }
 
     if confirm_mode == ConfirmMode::Prompt {
         print!("Update to v{}? [y/N]: ", latest.version);
@@ -168,7 +193,7 @@ pub fn run_self_update(yes: bool) -> Result<()> {
         std::io::stdin().read_line(&mut answer)?;
         if !is_affirmative(&answer) {
             println!("Update cancelled");
-            return Ok(());
+            return Ok(UpdateOutcome::NotUpdated);
         }
     }
 
@@ -189,11 +214,11 @@ pub fn run_self_update(yes: bool) -> Result<()> {
             "Updated {BIN_NAME} from v{current_version} to {}",
             status.version()
         );
+        Ok(UpdateOutcome::Updated)
     } else {
         println!("{BIN_NAME} is already up to date (v{current_version})");
+        Ok(UpdateOutcome::NotUpdated)
     }
-
-    Ok(())
 }
 
 /// Checks GitHub for a newer released version than the running binary,

--- a/rinkaku/src/update_prompt.rs
+++ b/rinkaku/src/update_prompt.rs
@@ -8,7 +8,7 @@
 //! function ([`decide_pre_analysis_prompt`]); the channel receive, the
 //! terminal read, and the `exec` are the thin IO shell around it.
 
-use crate::self_update;
+use crate::self_update::{self, Announcement, UpdateOutcome};
 use anyhow::Result;
 use std::io::{IsTerminal, Write};
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
@@ -39,26 +39,38 @@ fn decide_pre_analysis_prompt(update_available: bool, stdin_is_tty: bool) -> Pre
     }
 }
 
-/// Requires an explicit `y`/`yes`, matching `self_update`'s own
-/// `is_affirmative`, so a stray newline can never be read as consent to
-/// replace the running binary.
-fn is_affirmative(answer: &str) -> bool {
-    matches!(answer.trim().to_lowercase().as_str(), "y" | "yes")
-}
-
-pub(crate) enum PreAnalysisOutcome {
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PreAnalysisOutcome<R = Receiver<String>> {
     /// The receiver is handed back when it may still deliver, so the
     /// TUI's status-line hint and `u` key remain the fallback path.
-    NotAsked(Option<Receiver<String>>),
+    NotAsked(Option<R>),
     /// The receiver is deliberately dropped, so the TUI cannot ask the
     /// same question a second time in one run.
     Declined,
 }
 
-/// Accepting never returns: the update runs and the process re-execs
-/// itself (see [`update_and_reexec`]).
+impl PreAnalysisOutcome {
+    /// A `Debug + PartialEq` stand-in for whole-value assertions, which
+    /// `Receiver` blocks by implementing neither usefully.
+    #[cfg(test)]
+    fn shape(&self) -> PreAnalysisOutcome<()> {
+        match self {
+            Self::NotAsked(receiver) => PreAnalysisOutcome::NotAsked(receiver.as_ref().map(|_| ())),
+            Self::Declined => PreAnalysisOutcome::Declined,
+        }
+    }
+}
+
+/// Accepting runs the update and, *only if the binary was actually
+/// replaced*, re-execs — in which case this never returns. An accepted
+/// prompt that ends up not updating (the release vanished, the crate
+/// reported no change) falls through to analysis like a declined one.
+///
+/// `before_reexec` runs on the one path this function does not return
+/// from; see [`reexec_current_command`].
 pub(crate) fn offer_pre_analysis_update(
     update_check: Option<Receiver<String>>,
+    before_reexec: impl FnOnce(),
 ) -> Result<PreAnalysisOutcome> {
     let Some(receiver) = update_check else {
         return Ok(PreAnalysisOutcome::NotAsked(None));
@@ -82,22 +94,45 @@ pub(crate) fn offer_pre_analysis_update(
     std::io::stdout().flush()?;
     let mut answer = String::new();
     std::io::stdin().read_line(&mut answer)?;
-    if !is_affirmative(&answer) {
+    if !self_update::is_affirmative(&answer) {
         return Ok(PreAnalysisOutcome::Declined);
     }
 
-    update_and_reexec()
+    update_and_reexec(before_reexec)
 }
 
-/// `yes: true` since the question was already answered above. On success
-/// the `exec` never returns, so there is no re-check loop to guard
-/// against: the replacement image is a newer version, and its own check
-/// finds nothing newer.
-fn update_and_reexec() -> Result<PreAnalysisOutcome> {
-    self_update::run_self_update(true)?;
-    reexec_current_command()
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AfterUpdate {
+    Reexec,
+    ContinueToAnalysis,
 }
 
+/// Re-execing on a merely *successful* `run_self_update` rather than an
+/// *updating* one would loop: the replacement image would be the same
+/// version, would find the same release newer, and would ask again.
+fn decide_after_update(outcome: UpdateOutcome) -> AfterUpdate {
+    match outcome {
+        UpdateOutcome::Updated => AfterUpdate::Reexec,
+        UpdateOutcome::NotUpdated => AfterUpdate::ContinueToAnalysis,
+    }
+}
+
+/// `yes: true` since the question was already answered above, and
+/// `AlreadyAnnounced` since the version was printed above too.
+fn update_and_reexec(before_reexec: impl FnOnce()) -> Result<PreAnalysisOutcome> {
+    let outcome = self_update::run_self_update(true, Announcement::AlreadyAnnounced)?;
+    match decide_after_update(outcome) {
+        AfterUpdate::Reexec => {
+            before_reexec();
+            reexec_current_command()
+        }
+        AfterUpdate::ContinueToAnalysis => Ok(PreAnalysisOutcome::NotAsked(None)),
+    }
+}
+
+/// `exec` replaces the process image, so no `Drop` in this thread's stack
+/// ever runs. Whatever needs releasing must be released before this call,
+/// which is what `offer_pre_analysis_update`'s `before_reexec` is for.
 #[cfg(unix)]
 fn reexec_current_command() -> Result<PreAnalysisOutcome> {
     use std::os::unix::process::CommandExt;
@@ -145,35 +180,25 @@ mod tests {
     }
 
     #[rstest]
-    #[case::should_accept_lowercase_y("y", true)]
-    #[case::should_accept_uppercase_y("Y", true)]
-    #[case::should_accept_lowercase_yes("yes", true)]
-    #[case::should_accept_mixed_case_yes("Yes", true)]
-    #[case::should_accept_y_with_surrounding_whitespace("  y  \n", true)]
-    #[case::should_reject_empty_string("", false)]
-    #[case::should_reject_whitespace_only_string("   \n", false)]
-    #[case::should_reject_n("n", false)]
-    #[case::should_reject_no("no", false)]
-    #[case::should_reject_y_as_prefix_of_longer_word("yesterday", false)]
-    fn should_check_is_affirmative(#[case] answer: &str, #[case] expected: bool) {
-        let actual = is_affirmative(answer);
+    #[case::should_reexec_when_the_binary_was_replaced(UpdateOutcome::Updated, AfterUpdate::Reexec)]
+    #[case::should_continue_to_analysis_when_nothing_was_replaced(
+        UpdateOutcome::NotUpdated,
+        AfterUpdate::ContinueToAnalysis
+    )]
+    fn should_decide_what_follows_an_accepted_update(
+        #[case] outcome: UpdateOutcome,
+        #[case] expected: AfterUpdate,
+    ) {
+        let actual = decide_after_update(outcome);
 
         assert_eq!(expected, actual);
     }
 
     #[test]
-    fn should_wait_at_most_300ms_for_the_background_check() {
-        assert_eq!(Duration::from_millis(300), CHECK_WAIT);
-    }
-
-    #[test]
     fn should_not_ask_when_there_is_no_version_check_at_all() {
-        let actual = offer_pre_analysis_update(None);
+        let actual = offer_pre_analysis_update(None, || {}).expect("offer");
 
-        assert_eq!(
-            true,
-            matches!(actual, Ok(PreAnalysisOutcome::NotAsked(None)))
-        );
+        assert_eq!(PreAnalysisOutcome::NotAsked(None), actual.shape());
     }
 
     #[test]
@@ -182,12 +207,12 @@ mod tests {
         // takes the `Timeout` branch rather than `Disconnected`.
         let (sender, receiver) = std::sync::mpsc::channel::<String>();
 
-        let actual = offer_pre_analysis_update(Some(receiver));
+        let started_at = std::time::Instant::now();
+        let actual = offer_pre_analysis_update(Some(receiver), || {}).expect("offer");
+        let waited = started_at.elapsed();
 
-        assert_eq!(
-            true,
-            matches!(actual, Ok(PreAnalysisOutcome::NotAsked(Some(_))))
-        );
+        assert_eq!(PreAnalysisOutcome::NotAsked(Some(())), actual.shape());
+        assert_eq!(true, waited >= CHECK_WAIT, "waited {waited:?}");
         drop(sender);
     }
 
@@ -196,12 +221,9 @@ mod tests {
         let (sender, receiver) = std::sync::mpsc::channel::<String>();
         drop(sender);
 
-        let actual = offer_pre_analysis_update(Some(receiver));
+        let actual = offer_pre_analysis_update(Some(receiver), || {}).expect("offer");
 
-        assert_eq!(
-            true,
-            matches!(actual, Ok(PreAnalysisOutcome::NotAsked(None)))
-        );
+        assert_eq!(PreAnalysisOutcome::NotAsked(None), actual.shape());
     }
 
     // `cargo test` runs with a non-TTY stdin, which is exactly the state
@@ -213,11 +235,8 @@ mod tests {
         let (sender, receiver) = std::sync::mpsc::channel::<String>();
         sender.send("9.9.9".to_string()).expect("send");
 
-        let actual = offer_pre_analysis_update(Some(receiver));
+        let actual = offer_pre_analysis_update(Some(receiver), || {}).expect("offer");
 
-        assert_eq!(
-            true,
-            matches!(actual, Ok(PreAnalysisOutcome::NotAsked(None)))
-        );
+        assert_eq!(PreAnalysisOutcome::NotAsked(None), actual.shape());
     }
 }

--- a/rinkaku/src/update_prompt.rs
+++ b/rinkaku/src/update_prompt.rs
@@ -1,0 +1,223 @@
+//! ADR 0062: the pre-analysis update confirmation — offered on the
+//! ordinary terminal before `TuiSession::init` opens the alternate
+//! screen, rather than as a TUI popup after analysis has already run.
+//!
+//! Kept next to `self_update.rs` in the bin crate for the same reason
+//! that module gives: this is process/network IO tied to how this
+//! binary is distributed. The decision of *whether* to ask is a pure
+//! function ([`decide_pre_analysis_prompt`]); the channel receive, the
+//! terminal read, and the `exec` are the thin IO shell around it.
+
+use crate::self_update;
+use anyhow::Result;
+use std::io::{IsTerminal, Write};
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::time::Duration;
+
+/// How long `main` blocks on the background version check before giving
+/// up and starting analysis. ADR 0062: ~4x the measured ~0.07s cost of
+/// the check, small enough that a slow network cannot make startup feel
+/// worse than not checking at all.
+const CHECK_WAIT: Duration = Duration::from_millis(300);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PreAnalysisPrompt {
+    Ask,
+    Skip,
+}
+
+/// The `stdin_is_tty` input carries more weight than "there is nobody to
+/// answer": a non-TTY stdin is very likely the diff itself
+/// (`gh pr diff 123 | rinkaku`), which a post-update re-exec could never
+/// read a second time. Refusing to ask here is what makes that case
+/// structurally unreachable rather than a special case downstream.
+fn decide_pre_analysis_prompt(update_available: bool, stdin_is_tty: bool) -> PreAnalysisPrompt {
+    if update_available && stdin_is_tty {
+        PreAnalysisPrompt::Ask
+    } else {
+        PreAnalysisPrompt::Skip
+    }
+}
+
+/// Requires an explicit `y`/`yes`, matching `self_update`'s own
+/// `is_affirmative`, so a stray newline can never be read as consent to
+/// replace the running binary.
+fn is_affirmative(answer: &str) -> bool {
+    matches!(answer.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
+pub(crate) enum PreAnalysisOutcome {
+    /// The receiver is handed back when it may still deliver, so the
+    /// TUI's status-line hint and `u` key remain the fallback path.
+    NotAsked(Option<Receiver<String>>),
+    /// The receiver is deliberately dropped, so the TUI cannot ask the
+    /// same question a second time in one run.
+    Declined,
+}
+
+/// Accepting never returns: the update runs and the process re-execs
+/// itself (see [`update_and_reexec`]).
+pub(crate) fn offer_pre_analysis_update(
+    update_check: Option<Receiver<String>>,
+) -> Result<PreAnalysisOutcome> {
+    let Some(receiver) = update_check else {
+        return Ok(PreAnalysisOutcome::NotAsked(None));
+    };
+    let version = match receiver.recv_timeout(CHECK_WAIT) {
+        Ok(version) => version,
+        Err(RecvTimeoutError::Timeout) => {
+            return Ok(PreAnalysisOutcome::NotAsked(Some(receiver)));
+        }
+        Err(RecvTimeoutError::Disconnected) => {
+            return Ok(PreAnalysisOutcome::NotAsked(None));
+        }
+    };
+    if decide_pre_analysis_prompt(true, std::io::stdin().is_terminal()) == PreAnalysisPrompt::Skip {
+        return Ok(PreAnalysisOutcome::NotAsked(None));
+    }
+
+    let current_version = env!("CARGO_PKG_VERSION");
+    println!("New release found: v{current_version} -> v{version}");
+    print!("Update to v{version} and re-run? [y/N]: ");
+    std::io::stdout().flush()?;
+    let mut answer = String::new();
+    std::io::stdin().read_line(&mut answer)?;
+    if !is_affirmative(&answer) {
+        return Ok(PreAnalysisOutcome::Declined);
+    }
+
+    update_and_reexec()
+}
+
+/// `yes: true` since the question was already answered above. On success
+/// the `exec` never returns, so there is no re-check loop to guard
+/// against: the replacement image is a newer version, and its own check
+/// finds nothing newer.
+fn update_and_reexec() -> Result<PreAnalysisOutcome> {
+    self_update::run_self_update(true)?;
+    reexec_current_command()
+}
+
+#[cfg(unix)]
+fn reexec_current_command() -> Result<PreAnalysisOutcome> {
+    use std::os::unix::process::CommandExt;
+
+    let exe = std::env::current_exe()?;
+    let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+    Err(anyhow::Error::from(
+        std::process::Command::new(exe).args(args).exec(),
+    ))
+}
+
+#[cfg(not(unix))]
+fn reexec_current_command() -> Result<PreAnalysisOutcome> {
+    println!("Re-run rinkaku to analyze with the updated binary");
+    std::process::exit(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::should_ask_when_an_update_is_available_and_stdin_is_a_tty(
+        true,
+        true,
+        PreAnalysisPrompt::Ask
+    )]
+    #[case::should_skip_when_no_update_is_available(false, true, PreAnalysisPrompt::Skip)]
+    #[case::should_skip_when_stdin_is_not_a_tty(true, false, PreAnalysisPrompt::Skip)]
+    #[case::should_skip_when_no_update_is_available_and_stdin_is_not_a_tty(
+        false,
+        false,
+        PreAnalysisPrompt::Skip
+    )]
+    fn should_decide_pre_analysis_prompt(
+        #[case] update_available: bool,
+        #[case] stdin_is_tty: bool,
+        #[case] expected: PreAnalysisPrompt,
+    ) {
+        let actual = decide_pre_analysis_prompt(update_available, stdin_is_tty);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[rstest]
+    #[case::should_accept_lowercase_y("y", true)]
+    #[case::should_accept_uppercase_y("Y", true)]
+    #[case::should_accept_lowercase_yes("yes", true)]
+    #[case::should_accept_mixed_case_yes("Yes", true)]
+    #[case::should_accept_y_with_surrounding_whitespace("  y  \n", true)]
+    #[case::should_reject_empty_string("", false)]
+    #[case::should_reject_whitespace_only_string("   \n", false)]
+    #[case::should_reject_n("n", false)]
+    #[case::should_reject_no("no", false)]
+    #[case::should_reject_y_as_prefix_of_longer_word("yesterday", false)]
+    fn should_check_is_affirmative(#[case] answer: &str, #[case] expected: bool) {
+        let actual = is_affirmative(answer);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_wait_at_most_300ms_for_the_background_check() {
+        assert_eq!(Duration::from_millis(300), CHECK_WAIT);
+    }
+
+    #[test]
+    fn should_not_ask_when_there_is_no_version_check_at_all() {
+        let actual = offer_pre_analysis_update(None);
+
+        assert_eq!(
+            true,
+            matches!(actual, Ok(PreAnalysisOutcome::NotAsked(None)))
+        );
+    }
+
+    #[test]
+    fn should_hand_the_receiver_back_when_the_check_thread_is_still_running() {
+        // The sender is kept alive but never sends, so `recv_timeout`
+        // takes the `Timeout` branch rather than `Disconnected`.
+        let (sender, receiver) = std::sync::mpsc::channel::<String>();
+
+        let actual = offer_pre_analysis_update(Some(receiver));
+
+        assert_eq!(
+            true,
+            matches!(actual, Ok(PreAnalysisOutcome::NotAsked(Some(_))))
+        );
+        drop(sender);
+    }
+
+    #[test]
+    fn should_not_hand_the_receiver_back_when_the_check_found_nothing() {
+        let (sender, receiver) = std::sync::mpsc::channel::<String>();
+        drop(sender);
+
+        let actual = offer_pre_analysis_update(Some(receiver));
+
+        assert_eq!(
+            true,
+            matches!(actual, Ok(PreAnalysisOutcome::NotAsked(None)))
+        );
+    }
+
+    // `cargo test` runs with a non-TTY stdin, which is exactly the state
+    // this test needs: a version arriving well within `CHECK_WAIT` must
+    // still not reach the prompt or the re-exec, since a piped stdin may
+    // be carrying the diff itself.
+    #[test]
+    fn should_not_prompt_when_a_version_arrives_in_time_but_stdin_is_not_a_tty() {
+        let (sender, receiver) = std::sync::mpsc::channel::<String>();
+        sender.send("9.9.9".to_string()).expect("send");
+
+        let actual = offer_pre_analysis_update(Some(receiver));
+
+        assert_eq!(
+            true,
+            matches!(actual, Ok(PreAnalysisOutcome::NotAsked(None)))
+        );
+    }
+}


### PR DESCRIPTION
Moves the self-update confirmation from a TUI popup shown *after*
analysis to a y/N question on the ordinary terminal shown *before* it,
and re-runs the same command with the updated binary. ADR 0062.

## Why

Two measurements on this repository:

- `run_analysis` on a typical `--base main` run: **~1.9s**.
- `self_update::check_update_available` (one `/releases/latest` call +
  a semver compare): **~0.07s** typical. Repeated sampling shows
  occasional outliers at ~0.3s and ~1.1s.

So the answer was already known before analysis was a tenth of the way
through, and the reviewer was nevertheless made to wait ~1.9s and then
have a modal thrown over the entry screen (ADR 0056's auto-open). Worse,
accepting the update quit the TUI and **discarded the analysis that was
just paid for** — the reviewer then had to re-run `rinkaku` by hand.

The confirmation was drawn as a TUI popup only because of where it sat
in the sequence. Before `TuiSession::init` there is an ordinary terminal
available, and `run_self_update` already owns a y/N prompt for exactly
this question.

## What changed

- **New `rinkaku/src/update_prompt.rs`.** After spawning ADR 0054's
  background check thread (unchanged), `main` does a single
  `recv_timeout(300ms)` on the receiver before `TuiSession::init`. If a
  newer version arrives in that window and stdin is a TTY, it asks on
  the terminal; answering `y` installs the release and — **only if the
  binary was actually replaced** — `exec`s the same command line
  (`std::env::args_os()`).
- **300ms, and the miss is tolerated.** ~4x the typical check cost, but
  short enough that a slow network can't make startup feel worse than
  not checking. A late result still reaches the TUI, still lights the
  status-line hint, and is still reachable via `u` — the receiver is
  handed back to `session.run` when the question wasn't asked, and
  dropped when it was, so the TUI can never ask twice in one run.
- **ADR 0056's auto-open is removed.** `should_auto_open_update_prompt`
  and `App::update_prompt_dismissed` are deleted;
  `notify_update_available` reverts to ADR 0054's plain setter. Its
  motivation was that the status-line hint went unnoticed for weeks — a
  pre-analysis terminal prompt cannot be missed. The status-line hint,
  the `u` key, `update_prompt_open`, `update_requested`, and the popup's
  `PopupConfirm`/`PopupCancel` handling all stay.
- `RINKAKU_UPDATE_CHECK=0` still skips the check, and therefore this
  whole path, entirely.

## stdin-piped input

`gh pr diff 123 | rinkaku` consumes stdin on the way in; a re-exec'd
process would find that pipe at EOF and analyze nothing.

The guard is the same rule `self-update` already uses: the pre-analysis
confirmation is only offered when stdin is a TTY. Piped input means
stdin is not a TTY → no confirmation → no update → no re-exec. The
dangerous case is **structurally unreachable** rather than specially
cased. `decide_pre_analysis_prompt` makes this explicit by taking
`stdin_is_tty` and returning `Skip` when false, and is unit-tested for
exactly that — including the case where a version *does* arrive within
the window but stdin is not a TTY (`cargo test` itself runs with a
non-TTY stdin, so that test genuinely exercises the guard).

`#[cfg(not(unix))]` falls back to a "re-run rinkaku" message; no
non-Unix target is built today.

## Re-exec is gated on the update having happened

`run_self_update` returns `Ok` **without updating** on three paths:
the version comparison finds nothing newer, the confirmation is
cancelled, and `updater.update()` reports `status.updated() == false`.
Re-execing on mere success would put the *same* version back at `main`,
where it would find the same release newer and ask the same question
again — a loop for as long as the user keeps answering `y`.

So `run_self_update` now returns `UpdateOutcome` (`Updated` /
`NotUpdated`) rather than `()`. Only `Updated` reaches the `exec`;
`NotUpdated` falls through to analysis exactly like a declined prompt.
The mapping is the pure `decide_after_update`, unit-tested for both
outcomes (the test fails against the previous unconditional re-exec).

Two smaller consequences of touching this boundary:

- **`exec` runs no destructors.** ADR 0033's `--tui` branch buffers
  `log::` records in a `DeferredLogSink` whose `ReleaseGuard` `Drop` is
  the safety net for abrupt exits — and replacing the process image
  skips every `Drop`, that guard included. `main` now hands
  `offer_pre_analysis_update` a `before_reexec` callback that drains
  the sink, invoked on the accept-and-updated path only; the paths that
  continue into the TUI keep deferring until the alternate screen is
  gone.
- **One "New release found" line, not two.** `run_self_update` takes an
  `Announcement`, so the pre-analysis caller (which already printed the
  version alongside its own question) suppresses the duplicate. The
  `self-update` subcommand and the TUI's `u` path pass
  `Announcement::Print` and are unchanged.
- **`is_affirmative` is shared, not duplicated.** `update_prompt` calls
  `self_update`'s `pub(crate)` one; the copy (which had already drifted
  into a weaker test table) is gone. One rule for what counts as
  consent to replace the running binary.

## Testing

`make test`: **1659 passed, 0 failed** (205 `rinkaku` / 423
`rinkaku-core` / 1031 `rinkaku-tui`). `make lint`: clean.

Unit tests cover: the `Ask`/`Skip` decision across both inputs;
`decide_after_update` for both `UpdateOutcome`s; and
`offer_pre_analysis_update`'s three no-ask paths (no receiver at all,
timeout with the thread still running, sender dropped) plus the
version-arrives-but-no-TTY path. The timeout test now also asserts the
call actually waited `CHECK_WAIT`, replacing a tautological
`assert_eq!(Duration::from_millis(300), CHECK_WAIT)`. Outcome
assertions compare whole values via a `shape()` projection instead of
`assert_eq!(true, matches!(..))`, so a failure shows what was returned.
`is_affirmative`'s table lives in `self_update.rs` alone now.

## Dynamic verification

Built and actually executed, all against this repo's own diff:

| Case | Result |
| --- | --- |
| `git diff \| rinkaku` (piped stdin, piped stdout) | Markdown, unchanged |
| same + `RINKAKU_UPDATE_CHECK=0` | identical output |
| `echo -n "" \| rinkaku` | `note: diff is empty, nothing to analyze` |
| `rinkaku --base main < /dev/null` (piped stdout) | Markdown, unchanged |
| `git diff \| rinkaku --tui` (piped stdin, piped stdout) | fails at `TuiSession::init` with `Device not configured`, **not** a hang on the prompt — confirms the non-TTY guard short-circuits before any read |
| `printf 'q' \| script -q /dev/null rinkaku --base main` (real pty) | TUI starts and exits cleanly in **0.56s**; **no** prompt printed (nothing newer available) |

TUI-side behavior is asserted via ratatui's `TestBackend` rather than
tmux: the update popup no longer appears from `notify_update_available`
alone, and does appear after `OpenUpdatePrompt`.

**Not verified end-to-end:** the actual "an update exists" path. The
local version (0.6.18) equals the latest release (v0.6.18), so the
check correctly finds nothing newer and the prompt/download/re-exec
sequence cannot be triggered from this checkout. The decision logic
around it is unit-tested; `run_self_update` itself is unchanged by this
PR.

## File sizes

All touched files under threshold. `rinkaku-tui/src/app/mod.rs` drops
44 lines (977); `rinkaku/src/update_prompt.rs` is new at 223.

