### PR TITLE
fix(tui): resolve debug panic when a deleted file has removed symbols

### DIFF
--- a/rinkaku-tui/src/app/tests/basics.rs
+++ b/rinkaku-tui/src/app/tests/basics.rs
@@ -3,8 +3,8 @@ use crate::app::{App, InputKey, Screen, SelectedDetail};
 use crate::detail::{DirDetail, FileDetail, FileSymbolSummary};
 use crate::order::OrderMode;
 use pretty_assertions::assert_eq;
-use rinkaku_core::extract::SymbolKind;
-use rinkaku_core::render::{FileReport, Report};
+use rinkaku_core::extract::{RemovedSymbol, SymbolKind};
+use rinkaku_core::render::{FileReport, Report, SkipReason, SkippedFile};
 
 #[test]
 fn should_start_on_entry_screen_with_topological_order_and_no_status() {
@@ -84,6 +84,47 @@ fn should_return_file_detail_when_cursor_is_on_a_file_row() {
             fan_in: 0,
         }],
         skip_reason: None,
+        test_symbol_count: None,
+        size_warning: None,
+    });
+    assert_eq!(Some(expected), actual);
+}
+
+#[test]
+fn should_return_file_detail_with_removed_symbols_when_file_was_wholly_deleted() {
+    // ADR 0065 regression, end-to-end through `App`: a whole-file deletion
+    // populates both `report.removed` and `report.skipped` for the same
+    // path, and the detail pane must surface both — the removed symbol
+    // list explaining *what* the deletion took away, `skip_reason`
+    // explaining *why* there is no head-side `FileReport`.
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        removed: vec![RemovedSymbol {
+            name: "gone".to_string(),
+            kind: SymbolKind::Function,
+            path: "lib.rs".to_string(),
+            signature: "fn gone()".to_string(),
+        }],
+        skipped: vec![SkippedFile {
+            path: "lib.rs".to_string(),
+            reason: SkipReason::Deleted,
+        }],
+        ..empty_report()
+    };
+    let app = App::new(&report);
+
+    let actual = app.selected_detail(&report);
+
+    let expected = SelectedDetail::File(FileDetail {
+        path: "lib.rs".to_string(),
+        symbols: vec![FileSymbolSummary {
+            name: "gone".to_string(),
+            kind: SymbolKind::Function,
+            classification: None,
+            removed: true,
+            fan_in: 0,
+        }],
+        skip_reason: Some(SkipReason::Deleted),
         test_symbol_count: None,
         size_warning: None,
     });

--- a/rinkaku-tui/src/tree/mod.rs
+++ b/rinkaku-tui/src/tree/mod.rs
@@ -257,11 +257,13 @@ pub struct Tree {
 /// shared path, rather than producing a duplicate row. `files`/`tests`
 /// overlapping on a path is a real, expected case — `pipeline::partition_test_symbols`
 /// can emit both a `FileReport` and a `TestFileSummary` for one mixed file
-/// (`TreeNode::test_symbol_count`'s own doc comment) — but `skipped`
-/// overlapping either `files` or `tests` on the same path is not expected
-/// from `pipeline::analyze_diff`'s own invariants (a skipped file has no
-/// `FileReport`/`TestFileSummary` of its own), and is only debug-asserted
-/// against, not handled gracefully, by `insert_skipped`/`insert_test_file`.
+/// (`TreeNode::test_symbol_count`'s own doc comment). `removed`/`skipped`
+/// overlapping on a path is likewise expected — a whole-file deletion
+/// reports both (ADR 0065). `skipped` overlapping `files` or `tests`
+/// themselves is not expected from `pipeline::analyze_diff`'s own
+/// invariants (a skipped file has no `FileReport`/`TestFileSummary` of its
+/// own), and is only debug-asserted against, not handled gracefully, by
+/// `insert_skipped`/`insert_test_file`.
 ///
 /// **Single-child directory collapsing**: a directory whose only content is
 /// exactly one child directory (and nothing else — no files or symbols of
@@ -496,15 +498,24 @@ impl<'a> TreeBuilder<'a> {
     }
 
     /// Inserts a skipped-file entry (`report.skipped`, see
-    /// `TreeNode::skip_reason`'s doc comment) as a childless `File` node.
+    /// `TreeNode::skip_reason`'s doc comment). Usually a childless `File`
+    /// node, except for a `SkipReason::Deleted` path that also carries
+    /// `insert_removed` children (ADR 0065: a whole-file deletion reports
+    /// both, deliberately, per `pipeline::analyze_diff`'s own invariant).
     fn insert_skipped(&mut self, path: &str, reason: SkipReason) {
         let segments: Vec<&str> = path.split('/').collect();
         let file_builder = self.root.file_at(&segments);
-        // Same overlap contract as `insert_file`'s debug_assert: a skipped
-        // file has no `FileReport`/`TestFileSummary` entry of its own, so
-        // neither real symbols nor a test count should already be set here.
+        // Same overlap contract as `insert_file`'s debug_assert, amended for
+        // ADR 0065: a skipped file never has a `FileReport`/`TestFileSummary`
+        // of its own, so no *non-removed* symbol or test count should
+        // already be set here — but base-side `RemovedSymbol`s from
+        // `insert_removed` legitimately coexist with `SkipReason::Deleted`.
         debug_assert!(
-            file_builder.symbols.is_empty() && file_builder.test_symbol_count.is_none(),
+            file_builder
+                .symbols
+                .iter()
+                .all(|(symbol_ref, _)| symbol_ref.removed)
+                && file_builder.test_symbol_count.is_none(),
             "path {path:?} was already listed in report.files/report.tests but was also listed \
              in report.skipped — report.skipped must not overlap report.files/report.tests on \
              the same path"

--- a/rinkaku-tui/src/tree/tree_tests/test_files_and_overlap.rs
+++ b/rinkaku-tui/src/tree/tree_tests/test_files_and_overlap.rs
@@ -173,3 +173,42 @@ fn should_keep_real_symbols_when_file_is_also_in_tests() {
     assert_eq!(Some(3), tree.roots[0].test_symbol_count);
     assert_eq!(None, tree.roots[0].skip_reason);
 }
+
+// ADR 0065 regression: a whole-file deletion reports both a `removed`
+// entry per base-side symbol *and* a `skipped` entry (`SkipReason::Deleted`)
+// for the same path — the two records deliberately co-exist (ADR 0065's
+// Decision section), unlike the `files`/`skipped` and `tests`/`skipped`
+// overlaps guarded above, which `analyze_diff` never produces together.
+// `insert_removed` runs before `insert_skipped` in `build_tree`'s
+// discovery order, so this is exactly the case `insert_skipped`'s
+// `debug_assert` must not reject.
+#[test]
+fn should_keep_removed_symbols_when_file_is_also_skipped_as_deleted() {
+    let report = Report {
+        origin: rinkaku_core::render::ReportOrigin::Diff,
+        removed: vec![RemovedSymbol {
+            name: "gone".to_string(),
+            kind: SymbolKind::Function,
+            path: "lib.rs".to_string(),
+            signature: "fn gone()".to_string(),
+        }],
+        skipped: vec![SkippedFile {
+            path: "lib.rs".to_string(),
+            reason: rinkaku_core::render::SkipReason::Deleted,
+        }],
+        ..empty_report()
+    };
+
+    let tree = build_tree(&report);
+
+    assert_eq!(1, tree.roots[0].children.len());
+    let NodeKind::Symbol(symbol_ref) = &tree.roots[0].children[0].kind else {
+        panic!("expected a Symbol child");
+    };
+    assert_eq!("gone", symbol_ref.name);
+    assert!(symbol_ref.removed);
+    assert_eq!(
+        Some(rinkaku_core::render::SkipReason::Deleted),
+        tree.roots[0].skip_reason
+    );
+}


### PR DESCRIPTION
## Root cause

ADR 0065 (#205) made `analyze_diff` report a whole-file deletion in
**both** `report.removed` (one `RemovedSymbol` per base-side symbol)
and `report.skipped` (`SkipReason::Deleted`) for the same path,
deliberately — the two records answer different questions ("what
contract vanished" vs. "why is there no head-side content").

`rinkaku-tui`'s `build_tree` inserts in the order `insert_file` →
`insert_removed` → `insert_test_file` → `insert_skipped`
(`rinkaku-tui/src/tree/mod.rs`). `insert_skipped`'s `debug_assert`
still carried the pre-ADR-0065 contract requiring the file's symbol
list to be empty before a skip reason is recorded. Since
`insert_removed` runs first and pushes the deleted file's base-side
symbols, any deleted file with extractable symbols hit that assert
and panicked — in debug builds only (`debug_assert!` compiles out in
release, which is why this wasn't caught before).

## Fix

`insert_skipped`'s assert now accepts a symbol list that is *entirely*
`removed: true` entries (i.e. only from `insert_removed`), while still
rejecting the real invariant violation: a non-removed symbol, or a
`test_symbol_count`, already present on a path that's also marked
skipped. Updated the surrounding doc comments (`insert_skipped`'s own
comment and `build_tree`'s top-level discovery-order comment) to state
the `removed`/`skipped` overlap is expected, matching the existing
treatment of the `files`/`tests` overlap comment right above it.

## Three-assert audit (`insert_file`, `insert_test_file`, `insert_skipped`)

- `insert_file`: guards `report.files`/`report.skipped` overlap. A
  deleted path never enters `report.files` (`analyze_diff` only pushes
  to `removed`/`skipped` for `ChangeKind::Deleted`), so this remains a
  real invariant — unchanged.
- `insert_test_file`: guards `report.tests`/`report.skipped` overlap.
  `report.tests` is only populated by `partition_test_symbols` from
  `report.files`-derived entries, which (as above) a deleted path never
  reaches — unchanged.
- `insert_skipped`: the one that needed relaxing, as above.

## Display check

`build_file_detail` (`rinkaku-tui/src/detail.rs`) and `entry_row_line`
(`rinkaku-tui/src/row_view.rs`) both already handle a `File` node with
symbol children independently of `skip_reason` — neither special-cases
"childless" for the skip-reason badge, and `Nav::rows` doesn't hide a
node's children based on `skip_reason` either. No behavioral changes
were needed there; added an app-level integration test
(`should_return_file_detail_with_removed_symbols_when_file_was_wholly_deleted`
in `rinkaku-tui/src/app/tests/basics.rs`) confirming the detail pane
correctly surfaces both the removed-symbol list and the skip reason
for the same file.

## QA

- Reproduced the panic with real data before fixing: built a scratch
  git repo with a committed then wholly-deleted `.rs` file containing
  two functions, ran the real `rinkaku` binary with `--base HEAD~1
  --format json` to confirm the pipeline really does produce a Report
  with the same path in both `removed` and `skipped`. Then, via a
  throwaway `rinkaku-tui` example (git-stashed the fix first, deleted
  after use — not part of this diff) that runs `analyze_diff` +
  `build_tree` against that same real repo end-to-end, confirmed:
  - **Before the fix**: panics with exactly the diagnosed message
    (`rinkaku-tui/src/tree/mod.rs:506`).
  - **After the fix**: `build_tree` succeeds, tree has 1 root.
- `make test`: 1104 passed, 0 failed.
- `make lint`: clean (`cargo fmt --all --check` + `cargo clippy
  --all-targets --all-features -- -D warnings`).

No new ADR: this is a bug fix bringing `rinkaku-tui` in line with the
already-accepted ADR 0065 contract, not a new decision. ADR 0065's
Consequences section makes no TUI-specific claim that this
contradicts, so no amendment was needed either.