### PR TITLE
ci: trigger release-please on push to main instead of merged PRs

### DIFF
--- a/.github/workflows/release-main.yaml
+++ b/.github/workflows/release-main.yaml
@@ -1,11 +1,14 @@
 name: Release
 
 on:
-  pull_request:
+  # `push` rather than `pull_request: closed`: workflows triggered by a
+  # pull_request event whose head lives in a fork run without repository
+  # secrets, so the app-token step below aborted on every fork-PR merge
+  # (issue #221). A push to main always runs in the base repo with
+  # secrets, wherever the merged PR came from.
+  push:
     branches:
       - main
-    types:
-      - closed
   # Manual re-run, e.g. when release-please-action aborts without creating
   # a tag/release (see the manifest/GitHub-Releases reconciliation issue
   # fixed by this workflow's tag-scheme change) and `gh run rerun` doesn't
@@ -19,7 +22,6 @@ concurrency:
 
 jobs:
   release-please:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Closes #221.

Every merge of the HCL series (#211–#216, all from a fork) failed the Release workflow with `Input required and not supplied: app_id`: `pull_request`-triggered workflows run **without repository secrets** when the PR head lives in a fork, so the app-token step aborted before release-please ever ran. Same-repo branches were unaffected, which is why this only surfaced with the first external contribution.

**Change**

- Trigger on `push: branches: [main]` — always runs in the base repo with secrets, wherever the merged PR came from. This is also release-please's standard trigger.
- Drop the `merged == true` guard: with a push trigger every push to main is exactly the event we want (release-please is idempotent against non-release pushes).
- Keep `workflow_dispatch` for manual reconciliation (used to recover #209 on 2026-08-02).

`pull_request_target` was rejected as the alternative: it grants secret access to fork-originating events, which this job doesn't need since it only reads post-merge `main` (see #221).

**QA**

- `actionlint` passes on the edited workflow.
- Trigger semantics can only be fully verified on the next merge to main after this lands; the failure mode it fixes is documented with run logs in #221.