### PR TITLE
ci: keep published release assets immutable across re-runs

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -16,8 +16,10 @@ on:
   #
   # publish-crates guards itself against re-publishing a version that's
   # already on crates.io, so a full re-run is safe even after a partial
-  # success; publish-release's `--clobber` makes re-uploading release
-  # assets safe too.
+  # success; publish-release skips assets that already exist on the
+  # release, so a re-run never rewrites a published artifact's checksum
+  # (issue #22 -- the v0.2.0 --clobber re-upload changed the tarball
+  # sha256 while the Homebrew formula kept the old one).
   workflow_dispatch:
     inputs:
       tag:
@@ -128,11 +130,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # --clobber makes this safe to re-run via workflow_dispatch
-          # against a tag whose assets were already uploaded.
-          gh release upload "${{ env.RELEASE_TAG }}" dist/* \
+          # Published assets are immutable (issue #22): a re-run must
+          # never replace an already-uploaded asset -- Rust builds are
+          # not bit-for-bit reproducible, so a rewritten tarball changes
+          # the sha256 the Homebrew formula was bumped with, while the
+          # formula bump itself is skipped on a re-run (version string
+          # unchanged). Skipping keeps re-runs useful for filling in
+          # *missing* assets only; a racing concurrent upload fails the
+          # non-clobber `gh release upload`, which also preserves
+          # immutability.
+          existing=$(gh release view "${{ env.RELEASE_TAG }}" \
             --repo "${{ github.repository }}" \
-            --clobber
+            --json assets --jq '.assets[].name')
+          for file in dist/*; do
+            name=$(basename "$file")
+            if printf '%s\n' "$existing" | grep -Fqx "$name"; then
+              echo "skipping ${name}: already published, kept immutable"
+            else
+              gh release upload "${{ env.RELEASE_TAG }}" "$file" \
+                --repo "${{ github.repository }}"
+            fi
+          done
 
   publish-crates:
     needs: [rust-test]


### PR DESCRIPTION
Closes #22

## Problem

A `workflow_dispatch` re-run of `build-and-publish.yaml` rebuilt the binaries and re-uploaded every release asset with `--clobber`. Rust builds are not reproducible bit-for-bit, so the tarball sha256 changed — while `bump-homebrew-formula-action` skipped the formula (version string unchanged). `brew install` then failed on a checksum mismatch (v0.2.0 incident, fixed by hand in the tap).

## Fix

`publish-release` now lists the release's existing assets once and uploads only the missing ones — published assets are never rewritten, so their checksums are immutable. Re-runs stay useful for exactly what they're for: filling in assets a partial failure left missing. A racing concurrent upload fails the non-clobber `gh release upload`, which also preserves immutability. The `workflow_dispatch` doc comment is updated to match.

## Issue's optional second item (formula sha256 drift verification)

Deliberately not implemented: immutable assets remove the only drift mechanism the incident exposed (re-run rewrites), and a tap-side verification step would add API calls and failure modes to every release for a scenario that can no longer occur from this workflow. Can be revisited if drift ever appears from another source.

## Verification

- `actionlint`: no new findings (the SC2086 info on the pre-existing `Package binary` step is on main too, untouched here)
- Skip logic simulated locally with a fake asset list: existing asset skipped with a log line, missing asset uploaded
- Release path itself is only exercisable on a real tag — first live validation will be the next release's (idempotent) run