### PR TITLE
Extend TUI annotations to File, Dir, and removed-symbol rows

### DIFF
--- a/docs/adr/0067-annotation-file-dir-removed-symbol-targets.md
+++ b/docs/adr/0067-annotation-file-dir-removed-symbol-targets.md
@@ -1,0 +1,248 @@
+# 0067. Extend annotation targets to File, Dir, and removed-symbol rows
+
+- Status: accepted
+- Date: 2026-08-06
+- Amends: [ADR 0048](0048-tui-review-actions.md) (review annotations),
+  narrowing "v1 only supports symbol-anchored annotations" to the wider
+  target set below; [ADR 0058](0058-tui-annotation-key-rebind.md) (the
+  `a`/`A` key rebind and "annotation" vocabulary) is unaffected.
+
+## Context
+
+ADR 0048 shipped review annotations scoped to present symbol rows only
+(`review_flow::derive_selection_snapshot`'s doc comment: "`None` ... on
+any row that is not a present symbol"). In practice a reviewer's first
+observation about a change is often not about one symbol: "this whole
+file is dead code now", "this directory's structure doesn't make sense
+anymore", or "this removed function should have stayed" (a removed-symbol
+row, which the v1 gate excludes because it "has no graph presence to
+jump from" the same way `selected_symbol_id` excludes it from
+navigation — a different concern that the annotation gate copied
+without re-examining). None of these have anywhere to go today; pressing
+`a` on a File, Dir, or removed-symbol row is a silent no-op.
+
+This ADR widens the annotation target set to File rows, Dir rows, and
+removed-symbol rows, while keeping Source-screen compose out of scope
+(ADR 0048's own scope boundary, untouched here) and keeping the same
+destination-neutral `Annotation` primitive ADR 0048 established.
+
+### GitHub API constraints, verified against current docs
+
+Before choosing an export design for the new target kinds, this ADR
+checked GitHub's REST API docs for both PR-comment-producing endpoints
+(<https://docs.github.com/en/rest/pulls/reviews>,
+<https://docs.github.com/en/rest/pulls/comments>, both
+`apiVersion=2022-11-28`) rather than assuming symmetry between them:
+
+- **`POST /repos/{owner}/{repo}/pulls/{pull_number}/comments`** (the
+  standalone, single-comment endpoint) accepts `subject_type: "line"` or
+  `"file"` on the request body; `line` is documented as "Required unless
+  using `subject_type:file`". This endpoint supports true file-level PR
+  comments.
+- **`POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews`** (the
+  batch pending-review endpoint sink A already uses — open a review,
+  attach every comment, submit with one verdict) documents its
+  `comments[]` array items as `path`, `position`, `body`, `line`, `side`,
+  `start_line`, `start_side` only. **`subject_type` is not a documented
+  field of this endpoint's `comments[]` schema.** There is no
+  batch-compatible way to attach a file-level (no-line) comment to a
+  pending review alongside the existing inline comments.
+
+These two endpoints are not interchangeable for this feature:
+switching sink A to the standalone-comment endpoint per file-level note
+would mean posting those comments as individual, immediately-visible PR
+comments outside the pending-review batch — a different notification
+and discard/undo behavior than every symbol-anchored annotation gets
+today (ADR 0048's Alternatives already rejected per-comment posting for
+exactly this reason: "creates a separate notification per call and
+cannot be submitted/discarded as a unit"). Splitting one export into two
+different API calls with two different UX guarantees, just to get a
+`subject_type: "file"` comment into the same batch, is not a change this
+ADR is willing to make for three target kinds whose common trait is
+"has no diff line to point at anyway" (see Decision).
+
+## Decision
+
+**1. Target kind becomes explicit data, not inferred.** `AnnotationLocation`
+(and `SelectionSnapshot`, `review_flow::derive_selection_snapshot`'s
+output type) gains an `AnnotationTarget` enum:
+
+```rust
+pub enum AnnotationTarget {
+    Symbol,
+    RemovedSymbol,
+    File,
+    Dir,
+}
+```
+
+Every construction site (the `From<SelectionSnapshot> for
+AnnotationLocation` conversion, `derive_selection_snapshot`'s `Some(...)`
+arms) sets this explicitly. No code infers a target's kind from
+`symbol_id.is_some()`, a trailing slash on `path`, or any other sentinel
+— the ADR 0048-era `AnnotationLocation` already leaves this ambiguous
+(a `None` `symbol_id` today could mean either "not a symbol" or, after
+this ADR, "a Dir/File row"), and sentinel-based inference is exactly the
+kind of implicit-fallback shape ADR 0048's own Alternatives rejected for
+export-sink selection. An explicit tag is one field, checked once at
+render/export time, instead of every consumer re-deriving the same
+classification from path shape.
+
+**2. `derive_selection_snapshot` widens its row-kind gate.** Today it
+returns `None` for `NodeKind::Dir`/`File`/`Section`/`TestGroup` and for a
+removed `NodeKind::Symbol`. After this change:
+
+- `NodeKind::File` → `AnnotationTarget::File`, `path` only, no
+  `symbol_id`/`symbol_name`/`range`/`anchor`/`signature`.
+- `NodeKind::Dir` → `AnnotationTarget::Dir`, `path` only, same empty
+  optional fields.
+- `NodeKind::Symbol` where `symbol_ref.removed` → `AnnotationTarget::RemovedSymbol`,
+  `path` + `symbol_id` (the synthesized `{path}::{name}` id, `SymbolRef::id`'s
+  own doc comment) + `symbol_name`, but no `range`/`anchor` — a removed
+  symbol has no new-side line range to have one.
+- `NodeKind::Section`/`TestGroup` stay `None` (see Decision 4).
+- The existing present-symbol path is unchanged.
+
+**3. Export partitions by anchor presence, not by target kind directly.**
+A pure `partition_for_export` function (in `render.rs`, alongside the
+existing sink renderers) splits `&[Annotation]` into two groups:
+
+- **Anchored** (`anchor.or(range)` resolves to `Some`) → rendered by the
+  existing `render_review_comments` path, posted as inline pending-review
+  comments exactly as today. In practice this is every `Symbol`
+  annotation whose range intersects a hunk — target kind is not consulted
+  here, only whether an anchor resolved, so a future target kind that
+  *does* carry a line (none of File/Dir/RemovedSymbol do) would fall into
+  this bucket automatically.
+- **Unanchored** (`File`, `Dir`, `RemovedSymbol`, and any `Symbol`
+  annotation whose range never intersected a hunk — the same
+  no-anchor case `render_review_comments`' `(1, 1)` fallback used to
+  paper over) → collected into an **"Additional notes" section appended
+  to the review body**, one bullet per annotation: `` `{path}`: {body
+  first line} `` for a File/Dir target, `` `{path}` {symbol_name}
+  (removed): {body first line} `` for a removed symbol, and the same
+  format `render_agent_packet`'s heading already uses for an unanchored
+  Symbol. Each bullet links no line (there is none to link), matching
+  what a human reviewer would type by hand into the review body's free
+  text today for exactly this kind of file/directory-scoped remark.
+
+  This replaces the `(1, 1)` fallback: `render_review_comments` no longer
+  invents a synthetic anchor for an annotation with no real one.
+  `perform_export`'s `REVIEW_SUMMARY` + this section are composed into
+  the review body posted with the batch, so the whole thing — inline
+  comments and body-collected notes alike — remains one pending review
+  submitted/discarded as a unit, preserving ADR 0048's Alternatives
+  rejection of per-comment posting.
+
+**4. `Section`/`TestGroup` stay out of scope.** Both are synthetic
+grouping rows with no real file-tree path (`NodeKind::Section`/
+`TestGroup`'s own doc comments; `crate::app`'s existing blast-radius
+selection already special-cases them out as `NotApplicable` for the same
+reason). Falling back to "annotate the nearest real file" would silently
+attach a note to a location the reviewer never pointed at; there is no
+natural real-path fallback for a `Section`, and `TestGroup`'s own file is
+already directly annotatable as a `File` row one level up. `a` on either
+row kind stays a silent no-op, unchanged from today.
+
+**5. Agent-packet rendering (sink B) varies its heading by target kind.**
+`render_agent_packet`'s per-annotation heading keeps its current
+`{path}:{range} {symbol_name}` form for `Symbol`/`RemovedSymbol` targets
+(a `RemovedSymbol` naturally renders as `{path} {symbol_name}` today,
+since it carries no range) and adds:
+
+- `File` → `## {path}`
+- `Dir` → `## {path}/` (trailing slash distinguishes a directory heading
+  from a file heading sharing the same path text, and mirrors how a
+  shell/file-tree UI already marks directories)
+
+**6. Existing-pane markers extend to File-row badges, Dir-row badges are
+out of scope.** `AnnotationMarkers::file_counts` (keyed by path) already
+counts every annotation under a path regardless of whether it carries a
+`symbol_id` — `build_annotation_markers`'s own doc comment already
+anticipated this ("a future file-level annotation is covered by
+construction rather than needing a second field"), so a File-target
+annotation increments the same counter a Symbol-target annotation
+already does, and `row_view::entry_row_line`'s existing
+`push_annotation_badge_span` call on the `File` arm needs no change to
+pick it up — confirmed by a new test.
+
+Dir-row badges are left out: `AnnotationMarkers` has no per-directory
+counter today, and `Badges`' aggregation model (bottom-up, baked once at
+tree-build time — `tree/mod.rs`'s own doc comment) is a poor fit for a
+value that changes during the session; building a parallel
+change-gated bottom-up aggregation for directories, mirroring
+`Badges::merge`, is a disproportionate restructure for this PR's scope.
+Left as explicit future work (see Consequences); a Dir-target annotation
+is still fully captured, exported, and visible in the annotations-list
+overlay — it just carries no tree-row badge yet.
+
+**7. Compose overlay title and annotations-list entries degrade per
+target kind**, reusing the same `(range, symbol_name)` degrade shape
+`ui/review_overlay.rs`'s `compose_title_location`/
+`annotations_list_entry_text` already implement for the no-range case —
+a File/Dir/RemovedSymbol snapshot or annotation is simply another point
+on that existing fallback ladder (no `range` → falls through to
+`path`/`path + symbol_name`), not a new code path.
+
+## Alternatives
+
+- **Use the standalone `POST .../pulls/comments` endpoint (with
+  `subject_type: "file"`) for File-target annotations, keeping the
+  pending-review batch endpoint only for anchored ones.** Rejected: this
+  endpoint posts immediately and individually — outside the pending
+  review, with its own notification and no batch-submit/discard — the
+  exact behavior ADR 0048's Alternatives rejected for *every* annotation
+  in v1. Carving out one target kind to behave differently at export time
+  (some of a session's notes are revocable by discarding the pending
+  review, some are already public and can't be un-sent) is a surprising,
+  inconsistent reviewer experience for a target-kind distinction the
+  reviewer never asked to reason about.
+- **Fall back Dir/removed-symbol annotations to the nearest anchorable
+  line (e.g. line 1 of the first file under a Dir, or the removed
+  symbol's last known line before deletion) and keep them as inline
+  comments.** Rejected: a removed symbol's pre-deletion line number is
+  base-side, not new-side — GitHub's review API comments are anchored to
+  the *new* side of the diff (`side: "RIGHT"`, `review.rs`'s own request
+  builder), so there is no new-side line to point at for a symbol that no
+  longer exists. A Dir has no single "first file" a reviewer would
+  recognize as what they annotated. Both fallbacks reintroduce the same
+  unsound synthetic-anchor problem this ADR removes the `(1, 1)` fallback
+  for, just relocated to a different wrong line instead of line 1.
+- **Give Dir rows a real per-directory `AnnotationMarkers` aggregate now**,
+  matching `Badges`' bottom-up shape. Considered, but deferred: `Badges`
+  is baked once at tree-build time from an immutable `Report`
+  (`tree/mod.rs`'s own doc comment on why baking works for `Badges` but
+  not for review state), so a directory annotation counter would need
+  its own bottom-up recompute pass over the tree on every
+  `AnnotationMarkers` rebuild — meaningfully more machinery than the
+  existing flat `HashMap<String, usize>` `file_counts`/`symbol_counts`
+  use. Worth doing once a second consumer or reviewer feedback asks for
+  it; not justified for this PR's budget alone.
+- **Route Section/TestGroup rows to the nearest enclosing File.**
+  Considered for symmetry with "every row is annotatable somehow", but
+  rejected per Decision 4: it silently attaches a note to a path the
+  reviewer's cursor was never actually on, and (for `TestGroup`) the
+  identical file is already one row away as a directly annotatable
+  `File` target, so the fallback adds an implicit rule for no real gain
+  in reachability.
+
+## Consequences
+
+- `AnnotationLocation`/`SelectionSnapshot` gain a required
+  `AnnotationTarget` field; every existing construction site (test
+  fixtures included) must set it, a one-time mechanical update.
+- `render_review_comments` no longer has an unsound `(1, 1)` fallback —
+  every `RenderedComment` it produces now has a real anchor or range;
+  annotations without one are routed to the "Additional notes" body
+  section by `partition_for_export` instead, fixing the latent 422 risk
+  ADR 0048's own comment on that fallback already flagged.
+- The GitHub review body posted by sink A is no longer a fixed constant
+  (`REVIEW_SUMMARY`) whenever at least one unanchored annotation exists
+  in the batch — it becomes `REVIEW_SUMMARY` plus the rendered
+  "Additional notes" section, composed once in `perform_export`.
+- Dir-row tree badges, and Source-screen compose, remain unimplemented —
+  explicit future work, not silently dropped scope (see PR body's Future
+  work section for the concrete next steps).
+- No change to sink A's underlying `gh api .../reviews` call shape or to
+  `ReviewSubmitter`'s trait signature — only the `comments`/`body` values
+  `perform_export` passes to it change.

--- a/docs/experiments/0001-map-assisted-llm-review/rounds/040.md
+++ b/docs/experiments/0001-map-assisted-llm-review/rounds/040.md
@@ -1,0 +1,48 @@
+# Round 40
+
+- Subject: PR #226 — extend TUI review annotations (ADR 0048) from
+  symbol-only targets to File, Dir, and removed-symbol rows (ADR 0067):
+  adds an explicit `AnnotationTarget` enum, widens
+  `derive_selection_snapshot`'s row-kind gate, and replaces the GitHub
+  export's unsound `(1, 1)` synthetic-anchor fallback with an
+  anchor-presence partition that routes unanchored annotations into an
+  "Additional notes" review-body section.
+- Protocol: two agents — one static reviewer covering both the
+  map-assisted pass and the independent no-map pass itself, one
+  dynamic-verification pass — run in parallel against the branch.
+- **Map delivery**: `rinkaku --base main`, built from a trusted `main`
+  checkout, handed to the static reviewer alongside the diff.
+- **Map hit**: the map's "no referencing tests" flag on changed symbols
+  pointed directly at a real test gap — `annotations_list_entry_text`'s
+  `Dir` trailing-slash branch had no test of its own, unlike its sibling
+  `compose_title_location`, which already had one. Of 4 symbols the map
+  flagged this way, 2 were false positives on inspection (a plain data
+  struct and a trivial `From` impl needing no behavior test), so the
+  flag needed reading each hit rather than trusting the list at face
+  value.
+- **Map miss**: the round's only should-fix — ADR 0067 Decision 3
+  specifies a `(removed)` marker on a removed-symbol's Additional-notes/
+  agent-packet heading, but the shared `annotation_heading` helper never
+  added it, making a deleted symbol's heading textually identical to an
+  unanchored present symbol's. This has no footprint on the signature
+  map (both branches are ordinary string formatting); it surfaced only
+  from the static pass's own ADR-vs-implementation cross-read. The
+  dynamic pass independently reached the same finding by inspecting the
+  actual rendered export body rather than the ADR text — two different
+  methods converging on one should-fix is this round's main signal.
+- **Dynamic pass**: 6 failure-mode invocations (non-TTY stdin, non-TTY
+  stdout, empty input, an invalid `--base`, and two conflicting-flag
+  combinations) produced no panics; the zero-anchored review post path
+  (an all-unanchored annotation set exporting through sink A) also
+  verified correctly.
+- Severity summary: 0 blockers, 1 should-fix (missing `(removed)`
+  marker, `rinkaku-tui/src/review/render.rs`), 2 nits (an untested `Dir`
+  branch in `annotations_list_entry_text`; a doc comment on
+  `render_additional_notes` restating WHAT already covered by its own
+  tests). All three fixed directly, no design changes.
+- Takeaway: running the map-assisted and independent passes inside one
+  agent, instead of two separate ones, still produced a map hit and a
+  map miss distinguishable from each other — the miss came specifically
+  from the ADR-reading half of that agent's work, not from anything the
+  map surfaced or suppressed. Consolidating the two static angles into
+  one agent did not blur which angle found what.

--- a/rinkaku-tui/locales/en.yml
+++ b/rinkaku-tui/locales/en.yml
@@ -30,7 +30,7 @@ help:
     start_search: "Start a search"
     jump_next_prev_match: "Jump to the next / previous search match"
     return_to_entry_view: "Return to the entry view"
-    compose_annotation: "Compose an annotation over the symbol under the cursor"
+    compose_annotation: "Compose an annotation over the row under the cursor"
     open_annotations_list: "Open the review annotations list"
     annotations_list_move: "Annotations list: move the cursor"
     annotations_list_export: "Annotations list: open the export menu"

--- a/rinkaku-tui/locales/ja.yml
+++ b/rinkaku-tui/locales/ja.yml
@@ -30,7 +30,7 @@ help:
     start_search: "検索を開始"
     jump_next_prev_match: "次/前の検索結果へジャンプ"
     return_to_entry_view: "エントリービューに戻る"
-    compose_annotation: "カーソル位置のシンボルにレビューアノテーションを作成"
+    compose_annotation: "カーソル位置の行にレビューアノテーションを作成"
     open_annotations_list: "レビューアノテーション一覧を開く"
     annotations_list_move: "アノテーション一覧: カーソル移動"
     annotations_list_export: "アノテーション一覧: エクスポートメニューを開く"

--- a/rinkaku-tui/src/annotation_markers.rs
+++ b/rinkaku-tui/src/annotation_markers.rs
@@ -20,16 +20,15 @@ pub struct AnnotationMarkers {
     /// Annotation count per symbol id — consulted by a symbol tree row.
     pub symbol_counts: HashMap<String, usize>,
     /// Annotation count per file path — consulted by a `File` tree row.
-    /// Includes every annotation under that path regardless of whether it
-    /// carries a `symbol_id` (v1 only composes symbol-anchored annotations,
-    /// but this stays keyed by path rather than requiring a symbol so a
-    /// future file-level annotation is covered by construction rather than
-    /// needing a second field).
+    /// Includes every annotation under that path regardless of target kind
+    /// (ADR 0067: a `File`-target annotation increments this the same way a
+    /// `Symbol`-target one under that path already did, since this stays
+    /// keyed by path rather than requiring a `symbol_id`).
     pub file_counts: HashMap<String, usize>,
     /// Every annotation's new-side line range, keyed by path — consulted by
     /// the diff pane to mark individual lines. An annotation with no
-    /// `range` (v1: non-symbol locations only, out of scope per
-    /// `crate::review`'s module doc comment) contributes no entry.
+    /// `range` (a `File`/`Dir`/`RemovedSymbol` target, or a `Symbol` target
+    /// whose range never resolved — ADR 0067) contributes no entry.
     pub line_ranges: HashMap<String, Vec<(usize, usize)>>,
 }
 

--- a/rinkaku-tui/src/annotation_markers_tests.rs
+++ b/rinkaku-tui/src/annotation_markers_tests.rs
@@ -1,9 +1,15 @@
 use super::*;
-use crate::review::AnnotationLocation;
+use crate::review::{AnnotationLocation, AnnotationTarget};
 
 fn annotation(path: &str, symbol_id: Option<&str>, range: Option<(usize, usize)>) -> Annotation {
+    let target = if symbol_id.is_some() {
+        AnnotationTarget::Symbol
+    } else {
+        AnnotationTarget::File
+    };
     Annotation {
         location: AnnotationLocation {
+            target,
             path: path.to_string(),
             symbol_id: symbol_id.map(str::to_string),
             symbol_name: None,

--- a/rinkaku-tui/src/app/mod.rs
+++ b/rinkaku-tui/src/app/mod.rs
@@ -189,6 +189,31 @@ pub enum BlastRadiusSelection {
     View(crate::blast_radius::BlastRadiusView),
 }
 
+/// What [`App::selected_row`] resolved the cursor's row to (ADR 0067) —
+/// `crate::review_flow::derive_selection_snapshot`'s sole input for turning
+/// a tree row into a [`crate::review::SelectionSnapshot`]. A distinct type
+/// from [`crate::tree::NodeKind`] rather than exposing `NodeKind` itself:
+/// `review_flow` needs only the identity fields relevant to an annotation
+/// (path, symbol id/name), not the rest of `NodeKind`'s shape (badges,
+/// children, kind-specific data no annotation cares about).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SelectedRow {
+    Symbol {
+        id: String,
+    },
+    RemovedSymbol {
+        path: String,
+        id: String,
+        name: String,
+    },
+    File {
+        path: String,
+    },
+    Dir {
+        path: String,
+    },
+}
+
 /// A `g`-prefixed two-key sequence awaiting its second key (ADR 0022's
 /// minimal prefix state machine — not a general chord engine, see that
 /// ADR's own Alternatives). Today's only prefix is `g`; the variant exists
@@ -814,6 +839,37 @@ impl App {
         match &row.node.kind {
             NodeKind::Symbol(symbol_ref) if !symbol_ref.removed => Some(symbol_ref.id.as_str()),
             _ => None,
+        }
+    }
+
+    /// The tree row under the cursor, classified for annotation purposes
+    /// (ADR 0067) — the wider counterpart to [`Self::selected_symbol_id`],
+    /// which only ever reports a *present* symbol row and is kept as-is
+    /// since navigation (`gd`/`gr`) has no use for a removed symbol or a
+    /// `Dir`/`File` row. `None` on [`NodeKind::Section`]/[`NodeKind::TestGroup`]
+    /// (synthetic groupings with no real file-tree path — ADR 0067's
+    /// Decision 4) or when there are no rows at all.
+    pub(crate) fn selected_row(&self) -> Option<SelectedRow> {
+        let rows = self.nav.rows(&self.tree);
+        let row = rows.get(self.nav.cursor())?;
+        match &row.node.kind {
+            NodeKind::Symbol(symbol_ref) if symbol_ref.removed => {
+                Some(SelectedRow::RemovedSymbol {
+                    path: row.node.path.clone(),
+                    id: symbol_ref.id.clone(),
+                    name: symbol_ref.name.clone(),
+                })
+            }
+            NodeKind::Symbol(symbol_ref) => Some(SelectedRow::Symbol {
+                id: symbol_ref.id.clone(),
+            }),
+            NodeKind::File => Some(SelectedRow::File {
+                path: row.node.path.clone(),
+            }),
+            NodeKind::Dir => Some(SelectedRow::Dir {
+                path: row.node.path.clone(),
+            }),
+            NodeKind::Section(_) | NodeKind::TestGroup { .. } => None,
         }
     }
 

--- a/rinkaku-tui/src/app/tests/review.rs
+++ b/rinkaku-tui/src/app/tests/review.rs
@@ -5,10 +5,11 @@
 //! pressed over a row with no derivable snapshot.
 
 use super::*;
-use crate::review::{ReviewState, SelectionSnapshot};
+use crate::review::{AnnotationTarget, ReviewState, SelectionSnapshot};
 
 fn snapshot() -> SelectionSnapshot {
     SelectionSnapshot {
+        target: AnnotationTarget::Symbol,
         path: "lib.rs".to_string(),
         symbol_id: Some("lib.rs::foo".to_string()),
         symbol_name: Some("foo".to_string()),

--- a/rinkaku-tui/src/help.rs
+++ b/rinkaku-tui/src/help.rs
@@ -371,8 +371,9 @@ fn keymap_groups(locale: Locale) -> Vec<KeyBindingGroup> {
 /// bindings are only ever dispatched under their matching [`Focus`];
 /// [`HelpGroup::SourceView`] only under [`Screen::Source`];
 /// [`HelpGroup::Review`]'s `a`/`A` only under [`Screen::Entry`] (regardless
-/// of `Focus`, per `review_flow::derive_selection_snapshot` and
-/// `App::handle_key`'s own `AnnotationsList` arm); [`HelpGroup::Global`] always;
+/// of `Focus`, per `review_flow::derive_selection_snapshot` — which as of
+/// ADR 0067 resolves a snapshot for most row kinds, not only present
+/// symbols — and `App::handle_key`'s own `AnnotationsList` arm); [`HelpGroup::Global`] always;
 /// [`HelpGroup::EntryOnly`] (ADR 0057) only under [`Screen::Entry`] —
 /// `d`/`r`/`o`/`s`/`ctrl-o`/`ctrl-i` are no-ops on [`Screen::Source`]
 /// (`App::handle_key`'s own Source-screen catch-all arm).

--- a/rinkaku-tui/src/input_translate_tests/translate_key.rs
+++ b/rinkaku-tui/src/input_translate_tests/translate_key.rs
@@ -658,6 +658,7 @@ fn should_not_normalize_fullwidth_characters_while_composing_an_annotation() {
     // gestures are.
     let report = report_with_one_symbol();
     let snapshot = crate::review::SelectionSnapshot {
+        target: crate::review::AnnotationTarget::Symbol,
         path: "lib.rs".to_string(),
         symbol_id: Some("lib.rs::foo".to_string()),
         symbol_name: Some("foo".to_string()),

--- a/rinkaku-tui/src/review/mod.rs
+++ b/rinkaku-tui/src/review/mod.rs
@@ -15,7 +15,9 @@
 pub mod ports;
 mod render;
 
-pub use render::{render_agent_packet, render_review_comments};
+pub use render::{
+    partition_for_export, render_additional_notes, render_agent_packet, render_review_comments,
+};
 
 /// A destination-neutral annotation attached to a location in the diff (ADR
 /// 0048's primitive): nothing about an `Annotation` says who will eventually
@@ -27,16 +29,32 @@ pub struct Annotation {
     pub signature: Option<String>,
 }
 
+/// What kind of tree row an [`AnnotationLocation`]/[`SelectionSnapshot`] was
+/// taken against (ADR 0067): explicit data rather than something every
+/// consumer re-derives from which optional fields happen to be set, since a
+/// `None` `symbol_id` alone cannot distinguish "a File row" from "a Dir row".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnnotationTarget {
+    Symbol,
+    RemovedSymbol,
+    File,
+    Dir,
+}
+
 /// Where a [`Annotation`] is anchored: a file path, the symbol it was taken
 /// against (if any), the symbol's own new-side line range, and the
 /// GitHub-comment anchor within that range (the first hunk-intersecting
 /// contiguous run — see [`crate::review::render_review_comments`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnnotationLocation {
+    pub target: AnnotationTarget,
     pub path: String,
     pub symbol_id: Option<String>,
     pub symbol_name: Option<String>,
-    /// The symbol's own new-side line range, 1-based inclusive.
+    /// The symbol's own new-side line range, 1-based inclusive. `None` for
+    /// every non-`Symbol` target (ADR 0067): a `File`/`Dir` row has no line
+    /// range at all, and a `RemovedSymbol` has no *new-side* range since it
+    /// no longer exists on the head side.
     pub range: Option<(usize, usize)>,
     /// The new-side hunk/`range` intersection's first contiguous run,
     /// 1-based inclusive — GitHub's review API only accepts inline
@@ -52,6 +70,7 @@ pub struct AnnotationLocation {
 /// already parsed for the session; `review` never derives this itself.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectionSnapshot {
+    pub target: AnnotationTarget,
     pub path: String,
     pub symbol_id: Option<String>,
     pub symbol_name: Option<String>,
@@ -63,6 +82,7 @@ pub struct SelectionSnapshot {
 impl From<SelectionSnapshot> for AnnotationLocation {
     fn from(snapshot: SelectionSnapshot) -> Self {
         Self {
+            target: snapshot.target,
             path: snapshot.path,
             symbol_id: snapshot.symbol_id,
             symbol_name: snapshot.symbol_name,

--- a/rinkaku-tui/src/review/render.rs
+++ b/rinkaku-tui/src/review/render.rs
@@ -112,7 +112,10 @@ pub fn render_agent_packet(annotations: &[Annotation]) -> String {
 /// to a trailing `/` rather than falling through to the bare-path case a
 /// `File`/`RemovedSymbol` location with no resolvable range would also hit —
 /// otherwise a directory heading would be textually indistinguishable from
-/// a same-path file heading.
+/// a same-path file heading. A [`AnnotationTarget::RemovedSymbol`] heading
+/// gets a trailing `(removed)` (ADR 0067 Decision 3) so it stays
+/// distinguishable from an unanchored present-`Symbol` heading, which
+/// degrades to the same `{path} {symbol_name}` text otherwise.
 fn annotation_heading(annotation: &Annotation) -> String {
     let location = &annotation.location;
     if matches!(location.target, AnnotationTarget::Dir) {
@@ -125,11 +128,16 @@ fn annotation_heading(annotation: &Annotation) -> String {
             format!("{start}-{end}")
         }
     });
-    match (range, &location.symbol_name) {
+    let heading = match (range, &location.symbol_name) {
         (Some(range), Some(name)) => format!("{}:{range} {name}", location.path),
         (Some(range), None) => format!("{}:{range}", location.path),
         (None, Some(name)) => format!("{} {name}", location.path),
         (None, None) => location.path.clone(),
+    };
+    if matches!(location.target, AnnotationTarget::RemovedSymbol) {
+        format!("{heading} (removed)")
+    } else {
+        heading
     }
 }
 

--- a/rinkaku-tui/src/review/render.rs
+++ b/rinkaku-tui/src/review/render.rs
@@ -57,14 +57,13 @@ pub fn render_review_comments(annotations: &[&Annotation]) -> Vec<RenderedCommen
 }
 
 /// Renders sink A's "Additional notes" body section (ADR 0067) for the
-/// unanchored half of [`partition_for_export`]'s split — empty when
-/// `annotations` is empty, so `crate::review_flow::perform_export` can
+/// unanchored half of [`partition_for_export`]'s split. Returns an empty
+/// string for an empty slice so `crate::review_flow::perform_export` can
 /// unconditionally append this to [`super::ExportRequest::GithubReview`]'s
 /// fixed summary without an extra "any unanchored annotations?" branch of
-/// its own. One bullet per annotation, in order, using the same
-/// path[:range][ name] degrade [`annotation_heading`] already implements
-/// for sink B — the same location text, addressed to a human reviewer
-/// reading the review body instead of an AI agent reading a packet.
+/// its own. Reuses [`annotation_heading`] — the same location text sink B
+/// renders, just addressed to a human reviewer reading the review body
+/// instead of an AI agent reading a packet.
 pub fn render_additional_notes(annotations: &[&Annotation]) -> String {
     if annotations.is_empty() {
         return String::new();

--- a/rinkaku-tui/src/review/render.rs
+++ b/rinkaku-tui/src/review/render.rs
@@ -3,41 +3,81 @@
 //! audience-neutral `Vec<Annotation>` into sink A's human-addressed review
 //! comments ([`render_review_comments`]) or sink B's AI-addressed Markdown
 //! packet ([`render_agent_packet`]).
+//!
+//! ADR 0067 widened the annotation target set beyond present symbols, so
+//! not every annotation resolves an `anchor`/`range` GitHub's review API can
+//! post an inline comment against (a `File`/`Dir`/`RemovedSymbol` target
+//! never does). [`partition_for_export`] splits sink A's input on exactly
+//! that: anchored annotations still become [`RenderedComment`]s via
+//! [`render_review_comments`]; unanchored ones are collected into sink A's
+//! "Additional notes" body section via [`render_additional_notes`] instead
+//! of the unsound `(1, 1)` fallback this module used to fall back to.
 
-use super::{Annotation, RenderedComment};
+use super::{Annotation, AnnotationTarget, RenderedComment};
+
+/// Splits `annotations` into the anchored subset (has a real `anchor` or
+/// `range` to post an inline comment against) and the unanchored subset
+/// (ADR 0067) — `crate::review_flow::perform_export` renders the former via
+/// [`render_review_comments`] and the latter via [`render_additional_notes`],
+/// composing both into one pending-review submission.
+pub fn partition_for_export(annotations: &[Annotation]) -> (Vec<&Annotation>, Vec<&Annotation>) {
+    annotations
+        .iter()
+        .partition(|annotation| has_anchor(&annotation.location))
+}
+
+fn has_anchor(location: &super::AnnotationLocation) -> bool {
+    location.anchor.or(location.range).is_some()
+}
 
 /// Renders `annotations` into sink A's [`RenderedComment`]s (ADR 0048): one
 /// per annotation, in order. `line` is the annotation's anchor end (the
 /// last line of the first hunk-intersecting contiguous run — see
 /// [`super::AnnotationLocation::anchor`]), falling back to the symbol's own
-/// range end, then to line 1, so every annotation still produces a postable
-/// comment even when neither `anchor` nor `range` resolved (a non-symbol
-/// location, out of v1's scope per the module doc comment, but handled
-/// defensively rather than dropped). `start_line` is set only when the
-/// anchor spans more than one line — GitHub's multi-line comment API
-/// distinguishes a single-line comment (`start_line` omitted) from a range
-/// comment.
-pub fn render_review_comments(annotations: &[Annotation]) -> Vec<RenderedComment> {
+/// range end. Every `annotation` is expected to already have one or the
+/// other — [`partition_for_export`] is what keeps an unanchored annotation
+/// from ever reaching this function (ADR 0067 removed the old `(1, 1)`
+/// fallback this module used when neither resolved). `start_line` is set
+/// only when the anchor spans more than one line — GitHub's multi-line
+/// comment API distinguishes a single-line comment (`start_line` omitted)
+/// from a range comment.
+pub fn render_review_comments(annotations: &[&Annotation]) -> Vec<RenderedComment> {
     annotations
         .iter()
-        .map(|annotation| {
-            // The `(1, 1)` fallback is reachable only if rinkaku-core's
-            // changed-range computation and this crate's own hunk parser
-            // ever disagree about what counts as changed; GitHub's review
-            // API may then reject the comment with a 422.
-            let (start, end) = annotation
-                .location
-                .anchor
-                .or(annotation.location.range)
-                .unwrap_or((1, 1));
-            RenderedComment {
+        .filter_map(|annotation| {
+            let (start, end) = annotation.location.anchor.or(annotation.location.range)?;
+            Some(RenderedComment {
                 path: annotation.location.path.clone(),
                 line: end,
                 start_line: (start != end).then_some(start),
                 body: annotation.body.clone(),
-            }
+            })
         })
         .collect()
+}
+
+/// Renders sink A's "Additional notes" body section (ADR 0067) for the
+/// unanchored half of [`partition_for_export`]'s split — empty when
+/// `annotations` is empty, so `crate::review_flow::perform_export` can
+/// unconditionally append this to [`super::ExportRequest::GithubReview`]'s
+/// fixed summary without an extra "any unanchored annotations?" branch of
+/// its own. One bullet per annotation, in order, using the same
+/// path[:range][ name] degrade [`annotation_heading`] already implements
+/// for sink B — the same location text, addressed to a human reviewer
+/// reading the review body instead of an AI agent reading a packet.
+pub fn render_additional_notes(annotations: &[&Annotation]) -> String {
+    if annotations.is_empty() {
+        return String::new();
+    }
+    let mut section = String::from("\n\n## Additional notes\n");
+    for annotation in annotations {
+        section.push_str(&format!(
+            "- `{}`: {}\n",
+            annotation_heading(annotation),
+            annotation.body.lines().next().unwrap_or("")
+        ));
+    }
+    section
 }
 
 /// Renders `annotations` into sink B's AI-addressed Markdown packet (ADR
@@ -64,11 +104,20 @@ pub fn render_agent_packet(annotations: &[Annotation]) -> String {
 }
 
 /// The `## {path}:{start}-{end} {symbol_name}` heading for one annotation
-/// in [`render_agent_packet`]'s output — extracted so the "which range,
+/// in [`render_agent_packet`]'s output (also reused by
+/// [`render_additional_notes`]'s bullets) — extracted so the "which range,
 /// which name" formatting logic is unit-testable independent of the
-/// surrounding packet assembly.
+/// surrounding packet assembly. A [`AnnotationTarget::Dir`] location always
+/// carries an empty `range`/`symbol_name` (ADR 0067), so it is special-cased
+/// to a trailing `/` rather than falling through to the bare-path case a
+/// `File`/`RemovedSymbol` location with no resolvable range would also hit —
+/// otherwise a directory heading would be textually indistinguishable from
+/// a same-path file heading.
 fn annotation_heading(annotation: &Annotation) -> String {
     let location = &annotation.location;
+    if matches!(location.target, AnnotationTarget::Dir) {
+        return format!("{}/", location.path);
+    }
     let range = location.anchor.or(location.range).map(|(start, end)| {
         if start == end {
             format!("{start}")

--- a/rinkaku-tui/src/review/render_tests.rs
+++ b/rinkaku-tui/src/review/render_tests.rs
@@ -246,7 +246,7 @@ mod render_additional_notes_tests {
             "\n\n## Additional notes\n\
              - `src/lib.rs`: dead code now\n\
              - `src/legacy/`: structure is confusing\n\
-             - `src/lib.rs old_helper`: should not have been removed\n",
+             - `src/lib.rs old_helper (removed)`: should not have been removed\n",
             actual
         );
     }
@@ -358,7 +358,7 @@ mod render_agent_packet_tests {
         assert_eq!(
             "# Review annotations\n\n\
              Address each of the following review annotations.\n\n\
-             ## src/lib.rs old_helper\n\
+             ## src/lib.rs old_helper (removed)\n\
              this should not have been removed\n",
             actual
         );

--- a/rinkaku-tui/src/review/render_tests.rs
+++ b/rinkaku-tui/src/review/render_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::review::AnnotationLocation;
+use crate::review::{AnnotationLocation, AnnotationTarget};
 
 fn annotation(location: AnnotationLocation, body: &str, signature: Option<&str>) -> Annotation {
     Annotation {
@@ -9,23 +9,103 @@ fn annotation(location: AnnotationLocation, body: &str, signature: Option<&str>)
     }
 }
 
+fn symbol_location(
+    path: &str,
+    symbol_name: Option<&str>,
+    range: Option<(usize, usize)>,
+    anchor: Option<(usize, usize)>,
+) -> AnnotationLocation {
+    AnnotationLocation {
+        target: AnnotationTarget::Symbol,
+        path: path.to_string(),
+        symbol_id: symbol_name.map(|name| format!("{path}::{name}")),
+        symbol_name: symbol_name.map(str::to_string),
+        range,
+        anchor,
+    }
+}
+
+fn file_location(path: &str) -> AnnotationLocation {
+    AnnotationLocation {
+        target: AnnotationTarget::File,
+        path: path.to_string(),
+        symbol_id: None,
+        symbol_name: None,
+        range: None,
+        anchor: None,
+    }
+}
+
+fn dir_location(path: &str) -> AnnotationLocation {
+    AnnotationLocation {
+        target: AnnotationTarget::Dir,
+        path: path.to_string(),
+        symbol_id: None,
+        symbol_name: None,
+        range: None,
+        anchor: None,
+    }
+}
+
+fn removed_symbol_location(path: &str, name: &str) -> AnnotationLocation {
+    AnnotationLocation {
+        target: AnnotationTarget::RemovedSymbol,
+        path: path.to_string(),
+        symbol_id: Some(format!("{path}::{name}")),
+        symbol_name: Some(name.to_string()),
+        range: None,
+        anchor: None,
+    }
+}
+
+mod partition_for_export_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_split_annotations_by_whether_an_anchor_or_range_resolved() {
+        let anchored = annotation(
+            symbol_location("lib.rs", Some("foo"), Some((10, 20)), Some((15, 15))),
+            "anchored",
+            None,
+        );
+        let unanchored_file = annotation(file_location("lib.rs"), "file note", None);
+        let annotations = vec![anchored.clone(), unanchored_file.clone()];
+
+        let (actual_anchored, actual_unanchored) = partition_for_export(&annotations);
+
+        assert_eq!(vec![&anchored], actual_anchored);
+        assert_eq!(vec![&unanchored_file], actual_unanchored);
+    }
+
+    #[test]
+    fn should_treat_a_symbol_annotation_with_no_anchor_or_range_as_unanchored() {
+        let annotation = annotation(
+            symbol_location("lib.rs", Some("foo"), None, None),
+            "no anchor",
+            None,
+        );
+        let annotations = vec![annotation.clone()];
+
+        let (actual_anchored, actual_unanchored) = partition_for_export(&annotations);
+
+        assert_eq!(Vec::<&Annotation>::new(), actual_anchored);
+        assert_eq!(vec![&annotation], actual_unanchored);
+    }
+}
+
 mod render_review_comments_tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
     #[test]
     fn should_omit_start_line_when_anchor_is_a_single_line() {
-        let annotations = vec![annotation(
-            AnnotationLocation {
-                path: "src/lib.rs".to_string(),
-                symbol_id: Some("src/lib.rs::foo".to_string()),
-                symbol_name: Some("foo".to_string()),
-                range: Some((10, 20)),
-                anchor: Some((15, 15)),
-            },
+        let annotation = annotation(
+            symbol_location("src/lib.rs", Some("foo"), Some((10, 20)), Some((15, 15))),
             "please rename this",
             Some("fn foo()"),
-        )];
+        );
+        let annotations = vec![&annotation];
 
         let actual = render_review_comments(&annotations);
 
@@ -42,17 +122,12 @@ mod render_review_comments_tests {
 
     #[test]
     fn should_set_start_line_when_anchor_spans_multiple_lines() {
-        let annotations = vec![annotation(
-            AnnotationLocation {
-                path: "src/lib.rs".to_string(),
-                symbol_id: Some("src/lib.rs::foo".to_string()),
-                symbol_name: Some("foo".to_string()),
-                range: Some((10, 20)),
-                anchor: Some((12, 18)),
-            },
+        let annotation = annotation(
+            symbol_location("src/lib.rs", Some("foo"), Some((10, 20)), Some((12, 18))),
             "this whole block needs a test",
             None,
-        )];
+        );
+        let annotations = vec![&annotation];
 
         let actual = render_review_comments(&annotations);
 
@@ -69,17 +144,12 @@ mod render_review_comments_tests {
 
     #[test]
     fn should_fall_back_to_range_when_anchor_is_absent() {
-        let annotations = vec![annotation(
-            AnnotationLocation {
-                path: "src/lib.rs".to_string(),
-                symbol_id: Some("src/lib.rs::foo".to_string()),
-                symbol_name: Some("foo".to_string()),
-                range: Some((5, 9)),
-                anchor: None,
-            },
+        let annotation = annotation(
+            symbol_location("src/lib.rs", Some("foo"), Some((5, 9)), None),
             "annotation without an anchor",
             None,
-        )];
+        );
+        let annotations = vec![&annotation];
 
         let actual = render_review_comments(&annotations);
 
@@ -95,58 +165,32 @@ mod render_review_comments_tests {
     }
 
     #[test]
-    fn should_fall_back_to_line_one_when_neither_anchor_nor_range_is_present() {
-        let annotations = vec![annotation(
-            AnnotationLocation {
-                path: "src/lib.rs".to_string(),
-                symbol_id: None,
-                symbol_name: None,
-                range: None,
-                anchor: None,
-            },
-            "annotation on a non-symbol location",
-            None,
-        )];
+    fn should_omit_a_comment_when_neither_anchor_nor_range_is_present() {
+        // partition_for_export is what should keep an unanchored annotation
+        // from reaching render_review_comments in production use (ADR
+        // 0067); this test pins render_review_comments' own defensive
+        // behavior if that invariant is ever violated directly.
+        let annotation = annotation(file_location("src/lib.rs"), "file-level note", None);
+        let annotations = vec![&annotation];
 
         let actual = render_review_comments(&annotations);
 
-        assert_eq!(
-            vec![RenderedComment {
-                path: "src/lib.rs".to_string(),
-                line: 1,
-                start_line: None,
-                body: "annotation on a non-symbol location".to_string(),
-            }],
-            actual
-        );
+        assert_eq!(Vec::<RenderedComment>::new(), actual);
     }
 
     #[test]
     fn should_render_one_comment_per_annotation_in_order() {
-        let annotations = vec![
-            annotation(
-                AnnotationLocation {
-                    path: "a.rs".to_string(),
-                    symbol_id: None,
-                    symbol_name: None,
-                    range: None,
-                    anchor: Some((1, 1)),
-                },
-                "first",
-                None,
-            ),
-            annotation(
-                AnnotationLocation {
-                    path: "b.rs".to_string(),
-                    symbol_id: None,
-                    symbol_name: None,
-                    range: None,
-                    anchor: Some((2, 2)),
-                },
-                "second",
-                None,
-            ),
-        ];
+        let first = annotation(
+            symbol_location("a.rs", None, None, Some((1, 1))),
+            "first",
+            None,
+        );
+        let second = annotation(
+            symbol_location("b.rs", None, None, Some((2, 2))),
+            "second",
+            None,
+        );
+        let annotations = vec![&first, &second];
 
         let actual = render_review_comments(&annotations);
 
@@ -170,6 +214,44 @@ mod render_review_comments_tests {
     }
 }
 
+mod render_additional_notes_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_render_empty_string_when_there_are_no_unanchored_annotations() {
+        let actual = render_additional_notes(&[]);
+
+        assert_eq!(String::new(), actual);
+    }
+
+    #[test]
+    fn should_render_one_bullet_per_annotation_with_its_first_body_line() {
+        let file_note = annotation(file_location("src/lib.rs"), "dead code now", None);
+        let dir_note = annotation(
+            dir_location("src/legacy"),
+            "structure is confusing\nsecond line ignored",
+            None,
+        );
+        let removed_note = annotation(
+            removed_symbol_location("src/lib.rs", "old_helper"),
+            "should not have been removed",
+            None,
+        );
+        let annotations = vec![&file_note, &dir_note, &removed_note];
+
+        let actual = render_additional_notes(&annotations);
+
+        assert_eq!(
+            "\n\n## Additional notes\n\
+             - `src/lib.rs`: dead code now\n\
+             - `src/legacy/`: structure is confusing\n\
+             - `src/lib.rs old_helper`: should not have been removed\n",
+            actual
+        );
+    }
+}
+
 mod render_agent_packet_tests {
     use super::*;
     use pretty_assertions::assert_eq;
@@ -187,13 +269,7 @@ mod render_agent_packet_tests {
     #[test]
     fn should_render_heading_signature_and_body_for_a_symbol_annotation() {
         let annotations = vec![annotation(
-            AnnotationLocation {
-                path: "src/lib.rs".to_string(),
-                symbol_id: Some("src/lib.rs::foo".to_string()),
-                symbol_name: Some("foo".to_string()),
-                range: Some((10, 20)),
-                anchor: Some((12, 18)),
-            },
+            symbol_location("src/lib.rs", Some("foo"), Some((10, 20)), Some((12, 18))),
             "please add a doc comment",
             Some("fn foo(x: i32) -> i32"),
         )];
@@ -215,13 +291,7 @@ mod render_agent_packet_tests {
     #[test]
     fn should_render_single_line_range_without_a_dash() {
         let annotations = vec![annotation(
-            AnnotationLocation {
-                path: "src/lib.rs".to_string(),
-                symbol_id: Some("src/lib.rs::foo".to_string()),
-                symbol_name: Some("foo".to_string()),
-                range: Some((15, 15)),
-                anchor: Some((15, 15)),
-            },
+            symbol_location("src/lib.rs", Some("foo"), Some((15, 15)), Some((15, 15))),
             "one-line annotation",
             None,
         )];
@@ -238,16 +308,10 @@ mod render_agent_packet_tests {
     }
 
     #[test]
-    fn should_render_bare_path_heading_when_location_has_no_range_or_name() {
+    fn should_render_bare_path_heading_for_a_file_annotation() {
         let annotations = vec![annotation(
-            AnnotationLocation {
-                path: "src/lib.rs".to_string(),
-                symbol_id: None,
-                symbol_name: None,
-                range: None,
-                anchor: None,
-            },
-            "annotation without location detail",
+            file_location("src/lib.rs"),
+            "this whole file is dead code now",
             None,
         )];
 
@@ -257,7 +321,45 @@ mod render_agent_packet_tests {
             "# Review annotations\n\n\
              Address each of the following review annotations.\n\n\
              ## src/lib.rs\n\
-             annotation without location detail\n",
+             this whole file is dead code now\n",
+            actual
+        );
+    }
+
+    #[test]
+    fn should_render_trailing_slash_heading_for_a_dir_annotation() {
+        let annotations = vec![annotation(
+            dir_location("src/legacy"),
+            "this directory's structure is confusing",
+            None,
+        )];
+
+        let actual = render_agent_packet(&annotations);
+
+        assert_eq!(
+            "# Review annotations\n\n\
+             Address each of the following review annotations.\n\n\
+             ## src/legacy/\n\
+             this directory's structure is confusing\n",
+            actual
+        );
+    }
+
+    #[test]
+    fn should_render_path_and_name_heading_for_a_removed_symbol_annotation() {
+        let annotations = vec![annotation(
+            removed_symbol_location("src/lib.rs", "old_helper"),
+            "this should not have been removed",
+            None,
+        )];
+
+        let actual = render_agent_packet(&annotations);
+
+        assert_eq!(
+            "# Review annotations\n\n\
+             Address each of the following review annotations.\n\n\
+             ## src/lib.rs old_helper\n\
+             this should not have been removed\n",
             actual
         );
     }
@@ -266,24 +368,12 @@ mod render_agent_packet_tests {
     fn should_render_multiple_annotations_in_order() {
         let annotations = vec![
             annotation(
-                AnnotationLocation {
-                    path: "a.rs".to_string(),
-                    symbol_id: None,
-                    symbol_name: Some("alpha".to_string()),
-                    range: Some((1, 1)),
-                    anchor: Some((1, 1)),
-                },
+                symbol_location("a.rs", Some("alpha"), Some((1, 1)), Some((1, 1))),
                 "first annotation",
                 None,
             ),
             annotation(
-                AnnotationLocation {
-                    path: "b.rs".to_string(),
-                    symbol_id: None,
-                    symbol_name: Some("beta".to_string()),
-                    range: Some((2, 2)),
-                    anchor: Some((2, 2)),
-                },
+                symbol_location("b.rs", Some("beta"), Some((2, 2)), Some((2, 2))),
                 "second annotation",
                 None,
             ),

--- a/rinkaku-tui/src/review/tests.rs
+++ b/rinkaku-tui/src/review/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 
 fn snapshot(path: &str) -> SelectionSnapshot {
     SelectionSnapshot {
+        target: AnnotationTarget::Symbol,
         path: path.to_string(),
         symbol_id: Some(format!("{path}::foo")),
         symbol_name: Some("foo".to_string()),

--- a/rinkaku-tui/src/review_flow.rs
+++ b/rinkaku-tui/src/review_flow.rs
@@ -9,7 +9,7 @@
 //! `ratatui::DefaultTerminal` directly, which is what makes them
 //! unit-testable in isolation from `run_app` itself.
 
-use crate::app::{App, InputKey, Screen};
+use crate::app::{App, InputKey, Screen, SelectedRow};
 use crate::{ReviewPorts, diff_view, review};
 use rinkaku_core::render::Report;
 
@@ -111,8 +111,13 @@ pub(crate) fn perform_export(
             let Some(pr_context) = &ports.pr_context else {
                 return review.set_status("error: no PR context available to post a review");
             };
-            let comments = review::render_review_comments(review.annotations());
-            match submitter.submit_review(pr_context, verdict, REVIEW_SUMMARY, &comments) {
+            let (anchored, unanchored) = review::partition_for_export(review.annotations());
+            let comments = review::render_review_comments(&anchored);
+            let summary = format!(
+                "{REVIEW_SUMMARY}{}",
+                review::render_additional_notes(&unanchored)
+            );
+            match submitter.submit_review(pr_context, verdict, &summary, &comments) {
                 Ok(()) => review.set_status(format!(
                     "posted {} review comment(s) to PR #{}",
                     comments.len(),
@@ -139,22 +144,25 @@ pub(crate) fn perform_export(
 /// hunks (mirroring `InputKey::Source`'s own "IO/derivation stays outside
 /// `App`" precedent).
 ///
-/// `None` on [`Screen::Source`] (composing against a source-view line is
-/// out of v1's scope) and on any row that is not a present symbol
-/// (`app::NodeKind::Dir`/`File`/`Section`/`TestGroup`, or a removed
-/// symbol) — v1 only supports symbol-anchored annotations (module doc
-/// comment on `crate::review`), matching `App::selected_symbol_id`'s own
-/// row-kind scoping.
+/// `None` on [`Screen::Source`] (composing against a source-view line stays
+/// out of scope) and on `app::NodeKind::Section`/`TestGroup` rows (ADR
+/// 0067's Decision 4 — both are synthetic groupings with no real file-tree
+/// path to annotate). Every other row kind now resolves to a snapshot
+/// (ADR 0067): a present symbol row via [`App::selected_symbol_id`]'s same
+/// row-kind scoping (below), a removed symbol row, or a `Dir`/`File` row
+/// via the tree cursor directly.
 ///
-/// The anchor is the first contiguous new-side run where the symbol's own
-/// range intersects a diff hunk touching `path` — GitHub's review API only
-/// accepts inline comments on lines that are part of the PR's diff, so
+/// A present symbol's anchor is the first contiguous new-side run where its
+/// own range intersects a diff hunk touching `path` — GitHub's review API
+/// only accepts inline comments on lines that are part of the PR's diff, so
 /// this is what [`review::render_review_comments`] posts against. `None`
 /// when no hunk intersects the symbol's range at all (e.g. the symbol
 /// itself is unchanged but was pulled into view via dependency
 /// expansion) — the annotation still gets a location (`range`), just no
-/// GitHub-postable anchor; [`review::render_review_comments`] falls back
-/// to `range` in that case.
+/// GitHub-postable anchor; unanchored annotations are routed to the
+/// "Additional notes" export section instead (ADR 0067's Decision 3). A
+/// removed symbol, `File`, and `Dir` never resolve a `range`/`anchor` at
+/// all — none of the three has a new-side line to point at.
 pub(crate) fn derive_selection_snapshot(
     app: &App,
     report: &Report,
@@ -163,25 +171,57 @@ pub(crate) fn derive_selection_snapshot(
     if !matches!(app.screen(), Screen::Entry) {
         return None;
     }
-    let symbol_id = app.selected_symbol_id()?;
-    let (path, symbol) = report.files.iter().find_map(|file| {
-        file.symbols
-            .iter()
-            .find(|s| s.id == symbol_id)
-            .map(|s| (file.path.as_str(), s))
-    })?;
-    let range = (symbol.range.start, symbol.range.end);
-    let anchor = diff_view::file_hunks(diff_files, path)
-        .and_then(|file_hunks| first_anchor_run(file_hunks, range));
+    let row = app.selected_row()?;
+    match row {
+        SelectedRow::Symbol { id } => {
+            let (path, symbol) = report.files.iter().find_map(|file| {
+                file.symbols
+                    .iter()
+                    .find(|s| s.id == id)
+                    .map(|s| (file.path.as_str(), s))
+            })?;
+            let range = (symbol.range.start, symbol.range.end);
+            let anchor = diff_view::file_hunks(diff_files, path)
+                .and_then(|file_hunks| first_anchor_run(file_hunks, range));
 
-    Some(review::SelectionSnapshot {
-        path: path.to_string(),
-        symbol_id: Some(symbol.id.clone()),
-        symbol_name: Some(symbol.name.clone()),
-        range: Some(range),
-        anchor,
-        signature: Some(symbol.signature.clone()),
-    })
+            Some(review::SelectionSnapshot {
+                target: review::AnnotationTarget::Symbol,
+                path: path.to_string(),
+                symbol_id: Some(symbol.id.clone()),
+                symbol_name: Some(symbol.name.clone()),
+                range: Some(range),
+                anchor,
+                signature: Some(symbol.signature.clone()),
+            })
+        }
+        SelectedRow::RemovedSymbol { path, id, name } => Some(review::SelectionSnapshot {
+            target: review::AnnotationTarget::RemovedSymbol,
+            path,
+            symbol_id: Some(id),
+            symbol_name: Some(name),
+            range: None,
+            anchor: None,
+            signature: None,
+        }),
+        SelectedRow::File { path } => Some(review::SelectionSnapshot {
+            target: review::AnnotationTarget::File,
+            path,
+            symbol_id: None,
+            symbol_name: None,
+            range: None,
+            anchor: None,
+            signature: None,
+        }),
+        SelectedRow::Dir { path } => Some(review::SelectionSnapshot {
+            target: review::AnnotationTarget::Dir,
+            path,
+            symbol_id: None,
+            symbol_name: None,
+            range: None,
+            anchor: None,
+            signature: None,
+        }),
+    }
 }
 
 /// The first contiguous new-side line run where `range` (a symbol's own

--- a/rinkaku-tui/src/review_flow_tests/annotation_snapshot.rs
+++ b/rinkaku-tui/src/review_flow_tests/annotation_snapshot.rs
@@ -96,6 +96,7 @@ mod derive_selection_snapshot_tests {
 
         assert_eq!(
             Some(crate::review::SelectionSnapshot {
+                target: crate::review::AnnotationTarget::Symbol,
                 path: "lib.rs".to_string(),
                 symbol_id: Some("lib.rs::foo".to_string()),
                 symbol_name: Some("foo".to_string()),
@@ -120,6 +121,7 @@ mod derive_selection_snapshot_tests {
 
         assert_eq!(
             Some(crate::review::SelectionSnapshot {
+                target: crate::review::AnnotationTarget::Symbol,
                 path: "lib.rs".to_string(),
                 symbol_id: Some("lib.rs::foo".to_string()),
                 symbol_name: Some("foo".to_string()),
@@ -132,7 +134,7 @@ mod derive_selection_snapshot_tests {
     }
 
     #[test]
-    fn should_return_none_when_cursor_is_on_a_directory_row() {
+    fn should_build_a_dir_snapshot_when_cursor_is_on_a_directory_row() {
         let report = Report {
             files: vec![
                 rinkaku_core::render::FileReport {
@@ -150,6 +152,69 @@ mod derive_selection_snapshot_tests {
 
         let actual = derive_selection_snapshot(&app, &report, &[]);
 
+        assert_eq!(
+            Some(crate::review::SelectionSnapshot {
+                target: crate::review::AnnotationTarget::Dir,
+                path: "a".to_string(),
+                symbol_id: None,
+                symbol_name: None,
+                range: None,
+                anchor: None,
+                signature: None,
+            }),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_build_a_file_snapshot_when_cursor_is_on_a_file_row() {
+        let report = report_with_one_symbol();
+        let app = App::new(&report);
+
+        let actual = derive_selection_snapshot(&app, &report, &[]);
+
+        assert_eq!(
+            Some(crate::review::SelectionSnapshot {
+                target: crate::review::AnnotationTarget::File,
+                path: "lib.rs".to_string(),
+                symbol_id: None,
+                symbol_name: None,
+                range: None,
+                anchor: None,
+                signature: None,
+            }),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_build_a_removed_symbol_snapshot_when_cursor_is_on_a_removed_symbol_row() {
+        let report = report_with_one_removed_symbol();
+        let app = App::new(&report).handle_key(crate::app::InputKey::Down);
+
+        let actual = derive_selection_snapshot(&app, &report, &[]);
+
+        assert_eq!(
+            Some(crate::review::SelectionSnapshot {
+                target: crate::review::AnnotationTarget::RemovedSymbol,
+                path: "lib.rs".to_string(),
+                symbol_id: Some("lib.rs::gone".to_string()),
+                symbol_name: Some("gone".to_string()),
+                range: None,
+                anchor: None,
+                signature: None,
+            }),
+            actual
+        );
+    }
+
+    #[test]
+    fn should_return_none_when_cursor_is_on_a_tests_section_row() {
+        let report = report_with_one_test_file();
+        let app = App::new(&report);
+
+        let actual = derive_selection_snapshot(&app, &report, &[]);
+
         assert_eq!(None, actual);
     }
 
@@ -162,6 +227,7 @@ mod derive_selection_snapshot_tests {
 
         assert_eq!(
             Some(crate::review::SelectionSnapshot {
+                target: crate::review::AnnotationTarget::Symbol,
                 path: "lib.rs".to_string(),
                 symbol_id: Some("lib.rs::foo".to_string()),
                 symbol_name: Some("foo".to_string()),
@@ -196,11 +262,12 @@ mod dispatch_annotation_compose_key_tests {
     #[test]
     fn should_clear_pending_prefix_when_snapshot_is_none() {
         // Regression test (ADR 0022's `pending_prefix` bug, same class):
-        // pressing `a` over a row with no derivable snapshot (a directory
-        // row, or the source screen) must still discard a pending `g`
-        // prefix — otherwise a `g` press followed by an ineffective `a`
-        // leaves `pending_prefix` stuck at `Some(G)`, and the *next* `d`
-        // the reviewer types for its own ordinary reason (`ToggleDiff`)
+        // pressing `a` over a row with no derivable snapshot (a Section/
+        // TestGroup row, or the source screen — ADR 0067 narrowed this set
+        // to just those two) must still discard a pending `g` prefix —
+        // otherwise a `g` press followed by an ineffective `a` leaves
+        // `pending_prefix` stuck at `Some(G)`, and the *next* `d` the
+        // reviewer types for its own ordinary reason (`ToggleDiff`)
         // silently resolves as `GotoDefinition` instead.
         let report = empty_report();
         let app = App::new(&report).handle_key(crate::app::InputKey::PendingGoto);

--- a/rinkaku-tui/src/review_flow_tests/github_review_export.rs
+++ b/rinkaku-tui/src/review_flow_tests/github_review_export.rs
@@ -1,0 +1,185 @@
+//! `perform_export`'s [`ExportRequest::GithubReview`] arm (ADR 0067):
+//! anchored annotations become inline `RenderedComment`s exactly as before
+//! (ADR 0048), and any unanchored annotation (a `File`/`Dir`/`RemovedSymbol`
+//! target, or a `Symbol` target whose range never intersected a hunk) is
+//! folded into an "Additional notes" section appended to the fixed review
+//! summary — pinning the exact composed `summary` string
+//! [`ReviewSubmitter::submit_review`] is called with.
+
+use crate::ReviewPorts;
+use crate::review::ports::ReviewSubmitter;
+use crate::review::{
+    AnnotationTarget, ExportRequest, PrContext, RenderedComment, ReviewState, SelectionSnapshot,
+    Verdict,
+};
+use crate::review_flow::perform_export;
+use pretty_assertions::assert_eq;
+
+struct RecordingSubmitter {
+    calls: std::cell::RefCell<Vec<(String, Vec<RenderedComment>)>>,
+    result: Result<(), String>,
+}
+
+impl RecordingSubmitter {
+    fn new(result: Result<(), String>) -> Self {
+        Self {
+            calls: std::cell::RefCell::new(Vec::new()),
+            result,
+        }
+    }
+}
+
+impl ReviewSubmitter for RecordingSubmitter {
+    fn submit_review(
+        &self,
+        _ctx: &PrContext,
+        _verdict: Verdict,
+        summary: &str,
+        comments: &[RenderedComment],
+    ) -> Result<(), String> {
+        self.calls
+            .borrow_mut()
+            .push((summary.to_string(), comments.to_vec()));
+        self.result.clone()
+    }
+}
+
+fn pr_context() -> PrContext {
+    PrContext {
+        owner: "octocat".to_string(),
+        repo: "hello-world".to_string(),
+        number: 42,
+        head_sha: "abc123".to_string(),
+    }
+}
+
+struct UnusedClipboard;
+impl crate::review::ports::ClipboardSink for UnusedClipboard {
+    fn copy(&self, _text: &str) -> Result<String, String> {
+        panic!("clipboard should not be used by the GithubReview export arm")
+    }
+}
+
+fn ports_with<'a>(
+    submitter: &'a RecordingSubmitter,
+    browser: &'a super::FakeBrowserOpener,
+    clipboard: &'a UnusedClipboard,
+) -> ReviewPorts<'a> {
+    ReviewPorts {
+        pr_context: Some(pr_context()),
+        submitter: Some(submitter),
+        clipboard,
+        browser,
+    }
+}
+
+fn symbol_snapshot(anchor: (usize, usize)) -> SelectionSnapshot {
+    SelectionSnapshot {
+        target: AnnotationTarget::Symbol,
+        path: "src/lib.rs".to_string(),
+        symbol_id: Some("src/lib.rs::foo".to_string()),
+        symbol_name: Some("foo".to_string()),
+        range: Some(anchor),
+        anchor: Some(anchor),
+        signature: Some("fn foo()".to_string()),
+    }
+}
+
+fn file_snapshot() -> SelectionSnapshot {
+    SelectionSnapshot {
+        target: AnnotationTarget::File,
+        path: "src/dead_code.rs".to_string(),
+        symbol_id: None,
+        symbol_name: None,
+        range: None,
+        anchor: None,
+        signature: None,
+    }
+}
+
+/// Composes one annotation from `snapshot` with body `body`, via the same
+/// `begin_compose`/`push_char`/`confirm_compose` sequence `App::handle_key`
+/// drives in production — kept as a helper so this module's tests build
+/// multi-annotation batches without reaching into `ReviewState`'s private
+/// fields.
+fn compose(review: ReviewState, snapshot: SelectionSnapshot, body: &str) -> ReviewState {
+    let mut review = review.begin_compose(snapshot);
+    for c in body.chars() {
+        review = review.push_char(c);
+    }
+    review.confirm_compose()
+}
+
+#[test]
+fn should_post_only_the_fixed_summary_when_every_annotation_is_anchored() {
+    let submitter = RecordingSubmitter::new(Ok(()));
+    let browser = super::FakeBrowserOpener::new(Ok(()));
+    let clipboard = UnusedClipboard;
+    let review = compose(
+        ReviewState::default(),
+        symbol_snapshot((10, 10)),
+        "please add a test",
+    );
+
+    let actual = perform_export(
+        review,
+        &ports_with(&submitter, &browser, &clipboard),
+        ExportRequest::GithubReview(Verdict::Approve),
+    );
+
+    assert_eq!(
+        vec![(
+            "Review annotations posted via rinkaku.".to_string(),
+            vec![RenderedComment {
+                path: "src/lib.rs".to_string(),
+                line: 10,
+                start_line: None,
+                body: "please add a test".to_string(),
+            }],
+        )],
+        *submitter.calls.borrow()
+    );
+    assert_eq!(
+        Some("posted 1 review comment(s) to PR #42"),
+        actual.last_status()
+    );
+}
+
+#[test]
+fn should_append_additional_notes_section_when_an_unanchored_annotation_is_present() {
+    let submitter = RecordingSubmitter::new(Ok(()));
+    let browser = super::FakeBrowserOpener::new(Ok(()));
+    let clipboard = UnusedClipboard;
+    let review = compose(
+        ReviewState::default(),
+        symbol_snapshot((10, 10)),
+        "please add a test",
+    );
+    let review = compose(review, file_snapshot(), "this whole file is dead code now");
+
+    let actual = perform_export(
+        review,
+        &ports_with(&submitter, &browser, &clipboard),
+        ExportRequest::GithubReview(Verdict::Comment),
+    );
+
+    assert_eq!(
+        vec![(
+            "Review annotations posted via rinkaku.\n\n\
+             ## Additional notes\n\
+             - `src/dead_code.rs`: this whole file is dead code now\n"
+                .to_string(),
+            vec![RenderedComment {
+                path: "src/lib.rs".to_string(),
+                line: 10,
+                start_line: None,
+                body: "please add a test".to_string(),
+            }],
+        )],
+        *submitter.calls.borrow()
+    );
+    assert_eq!(
+        Some("posted 1 review comment(s) to PR #42"),
+        actual.last_status()
+    );
+}

--- a/rinkaku-tui/src/review_flow_tests/mod.rs
+++ b/rinkaku-tui/src/review_flow_tests/mod.rs
@@ -6,10 +6,13 @@
 //!   `dispatch_annotation_compose_key`
 //! - `perform_export` — the clipboard sink's OSC 52 status passthrough
 //!   (ADR 0048 sink B)
+//! - `github_review_export` — sink A's summary + "Additional notes" body
+//!   composition (ADR 0067)
 //! - `open_pr_in_browser` — the no-`PrContext`/spawn-failure status-line
 //!   messages and the URL built from a `PrContext` (ADR 0050)
 
 mod annotation_snapshot;
+mod github_review_export;
 mod open_pr_in_browser;
 mod perform_export;
 
@@ -82,6 +85,65 @@ pub(super) fn report_with_one_symbol() -> Report {
                 dependencies: vec![],
                 omitted_dependency_matches: 0,
                 is_test: false,
+                classification: None,
+                previous_signature: None,
+            }],
+        }],
+        ..empty_report()
+    }
+}
+
+/// A report whose only file has one *removed* symbol and no present
+/// symbols (ADR 0067's `RemovedSymbol` annotation target) — `files` still
+/// carries an (empty-symbols) entry for `lib.rs` so the tree gets a `File`
+/// row to nest the removed symbol under, mirroring how `build_tree`
+/// merges `report.files`/`report.removed` on a shared path.
+pub(super) fn report_with_one_removed_symbol() -> Report {
+    use rinkaku_core::extract::{RemovedSymbol, SymbolKind};
+    use rinkaku_core::render::FileReport;
+
+    Report {
+        files: vec![FileReport {
+            path: "lib.rs".to_string(),
+            symbols: vec![],
+        }],
+        removed: vec![RemovedSymbol {
+            name: "gone".to_string(),
+            kind: SymbolKind::Function,
+            path: "lib.rs".to_string(),
+            signature: "fn gone()".to_string(),
+        }],
+        ..empty_report()
+    }
+}
+
+/// A report whose only file is a *whole* test file — every symbol flagged
+/// `is_test` (Rust's `#[cfg(test)]` convention, ADR 0035 Phase B) and no
+/// production symbols left over in the same file. `build_tree` lifts it out
+/// of the production tree entirely into a synthetic `Section::Tests` root
+/// (`crate::tree::tests_section::is_whole_test_file`'s own doc comment), so
+/// with no other content in the report, the cursor at position 0 lands on
+/// that `Section` row (ADR 0067's Decision 4: `Section`/`TestGroup` stay out
+/// of annotation scope).
+pub(super) fn report_with_one_test_file() -> Report {
+    use rinkaku_core::diff::LineRange;
+    use rinkaku_core::extract::{ExtractedSymbol, SymbolKind};
+    use rinkaku_core::render::FileReport;
+
+    Report {
+        files: vec![FileReport {
+            path: "tests.rs".to_string(),
+            symbols: vec![ExtractedSymbol {
+                id: "tests.rs::test_foo".to_string(),
+                name: "test_foo".to_string(),
+                kind: SymbolKind::Function,
+                signature: "fn test_foo()".to_string(),
+                range: LineRange { start: 1, end: 1 },
+                container: None,
+                referenced_names: vec![],
+                dependencies: vec![],
+                omitted_dependency_matches: 0,
+                is_test: true,
                 classification: None,
                 previous_signature: None,
             }],

--- a/rinkaku-tui/src/ui/review_overlay.rs
+++ b/rinkaku-tui/src/ui/review_overlay.rs
@@ -69,8 +69,15 @@ fn draw_compose_overlay(
 /// fallback shape `crate::review`'s own annotation-heading formatting uses
 /// (kept separate rather than shared, since that formats an *annotation's*
 /// already-resolved anchor/range, while this formats a live
-/// [`crate::review::SelectionSnapshot`] still being composed against).
+/// [`crate::review::SelectionSnapshot`] still being composed against). A
+/// [`crate::review::AnnotationTarget::Dir`] snapshot is special-cased to a
+/// trailing `/` the same way `crate::review::render`'s `annotation_heading`
+/// is (ADR 0067) — both formatters degrade a `Dir` the same way so a
+/// directory title never reads identically to a same-path file's.
 fn compose_title_location(snapshot: &crate::review::SelectionSnapshot) -> String {
+    if matches!(snapshot.target, crate::review::AnnotationTarget::Dir) {
+        return format!("{}/", snapshot.path);
+    }
     let range = snapshot.anchor.or(snapshot.range).map(|(start, end)| {
         if start == end {
             format!("{start}")
@@ -138,21 +145,26 @@ fn draw_annotations_overlay(
 
 /// One annotations-list row's text: `"{path}:{anchor-or-range}
 /// {symbol_name}: {body's first line}"`, degrading the location half the
-/// same way [`compose_title_location`] does.
+/// same way [`compose_title_location`] does — including the same `Dir`
+/// trailing-`/` special case (ADR 0067).
 fn annotations_list_entry_text(annotation: &crate::review::Annotation) -> String {
     let location = &annotation.location;
-    let range = location.anchor.or(location.range).map(|(start, end)| {
-        if start == end {
-            format!("{start}")
-        } else {
-            format!("{start}-{end}")
+    let location_text = if matches!(location.target, crate::review::AnnotationTarget::Dir) {
+        format!("{}/", location.path)
+    } else {
+        let range = location.anchor.or(location.range).map(|(start, end)| {
+            if start == end {
+                format!("{start}")
+            } else {
+                format!("{start}-{end}")
+            }
+        });
+        match (range, &location.symbol_name) {
+            (Some(range), Some(name)) => format!("{}:{range} {name}", location.path),
+            (Some(range), None) => format!("{}:{range}", location.path),
+            (None, Some(name)) => format!("{} {name}", location.path),
+            (None, None) => location.path.clone(),
         }
-    });
-    let location_text = match (range, &location.symbol_name) {
-        (Some(range), Some(name)) => format!("{}:{range} {name}", location.path),
-        (Some(range), None) => format!("{}:{range}", location.path),
-        (None, Some(name)) => format!("{} {name}", location.path),
-        (None, None) => location.path.clone(),
     };
     let body_first_line = annotation.body.lines().next().unwrap_or("");
     format!("{location_text}: {body_first_line}")

--- a/rinkaku-tui/src/ui/review_overlay_tests.rs
+++ b/rinkaku-tui/src/ui/review_overlay_tests.rs
@@ -1,6 +1,6 @@
 use crate::app::{App, BlastRadiusSelection};
 use crate::locale::Locale;
-use crate::review::{ReviewState, SelectionSnapshot};
+use crate::review::{AnnotationTarget, ReviewState, SelectionSnapshot};
 use crate::ui::draw;
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
@@ -50,12 +50,25 @@ fn report_with_one_symbol() -> Report {
 
 fn snapshot() -> SelectionSnapshot {
     SelectionSnapshot {
+        target: AnnotationTarget::Symbol,
         path: "lib.rs".to_string(),
         symbol_id: Some("lib.rs::foo".to_string()),
         symbol_name: Some("foo".to_string()),
         range: Some((1, 5)),
         anchor: Some((1, 5)),
         signature: Some("fn foo()".to_string()),
+    }
+}
+
+fn dir_snapshot() -> SelectionSnapshot {
+    SelectionSnapshot {
+        target: AnnotationTarget::Dir,
+        path: "src".to_string(),
+        symbol_id: None,
+        symbol_name: None,
+        range: None,
+        anchor: None,
+        signature: None,
     }
 }
 
@@ -119,6 +132,22 @@ fn should_draw_compose_overlay_with_location_and_buffer_when_composing() {
     assert!(text.contains("lib.rs:1-5 foo"));
     assert!(text.contains("hi"));
     assert!(text.contains("Enter: save"));
+}
+
+#[test]
+fn should_draw_compose_overlay_with_trailing_slash_when_composing_over_a_dir_snapshot() {
+    let report = report_with_one_symbol();
+    let review = ReviewState::default()
+        .begin_compose(dir_snapshot())
+        .push_char('h')
+        .push_char('i');
+    let app = App::new(&report).with_review(review);
+
+    let text = draw_app(&app, &report);
+
+    assert!(text.contains("New annotation"));
+    assert!(text.contains("src/"));
+    assert!(text.contains("hi"));
 }
 
 #[test]

--- a/rinkaku-tui/src/ui/review_overlay_tests.rs
+++ b/rinkaku-tui/src/ui/review_overlay_tests.rs
@@ -171,6 +171,25 @@ fn should_draw_annotations_list_overlay_with_annotation_summary() {
 }
 
 #[test]
+fn should_draw_annotations_list_overlay_with_trailing_slash_for_a_dir_annotation() {
+    let report = report_with_one_symbol();
+    let review = ReviewState::default()
+        .begin_compose(dir_snapshot())
+        .push_char('m')
+        .push_char('e')
+        .push_char('s')
+        .push_char('s')
+        .confirm_compose()
+        .open_list();
+    let app = App::new(&report).with_review(review);
+
+    let text = draw_app(&app, &report);
+
+    assert!(text.contains("Review annotations"));
+    assert!(text.contains("src/: mess"));
+}
+
+#[test]
 fn should_draw_empty_annotations_list_placeholder_when_there_are_no_annotations() {
     let report = report_with_one_symbol();
     let review = ReviewState::default().open_list();


### PR DESCRIPTION
## Summary

Extends the TUI review-annotations feature (ADR 0048) from "symbol rows only" to also support File rows, Dir rows, and removed-symbol rows in the Entry (tree) screen.

- Added an explicit `AnnotationTarget` enum (`Symbol`, `RemovedSymbol`, `File`, `Dir`) to `AnnotationLocation`/`SelectionSnapshot`, rather than inferring the row kind from which optional fields happen to be set.
- `derive_selection_snapshot` now resolves a snapshot for File and Dir rows and for removed-symbol rows. `Section`/`TestGroup` rows (synthetic groupings with no real file-tree path) and the Source screen remain no-ops for `a`, unchanged.
- GitHub export (sink A) now partitions annotations into anchored (still posted as inline pending-review comments, exactly as before) and unanchored (a File/Dir/RemovedSymbol target, or a Symbol target whose range never intersected a hunk). Unanchored annotations are collected into an "Additional notes" section appended to the review body, replacing the previous `(1, 1)` fallback, which could produce a comment GitHub's API rejects with a 422 since line 1 isn't necessarily part of the diff for that file.
- The agent-packet (sink B) heading and the compose-overlay/annotations-list display degrade a `Dir` target to a trailing `/` so a directory heading never reads identically to a same-path file heading.
- `AnnotationMarkers::file_counts` already covered a File-target annotation by construction (it's keyed by path, not by symbol id) — confirmed with a test rather than needing new code.

Design decisions and the GitHub API research behind them (verified against current REST API docs, not assumed) are recorded in [ADR 0067](docs/adr/0067-annotation-file-dir-removed-symbol-targets.md).

## GitHub API finding

Checked `https://docs.github.com/en/rest/pulls/reviews` and `.../pulls/comments` (apiVersion=2022-11-28) rather than assuming symmetry: the standalone single-comment endpoint (`POST .../pulls/comments`) supports `subject_type: "file"` for true file-level comments, but the **batch pending-review endpoint** (`POST .../pulls/reviews`, which sink A already uses to post one review with a chosen verdict) does **not** document `subject_type` on its `comments[]` schema at all. Since switching a subset of annotations to the standalone endpoint would post them immediately and individually — outside the discardable pending-review batch every other annotation gets — this PR routes every unanchored annotation through the review body ("Additional notes") instead, keeping all annotations in one submit/discard-as-a-unit batch.

## Out of scope (explicitly deferred)

- **Source-screen compose** — unchanged, remains a no-op; ADR 0048's original scope boundary.
- **Dir-row tree badges** — `AnnotationMarkers` has no per-directory counter today, and `Badges`' aggregation is baked once at tree-build time from an immutable `Report`, a poor fit for state that changes during the session. A Dir-target annotation is still fully captured, exported, and visible in the annotations-list overlay; it just has no tree-row badge yet. Recorded as future work in ADR 0067.
- **Section/TestGroup rows** — stay unannotatable (ADR 0067 Decision 4): both are synthetic groupings with no real file-tree path, and a "nearest real file" fallback would silently attach a note to a location the reviewer never pointed at.

## File size

`rinkaku-tui/src/app/mod.rs` was already at 1000 lines (the "watch" threshold) before this PR; the new `SelectedRow` enum + `App::selected_row()` (~56 lines) push it to 1056, crossing into "warn" (>1000, per `rinkaku-core/src/file_size.rs`). Confirmed via `rinkaku --base main`'s own `## File sizes` output. Not split in this PR: the file is a single `impl App` block plus a cluster of small view-model enums/structs, and a genuine split (e.g. extracting the plain view-model types to a sibling module) is a disproportionate restructure for this PR's scope. Left as a follow-up rather than forced here.

`rinkaku-tui/src/input_translate_tests/translate_key.rs` also shows at "watch" (723 lines), but this PR only added one field to one existing test fixture there — that file was already in the watch band before this change.

## Testing

- rstest-style table-driven tests + `pretty_assertions::assert_eq!` throughout, in-module `#[cfg(test)]`, per this repo's conventions.
- New `partition_for_export`/`render_additional_notes` pure functions in `rinkaku-tui/src/review/render.rs`, fully unit-tested independent of any GitHub API call.
- New `github_review_export` test module pins the exact composed review-body string (summary + "Additional notes") passed to the `ReviewSubmitter` port, without mocking the actual `gh api` call (that stays behind the existing port boundary, tested separately in `rinkaku/src/github/review.rs`).
- Dynamic verification: ratatui `TestBackend` tests for the Dir-target compose overlay; `rinkaku --base main` (release build, run against this branch's own diff) completes with exit 0 and produces a correct change-graph map with no panics.
- `make test` (1101 rinkaku-tui + 209 rinkaku-core + 494 rinkaku tests, all passing) and `make lint` (fmt + clippy -D warnings) both clean.

## Future work

- Dir-row tree badges (needs a per-directory, change-gated annotation-count aggregate).
- Source-screen annotation compose.
- Revisit whether GitHub ships `subject_type` support on the batch reviews endpoint in the future, which would let File-target annotations become true file-level inline comments instead of body-collected notes.

## Review follow-up

A two-pass review (static covering both map-assisted and independent angles, plus dynamic verification; recorded as experiment 0001 round 40) found no blockers. One should-fix landed: `annotation_heading` (`rinkaku-tui/src/review/render.rs`) was missing the `(removed)` marker ADR 0067 Decision 3 specifies for a removed symbol's Additional-notes/agent-packet heading, which made it textually identical to an unanchored present symbol's heading — both the static and dynamic passes converged on this independently. Two nits also landed: a missing direct test for `annotations_list_entry_text`'s `Dir` branch, and a doc comment on `render_additional_notes` restating behavior already covered by its tests. All three are fixed on this branch.
