### PR TITLE
refactor: dispatch symbol construction through build_symbols for one-to-many kinds

### DIFF
--- a/docs/adr/0066-hcl-terraform-language-support.md
+++ b/docs/adr/0066-hcl-terraform-language-support.md
@@ -1,0 +1,223 @@
+# 0066. HCL (Terraform) language support
+
+Date: 2026-08-01
+
+## Status
+
+Accepted
+
+## Context
+
+Terraform repositories produce exactly the kind of PRs rinkaku exists
+for: large, mechanically generated diffs (module upgrades, provider
+bumps, environment fan-out) whose reviewable surface — which resources,
+variables, and outputs changed shape — is much smaller than the diff.
+ADR 0002 made language support additive: a `LanguageSupport` impl plus a
+registry entry, with the extraction pipeline unchanged. HCL is the first
+candidate language whose definitions are not functions/types but named
+configuration blocks, which stresses four assumptions the v1 languages
+share:
+
+1. Definitions expose their name through a tree-sitter `name` field —
+   HCL blocks are named by a block-type identifier plus quoted labels
+   (`resource "aws_instance" "web"`).
+2. A definition's name appears literally in its defining file —
+   Terraform *references* (`var.region`) do not textually match their
+   *definitions* (`variable "region"`), which breaks the documented
+   invariant of `TagsResolver`'s aho-corasick prefilter.
+3. One captured node = one symbol — a `locals` block defines one symbol
+   per attribute, not one symbol for the block.
+4. A language is identified by the path's final `.`-separated segment —
+   the agreed scope (Terraform's `*.tftest.hcl` in, plain `.hcl`
+   dialects out) is not expressible that way, since both end in `hcl`.
+
+The grammar side is solved: crates.io `tree-sitter-hcl` 1.1.0
+(Apache-2.0, tree-sitter-grammars org) binds via `tree-sitter-language
+^0.1` — the same mechanism as the four existing grammar crates — and was
+spike-verified to compile and parse against tree-sitter 0.26.
+
+Discussed with the maintainer in issue #210; the decisions below record
+the agreed answers to the four design points raised there.
+
+## Decision
+
+Add HCL (Terraform) as a built-in language using `tree-sitter-hcl`
+1.1.0, registered for the path suffixes `.tf`, `.tofu`, and
+`.tftest.hcl`.
+
+1. **Registry routing becomes suffix-based** (issue #210 follow-up):
+   `RegistryEntry` declares path *suffixes* instead of final extension
+   segments, and `language_for_path` matches with `path.ends_with`.
+   This keeps the registry declarative while letting an entry name a
+   multi-segment convention (`.tftest.hcl`) without claiming every file
+   whose final segment merely coincides (plain `.hcl`). Behavior for
+   the existing entries is unchanged (`.rs`, `.go`, `.py`, `.ts`,
+   `.tsx` match the same files); entries list more-specific suffixes
+   first as a convention. Plain `.hcl` dialects (Packer, Nomad) stay
+   out of v1 — Terraform-flavored reference prefixes on non-Terraform
+   dialects would mislead more than help; widening later is additive.
+
+2. **Definitions are top-level blocks**, captured as
+   `(config_file (body (block) @definition))`. Nested blocks (`tags`,
+   `dynamic`, provisioners) are never captured. The recognized block
+   types and their symbol names use **Terraform reference syntax**, so
+   a definition's name equals the string other files use to reference
+   it and the existing name-keyed `TagsResolver` and `collect_edges`
+   work unchanged:
+
+   | Block | Symbol name |
+   |---|---|
+   | `resource "T" "N"` | `T.N` |
+   | `data "T" "N"` | `data.T.N` |
+   | `module "N"` | `module.N` |
+   | `variable "N"` | `var.N` |
+   | `output "N"` | `output.N` |
+   | `provider "P"` | `provider.P` |
+   | `locals { a = … }` | `local.a` (one symbol per attribute) |
+
+   `terraform`, `moved`, `import`, `check`, and unrecognized block
+   types are not reported. A `locals` block expands to one symbol per
+   attribute — per-name fan-in is the point of name-keyed matching —
+   via a one-node-to-many `build_symbols` dispatcher in `extract`
+   (capturing attributes directly in the query would poison the
+   narrowest-enclosing-definition suppression for resource bodies).
+
+3. **Signatures follow the contract/implementation split** the other
+   languages already encode: `variable` and `output` blocks keep their
+   whole text (type/default/description/value *are* the contract, so
+   editing them classifies as `signature_changed`); `resource`, `data`,
+   `module`, and `provider` blocks keep only their header (the body is
+   implementation, so argument edits classify as `body_only`); a
+   `locals` attribute keeps its whole text.
+
+4. **References are collected by a code walk, not the reference
+   query**: HCL references are traversals
+   (`(variable_expr (identifier)) (get_attr …)*`), normalized to the
+   same reference syntax as definition names — `var.A`, `local.A`,
+   `module.A`, `data.A.B`, and `T.A` for resource references; the
+   meta-roots `each`, `count`, `self`, `path`, and `terraform` are
+   dropped. The walk lives beside the existing Rust-only walks (ADR
+   0063/0064) and is inert for other grammars (`variable_expr` exists
+   only in the HCL grammar). The reference query itself captures only
+   `function_call` names (HCL built-ins simply fail to resolve, the
+   same non-resolving story as Go's built-in types). Per-language
+   extraction logic stays in `extract`'s flat match arms and walks —
+   promoting extraction hooks into `LanguageSupport` is deliberately
+   deferred to a follow-up ADR once HCL's concrete shape exists
+   (issue #210, design point 1).
+
+5. **The prefilter invariant is restored by pattern expansion**:
+   `TagsResolver::new` adds each dot-separated component of a dotted
+   reference name to the aho-corasick pattern set, so
+   `variable "region"`'s file passes the prefilter for the reference
+   `var.region` via its `region` component. Every component is added,
+   including single-character ones (`variable "x"` must stay findable
+   for `var.x`) — a short pattern passes more files through the
+   prefilter, which costs parsing time, never recall.
+
+6. **`.terraform.lock.hcl` is treated as generated by path**, mirroring
+   GitHub linguist's own path rule for it. Under this ADR's suffix
+   scope no `LanguageSupport` ever claims the lock file (it matches
+   none of `.tf`/`.tofu`/`.tftest.hcl`), so it could never produce
+   symbols; the path rule exists to label it `generated` rather than
+   `unsupported_language` in `skipped` on the very common provider-bump
+   PR, and to future-proof any later widening to plain `.hcl`. The
+   check applies only in `analyze_diff`'s skip classification and
+   carries its own explicit `--include-generated` guard — unlike the
+   `.gitattributes` set, which the caller empties when the flag is
+   set, a path predicate has no caller-side off switch.
+
+7. **`*.tftest.hcl` files are test files** (`is_test_path`), matching
+   Terraform's native test convention. Node-level `is_test_definition`
+   stays the default `false`.
+
+8. **SymbolKind gains one generic `Block` variant** (issue #210, design
+   point 2), rendered as `block`; the name already carries the
+   Terraform-specific semantics (`var.region`, `aws_instance.web`),
+   the enum's language-neutral naming rule stays intact, and finer
+   kinds later would be additive JSON output changes.
+
+9. **No TUI syntax highlighting for HCL in v1**: tree-sitter-hcl
+   exports no highlights query; `highlight.rs` falls back to plain text
+   gracefully. Vendoring `queries/highlights.scm` (Apache-2.0 notice
+   required) is a possible follow-up.
+
+### Landing strategy
+
+Per the maintainer's request in issue #210, the language-neutral
+shared-code changes land as small preparatory PRs so the HCL PR itself
+stays close to purely additive:
+
+1. This ADR.
+2. Suffix-based registry routing (decision 1).
+3. `symbol_kind` takes source bytes (block-type dispatch needs
+   identifier text).
+4. `build_symbol` → `build_symbols` one-node-to-many dispatcher
+   (decision 2's locals expansion, landed behavior-neutral).
+5. `.terraform.lock.hcl` generated-path check (decision 6).
+6. HCL itself: grammar dependency, `language/hcl.rs`, extraction
+   arms, reference walk, prefilter expansion, `SymbolKind::Block`,
+   tests, docs.
+
+Mermaid needs no preparation: node ids are already mapped to a
+sequential mermaid-safe `n{i}` space precisely because `NodeId`s
+contain `/`, `:`, `@`, and `.` — dotted HCL names ride the existing
+mechanism, pinned by a rendering test in PR 6.
+
+## Alternatives considered
+
+- **hcl-rs / non-tree-sitter parsing** — rejected: ADR 0002's whole
+  premise is one extraction pipeline over tree-sitter grammars.
+- **Naming definitions by bare label** (`region` instead of
+  `var.region`) — rejected: collides across block types (`variable
+  "web"` vs `resource "aws_instance" "web"`), and reference text would
+  need de-prefixing anyway, losing the exact-match property with
+  `collect_edges`/`TagsResolver`.
+- **Registering plain `.hcl` and `.tf.json`** — rejected for v1: plain
+  `.hcl` dialects would get misleading Terraform-flavored prefixes;
+  `.tf.json` is JSON syntax with a different grammar.
+- **A path-filter callback in front of an extension-keyed `hcl` entry**
+  (instead of suffix matching) — rejected: pushes routing logic into
+  code where the registry is otherwise declarative data; suffix
+  matching expresses the same scope as data.
+- **Per-language extraction trait now** — deferred, not rejected: HCL
+  is the first concrete second use case, but the right shape for the
+  hooks is only knowable once HCL's extraction logic exists; a
+  follow-up ADR will revisit (issue #210, design point 1).
+- **`#eq?` query predicates for block-type filtering** — rejected: the
+  Rust binding leaves text predicates to the caller, and rinkaku's raw
+  `QueryCursor` iteration deliberately does not evaluate them; the
+  established pattern is per-language dispatch in `extract` code.
+
+## Consequences
+
+- Terraform PRs get symbol-level condensation; multi-environment repos
+  benefit from the existing path-proximity ranking for same-named
+  resources.
+- JSON output gains one new `kind` value (`Block`); Markdown/TUI gain
+  the `block` label. Additive, not breaking. In the Markdown change
+  graph, `Block` symbols fold like the other non-function kinds
+  (`is_foldable`): a `var.region` repeated under several resources
+  reads as a repeated data shape, "(see above)" on repeats.
+- `language_for_path` routes by suffix rather than final segment: a
+  file literally named `rs`/`go`/`py`/`ts` (no dot) no longer routes to
+  a language — an intentional fix that falls out of the change.
+- `extract/mod.rs`'s `symbol_kind` takes the source bytes, and its
+  "node kinds are unique across grammars" doc invariant is rewritten —
+  `block` exists in other grammars but is never captured by their
+  definition queries.
+- The prefilter's documented "a definition's name always appears
+  literally in its own declaration" invariant is amended to cover
+  dotted-name component expansion.
+- The entry-point ordering (ADR 0008) degrades meaningfully for
+  Terraform: roots are resources/outputs nothing references;
+  `var.*`/`local.*` sink to the bottom as high-fan-in foundations. The
+  graph remains an approximation (no `count`/`for_each` expansion, no
+  provider edges — ADR 0003's accepted trade-off).
+- Provider-defined types (`aws_instance`) never resolve as
+  dependencies — consistent with built-in types in other languages.
+- Cross-module output references (`module.vpc.subnet_id`) resolve to
+  the `module.vpc` block, not the inner `output` — accepted under the
+  1-hop philosophy.
+- OpenTofu's `*.tofutest.hcl` test convention is not registered in v1;
+  adding it later is a one-line suffix addition.

--- a/rinkaku-core/src/extract/mod.rs
+++ b/rinkaku-core/src/extract/mod.rs
@@ -195,7 +195,8 @@ pub fn extract_changed_symbols(
                     .iter()
                     .any(|other| other != *node && is_descendant_of(*other, **node))
             })
-            .filter_map(|node| build_symbol(*node, source_bytes, reference_query, lang))
+            .flat_map(|node| build_symbols(*node, source_bytes, reference_query, lang))
+            .filter(|symbol| overlaps_any(symbol.range, changed_ranges))
             .collect()
     })
 }
@@ -216,7 +217,7 @@ pub fn extract_all_symbols(source: &str, lang: &dyn LanguageSupport) -> Vec<Extr
     with_definition_nodes(source, lang, |all_nodes, source_bytes, reference_query| {
         all_nodes
             .iter()
-            .filter_map(|node| build_symbol(*node, source_bytes, reference_query, lang))
+            .flat_map(|node| build_symbols(*node, source_bytes, reference_query, lang))
             .collect()
     })
 }
@@ -403,6 +404,25 @@ fn overlaps_any(range: LineRange, others: &[LineRange]) -> bool {
     others
         .iter()
         .any(|other| range.start <= other.end && other.start <= range.end)
+}
+
+/// Builds every symbol a captured definition node yields. One node is
+/// one symbol for every current kind; kinds that expand a single
+/// captured node into several symbols (HCL `locals` blocks, one symbol
+/// per attribute — ADR 0066) get their own branch here rather than in
+/// `build_symbol`, whose single-`Option` shape they cannot fit.
+/// `extract_changed_symbols` re-filters the expansion by changed-range
+/// overlap — a no-op for single-node symbols, whose range is the
+/// already-touched captured node's own.
+fn build_symbols(
+    node: tree_sitter::Node,
+    source: &[u8],
+    reference_query: &tree_sitter::Query,
+    lang: &dyn LanguageSupport,
+) -> Vec<ExtractedSymbol> {
+    build_symbol(node, source, reference_query, lang)
+        .into_iter()
+        .collect()
 }
 
 /// Builds an [`ExtractedSymbol`] from a captured definition node, or

--- a/rinkaku-core/src/extract/mod.rs
+++ b/rinkaku-core/src/extract/mod.rs
@@ -415,7 +415,7 @@ fn build_symbol(
     reference_query: &tree_sitter::Query,
     lang: &dyn LanguageSupport,
 ) -> Option<ExtractedSymbol> {
-    let kind = symbol_kind(node)?;
+    let kind = symbol_kind(node, source)?;
     let name = definition_name(node, source)?;
     let signature = slice_signature(node, source);
     let container = find_container(node, source);
@@ -446,15 +446,19 @@ fn build_symbol(
 }
 
 /// Maps a captured definition node to a language-neutral [`SymbolKind`].
-/// Node kind strings are unique across the grammars this module supports
-/// (Rust, Go, Python, TypeScript/TSX), so a single flat match is sufficient
-/// without needing to know which `LanguageSupport` a node came from.
+/// Node kind strings are matched flat across every supported grammar;
+/// kinds that collide across grammars (`block` also names ordinary
+/// braced blocks in the Rust/Go/Python grammars) are safe because this
+/// function only ever receives nodes captured by some language's
+/// `definition_query`, and only HCL's query captures `block` (ADR
+/// 0066). The source bytes are here for kinds whose classification
+/// needs identifier text rather than node shape alone.
 ///
 /// Takes the node rather than just its kind string because Go's
 /// `type_spec` needs to inspect its `type` field to tell a struct from an
 /// interface — the definition query captures `type_spec` for both (see
 /// `language/go.rs`), so the node kind alone is ambiguous for Go.
-fn symbol_kind(node: tree_sitter::Node) -> Option<SymbolKind> {
+fn symbol_kind(node: tree_sitter::Node, _source: &[u8]) -> Option<SymbolKind> {
     match node.kind() {
         // Rust.
         "function_item" | "function_signature_item" => Some(SymbolKind::Function),

--- a/rinkaku-core/src/language/mod.rs
+++ b/rinkaku-core/src/language/mod.rs
@@ -59,27 +59,32 @@ pub trait LanguageSupport {
     }
 }
 
-/// Looks up the `LanguageSupport` registered for a file path, based on its
-/// extension. Returns `None` for unrecognized extensions so callers can
-/// skip files rinkaku doesn't understand yet, rather than erroring out.
+/// Looks up the `LanguageSupport` registered for a file path, based on
+/// its path suffix. Returns `None` for unrecognized paths so callers
+/// can skip files rinkaku doesn't understand yet, rather than erroring
+/// out.
 pub fn language_for_path(path: &str) -> Option<&'static dyn LanguageSupport> {
-    let extension = path.rsplit('.').next()?;
     REGISTRY
         .iter()
-        .find(|lang| lang.extensions().contains(&extension))
+        .find(|lang| lang.suffixes().iter().any(|suffix| path.ends_with(suffix)))
         .map(|lang| lang.support())
 }
 
-/// One entry in the built-in language registry: the file extensions that
-/// route to a `LanguageSupport` impl.
+/// One entry in the built-in language registry: the path suffixes that
+/// route to a `LanguageSupport` impl. Suffixes rather than final
+/// `.`-separated segments (ADR 0066): an entry can then name a
+/// multi-segment convention (`.tftest.hcl`) without claiming every
+/// file whose final segment merely coincides (plain `.hcl`). Entries
+/// list more-specific suffixes first by convention; the first matching
+/// entry wins.
 struct RegistryEntry {
-    extensions: &'static [&'static str],
+    suffixes: &'static [&'static str],
     support: fn() -> &'static dyn LanguageSupport,
 }
 
 impl RegistryEntry {
-    fn extensions(&self) -> &'static [&'static str] {
-        self.extensions
+    fn suffixes(&self) -> &'static [&'static str] {
+        self.suffixes
     }
 
     fn support(&self) -> &'static dyn LanguageSupport {
@@ -87,7 +92,7 @@ impl RegistryEntry {
     }
 }
 
-/// Built-in languages, keyed by file extension. Adding a language means
+/// Built-in languages, keyed by path suffix. Adding a language means
 /// adding an entry here plus its `LanguageSupport` impl module — the
 /// extraction pipeline itself does not change (ADR 0002).
 ///
@@ -98,23 +103,23 @@ impl RegistryEntry {
 /// TS-specific constructs. Revisit once there's a concrete need.
 static REGISTRY: &[RegistryEntry] = &[
     RegistryEntry {
-        extensions: &["rs"],
+        suffixes: &[".rs"],
         support: || &rust::RustSupport,
     },
     RegistryEntry {
-        extensions: &["go"],
+        suffixes: &[".go"],
         support: || &go::GoSupport,
     },
     RegistryEntry {
-        extensions: &["py"],
+        suffixes: &[".py"],
         support: || &python::PythonSupport,
     },
     RegistryEntry {
-        extensions: &["ts"],
+        suffixes: &[".ts"],
         support: || &typescript::TypeScriptSupport,
     },
     RegistryEntry {
-        extensions: &["tsx"],
+        suffixes: &[".tsx"],
         support: || &typescript::TsxSupport,
     },
 ];
@@ -127,6 +132,7 @@ pub mod typescript;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn should_return_rust_support_when_path_has_rs_extension() {
@@ -178,6 +184,18 @@ mod tests {
     #[test]
     fn should_return_none_when_path_has_no_extension() {
         let actual = language_for_path("Makefile");
+
+        assert!(actual.is_none());
+    }
+
+    #[rstest]
+    #[case::should_return_none_when_filename_is_bare_rs("rs")]
+    #[case::should_return_none_when_filename_is_bare_go("go")]
+    #[case::should_return_none_when_filename_is_bare_py("py")]
+    #[case::should_return_none_when_filename_is_bare_ts("ts")]
+    #[case::should_return_none_when_filename_is_bare_tsx("tsx")]
+    fn bare_extension_filenames_do_not_route(#[case] path: &str) {
+        let actual = language_for_path(path);
 
         assert!(actual.is_none());
     }


### PR DESCRIPTION
Part 4/6 of the HCL (Terraform) support series (#210, ADR 0066). Stacked on https://github.com/hiro-o918/rinkaku/pull/213; review scope is the last commit only.

Behavior-neutral refactor: symbol construction goes through a one-node-to-many `build_symbols` dispatcher (plus a changed-range re-filter that is a provable no-op for single-node symbols), preparing for HCL `locals` blocks expanding to one symbol per attribute. Zero behavior change — the entire existing suite passes with no test edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
