### PR TITLE
fix: harden --pr mode ergonomics and extract the head mismatch check

### DIFF
--- a/rinkaku/src/cli.rs
+++ b/rinkaku/src/cli.rs
@@ -34,7 +34,8 @@ pub(crate) struct Cli {
     /// number (`76`). A bare number must be run inside a local clone of
     /// the target repository; a URL also works from any other directory
     /// by auto-cloning into a cache. Requires `gh` installed and
-    /// authenticated.
+    /// authenticated. Mutually exclusive with `--base`/`--head`, which
+    /// diff local refs instead.
     // See ADR 0004 for the resolve-then-fetch design and ADR 0005 for the
     // auto-clone-into-cache behavior this drives in `main`.
     #[arg(long)]

--- a/rinkaku/src/github/pr_arg.rs
+++ b/rinkaku/src/github/pr_arg.rs
@@ -30,13 +30,15 @@ impl PrArg {
 /// Extracts a validated `--pr` argument: either a bare number (`"76"`) or
 /// a GitHub PR URL
 /// (`https://github.com/<owner>/<repo>/pull/<number>`, tolerating a
-/// trailing slash or extra path segments like `/files`).
+/// trailing slash, extra path segments like `/files`, an `http://`
+/// scheme, and any capitalization of the scheme/host — browsers and chat
+/// clients produce all of these, and rejecting them helps no one).
 ///
 /// `0` is rejected even though it parses as a `u64`: GitHub PR numbers
 /// are 1-indexed, so `0` can only be a typo, and failing fast here beats
 /// a confusing `gh pr view 0` error downstream.
 pub(crate) fn parse_pr_arg(value: &str) -> anyhow::Result<PrArg> {
-    match value.trim().strip_prefix("https://github.com/") {
+    match strip_github_url_prefix(value.trim()) {
         Some(rest) => {
             // Expect `<owner>/<repo>/pull/<number>[/...]`.
             let segments: Vec<&str> = rest.split('/').filter(|s| !s.is_empty()).collect();
@@ -57,6 +59,19 @@ pub(crate) fn parse_pr_arg(value: &str) -> anyhow::Result<PrArg> {
             value,
         )?)),
     }
+}
+
+/// Strips a GitHub PR URL's `http(s)://github.com/` prefix, matching the
+/// scheme and host case-insensitively while leaving the returned
+/// owner/repo path slice untouched (owner/repo capitalization is
+/// preserved for display; matching against a clone's `origin` is
+/// case-insensitive anyway, per `super::remote::github_remote_matches`).
+/// `None` when `value` does not start with either prefix.
+fn strip_github_url_prefix(value: &str) -> Option<&str> {
+    let lower = value.to_ascii_lowercase();
+    ["https://github.com/", "http://github.com/"]
+        .iter()
+        .find_map(|prefix| lower.starts_with(prefix).then(|| &value[prefix.len()..]))
 }
 
 /// Parses `candidate` as a positive `u64` PR number, reporting errors
@@ -102,6 +117,22 @@ mod tests {
         PrArg::Url {
             owner: "octocat".to_string(),
             repo: "hello-world".to_string(),
+            number: 123,
+        }
+    )]
+    #[case::should_parse_http_pull_url(
+        "http://github.com/octocat/hello-world/pull/123",
+        PrArg::Url {
+            owner: "octocat".to_string(),
+            repo: "hello-world".to_string(),
+            number: 123,
+        }
+    )]
+    #[case::should_parse_mixed_case_scheme_and_host_preserving_owner_and_repo_case(
+        "HTTPS://GitHub.com/Octocat/Hello-World/pull/123",
+        PrArg::Url {
+            owner: "Octocat".to_string(),
+            repo: "Hello-World".to_string(),
             number: 123,
         }
     )]

--- a/rinkaku/src/github/pr_info.rs
+++ b/rinkaku/src/github/pr_info.rs
@@ -24,6 +24,30 @@ pub(crate) fn parse_pr_view_json(json: &str) -> anyhow::Result<PrInfo> {
     Ok(serde_json::from_str(json)?)
 }
 
+/// Checks that the head commit `git fetch refs/pull/<number>/head`
+/// actually retrieved (`fetched_head`) is the one `gh pr view` reported
+/// (`reported_head`). A mismatch usually means the PR belongs to a
+/// different repository than the target clone's `origin` remote (see
+/// [`fetch_pr_info`]'s doc comment on why `gh` and `git` are deliberately
+/// allowed to disagree so this check can catch it), or that the PR was
+/// updated between resolving and fetching. Extracted from `main` as a
+/// pure function so the check is unit-testable without `gh`/`git`.
+pub(crate) fn ensure_fetched_head_matches(
+    number: u64,
+    fetched_head: &str,
+    reported_head: &str,
+) -> anyhow::Result<()> {
+    if fetched_head == reported_head {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "fetched PR #{number} head ({fetched_head}) does not match `gh`'s reported head \
+         ({reported_head}); this usually means the PR belongs to a different repository than \
+         the target clone's `origin` remote, or the PR was updated between resolving it \
+         and fetching it — verify `origin` points at the PR's repository and re-run",
+    );
+}
+
 /// Runs `gh pr view <arg> --json number,baseRefName,baseRefOid,headRefOid`
 /// and parses the result.
 ///
@@ -88,5 +112,26 @@ mod tests {
         let actual = parse_pr_view_json(json);
 
         assert!(actual.is_err());
+    }
+
+    #[test]
+    fn should_accept_fetched_head_when_it_matches_the_reported_head() {
+        let actual = ensure_fetched_head_matches(76, "abc123", "abc123");
+
+        assert!(actual.is_ok());
+    }
+
+    #[test]
+    fn should_reject_fetched_head_with_a_repository_hint_when_it_differs_from_the_reported_head() {
+        let actual = ensure_fetched_head_matches(76, "abc123", "def456");
+
+        let message = actual.expect_err("expected a mismatch error").to_string();
+        assert_eq!(
+            "fetched PR #76 head (abc123) does not match `gh`'s reported head (def456); this \
+             usually means the PR belongs to a different repository than the target clone's \
+             `origin` remote, or the PR was updated between resolving it and fetching it — \
+             verify `origin` points at the PR's repository and re-run",
+            message
+        );
     }
 }

--- a/rinkaku/src/main.rs
+++ b/rinkaku/src/main.rs
@@ -70,7 +70,7 @@ use github::base_sha::{
     fetch_branch_head, fetch_oid, fetch_pr_head, object_exists_locally, resolve_pr_base_sha,
 };
 use github::pr_arg::{PrArg, parse_pr_arg};
-use github::pr_info::fetch_pr_info;
+use github::pr_info::{ensure_fetched_head_matches, fetch_pr_info};
 use github::remote::{git_remote_origin_url, parse_github_remote};
 use github::review::GhReviewSubmitter;
 use github::workdir::resolve_pr_workdir;
@@ -450,15 +450,7 @@ fn run_analysis(cli: &Cli, progress: &dyn AnalysisProgress) -> anyhow::Result<An
         log::debug!("fetching PR #{number} head");
         let head_sha = fetch_pr_head(number, cwd)?;
         pr_head_sha = Some(head_sha.clone());
-        if head_sha != pr_info.head_ref_oid {
-            anyhow::bail!(
-                "fetched PR #{number} head ({head_sha}) does not match `gh`'s reported head \
-                 ({expected}); this usually means the PR belongs to a different repository than \
-                 the target clone's `origin` remote, or the PR was updated between resolving it \
-                 and fetching it — verify `origin` points at the PR's repository and re-run",
-                expected = pr_info.head_ref_oid,
-            );
-        }
+        ensure_fetched_head_matches(number, &head_sha, &pr_info.head_ref_oid)?;
         log::debug!("resolving PR #{number} base commit");
         let (base_sha, used_fallback) = resolve_pr_base_sha(
             &pr_info.base_ref_oid,


### PR DESCRIPTION
Closes #24

## Changes

1. **Mismatch check extracted and tested** (issue item 2): `main()`'s embedded head-SHA comparison moved to `github::pr_info::ensure_fetched_head_matches`, a pure function unit-tested without `gh`/`git` — including an exact-message assert so the repository-hint wording can't silently regress.
2. **URL friendliness** (issue nit): `--pr` now accepts `http://` and any capitalization of the scheme/host (`HTTPS://GitHub.com/...`), while preserving owner/repo capitalization for display; matching against `origin` was already case-insensitive via `github_remote_matches`.
3. **Help text** (issue nit): `--pr`'s `--help` entry now states the `--base`/`--head` exclusivity instead of relying on the conflict error.

## Issue item 1 (pre-flight owner/repo comparison) — obsolete

Since ADR 0005/0006 (which post-date the issue), `--pr <URL>` resolves a matching workdir *before* any fetch: the cwd's `origin` is compared against the URL's owner/repo (`github_remote_matches`, case-insensitive), then ghq clones are searched, then a cache clone is created. A foreign-repo URL therefore ends up analyzed against a correct clone rather than producing the confusing SHA-mismatch failure the issue describes; the post-hoc check remains as the safety net for races (PR updated between resolve and fetch) and for bare-number mode, where the argument carries no owner/repo to pre-flight against.

## Verification

- `make test` (209 rinkaku-bin tests, all crates pass) / `make lint` clean
- Dynamic: `--help` shows the new exclusivity sentence; `--pr abc` fails with the friendly parse error; `--pr 1 --base main` fails with clap's conflict error