### PR TITLE
fix: extract macro-body references and count transitive test coverage (ADR 0063)

### DIFF
--- a/docs/adr/0059-test-coverage-per-symbol.md
+++ b/docs/adr/0059-test-coverage-per-symbol.md
@@ -214,4 +214,5 @@ The section heading is `## Changes with no referencing tests`
 support.
 
 Improving precision — resolving references inside macro bodies, or
-walking the reference graph transitively — is left to a follow-up ADR.
+walking the reference graph transitively — is left to a follow-up ADR:
+[ADR 0063](0063-macro-body-references-and-transitive-test-coverage.md).

--- a/docs/adr/0063-macro-body-references-and-transitive-test-coverage.md
+++ b/docs/adr/0063-macro-body-references-and-transitive-test-coverage.md
@@ -1,0 +1,151 @@
+# 0063. Extract macro-body references and count transitive test coverage
+
+- Status: accepted
+- Date: 2026-07-30
+- Relates to: [ADR 0059](0059-test-coverage-per-symbol.md) (per-symbol
+  test coverage; its amendment scoped this follow-up), [ADR
+  0042](0042-exclude-test-referrers-from-fan-in.md) (`Node::is_test`),
+  [ADR 0003](0003-name-based-dependency-resolution.md) (name-only
+  reference resolution), [ADR 0013](0013-hotspots-fan-in-section.md)
+  (fan-in aggregation)
+
+## Context
+
+ADR 0059's amendment measured its `test_count == 0` signal at a 67%
+false-positive rate in whole-repo outline mode (513 of 763 symbols
+reported zero coverage in a repo with 1600+ passing tests) and traced
+it to three mechanisms. Two are fixable inside the current name-based
+resolution model and were left to this follow-up:
+
+- **References inside macro bodies are not extracted.** The Rust
+  reference query matches `call_expression`/`type_identifier` nodes,
+  but everything inside a macro invocation is a flat `token_tree` of
+  raw tokens — `assert_eq!(inner(), 2)` contains no `call_expression`,
+  so `inner` gets no edge. This repo's own house idiom
+  (`pretty_assertions::assert_eq!` on whole values) means most test
+  bodies reference their subject *only* from inside a macro.
+- **No transitive closure.** Coverage counted direct references only:
+  a test calling `outer()`, which calls `inner()`, left `inner` at
+  `test_count: 0` even though the test exercises it.
+
+The third mechanism — diff scope, where a symbol's tests exist but are
+outside the diff — is inherent to diff mode's "graph over changed
+symbols" contract and stays out of scope here.
+
+Empirically (tree-sitter-rust), a macro body parses as nested
+`token_tree` nodes whose leaves are plain tokens: identifiers (type
+names included — `Config::V1` lexes as `identifier "Config"`,
+`identifier "V1"`), operators, and literals. Attribute arguments
+(`#[cfg(test)]`, `#[derive(Debug)]`) are *also* `token_tree`s, but
+under an `attribute` node, not a `macro_invocation`.
+
+## Decision
+
+Two changes, one per mechanism.
+
+**1. Walk `macro_invocation` token trees during Rust reference
+extraction.** `extract::collect_referenced_names` additionally walks
+the subtree for `macro_invocation` nodes and collects the identifier
+tokens inside their `token_tree`, at any nesting depth, into
+`referenced_names` — subject to the same `is_noise_name` filter as
+query captures. Two token classes are skipped:
+
+- the macro's own name (the `macro` field is not part of the walked
+  `token_tree`), and
+- any identifier immediately followed by a `!` token — a *nested*
+  macro's name (`matches` in `assert!(matches!(...))`), which is a
+  macro reference, not a symbol reference.
+
+This is a code walk in `extract.rs`, not a query pattern, for two
+reasons: a query has no way to express "identifier *not* followed by
+`!`", and the nested-depth pattern `(token_tree (token_tree
+(identifier)))` would also match attribute arguments, fabricating
+references named `test`, `feature`, or every derive name in the file.
+Matching on the `macro_invocation` node kind in language-neutral code
+follows `extract::symbol_kind`'s existing precedent (node kind strings
+are unique across the supported grammars, so the walk is inert for Go,
+Python, and TypeScript — none of which have an equivalent construct).
+
+The new names flow into `referenced_names` itself, not a
+coverage-only side channel, so dependency resolution (`deps.rs`),
+graph edges, fan-in, and test coverage all see them. This is
+deliberate: a macro-body reference is a real reference, and fan-in had
+the same blind spot (a symbol called only via `matches!`/`write!` in
+production code was invisible to it). One graph, one definition of
+"references".
+
+**2. Count transitive coverage in `compute_test_coverage`.** Instead
+of keeping only direct test→target edges, traverse the reference graph
+from each test node (following outgoing edges through any intermediate
+node, cycles handled by a visited set) and record that test in the
+`covering_tests` of every non-test node it reaches. A test that
+exercises `outer()` genuinely executes `inner()`; reachability
+over-approximates execution, but for a signal whose job is flagging
+*zero* coverage, a false "covered" is the cheaper error — the ADR 0059
+amendment showed the opposite bias destroys the signal entirely.
+
+The output shape (JSON `test_coverage` array, `TestCoverage` struct)
+is unchanged; direct and transitive coverage are not distinguished.
+The Markdown heading stays `## Changes with no referencing tests` — a
+transitive reach is still a reference chain.
+
+`compute_fan_ins` stays direct-only: fan-in measures blast radius of a
+signature change, which propagates one edge at a time and is already
+rendered transitively by the tree view; only the coverage question is
+inherently transitive ("does *any* test end up here").
+
+## Alternatives
+
+- **Query-only extraction of macro-body identifiers**: rejected above
+  — cannot skip nested macro names, and the depth-generic pattern
+  leaks attribute arguments (`cfg`/`derive` contents) into references.
+- **Count macro-body references for coverage only, not fan-in/deps**:
+  rejected — two divergent definitions of "reference" over the same
+  graph, and the fan-in blind spot is the same bug wearing a different
+  aggregation.
+- **Depth-capped transitive walk**: rejected — the graph is small
+  (hundreds of nodes), a visited set already bounds the walk, and any
+  cap reintroduces arbitrary false zeros just beyond the cap.
+- **LSP-based resolution**: the eventual precise answer (the
+  `Resolver` trait is the plug point), but a much larger dependency
+  and out of scope for closing a measured 67% gap with the tools
+  already in hand.
+- **Fixing the diff-scope mechanism**: would require parsing files the
+  diff never touched, breaking diff mode's cost model. Repo-outline
+  mode already provides the full-graph answer.
+
+## Consequences
+
+- **Output changes** (pre-1.0 breaking, consistent with ADR
+  0013/0042/0059 precedent): `referenced_names`-derived surfaces —
+  "Depends on" lists, fan-in counts, graph edges, test coverage — may
+  all grow. Existing expectation-pinning tests are updated in the same
+  change.
+- Macro-body identifiers are collected without call-shape filtering,
+  so plain variable names inside macro bodies (`assert_eq!(expected,
+  actual)`) enter `referenced_names`. Under name-only resolution (ADR
+  0003) they only become edges when a same-named symbol exists in the
+  graph — the accepted imprecision baseline since ADR 0003.
+- Measured on this repo's whole-repo outline (same tree, same flags,
+  main build vs. this change): the zero-coverage rate drops from 522
+  of 784 (67%) to 172 of 784 (22%). Symbols the ADR 0059 amendment
+  called out as false positives — `entry_row_line`, `build_tree`,
+  `render_markdown`'s caller `render` — now report their real
+  coverage.
+- The dominant *remaining* false-positive mechanism is now visible:
+  cross-module scoped calls. `render(...)` reaching `render_markdown`
+  via `markdown::render_markdown(report)` produces no edge, because
+  the reference query captures only the path head of a
+  `scoped_identifier` — the same deliberate decision that keeps
+  `Format::default()` from fabricating references to every changed
+  symbol named `default` (the two shapes are syntactically
+  indistinguishable without type resolution). Extending capture to the
+  scoped name is a precision/noise tradeoff (`new`, `default`, `get`
+  collide across files) left to a follow-up ADR; the rest of the
+  surviving 22% is genuinely test-light wiring (`main.rs`, TUI event
+  glue).
+- The ADR 0059 amendment's decision to keep the `!` risk-marker
+  escalation withdrawn is unchanged: at a measured 22% false-zero rate
+  (`symbol_badges` still reads zero through the scoped-call gap), the
+  signal is not yet clean enough for the TUI's scarcest visual
+  channel.

--- a/rinkaku-core/src/extract.rs
+++ b/rinkaku-core/src/extract.rs
@@ -493,7 +493,67 @@ fn collect_referenced_names(
         }
     }
 
+    collect_macro_body_names(node, source, &mut names);
+
     names.into_iter().collect()
+}
+
+/// Rust macro bodies parse as raw `token_tree` tokens, so the
+/// `call_expression`/`type_identifier` patterns in `reference_query` never
+/// match inside them — identifiers there are collected by this walk
+/// instead (ADR 0063). `macro_invocation` is a Rust-only node kind, so
+/// the walk is inert for the other grammars (same cross-grammar
+/// reasoning as [`symbol_kind`]). Attribute arguments are `token_tree`s
+/// under an `attribute` node, not a `macro_invocation`, and are
+/// deliberately not walked.
+fn collect_macro_body_names(
+    node: tree_sitter::Node,
+    source: &[u8],
+    names: &mut std::collections::BTreeSet<String>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "macro_invocation" {
+            let mut invocation_cursor = child.walk();
+            for part in child.children(&mut invocation_cursor) {
+                if part.kind() == "token_tree" {
+                    collect_token_tree_names(part, source, names);
+                }
+            }
+        } else {
+            collect_macro_body_names(child, source, names);
+        }
+    }
+}
+
+/// Collects `identifier` tokens at any nesting depth of a macro body's
+/// `token_tree`, skipping an identifier immediately followed by a `!`
+/// token — that is a *nested* macro's name, a macro reference rather
+/// than a symbol reference.
+fn collect_token_tree_names(
+    token_tree: tree_sitter::Node,
+    source: &[u8],
+    names: &mut std::collections::BTreeSet<String>,
+) {
+    let mut cursor = token_tree.walk();
+    let children: Vec<tree_sitter::Node> = token_tree.children(&mut cursor).collect();
+    for (index, child) in children.iter().enumerate() {
+        match child.kind() {
+            "token_tree" => collect_token_tree_names(*child, source, names),
+            "identifier" => {
+                let names_a_nested_macro = children
+                    .get(index + 1)
+                    .is_some_and(|next| next.kind() == "!");
+                if !names_a_nested_macro
+                    && let Ok(text) = child.utf8_text(source)
+                    && !is_noise_name(text)
+                {
+                    names.insert(text.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Whether `name` is too generic to be worth resolving: the bare `_`

--- a/rinkaku-core/src/extract_tests/rust.rs
+++ b/rinkaku-core/src/extract_tests/rust.rs
@@ -173,6 +173,116 @@ fn should_collect_scoped_identifier_path_references(
     assert_eq!(expected, actual);
 }
 
+#[rstest]
+#[case::should_collect_call_and_path_identifiers_inside_macro_body(
+    "\
+fn build() -> Format {
+    assert_eq!(inner(), Config::V1)
+}
+",
+    vec![
+        "Config".to_string(),
+        "Format".to_string(),
+        "V1".to_string(),
+        "inner".to_string(),
+    ],
+)]
+#[case::should_skip_nested_macro_name_inside_macro_body(
+    "\
+fn build() -> Format {
+    assert!(matches!(value, Foo::Bar))
+}
+",
+    vec![
+        "Bar".to_string(),
+        "Foo".to_string(),
+        "Format".to_string(),
+        "value".to_string(),
+    ],
+)]
+#[case::should_collect_identifiers_inside_bracket_macro_body(
+    "\
+fn build() -> Format {
+    vec![make_thing(input)]
+}
+",
+    vec![
+        "Format".to_string(),
+        "input".to_string(),
+        "make_thing".to_string(),
+    ],
+)]
+#[case::should_keep_identifier_before_not_equal_operator_inside_macro_body(
+    "\
+fn build() -> Format {
+    assert!(left != right)
+}
+",
+    vec![
+        "Format".to_string(),
+        "left".to_string(),
+        "right".to_string(),
+    ],
+)]
+fn should_collect_macro_body_references(
+    #[case] source: &str,
+    #[case] referenced_names: Vec<String>,
+) {
+    let lang = RustSupport;
+    let changed_ranges = vec![LineRange { start: 1, end: 1 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "build".to_string(),
+        kind: SymbolKind::Function,
+        signature: "fn build() -> Format".to_string(),
+        range: LineRange { start: 1, end: 3 },
+        container: None,
+        referenced_names,
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_not_collect_attribute_arguments_as_referenced_names() {
+    // `#[derive(...)]`/`#[cfg(...)]` arguments are token_trees too, but
+    // under an `attribute` node — the macro-body walk (ADR 0063) must not
+    // turn derive names into references.
+    let source = "\
+#[derive(Debug, Clone)]
+struct Point {
+    x: i32,
+}
+";
+    let lang = RustSupport;
+    let changed_ranges = vec![LineRange { start: 2, end: 2 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Point".to_string(),
+        kind: SymbolKind::Struct,
+        signature: "struct Point {\n    x: i32,\n}".to_string(),
+        range: LineRange { start: 2, end: 4 },
+        container: None,
+        referenced_names: vec!["Point".to_string()],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
 #[test]
 fn should_mark_symbol_as_test_when_nested_inside_cfg_test_mod() {
     let source = "\

--- a/rinkaku-core/src/graph.rs
+++ b/rinkaku-core/src/graph.rs
@@ -206,12 +206,16 @@ pub struct TestCoverage {
     pub test_count: usize,
 }
 
-/// Aggregates `graph.edges` by target node into [`TestCoverage`]s: the
-/// inverse filter of [`compute_fan_ins`] (keeps only edges whose referrer
-/// *is* `Node::is_test`, ADR 0042's classification) over every changed,
-/// non-test node — including nodes with zero test referrers, since an
-/// empty `covering_tests` list is the untested-symbol signal this
-/// aggregation exists to surface, not a case to omit.
+/// Computes [`TestCoverage`] for every changed, non-test node: which test
+/// nodes (`Node::is_test`, ADR 0042's classification) *reach* it through
+/// the reference graph. Coverage is transitive (ADR 0063): a test walking
+/// into `outer()` exercises everything `outer` references, so the walk
+/// follows outgoing edges from each test node through any intermediate —
+/// reachability over-approximates execution, but for a signal whose job is
+/// flagging *zero* coverage, a false "covered" is the cheaper error. Nodes
+/// with zero reaching tests are included, since an empty `covering_tests`
+/// list is the untested-symbol signal this aggregation exists to surface,
+/// not a case to omit.
 ///
 /// A graph holding no test node at all is the one exception: coverage is
 /// then *unknown* rather than zero (`--exclude-tests` drops test symbols
@@ -226,19 +230,23 @@ pub fn compute_test_coverage(graph: &SymbolGraph) -> Vec<TestCoverage> {
 
     let node_by_id: HashMap<&str, &Node> = graph.nodes.iter().map(|n| (n.id.as_str(), n)).collect();
 
-    let mut covering_tests_by_target: HashMap<&str, Vec<&str>> = HashMap::new();
+    let mut outgoing: HashMap<&str, Vec<&str>> = HashMap::new();
     for edge in &graph.edges {
-        if !node_by_id
-            .get(edge.from.as_str())
-            .is_some_and(|referrer| referrer.is_test)
-        {
-            continue;
-        }
-        let covering_tests = covering_tests_by_target
-            .entry(edge.to.as_str())
-            .or_default();
-        if !covering_tests.contains(&edge.from.as_str()) {
-            covering_tests.push(edge.from.as_str());
+        outgoing
+            .entry(edge.from.as_str())
+            .or_default()
+            .push(edge.to.as_str());
+    }
+
+    let mut covering_tests_by_target: HashMap<&str, Vec<&str>> = HashMap::new();
+    for test_node in graph.nodes.iter().filter(|node| node.is_test) {
+        for reached in reachable_from(test_node.id.as_str(), &outgoing) {
+            if node_by_id.get(reached).is_some_and(|node| !node.is_test) {
+                covering_tests_by_target
+                    .entry(reached)
+                    .or_default()
+                    .push(test_node.id.as_str());
+            }
         }
     }
 
@@ -273,6 +281,25 @@ pub fn compute_test_coverage(graph: &SymbolGraph) -> Vec<TestCoverage> {
     });
 
     test_coverage
+}
+
+/// Every node reachable from `start` by following `outgoing` edges,
+/// excluding `start` itself. Cycle edges are followed like any other edge
+/// (they are real references); the visited set bounds the walk.
+fn reachable_from<'a>(start: &'a str, outgoing: &HashMap<&'a str, Vec<&'a str>>) -> Vec<&'a str> {
+    let mut visited: HashSet<&str> = HashSet::from([start]);
+    let mut queue: Vec<&str> = vec![start];
+    while let Some(current) = queue.pop() {
+        for &next in outgoing.get(current).into_iter().flatten() {
+            if visited.insert(next) {
+                queue.push(next);
+            }
+        }
+    }
+    visited.remove(start);
+    let mut reached: Vec<&str> = visited.into_iter().collect();
+    reached.sort_unstable();
+    reached
 }
 
 /// Builds a [`SymbolGraph`] over every symbol in `files`.

--- a/rinkaku-core/src/graph_tests/compute_test_coverage.rs
+++ b/rinkaku-core/src/graph_tests/compute_test_coverage.rs
@@ -225,6 +225,109 @@ fn should_sort_covering_tests_by_id_ascending_regardless_of_edge_order() {
 }
 
 #[test]
+fn should_count_transitive_coverage_when_test_reaches_symbol_through_intermediate() {
+    // spec → outer → inner: the test exercises inner through outer, so
+    // both get spec in covering_tests (ADR 0063), not just the directly
+    // referenced outer.
+    let mut spec = symbol("spec", vec!["outer"]);
+    spec.is_test = true;
+    let files = vec![FileReport {
+        path: "src/lib.rs".to_string(),
+        symbols: vec![
+            spec,
+            symbol("outer", vec!["inner"]),
+            symbol("inner", vec![]),
+        ],
+    }];
+    let graph = build_graph(&files);
+
+    let expected = vec![
+        TestCoverage {
+            id: "src/lib.rs::inner".to_string(),
+            path: "src/lib.rs".to_string(),
+            name: "inner".to_string(),
+            covering_tests: vec!["src/lib.rs::spec".to_string()],
+            test_count: 1,
+        },
+        TestCoverage {
+            id: "src/lib.rs::outer".to_string(),
+            path: "src/lib.rs".to_string(),
+            name: "outer".to_string(),
+            covering_tests: vec!["src/lib.rs::spec".to_string()],
+            test_count: 1,
+        },
+    ];
+    let actual = compute_test_coverage(&graph);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_count_coverage_reached_through_a_test_helper() {
+    // spec → helper (both test code) → shared: the walk passes through
+    // test intermediates, and the helper itself also counts as a
+    // covering test (it did under the direct-edge rule too).
+    let mut spec = symbol("spec", vec!["helper"]);
+    spec.is_test = true;
+    let mut helper = symbol("helper", vec!["shared"]);
+    helper.is_test = true;
+    let files = vec![FileReport {
+        path: "src/lib.rs".to_string(),
+        symbols: vec![spec, helper, symbol("shared", vec![])],
+    }];
+    let graph = build_graph(&files);
+
+    let expected = vec![TestCoverage {
+        id: "src/lib.rs::shared".to_string(),
+        path: "src/lib.rs".to_string(),
+        name: "shared".to_string(),
+        covering_tests: vec![
+            "src/lib.rs::helper".to_string(),
+            "src/lib.rs::spec".to_string(),
+        ],
+        test_count: 2,
+    }];
+    let actual = compute_test_coverage(&graph);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_terminate_and_cover_all_members_when_reference_graph_has_cycle() {
+    let mut spec = symbol("spec", vec!["alpha"]);
+    spec.is_test = true;
+    let files = vec![FileReport {
+        path: "src/lib.rs".to_string(),
+        symbols: vec![
+            spec,
+            symbol("alpha", vec!["beta"]),
+            symbol("beta", vec!["alpha"]),
+        ],
+    }];
+    let graph = build_graph(&files);
+
+    let expected = vec![
+        TestCoverage {
+            id: "src/lib.rs::alpha".to_string(),
+            path: "src/lib.rs".to_string(),
+            name: "alpha".to_string(),
+            covering_tests: vec!["src/lib.rs::spec".to_string()],
+            test_count: 1,
+        },
+        TestCoverage {
+            id: "src/lib.rs::beta".to_string(),
+            path: "src/lib.rs".to_string(),
+            name: "beta".to_string(),
+            covering_tests: vec!["src/lib.rs::spec".to_string()],
+            test_count: 1,
+        },
+    ];
+    let actual = compute_test_coverage(&graph);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn should_sort_results_by_test_count_ascending_then_path_name_id() {
     // "tested" has coverage (test_count 1); "untested_b" and
     // "untested_a" both have zero coverage — the untested symbols must


### PR DESCRIPTION
## Summary
- Closes the follow-up ADR 0059's amendment scoped after PR #185 measured a 67% false-positive rate in `test_count == 0`: two of the three mechanisms are fixed here, per the new [ADR 0063](docs/adr/0063-macro-body-references-and-transitive-test-coverage.md).
- **Macro-body references** (`rinkaku-core/src/extract.rs`): Rust macro bodies parse as raw `token_tree` tokens, invisible to the reference query — so `assert_eq!(subject(), …)`, this repo's mandated assertion idiom, produced no edge. `collect_referenced_names` now walks `macro_invocation` token trees and collects identifier tokens (nested macro names — identifier followed by `!` — skipped; attribute token trees deliberately not walked, so `cfg`/`derive` arguments don't fabricate references). The names flow into `referenced_names` itself, so deps, fan-in, and coverage all see them — one graph, one definition of "references".
- **Transitive coverage** (`rinkaku-core/src/graph.rs`): `compute_test_coverage` now walks outgoing edges from each test node (visited set bounds cycles) instead of counting direct edges only — a test reaching a symbol through an intermediate caller exercises it just the same. Output shapes (JSON array, Markdown section, TUI badge) are unchanged; the no-test-node suppression and `--exclude-tests` behavior are preserved.

## Measurements (same tree, same flags, main build vs. this branch)
- Whole-repo outline zero-coverage rate: **522/784 (67%) → 172/784 (22%)**.
- PR #185's named false positives now report real coverage: `entry_row_line` tests=148, `build_tree` tests=269, `render` tests=265.
- Synthetic end-to-end (fn + `assert_eq!`-only test): before both `outer`/`inner` read tests=0; after, `outer` (macro-body edge) and `inner` (transitive) both read tests=1.
- Dominant remaining mechanism, documented in ADR 0063: cross-module scoped calls (`markdown::render_markdown(...)`, `tree::symbol_badges(...)`) capture only the path head — same deliberate decision that keeps `Format::default()` from referencing every `default`. Extending it is a precision/noise tradeoff left to a follow-up ADR. The `!` risk-marker escalation stays withdrawn at 22%.

## Test plan
- [x] TDD red/green for both fixes (`should_collect_macro_body_references` ×4 cases incl. `!=` operator and nested-macro skip, attribute non-collection, transitive/cycle/test-helper coverage)
- [x] `make test` — 205 + 445 + 1038 pass; no existing expectation-pinning test needed updating
- [x] `make lint` — clean
- [x] Dynamic verification: empty stdin, garbage input, conflicting flags, `--exclude-tests` suppression — all behave as on main
- [x] File sizes: all touched files in "watch" band, no warn/split entries (`extract.rs` 992, `graph.rs` 793)

Note: review passes (map-assisted + independent + dynamic) were performed by a single agent this round — the session's subagent infrastructure was unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)