### PR TITLE
fix: exclude diff-internal dependency matches by container-aware identity

### DIFF
--- a/rinkaku-core/src/deps.rs
+++ b/rinkaku-core/src/deps.rs
@@ -64,6 +64,15 @@ pub struct ResolvedSymbol {
     /// Path of the file the definition lives in, as provided to the
     /// resolver's file source (e.g. `TagsResolver::new`'s `files`).
     pub path: String,
+    /// The enclosing impl/trait/class block's descriptive name, mirroring
+    /// `ExtractedSymbol::container`. Carried through so `resolve_dependencies`
+    /// can key its diff-internal/self-reference exclusions on `(name,
+    /// container, path)`, matching how `extract::classify_symbols` already
+    /// identifies a symbol — a name and path alone collide whenever a diff
+    /// adds a same-named member under a different container (e.g. a new
+    /// class defining a method that shares its name with an unrelated
+    /// top-level definition).
+    pub container: Option<String>,
 }
 
 /// Resolves a referenced name (a called function, a referenced type, ...)
@@ -226,6 +235,7 @@ impl TagsResolver {
                     index.entry(symbol.name).or_default().push(ResolvedSymbol {
                         signature: symbol.signature,
                         path: path.clone(),
+                        container: symbol.container,
                     });
                 }
             }
@@ -348,16 +358,23 @@ impl Resolver for TagsResolver {
 ///   full elsewhere in the report; repeating it under "dependencies" adds
 ///   noise without adding information.
 ///
-/// Matching for both exclusions is keyed on `(name, path)`, not name
-/// alone: a `referenced_names` entry only carries a bare name, but each
-/// candidate it resolves to (`ResolvedSymbol`) carries its own `path`, so
-/// exclusion is checked per resolved candidate rather than by filtering
-/// `referenced_names` up front. Name-only matching would wrongly drop a
-/// dependency whenever the diff happens to also touch an unrelated,
-/// same-named symbol in a *different* file (e.g. a changed `a.rs::helper`
-/// coinciding with the actual dependency target `b.rs::helper`) — see
-/// ADR 0003 for why resolution itself stays name-based (no type info),
-/// but exclusion does not need to inherit that imprecision.
+/// Matching for both exclusions is keyed on `(name, container, path)`, not
+/// `(name, path)`: a `referenced_names` entry only carries a bare name, but
+/// each candidate it resolves to (`ResolvedSymbol`) carries its own
+/// `path`/`container`, so exclusion is checked per resolved candidate
+/// rather than by filtering `referenced_names` up front. Name-only or
+/// `(name, path)` matching would wrongly drop a dependency whenever the
+/// diff happens to also touch an unrelated, same-named symbol:
+/// - in a *different* file (e.g. a changed `a.rs::helper` coinciding with
+///   the actual dependency target `b.rs::helper`) — see ADR 0003 for why
+///   resolution itself stays name-based (no type info), but exclusion does
+///   not need to inherit that imprecision.
+/// - in the *same* file but a different container (e.g. the diff adds
+///   `class Baz { fn Foo() }` to `a.rs`, which shares a name and path with
+///   an actual dependency target `class Foo` defined elsewhere in
+///   `a.rs`). Keying on `container` too — mirroring how
+///   `extract::classify_symbols` already identifies a symbol — keeps these
+///   apart.
 ///
 /// Also caps same-name candidates at [`MAX_MATCHES_PER_NAME`] per
 /// referenced name, ranked by [`path_proximity_rank`] so the kept matches
@@ -379,12 +396,16 @@ pub fn resolve_dependencies(
     files: Vec<crate::render::FileReport>,
     resolver: &dyn Resolver,
 ) -> Vec<crate::render::FileReport> {
-    let diff_symbols: std::collections::HashSet<(String, String)> = files
+    let diff_symbols: std::collections::HashSet<(String, Option<String>, String)> = files
         .iter()
         .flat_map(|file| {
-            file.symbols
-                .iter()
-                .map(move |symbol| (symbol.name.clone(), file.path.clone()))
+            file.symbols.iter().map(move |symbol| {
+                (
+                    symbol.name.clone(),
+                    symbol.container.clone(),
+                    file.path.clone(),
+                )
+            })
         })
         .collect();
 
@@ -398,7 +419,11 @@ pub fn resolve_dependencies(
                     .symbols
                     .into_iter()
                     .map(|mut symbol| {
-                        let own_key = (symbol.name.clone(), file_path.clone());
+                        let own_key = (
+                            symbol.name.clone(),
+                            symbol.container.clone(),
+                            file_path.clone(),
+                        );
                         let mut dependencies = Vec::new();
                         let mut omitted = 0usize;
 
@@ -407,7 +432,11 @@ pub fn resolve_dependencies(
                                 .resolve(name)
                                 .into_iter()
                                 .filter(|resolved| {
-                                    let key = (name.clone(), resolved.path.clone());
+                                    let key = (
+                                        name.clone(),
+                                        resolved.container.clone(),
+                                        resolved.path.clone(),
+                                    );
                                     key != own_key && !diff_symbols.contains(&key)
                                 })
                                 .collect();

--- a/rinkaku-core/src/deps_tests/prefilter.rs
+++ b/rinkaku-core/src/deps_tests/prefilter.rs
@@ -23,6 +23,7 @@ fn should_index_definitions_from_file_containing_a_referenced_name() {
     let expected = vec![ResolvedSymbol {
         signature: "fn helper(x: i32) -> i32".to_string(),
         path: "src/lib.rs".to_string(),
+        container: None,
     }];
     let actual = resolver.resolve("helper");
 
@@ -87,6 +88,7 @@ fn should_still_index_file_when_referenced_name_appears_incidentally_in_content(
     let expected = vec![ResolvedSymbol {
         signature: "fn helper() -> i32".to_string(),
         path: "src/lib.rs".to_string(),
+        container: None,
     }];
     let actual = resolver.resolve("helper");
 
@@ -138,6 +140,7 @@ fn should_resolve_dotted_reference_when_definition_file_only_contains_its_compon
     let expected = vec![ResolvedSymbol {
         signature: "variable \"region\" {\n  type = string\n}".to_string(),
         path: "envs/prod/vars.tf".to_string(),
+        container: None,
     }];
     let actual = resolver.resolve("var.region");
 
@@ -165,6 +168,7 @@ fn should_resolve_single_character_variable_name_when_referenced() {
     let expected = vec![ResolvedSymbol {
         signature: "variable \"x\" {\n  type = string\n}".to_string(),
         path: "envs/prod/x.tf".to_string(),
+        container: None,
     }];
     let actual = resolver.resolve("var.x");
 

--- a/rinkaku-core/src/deps_tests/resolve_dependencies.rs
+++ b/rinkaku-core/src/deps_tests/resolve_dependencies.rs
@@ -122,6 +122,36 @@ fn should_exclude_self_reference_from_dependencies() {
 }
 
 #[test]
+fn should_exclude_self_reference_when_symbol_and_candidate_containers_match() {
+    // Guards the (name, container, path) key against a regression where a
+    // contained symbol's self-reference (e.g. a recursive method) would
+    // survive exclusion because own_key and the candidate disagree on
+    // container.
+    let files = vec![FileReport {
+        path: "a.py".to_string(),
+        symbols: vec![symbol_with_container("area", "class Circle", vec!["area"])],
+    }];
+    let resolver = FakeResolver {
+        matches: HashMap::from([(
+            "area",
+            vec![ResolvedSymbol {
+                signature: "def area(self):".to_string(),
+                path: "a.py".to_string(),
+                container: Some("class Circle".to_string()),
+            }],
+        )]),
+    };
+
+    let expected = vec![FileReport {
+        path: "a.py".to_string(),
+        symbols: vec![symbol_with_container("area", "class Circle", vec!["area"])],
+    }];
+    let actual = resolve_dependencies(files, &resolver);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn should_exclude_dependency_already_reported_elsewhere_in_the_diff() {
     // "helper" is itself a changed symbol reported in this diff
     // (a different file than "foo"), so it must not be repeated

--- a/rinkaku-core/src/deps_tests/resolve_dependencies.rs
+++ b/rinkaku-core/src/deps_tests/resolve_dependencies.rs
@@ -36,6 +36,17 @@ fn symbol(name: &str, referenced_names: Vec<&str>) -> ExtractedSymbol {
     }
 }
 
+fn symbol_with_container(
+    name: &str,
+    container: &str,
+    referenced_names: Vec<&str>,
+) -> ExtractedSymbol {
+    ExtractedSymbol {
+        container: Some(container.to_string()),
+        ..symbol(name, referenced_names)
+    }
+}
+
 /// Builds a `ResolvedSymbol` candidate at `path`, with a signature
 /// derived from the path so mismatched ordering is easy to spot in
 /// a failing assertion.
@@ -43,6 +54,7 @@ fn candidate(path: &str) -> ResolvedSymbol {
     ResolvedSymbol {
         signature: format!("fn helper() // {path}"),
         path: path.to_string(),
+        container: None,
     }
 }
 
@@ -58,6 +70,7 @@ fn should_populate_dependencies_when_referenced_name_resolves() {
             vec![ResolvedSymbol {
                 signature: "fn helper()".to_string(),
                 path: "src/util.rs".to_string(),
+                container: None,
             }],
         )]),
     };
@@ -68,6 +81,7 @@ fn should_populate_dependencies_when_referenced_name_resolves() {
             dependencies: vec![ResolvedSymbol {
                 signature: "fn helper()".to_string(),
                 path: "src/util.rs".to_string(),
+                container: None,
             }],
             ..symbol("foo", vec!["helper"])
         }],
@@ -93,6 +107,7 @@ fn should_exclude_self_reference_from_dependencies() {
             vec![ResolvedSymbol {
                 signature: "struct Point".to_string(),
                 path: "src/lib.rs".to_string(),
+                container: None,
             }],
         )]),
     };
@@ -127,6 +142,7 @@ fn should_exclude_dependency_already_reported_elsewhere_in_the_diff() {
             vec![ResolvedSymbol {
                 signature: "fn helper()".to_string(),
                 path: "src/util.rs".to_string(),
+                container: None,
             }],
         )]),
     };
@@ -144,7 +160,7 @@ fn should_keep_dependency_when_a_same_named_symbol_exists_elsewhere_in_the_diff(
     // "src/b.rs::helper". Excluding by name alone would wrongly
     // drop this dependency just because a same-named, unrelated
     // symbol happens to also be part of the diff; exclusion must
-    // be keyed on (name, path), not name alone.
+    // be keyed on (name, container, path), not name alone.
     let files = vec![
         FileReport {
             path: "src/a.rs".to_string(),
@@ -161,6 +177,7 @@ fn should_keep_dependency_when_a_same_named_symbol_exists_elsewhere_in_the_diff(
             vec![ResolvedSymbol {
                 signature: "fn helper()".to_string(),
                 path: "src/b.rs".to_string(),
+                container: None,
             }],
         )]),
     };
@@ -173,6 +190,7 @@ fn should_keep_dependency_when_a_same_named_symbol_exists_elsewhere_in_the_diff(
                     dependencies: vec![ResolvedSymbol {
                         signature: "fn helper()".to_string(),
                         path: "src/b.rs".to_string(),
+                        container: None,
                     }],
                     ..symbol("foo", vec!["helper"])
                 },
@@ -184,6 +202,51 @@ fn should_keep_dependency_when_a_same_named_symbol_exists_elsewhere_in_the_diff(
             symbols: vec![],
         },
     ];
+    let actual = resolve_dependencies(files, &resolver);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_keep_dependency_when_diff_symbol_shares_name_and_path_but_differs_in_container() {
+    // The diff adds "class Baz { fn Foo() }" to "a.py", and "use_foo"
+    // (also in this diff) references "Foo". The actual dependency
+    // target is the unrelated top-level "class Foo" in the same file,
+    // not the new "Foo" method under "class Baz". A (name, path) key
+    // cannot tell these apart since both share name "Foo" and path
+    // "a.py"; only adding container to the key does.
+    let files = vec![FileReport {
+        path: "a.py".to_string(),
+        symbols: vec![
+            symbol("use_foo", vec!["Foo"]),
+            symbol_with_container("Foo", "class Baz", vec![]),
+        ],
+    }];
+    let resolver = FakeResolver {
+        matches: HashMap::from([(
+            "Foo",
+            vec![ResolvedSymbol {
+                signature: "class Foo".to_string(),
+                path: "a.py".to_string(),
+                container: None,
+            }],
+        )]),
+    };
+
+    let expected = vec![FileReport {
+        path: "a.py".to_string(),
+        symbols: vec![
+            ExtractedSymbol {
+                dependencies: vec![ResolvedSymbol {
+                    signature: "class Foo".to_string(),
+                    path: "a.py".to_string(),
+                    container: None,
+                }],
+                ..symbol("use_foo", vec!["Foo"])
+            },
+            symbol_with_container("Foo", "class Baz", vec![]),
+        ],
+    }];
     let actual = resolve_dependencies(files, &resolver);
 
     assert_eq!(expected, actual);
@@ -376,18 +439,22 @@ fn should_accumulate_omitted_matches_across_multiple_referenced_names() {
                     ResolvedSymbol {
                         signature: "fn other() // src/pkg/f.rs".to_string(),
                         path: "src/pkg/f.rs".to_string(),
+                        container: None,
                     },
                     ResolvedSymbol {
                         signature: "fn other() // src/pkg/g.rs".to_string(),
                         path: "src/pkg/g.rs".to_string(),
+                        container: None,
                     },
                     ResolvedSymbol {
                         signature: "fn other() // src/pkg/h.rs".to_string(),
                         path: "src/pkg/h.rs".to_string(),
+                        container: None,
                     },
                     ResolvedSymbol {
                         signature: "fn other() // src/pkg/i.rs".to_string(),
                         path: "src/pkg/i.rs".to_string(),
+                        container: None,
                     },
                 ],
             ),

--- a/rinkaku-core/src/deps_tests/tags_resolver_exclusions.rs
+++ b/rinkaku-core/src/deps_tests/tags_resolver_exclusions.rs
@@ -42,6 +42,7 @@ fn should_include_test_path_file_in_index_when_include_tests_is_true() {
     let expected = vec![ResolvedSymbol {
         signature: "func TestFoo(t *testing.T)".to_string(),
         path: "src/repo_test.go".to_string(),
+        container: None,
     }];
     let actual = resolver.resolve("TestFoo");
 
@@ -160,6 +161,7 @@ func Foo() int {
     let expected = vec![ResolvedSymbol {
         signature: "func Foo() int".to_string(),
         path: "models/user.go".to_string(),
+        container: None,
     }];
     let actual = resolver.resolve("Foo");
 
@@ -192,6 +194,7 @@ fn should_still_index_ordinary_files_when_a_generated_file_is_excluded() {
     let expected_helper = vec![ResolvedSymbol {
         signature: "fn helper() -> i32".to_string(),
         path: "src/lib.rs".to_string(),
+        container: None,
     }];
     assert_eq!(expected_foo, resolver.resolve("Foo"));
     assert_eq!(expected_helper, resolver.resolve("helper"));
@@ -232,6 +235,7 @@ fn should_add_two_numbers() {}
     let expected = vec![ResolvedSymbol {
         signature: "fn add(a: i32, b: i32) -> i32".to_string(),
         path: "src/lib.rs".to_string(),
+        container: None,
     }];
     let actual = resolver.resolve("add");
 
@@ -285,6 +289,7 @@ fn should_index_definitions_across_multiple_languages() {
     let expected = vec![ResolvedSymbol {
         signature: "func greet() string".to_string(),
         path: "repo.go".to_string(),
+        container: None,
     }];
     let actual = resolver.resolve("greet");
 

--- a/rinkaku-core/src/deps_tests/tags_resolver_indexing.rs
+++ b/rinkaku-core/src/deps_tests/tags_resolver_indexing.rs
@@ -20,6 +20,7 @@ fn should_resolve_function_call_when_callee_is_defined_in_repo() {
     let expected = vec![ResolvedSymbol {
         signature: "fn helper(x: i32) -> i32".to_string(),
         path: "src/lib.rs".to_string(),
+        container: None,
     }];
     let actual = resolver.resolve("helper");
 
@@ -45,6 +46,7 @@ fn should_resolve_type_reference_when_type_is_defined_in_repo() {
     let expected = vec![ResolvedSymbol {
         signature: "struct Point {\n    x: i32,\n}".to_string(),
         path: "src/point.rs".to_string(),
+        container: None,
     }];
     let actual = resolver.resolve("Point");
 
@@ -109,10 +111,12 @@ fn should_return_all_matches_when_name_is_defined_multiple_times() {
         ResolvedSymbol {
             signature: "fn helper() -> i32".to_string(),
             path: "src/a.rs".to_string(),
+            container: None,
         },
         ResolvedSymbol {
             signature: "fn helper() -> i32".to_string(),
             path: "src/b.rs".to_string(),
+            container: None,
         },
     ];
     let mut actual = resolver.resolve("helper");

--- a/rinkaku-core/src/render/markdown_tests/definition_body.rs
+++ b/rinkaku-core/src/render/markdown_tests/definition_body.rs
@@ -73,6 +73,7 @@ fn should_render_depends_on_list_when_symbol_has_dependencies() {
                 dependencies: vec![crate::deps::ResolvedSymbol {
                     signature: "struct Point { x: i32, y: i32 }".to_string(),
                     path: "src/point.rs".to_string(),
+                    container: None,
                 }],
                 ..symbol(
                     "src/lib.rs::foo",
@@ -135,6 +136,7 @@ fn should_collapse_multiline_dependency_signature_to_one_line() {
                 dependencies: vec![crate::deps::ResolvedSymbol {
                     signature: "struct Point {\n    x: i32,\n    y: i32,\n}".to_string(),
                     path: "src/point.rs".to_string(),
+                    container: None,
                 }],
                 ..symbol(
                     "src/lib.rs::foo",
@@ -194,10 +196,12 @@ fn should_render_multiple_depends_on_entries_when_symbol_has_several_dependencie
                     crate::deps::ResolvedSymbol {
                         signature: "struct Point { x: i32 }".to_string(),
                         path: "src/a.rs".to_string(),
+                        container: None,
                     },
                     crate::deps::ResolvedSymbol {
                         signature: "struct Point { y: i32 }".to_string(),
                         path: "src/b.rs".to_string(),
+                        container: None,
                     },
                 ],
                 ..symbol(
@@ -258,6 +262,7 @@ fn should_render_omitted_matches_note_when_dependency_matches_were_capped() {
                 dependencies: vec![crate::deps::ResolvedSymbol {
                     signature: "struct Point { x: i32 }".to_string(),
                     path: "src/a.rs".to_string(),
+                    container: None,
                 }],
                 omitted_dependency_matches: 2,
                 ..symbol(


### PR DESCRIPTION
## Summary

`resolve_dependencies` in `rinkaku-core/src/deps.rs` drops a real
dependency from a symbol's "Depends on" list whenever the diff also
adds a same-named, same-path symbol under a *different* container.

Reproduction: a diff adds a class `Baz` with a method also named
`Foo` to `a.py`, which already defines `class Foo`. `b.py`'s
`use_foo()` references `Foo` (the class). Before this fix, `use_foo`'s
"Depends on" section disappears entirely from the output, even though
its actual dependency (`class Foo`) is untouched by the diff.

## Root cause

The diff-internal-symbol and self-reference exclusions in
`resolve_dependencies` were keyed on `(name, path)` only. The new
`class Baz { fn Foo() }` (name `Foo`, container `Some("class Baz")`,
path `a.py`) collides under that key with the resolver's real match
`class Foo` (name `Foo`, container `None`, path `a.py`), so the real
dependency is wrongly treated as "already shown elsewhere in the
diff" and excluded.

## Fix

- Added `container: Option<String>` to `ResolvedSymbol`, populated
  from the indexed `ExtractedSymbol::container` in
  `TagsResolver::new`.
- Reworked both exclusion keys (`own_key` for self-reference,
  `diff_symbols` for diff-internal matches) in `resolve_dependencies`
  to `(name, container, path)`, mirroring how
  `extract::classify_symbols` already identifies a symbol.
- `ResolvedSymbol` gaining a field is additive to JSON output
  (`dependencies[].container`); Markdown/digest rendering only reads
  `path`/`signature` and is unchanged.

## Known remaining limitation

`graph.rs`'s edge matching (`collect_edges`) still matches by name
only (ADR 0003) and is not touched by this PR — a false graph edge
can still form in the same scenario, this fix only restores the
dropped "Depends on" entry in symbol output.

## Test plan

- [x] Added a failing-first (TDD) unit test in
      `deps_tests/resolve_dependencies.rs`:
      `should_keep_dependency_when_diff_symbol_shares_name_and_path_but_differs_in_container`
      — confirmed Red against the old `(name, path)` key, Green with
      the fix.
- [x] `make test` (1793 tests across the workspace) and `make lint`
      pass.
- [x] Manual e2e repro with a real tempdir git repo and both the
      pre-fix and post-fix binaries, confirming the "Depends on:
      a.py: class Foo" line reappears (see PR discussion / commit
      message for the exact before/after).