### PR TITLE
fix(tui): cancel confirmed tree search on gd/gr and jumplist jumps

### DIFF
--- a/rinkaku-tui/src/app/handle_key.rs
+++ b/rinkaku-tui/src/app/handle_key.rs
@@ -641,6 +641,11 @@ impl App {
                         self.nav = nav;
                         self.right_pane_scroll = entry.right_pane_scroll;
                         preserve_scroll_after_jump = true;
+                        // Restoring a jumplist entry can expand collapsed
+                        // ancestors, reshaping the row list a confirmed tree
+                        // search's frozen indices were built against — same
+                        // invariant as `App::jump_to_symbol`'s own cancel.
+                        self.search = self.search.clone().cancel();
                     } else {
                         self.status = Some(format!(
                             "note: symbol {} is no longer present",
@@ -665,6 +670,9 @@ impl App {
                         self.nav = nav;
                         self.right_pane_scroll = entry.right_pane_scroll;
                         preserve_scroll_after_jump = true;
+                        // Same reshaping invariant as the `JumpBack` arm
+                        // above.
+                        self.search = self.search.clone().cancel();
                     } else {
                         self.status = Some(format!(
                             "note: symbol {} is no longer present",

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -843,6 +843,14 @@ impl App {
     /// expected to have already confirmed the id exists via
     /// `crate::detail::symbol_mentions`, but `App` does not trust that
     /// blindly).
+    ///
+    /// A successful jump also cancels any confirmed tree search: expanding
+    /// collapsed ancestors reshapes the visible row list a confirmed
+    /// search's frozen row indices were built against — the same invariant
+    /// `Self::handle_key`'s `Select`/`ExpandAll`/`CollapseAll`/`ToggleOrder`
+    /// arms enforce (ADR 0057 decision 2's "cancel means stop searching
+    /// altogether"). The failed-jump early return above deliberately keeps
+    /// the search: nothing moved, so the frozen indices are still valid.
     pub fn jump_to_symbol(mut self, symbol_id: &str) -> Self {
         let current_id = self.selected_symbol_id().map(str::to_string);
 
@@ -861,6 +869,7 @@ impl App {
         }
         self.nav = nav;
         self.right_pane_scroll = 0;
+        self.search = self.search.clone().cancel();
         self
     }
 

--- a/rinkaku-tui/src/app/tests/search.rs
+++ b/rinkaku-tui/src/app/tests/search.rs
@@ -8,7 +8,9 @@
 //! `Screen::Entry` + `Focus::Tree` instead, and staying a no-op on
 //! `Focus::Right`, and the search being cancelled by every key that
 //! reshapes the tree's row list or leaves the entry screen (the frozen
-//! row-index invariant `App::handle_key`'s `Select` arm documents).
+//! row-index invariant `App::handle_key`'s `Select` arm documents),
+//! including successful `gd`/`gr` jumps (`App::jump_to_symbol`) and
+//! jumplist restores, which can expand collapsed ancestors.
 //! `App::with_nav_cursor` (the tree-search jump primitive) is also pinned
 //! here, alongside the dispatch it backs.
 
@@ -312,6 +314,73 @@ fn should_clear_a_confirmed_tree_search_when_open_expands_a_directory_row() {
     assert_eq!(Focus::Tree, app.focus());
 
     let actual = app.handle_key(InputKey::Open);
+
+    assert_eq!(&SearchState::default(), actual.search());
+}
+
+#[test]
+fn should_clear_a_confirmed_tree_search_when_jump_to_symbol_expands_a_collapsed_ancestor() {
+    let report = super::report_with_two_directories();
+    let app = App::new(&report).handle_key(InputKey::CollapseAll);
+    let search = SearchState::default()
+        .start()
+        .push_char('a')
+        .confirm(&["a".to_string(), "b".to_string()], 0);
+    let app = app.with_search(search);
+    assert_eq!(Some("a"), app.search().query());
+
+    let actual = app.jump_to_symbol("b/two.rs::bar");
+
+    assert_eq!(&SearchState::default(), actual.search());
+}
+
+#[test]
+fn should_keep_a_confirmed_tree_search_when_jump_to_symbol_target_does_not_exist() {
+    let report = super::report_with_two_directories();
+    let search = SearchState::default()
+        .start()
+        .push_char('a')
+        .confirm(&["a".to_string(), "b".to_string()], 0);
+    let expected = search.clone();
+    let app = App::new(&report).with_search(search);
+
+    let actual = app.jump_to_symbol("no/such::id");
+
+    assert_eq!(&expected, actual.search());
+}
+
+#[test]
+fn should_clear_a_confirmed_tree_search_when_jump_back_expands_a_collapsed_ancestor() {
+    let report = super::report_with_two_directories();
+    let app = App::new(&report)
+        .with_nav_cursor(2)
+        .jump_to_symbol("b/two.rs::bar")
+        .handle_key(InputKey::CollapseAll);
+    let search = SearchState::default()
+        .start()
+        .push_char('a')
+        .confirm(&["a".to_string(), "b".to_string()], 0);
+    let app = app.with_search(search);
+
+    let actual = app.handle_key(InputKey::JumpBack);
+
+    assert_eq!(&SearchState::default(), actual.search());
+}
+
+#[test]
+fn should_clear_a_confirmed_tree_search_when_jump_forward_restores_a_jump() {
+    let report = super::report_with_two_directories();
+    let app = App::new(&report)
+        .with_nav_cursor(2)
+        .jump_to_symbol("b/two.rs::bar")
+        .handle_key(InputKey::JumpBack);
+    let search = SearchState::default()
+        .start()
+        .push_char('o')
+        .confirm(&["foo".to_string(), "bar".to_string()], 0);
+    let app = app.with_search(search);
+
+    let actual = app.handle_key(InputKey::JumpForward);
 
     assert_eq!(&SearchState::default(), actual.search());
 }


### PR DESCRIPTION
Closes #195

## Problem

A confirmed tree search (ADR 0057 amendment) holds row indices frozen at confirm time. #186 cancelled it on every arm that reshapes the visible row list (`Select`/`Open` on a collapsible row, `ExpandAll`, `CollapseAll`, `ToggleOrder`, Entry→Source), but the jump paths — `gd`/`gr` via `App::jump_to_symbol` (including the jump popup's confirm) and `Ctrl-o`/`Ctrl-i` (`JumpBack`/`JumpForward`) — expand collapsed ancestors via `Nav::move_cursor_to_symbol` and were left out of that sweep.

## Fix

- `App::jump_to_symbol`: cancel the search after a successful jump. The failed-jump early return deliberately keeps the search — nothing moved, so the frozen indices are still valid (pinned by a test).
- `JumpBack`/`JumpForward` arms: cancel on a successful restore, same invariant. These arms do not go through `jump_to_symbol` (they manage the jumplist stacks themselves), hence the two extra sites.

Cancelling is unconditional on a successful jump (not gated on "an ancestor was actually collapsed"), consistent with the existing `Select`/`ExpandAll` arms which also cancel regardless of whether the toggle reshaped anything.

## Tests

- `should_clear_a_confirmed_tree_search_when_jump_to_symbol_expands_a_collapsed_ancestor`
- `should_keep_a_confirmed_tree_search_when_jump_to_symbol_target_does_not_exist`
- `should_clear_a_confirmed_tree_search_when_jump_back_expands_a_collapsed_ancestor`
- `should_clear_a_confirmed_tree_search_when_jump_forward_restores_a_jump`

## Verification

- `make test`: 1081 tui tests + all crates pass
- `make lint`: clean