### PR TITLE
test(tui): assert whole values in tree cursor/search tests

### DIFF
--- a/rinkaku-tui/src/app/tests/source_screen.rs
+++ b/rinkaku-tui/src/app/tests/source_screen.rs
@@ -63,11 +63,11 @@ fn should_scroll_source_screen_and_not_move_tree_cursor_when_down_is_pressed() {
     let app = App::new(&report)
         .handle_key(InputKey::Down)
         .handle_key(InputKey::Source);
-    let cursor_before = app.nav().cursor();
+    let nav_before = app.nav().clone();
 
     let app = app.handle_key(InputKey::Down);
 
-    assert_eq!(cursor_before, app.nav().cursor());
+    assert_eq!(&nav_before, app.nav());
     assert_eq!(
         Screen::Source {
             symbol_id: "lib.rs::foo".to_string(),
@@ -256,6 +256,11 @@ fn should_leave_right_pane_scroll_untouched_when_focus_tree_and_scroll_half_page
 // `report_with_two_directories` (6 rows: a(0), a/one.rs(1), foo(2), b(3),
 // b/two.rs(4), bar(5)) so half-page motion has more than one row of
 // headroom to exercise.
+//
+// Each assert compares the whole `Nav` against `App::with_nav_cursor`'s
+// (cursor moved, collapse state untouched), not just the cursor index —
+// a scroll key that corrupted collapse state on the way would otherwise
+// pass.
 
 #[test]
 fn should_move_tree_cursor_down_by_half_viewport_when_focus_tree_scroll_half_page_down() {
@@ -267,7 +272,8 @@ fn should_move_tree_cursor_down_by_half_viewport_when_focus_tree_scroll_half_pag
     // Viewport height 4 -> step size 2.
     let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, 4);
 
-    assert_eq!(2, app.nav().cursor());
+    let expected = App::new(&report).with_nav_cursor(2);
+    assert_eq!(expected.nav(), app.nav());
 }
 
 #[test]
@@ -277,7 +283,8 @@ fn should_clamp_tree_cursor_to_last_row_when_focus_tree_scroll_half_page_down_ov
 
     let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, 100);
 
-    assert_eq!(5, app.nav().cursor());
+    let expected = App::new(&report).with_nav_cursor(5);
+    assert_eq!(expected.nav(), app.nav());
 }
 
 #[rstest]
@@ -292,7 +299,8 @@ fn should_move_tree_cursor_by_one_row_when_viewport_is_too_short_for_a_half_page
 
     let app = app.handle_scroll_key(InputKey::ScrollHalfPageDown, viewport_height);
 
-    assert_eq!(1, app.nav().cursor());
+    let expected = App::new(&report).with_nav_cursor(1);
+    assert_eq!(expected.nav(), app.nav());
 }
 
 #[test]
@@ -304,7 +312,8 @@ fn should_move_tree_cursor_up_by_half_viewport_when_focus_tree_scroll_half_page_
     // Viewport height 4 -> step size 2.
     let app = app.handle_scroll_key(InputKey::ScrollHalfPageUp, 4);
 
-    assert_eq!(3, app.nav().cursor());
+    let expected = App::new(&report).with_nav_cursor(3);
+    assert_eq!(expected.nav(), app.nav());
 }
 
 #[test]
@@ -315,7 +324,8 @@ fn should_move_tree_cursor_to_first_row_when_focus_tree_scroll_to_top() {
 
     let app = app.handle_scroll_key(InputKey::ScrollToTop, 4);
 
-    assert_eq!(0, app.nav().cursor());
+    let expected = App::new(&report).with_nav_cursor(0);
+    assert_eq!(expected.nav(), app.nav());
 }
 
 #[test]
@@ -326,7 +336,8 @@ fn should_move_tree_cursor_to_last_row_when_focus_tree_scroll_to_bottom() {
 
     let app = app.handle_scroll_key(InputKey::ScrollToBottom, 4);
 
-    assert_eq!(5, app.nav().cursor());
+    let expected = App::new(&report).with_nav_cursor(5);
+    assert_eq!(expected.nav(), app.nav());
 }
 
 #[test]

--- a/rinkaku-tui/src/event_loop/tests.rs
+++ b/rinkaku-tui/src/event_loop/tests.rs
@@ -669,12 +669,17 @@ fn should_confirm_and_jump_the_tree_cursor_to_first_match_on_entry_screen() {
 
     let actual = dispatch_search_confirm(app, None);
 
-    assert_eq!(
-        Some("foo".to_string()),
-        actual.search().query().map(str::to_string)
-    );
-    assert_eq!(&[1], actual.search().matches());
-    assert_eq!(1, actual.nav().cursor());
+    // The whole confirmed `SearchState` (query, matches, current match),
+    // built by confirming against the same row texts the dispatch sees.
+    let expected_search = crate::search::SearchState::default()
+        .start()
+        .push_char('f')
+        .push_char('o')
+        .push_char('o')
+        .confirm(&["lib.rs".to_string(), "foo".to_string()], 0);
+    assert_eq!(&expected_search, actual.search());
+    let expected_nav = App::new(&report).with_nav_cursor(1);
+    assert_eq!(expected_nav.nav(), actual.nav());
 }
 
 #[test]
@@ -684,9 +689,9 @@ fn should_leave_the_tree_cursor_untouched_when_confirming_a_tree_search_with_no_
         .handle_key(InputKey::SearchStart)
         .handle_key(InputKey::SearchChar('z'))
         .handle_key(InputKey::SearchChar('z'));
-    assert_eq!(0, app.nav().cursor());
+    let nav_before = app.nav().clone();
 
     let actual = dispatch_search_confirm(app, None);
 
-    assert_eq!(0, actual.nav().cursor());
+    assert_eq!(&nav_before, actual.nav());
 }

--- a/rinkaku-tui/src/nav.rs
+++ b/rinkaku-tui/src/nav.rs
@@ -274,7 +274,10 @@ impl Nav {
                 return self;
             }
             Action::CursorTop => {
-                self.cursor = 0;
+                let row_count = self.rows(tree).len();
+                if row_count > 0 {
+                    self.cursor = 0;
+                }
                 return self;
             }
             Action::CursorBottom => {

--- a/rinkaku-tui/src/nav_tests/cursor_jump.rs
+++ b/rinkaku-tui/src/nav_tests/cursor_jump.rs
@@ -4,81 +4,100 @@ use pretty_assertions::assert_eq;
 // `deep_tree()`'s expanded row order: src(0), src/pkg(1), src/pkg/lib.rs(2),
 // foo(3), bar(4) — 5 rows total, used throughout so `CursorPageDown`/
 // `CursorPageUp`'s clamping has more than one row of headroom to exercise.
+//
+// Every assert compares the whole `Nav` (cursor *and* collapse state): a
+// cursor-only assert would pass even if a cursor action corrupted the
+// collapse set on the way.
+
+fn nav_at_cursor(cursor: usize) -> Nav {
+    Nav {
+        cursor,
+        ..Nav::new()
+    }
+}
 
 #[test]
 fn should_move_cursor_to_last_row_when_cursor_bottom() {
     let tree = deep_tree();
-    let nav = Nav::new().handle(Action::CursorBottom, &tree);
+    let actual = Nav::new().handle(Action::CursorBottom, &tree);
 
-    assert_eq!(4, nav.cursor());
+    assert_eq!(nav_at_cursor(4), actual);
 }
 
 #[test]
 fn should_move_cursor_to_first_row_when_cursor_top() {
     let tree = deep_tree();
-    let nav = Nav::new()
+    let actual = Nav::new()
         .handle(Action::CursorBottom, &tree)
         .handle(Action::CursorTop, &tree);
 
-    assert_eq!(0, nav.cursor());
+    assert_eq!(nav_at_cursor(0), actual);
 }
 
 #[test]
 fn should_keep_cursor_at_first_row_when_cursor_top_and_already_at_top() {
     let tree = deep_tree();
-    let nav = Nav::new().handle(Action::CursorTop, &tree);
+    let actual = Nav::new().handle(Action::CursorTop, &tree);
 
-    assert_eq!(0, nav.cursor());
+    assert_eq!(nav_at_cursor(0), actual);
+}
+
+#[test]
+fn should_leave_nav_untouched_when_cursor_top_and_tree_has_no_rows() {
+    let tree = Tree { roots: vec![] };
+    let actual = Nav::new().handle(Action::CursorTop, &tree);
+
+    assert_eq!(Nav::new(), actual);
 }
 
 #[test]
 fn should_move_cursor_down_by_step_when_cursor_page_down() {
     let tree = deep_tree();
-    let nav = Nav::new().handle(Action::CursorPageDown(2), &tree);
+    let actual = Nav::new().handle(Action::CursorPageDown(2), &tree);
 
-    assert_eq!(2, nav.cursor());
+    assert_eq!(nav_at_cursor(2), actual);
 }
 
 #[test]
 fn should_clamp_cursor_to_last_row_when_cursor_page_down_overshoots() {
     let tree = deep_tree();
-    let nav = Nav::new().handle(Action::CursorPageDown(100), &tree);
+    let actual = Nav::new().handle(Action::CursorPageDown(100), &tree);
 
-    assert_eq!(4, nav.cursor());
+    assert_eq!(nav_at_cursor(4), actual);
 }
 
 #[test]
 fn should_move_cursor_up_by_step_when_cursor_page_up() {
     let tree = deep_tree();
-    let nav = Nav::new()
+    let actual = Nav::new()
         .handle(Action::CursorBottom, &tree)
         .handle(Action::CursorPageUp(2), &tree);
 
-    assert_eq!(2, nav.cursor());
+    assert_eq!(nav_at_cursor(2), actual);
 }
 
 #[test]
 fn should_clamp_cursor_to_first_row_when_cursor_page_up_undershoots() {
     let tree = deep_tree();
-    let nav = Nav::new()
+    let actual = Nav::new()
         .handle(Action::CursorBottom, &tree)
         .handle(Action::CursorPageUp(100), &tree);
 
-    assert_eq!(0, nav.cursor());
+    assert_eq!(nav_at_cursor(0), actual);
 }
 
 #[test]
 fn should_move_cursor_to_the_given_index_when_cursor_to() {
     let tree = deep_tree();
-    let nav = Nav::new().handle(Action::CursorTo(3), &tree);
+    let actual = Nav::new().handle(Action::CursorTo(3), &tree);
 
-    assert_eq!(3, nav.cursor());
+    assert_eq!(nav_at_cursor(3), actual);
 }
 
 #[test]
 fn should_clamp_cursor_to_last_row_when_cursor_to_index_is_out_of_bounds() {
     let tree = deep_tree();
-    let nav = Nav::new().handle(Action::CursorTo(100), &tree);
+    let actual = Nav::new().handle(Action::CursorTo(100), &tree);
 
-    assert_eq!(4, nav.cursor());
+    assert_eq!(nav_at_cursor(4), actual);
 }

--- a/rinkaku-tui/src/nav_tests/search_text.rs
+++ b/rinkaku-tui/src/nav_tests/search_text.rs
@@ -2,38 +2,22 @@ use super::*;
 use pretty_assertions::assert_eq;
 
 #[test]
-fn should_use_the_node_path_as_search_text_for_dir_and_file_rows() {
+fn should_use_the_node_path_for_dir_and_file_rows_and_the_symbol_name_for_symbol_rows() {
     let tree = sample_tree();
     let nav = Nav::new();
     let rows = nav.rows(&tree);
 
-    let texts = row_search_texts(&rows);
+    let actual = row_search_texts(&rows);
 
     // sample_tree()'s expanded row order: src(0, Dir), src/lib.rs(1, File),
     // foo(2, Symbol), bar(3, Symbol).
-    assert_eq!("src", texts[0]);
-    assert_eq!("src/lib.rs", texts[1]);
-}
-
-#[test]
-fn should_use_the_symbol_name_as_search_text_for_symbol_rows() {
-    let tree = sample_tree();
-    let nav = Nav::new();
-    let rows = nav.rows(&tree);
-
-    let texts = row_search_texts(&rows);
-
-    assert_eq!("foo", texts[2]);
-    assert_eq!("bar", texts[3]);
-}
-
-#[test]
-fn should_return_one_text_per_row_in_the_same_order() {
-    let tree = sample_tree();
-    let nav = Nav::new();
-    let rows = nav.rows(&tree);
-
-    let texts = row_search_texts(&rows);
-
-    assert_eq!(rows.len(), texts.len());
+    assert_eq!(
+        vec![
+            "src".to_string(),
+            "src/lib.rs".to_string(),
+            "foo".to_string(),
+            "bar".to_string(),
+        ],
+        actual
+    );
 }


### PR DESCRIPTION
Closes #198

## Changes

Assertion tightening (CLAUDE.md: "Compare whole structs/values, not individual fields"):

- `nav_tests/search_text.rs` — the three per-element tests (`texts[0]`/`texts[1]`, `texts[2]`/`texts[3]`, length) merged into one test with a single whole-`Vec<String>` assert that subsumes all three.
- `nav_tests/cursor_jump.rs` — every test now compares the whole `Nav` (the tests module sits inside `nav` via `#[path]`, so a `Nav { cursor, ..Nav::new() }` expected value is constructible directly). A cursor action that corrupted collapse state would previously have passed. Added `should_leave_nav_untouched_when_cursor_top_and_tree_has_no_rows` pinning the new guard (below).
- `app/tests/source_screen.rs` — the six Focus::Tree scroll-key tests compare the whole `Nav` against `App::with_nav_cursor(n)`'s (cursor moved, collapse untouched); the "source scroll must not move the tree cursor" test pins the whole pre-move `Nav` instead of just its cursor index.
- `event_loop/tests.rs` — `should_confirm_and_jump_the_tree_cursor_to_first_match_on_entry_screen` now compares the whole confirmed `SearchState` (query + matches + current match in one assert) plus the whole `Nav`; the no-match companion pins the whole pre-confirm `Nav`.

Code consistency fix from the same review:

- `nav::Action::CursorTop` now guards on `row_count > 0` like its `CursorPageDown`/`CursorTo` siblings (was never a reachable panic, just inconsistent).

Deliberately out of scope (pre-existing, per the issue): `Ctrl-d`'s half-page step not accounting for the "… N more" indicator rows.

## Verification

- `make test`: all crates pass (1076 tui tests — 3 search-text tests merged into 1, 1 new empty-tree case)
- `make lint`: clean