### PR TITLE
fix(tui): keep every status-line hint set within 80 columns

### DIFF
--- a/docs/adr/0026-tui-source-screen-scrolling.md
+++ b/docs/adr/0026-tui-source-screen-scrolling.md
@@ -239,3 +239,19 @@ rule.
 
 No change to the `Screen::Source`/`Focus::Right` cases — this
 amendment only fills in the previously-unhandled third branch.
+
+## Amendment: status-line hints trimmed to an 80-column budget
+
+The amendment above (and ADR 0057's tree-search amendment after it)
+kept growing the always-on status-line hint set until the Tree-focus
+line reached ~224 columns. `draw_status_line` renders a single
+unwrapped row, so on any realistic terminal width the tail — including
+`?: help  q: quit`, the only on-screen pointer to the full reference —
+was silently cut (#196).
+
+The status-line half of this amendment's discoverability consequence is
+therefore superseded: each hint set is now a subset sized so the whole
+line (order-mode prefix included) fits 80 columns, and the `?` overlay
+alone carries the full keymap, which is what decision 6's
+discoverability rule actually requires. `ctrl-d`/`ctrl-u` and `gg`/`G`
+keep their `?` overlay entries; only their always-on hints are gone.

--- a/docs/adr/0057-tui-source-view-search.md
+++ b/docs/adr/0057-tui-source-view-search.md
@@ -345,3 +345,11 @@ No change to the Source-screen search this ADR originally shipped —
 this amendment only fills in the tree-row half of the Entry-screen gap
 the original Context section explicitly carved out, leaving the
 Diff/Detail-pane half exactly as undesigned as it was.
+
+## Amendment: status-line hints trimmed (see ADR 0026)
+
+The `/: search  n/N: next/prev match` status-line segment the amendment
+above added pushed the Tree-focus line past every realistic terminal
+width. Per ADR 0026's own trimming amendment (#196), the always-on line
+now carries only `/: search`; `n`/`N` remain discoverable via the `?`
+overlay and the confirmed-search `N/M` match-position prefix.

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -31,18 +31,22 @@ pub(crate) fn draw_status_line(frame: &mut Frame, app: &App, report: &Report, ar
 /// keymap/glossary overlay is always one keypress away. [`Screen::Source`]
 /// keeps its own short hint, unaffected by focus (drilling into source is
 /// reached only via `Focus::Right` already, so a focus distinction there
-/// would be redundant); it now also advertises `v: split` (ADR 0049),
-/// since the same toggle applies to the source view's diff overlay.
+/// would be redundant).
 ///
-/// The `]/[: next/prev hunk` hint only appears while Right-focused *and*
+/// Each hint set is deliberately a *subset* of the bindings, sized so the
+/// whole line (order-mode prefix included) fits an 80-column terminal —
+/// `draw_status_line` renders a single unwrapped row, so anything past the
+/// frame edge is silently cut, and the tail is where `?: help  q: quit`
+/// live (#196). The `?` overlay is the full keymap reference (ADR 0020's
+/// discoverability rule); the always-on line only advertises the primary
+/// movement/action keys plus the way into that overlay.
+///
+/// The `]/[: hunk` hint only appears while Right-focused *and*
 /// [`crate::app::RightPane::Diff`] is showing — `crate::run_app` only wires up the
 /// `]`/`[` jump for that pane/focus combination (it needs the Diff pane's
 /// shaped hunk-offset table, which Detail/BlastRadius have no equivalent
 /// of), so advertising the key while Detail/BlastRadius is showing would
-/// describe a binding that does nothing there. `v: split`
-/// ([`crate::app::InputKey::ToggleSplitView`], ADR 0044/0049) is scoped
-/// the same way on [`Screen::Entry`]: the toggle is global, but it only
-/// has a visible effect while the Diff pane is on screen there.
+/// describe a binding that does nothing there.
 ///
 /// Extracted as its own pure function (no `ratatui` types) so the text
 /// itself — not just that *something* renders — is unit-testable, mirroring
@@ -80,21 +84,15 @@ pub(crate) fn status_line_text(app: &App, report: &Report) -> String {
                 crate::order::OrderMode::AlphaNumeric => "alphabetical",
             };
             let keys = match app.focus() {
-                crate::app::Focus::Tree => {
-                    "j/k: move  ctrl-d/u: half  gg/G: top/bot  /: search  n/N: next/prev match  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
-                }
+                crate::app::Focus::Tree => "j/k: move  /: search  enter: open  ?: help  q: quit",
                 crate::app::Focus::Right if app.right_pane() == crate::app::RightPane::Diff => {
-                    "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  ]/[: next/prev hunk  v: split  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
+                    "j/k: scroll  h/esc: back  ]/[: hunk  ?: help  q: quit"
                 }
-                crate::app::Focus::Right => {
-                    "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
-                }
+                crate::app::Focus::Right => "j/k: scroll  h/esc: back  ?: help  q: quit",
             };
             format!("order: {order}  |  {keys}")
         }
-        Screen::Source { .. } => {
-            "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  v: split  /: search  n/N: next/prev match  esc/q: back".to_string()
-        }
+        Screen::Source { .. } => "j/k: scroll  v: split  /: search  esc/q: back".to_string(),
     };
 
     // ADR 0057 decision 7: once a query is confirmed, its match position
@@ -256,12 +254,10 @@ mod tests {
     fn should_draw_status_line_help_text_on_entry_screen() {
         let report = report_with_one_symbol();
         let app = App::new(&report);
-        // Wider than the default 80 columns used elsewhere in this test
-        // module: the full help text (order mode + Tree-focus key hints,
-        // ADR 0020/0022/0026 amendment/0057 amendment) is ~224 columns and
-        // would otherwise be truncated (the status line intentionally does
-        // not wrap), hiding the "quit" fragment this test checks for.
-        let mut terminal = Terminal::new(TestBackend::new(230, 20)).expect("terminal");
+        // 80 columns on purpose: the status line renders a single unwrapped
+        // row, so the trailing "quit" hint only survives here if the whole
+        // Tree-focus line actually fits a realistic terminal width (#196).
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).expect("terminal");
 
         terminal
             .draw(|frame| {
@@ -295,9 +291,30 @@ mod tests {
         let actual = status_line_text(&app, &report);
 
         assert_eq!(
-            "order: topological  |  j/k: move  ctrl-d/u: half  gg/G: top/bot  /: search  n/N: next/prev match  enter: open  space: expand  e/c: expand/collapse  o: order  d: diff  r: blast radius  s: source  gd/gr: jump  ?: help  q: quit"
+            "order: topological  |  j/k: move  /: search  enter: open  ?: help  q: quit"
                 .to_string(),
             actual
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::tree_focus(vec![])]
+    #[case::tree_focus_alphabetical(vec![crate::app::InputKey::ToggleOrder])]
+    #[case::right_focus_diff(vec![crate::app::InputKey::Open])]
+    #[case::right_focus_detail(vec![crate::app::InputKey::Open, crate::app::InputKey::ToggleDiff])]
+    #[case::source_screen(vec![crate::app::InputKey::Down, crate::app::InputKey::Source])]
+    fn should_fit_the_default_hint_line_within_80_columns(#[case] keys: Vec<crate::app::InputKey>) {
+        let report = report_with_one_symbol();
+        let app = keys
+            .into_iter()
+            .fold(App::new(&report), |app, key| app.handle_key(key));
+
+        let actual = status_line_text(&app, &report);
+
+        assert!(
+            actual.chars().count() <= 80,
+            "hint line is {} columns, over the 80-column budget (#196): {actual}",
+            actual.chars().count(),
         );
     }
 
@@ -323,7 +340,7 @@ mod tests {
         let actual = status_line_text(&app, &report);
 
         assert_eq!(
-            "order: topological  |  j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  ]/[: next/prev hunk  v: split  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
+            "order: topological  |  j/k: scroll  h/esc: back  ]/[: hunk  ?: help  q: quit"
                 .to_string(),
             actual
         );
@@ -344,8 +361,7 @@ mod tests {
         let actual = status_line_text(&app, &report);
 
         assert_eq!(
-            "order: topological  |  j/k: scroll  ctrl-d/u: half  gg/G: top/bot  h/esc: back  d: diff  r: blast radius  gd/gr: jump  ?: help  q: quit"
-                .to_string(),
+            "order: topological  |  j/k: scroll  h/esc: back  ?: help  q: quit".to_string(),
             actual
         );
     }
@@ -367,8 +383,7 @@ mod tests {
         let actual = status_line_text(&app, &report);
 
         assert_eq!(
-            "j/k: scroll  ctrl-d/u: half  gg/G: top/bot  v: split  /: search  n/N: next/prev match  esc/q: back"
-                .to_string(),
+            "j/k: scroll  v: split  /: search  esc/q: back".to_string(),
             actual
         );
     }


### PR DESCRIPTION
Closes #196

## Problem

The `Focus::Tree` status line had grown to ~224 columns after #186; `draw_status_line` renders a single unwrapped row, so at 80–160 columns the tail — `enter: open`, `gd/gr: jump`, and crucially `?: help  q: quit` — was silently cut. The Right-focus (~166/~133 col) and Source (~96 col) lines had the same defect at smaller scale, so all four variants are trimmed together.

## Decision: drop rarely-needed hints (issue direction (a))

Kept per variant (always ending with the way into the full reference):

- Tree focus: `j/k: move  /: search  enter: open  ?: help  q: quit` (74 cols with prefix)
- Right + Diff: `j/k: scroll  h/esc: back  ]/[: hunk  ?: help  q: quit` (75 cols)
- Right + Detail/BlastRadius: `j/k: scroll  h/esc: back  ?: help  q: quit` (65 cols)
- Source: `j/k: scroll  v: split  /: search  esc/q: back` (45 cols)

Dropped: `ctrl-d/u`, `gg/G`, `n/N`, `space`, `e/c`, `o`, `d`, `r`, `s`, `gd/gr`, `v` (entry) — all already listed in the `?` overlay (verified), which is what ADR 0026 decision 6's discoverability rule requires. `n`/`N` additionally stay discoverable via the confirmed-search `N/M` prefix.

Both ADR 0026 and ADR 0057 said the new keys get status-line entries, so each gains a short amendment superseding that half; the `?`-overlay half is unchanged.

## Tests

- `should_draw_status_line_help_text_on_entry_screen` back to an 80-column `TestBackend` (the 230-column widening from #186 was masking the regression) — pins that `quit` actually renders at a realistic width.
- New `should_fit_the_default_hint_line_within_80_columns` (rstest, 5 cases: tree/topological, tree/alphabetical, right+diff, right+detail, source) pins the budget so the line cannot silently regrow.
- Exact-string assertions updated to the trimmed lines.

## Verification

- `make test`: 1082 tui tests + all crates pass
- `make lint`: clean