### PR TITLE
fix: restrict dependency candidates by reference capture kind

### DIFF
--- a/docs/adr/0068-container-aware-edge-matching-for-bare-references.md
+++ b/docs/adr/0068-container-aware-edge-matching-for-bare-references.md
@@ -157,3 +157,35 @@ matching:
 - The `deps.rs` candidate-enumeration gap (Decision point 5) remains
   open; tracked as
   [#227](https://github.com/hiro-o918/rinkaku/issues/227).
+
+## Amendment (2026-08-07, fix/capture-kind-aware-dependency-candidates)
+
+Closes the Decision point 5 gap tracked as
+[#227](https://github.com/hiro-o918/rinkaku/issues/227):
+`deps::resolve_dependencies`'s candidate enumeration had the same
+imprecision this ADR fixed for `graph::collect_edges` — it resolved
+`referenced_names` against a repo-wide index with no container
+awareness, so a bare reference's "Depends on" list could include a
+same-named symbol nested in an unrelated container.
+
+Change: `resolve_dependencies` now applies the same `ContainerRule`
+distinction `collect_edges` uses, to dependency candidates rather than
+graph edges. A `referenced_names` (bare) candidate is only kept if its
+`container` is `None` or matches the referencing symbol's own
+container; a `referenced_method_names` candidate is kept regardless of
+container. Container-restricted-away candidates are dropped before
+ranking and are not counted in `omitted_dependency_matches`, which
+stays reserved for candidates cut by `MAX_MATCHES_PER_NAME`.
+
+Measured on this repo's own reproduction case (issue #227's
+`a.py`/`b.py` sketch, built from a trusted `main` checkout per this
+repo's dogfooding convention): before the fix, a bare `Foo()` call's
+"Depends on" listed both the top-level `def Foo():` and the unrelated
+`class Baz`'s `def Foo(self):`; after, only the top-level definition
+remains. A same-file Rust `impl` method-call scenario (`b.foo()`, a
+`referenced_method_names` entry) confirmed unrestricted resolution is
+unchanged for that set.
+
+`ExtractedSymbol::dependencies`/`omitted_dependency_matches` output
+narrows as a result (candidates that were previously listed and are
+now excluded); no new field or output shape is introduced.

--- a/rinkaku-core/src/deps.rs
+++ b/rinkaku-core/src/deps.rs
@@ -340,10 +340,24 @@ impl Resolver for TagsResolver {
 }
 
 /// Populates every symbol's `dependencies` by resolving its
-/// `referenced_names` through `resolver`, across every file in the
-/// report — a symbol in one changed file may reference a symbol changed
-/// in another, so exclusion is computed over the whole diff, not
-/// per-file.
+/// `referenced_names` and `referenced_method_names` through `resolver`,
+/// across every file in the report — a symbol in one changed file may
+/// reference a symbol changed in another, so exclusion is computed over
+/// the whole diff, not per-file.
+///
+/// The two reference sets are container-filtered by different rules
+/// (ADR 0068, extended here to dependency candidates per issue #227,
+/// mirroring `graph::collect_edges`'s `ContainerRule`): a
+/// `referenced_names` entry (a bare call/type reference) only keeps
+/// candidates whose `container` is `None` (top-level) or equal to the
+/// referencing symbol's own container, since a bare reference cannot
+/// syntactically denote an arbitrary container's member in Python, Go,
+/// or TypeScript. A `referenced_method_names` entry (a receiver-based
+/// call or method-spec name) keeps candidates regardless of container,
+/// since it is unambiguous about targeting a contained symbol.
+/// Container-restricted-away candidates are dropped before ranking and
+/// are not counted in `omitted_dependency_matches`, which is reserved
+/// for candidates cut by [`MAX_MATCHES_PER_NAME`].
 ///
 /// Two kinds of matches are deliberately excluded from the resulting
 /// `dependencies`, both to avoid redundant noise rather than because they
@@ -428,33 +442,28 @@ pub fn resolve_dependencies(
                         let mut omitted = 0usize;
 
                         for name in &symbol.referenced_names {
-                            let mut candidates: Vec<ResolvedSymbol> = resolver
-                                .resolve(name)
-                                .into_iter()
-                                .filter(|resolved| {
-                                    let key = (
-                                        name.clone(),
-                                        resolved.container.clone(),
-                                        resolved.path.clone(),
-                                    );
-                                    key != own_key && !diff_symbols.contains(&key)
-                                })
-                                .collect();
-
-                            // Rank before truncating: the cap must keep the
-                            // closest matches, not an arbitrary prefix of
-                            // whatever order the resolver happened to
-                            // return them in (see
-                            // `rank_by_path_proximity`'s doc comment).
-                            candidates.sort_by_key(|resolved| {
-                                path_proximity_rank(&file_path, &resolved.path)
-                            });
-
-                            if candidates.len() > MAX_MATCHES_PER_NAME {
-                                omitted += candidates.len() - MAX_MATCHES_PER_NAME;
-                                candidates.truncate(MAX_MATCHES_PER_NAME);
-                            }
-                            dependencies.extend(candidates);
+                            collect_candidates(
+                                resolver,
+                                name,
+                                &own_key,
+                                &diff_symbols,
+                                &file_path,
+                                ContainerRule::SameOrNone(symbol.container.as_deref()),
+                                &mut dependencies,
+                                &mut omitted,
+                            );
+                        }
+                        for name in &symbol.referenced_method_names {
+                            collect_candidates(
+                                resolver,
+                                name,
+                                &own_key,
+                                &diff_symbols,
+                                &file_path,
+                                ContainerRule::Any,
+                                &mut dependencies,
+                                &mut omitted,
+                            );
                         }
 
                         symbol.dependencies = dependencies;
@@ -465,6 +474,76 @@ pub fn resolve_dependencies(
             }
         })
         .collect()
+}
+
+/// The container-matching rule [`collect_candidates`] applies to one
+/// reference set, mirroring `graph::collect_edges`'s `ContainerRule`
+/// (ADR 0068).
+enum ContainerRule<'a> {
+    /// A candidate only matches if its container is `None`, or equal to
+    /// the referencing symbol's own container — the restriction bare
+    /// references (`referenced_names`) are limited to.
+    SameOrNone(Option<&'a str>),
+    /// A candidate matches regardless of its container — the rule
+    /// `referenced_method_names` entries use.
+    Any,
+}
+
+/// Resolves `name` against `resolver`, applies `rule`'s container
+/// restriction, then applies the shared self-reference/diff-internal
+/// exclusion, proximity ranking, and [`MAX_MATCHES_PER_NAME`] cap —
+/// appending survivors to `dependencies` and adding any capped-away
+/// count to `omitted`.
+///
+/// Candidates dropped by `rule`'s container restriction are excluded
+/// before this counting, not added to `omitted`: that count is reserved
+/// for candidates cut by the cap, a distinct reason from "this
+/// candidate's container makes it syntactically unreachable from a bare
+/// reference".
+#[allow(clippy::too_many_arguments)]
+fn collect_candidates(
+    resolver: &dyn Resolver,
+    name: &str,
+    own_key: &(String, Option<String>, String),
+    diff_symbols: &std::collections::HashSet<(String, Option<String>, String)>,
+    referencing_path: &str,
+    rule: ContainerRule<'_>,
+    dependencies: &mut Vec<ResolvedSymbol>,
+    omitted: &mut usize,
+) {
+    let mut candidates: Vec<ResolvedSymbol> = resolver
+        .resolve(name)
+        .into_iter()
+        .filter(|resolved| {
+            let container_ok = match rule {
+                ContainerRule::Any => true,
+                ContainerRule::SameOrNone(referencing_container) => {
+                    resolved.container.is_none()
+                        || resolved.container.as_deref() == referencing_container
+                }
+            };
+            if !container_ok {
+                return false;
+            }
+            let key = (
+                name.to_string(),
+                resolved.container.clone(),
+                resolved.path.clone(),
+            );
+            &key != own_key && !diff_symbols.contains(&key)
+        })
+        .collect();
+
+    // Rank before truncating: the cap must keep the closest matches, not
+    // an arbitrary prefix of whatever order the resolver happened to
+    // return them in (see `path_proximity_rank`'s doc comment).
+    candidates.sort_by_key(|resolved| path_proximity_rank(referencing_path, &resolved.path));
+
+    if candidates.len() > MAX_MATCHES_PER_NAME {
+        *omitted += candidates.len() - MAX_MATCHES_PER_NAME;
+        candidates.truncate(MAX_MATCHES_PER_NAME);
+    }
+    dependencies.extend(candidates);
 }
 
 /// Maximum number of same-name candidate definitions kept per referenced

--- a/rinkaku-core/src/deps_tests/mod.rs
+++ b/rinkaku-core/src/deps_tests/mod.rs
@@ -15,8 +15,9 @@
 //!   `mod prefilter_tests` nested module
 //! - `resolve_dependencies` — `resolve_dependencies` cross-file behavior:
 //!   self-reference exclusion, diff-collision exclusion, proximity
-//!   ranking, per-name cap boundary (via `rstest`), and cross-name
-//!   omitted-count accumulation
+//!   ranking, per-name cap boundary (via `rstest`), cross-name
+//!   omitted-count accumulation, and container-aware filtering of bare
+//!   vs. method-reference candidates (ADR 0068 amendment, issue #227)
 
 use super::*;
 use crate::language::go::GoSupport;

--- a/rinkaku-core/src/deps_tests/resolve_dependencies.rs
+++ b/rinkaku-core/src/deps_tests/resolve_dependencies.rs
@@ -48,6 +48,16 @@ fn symbol_with_container(
     }
 }
 
+fn symbol_with_method_reference(name: &str, referenced_method_names: Vec<&str>) -> ExtractedSymbol {
+    ExtractedSymbol {
+        referenced_method_names: referenced_method_names
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        ..symbol(name, vec![])
+    }
+}
+
 /// Builds a `ResolvedSymbol` candidate at `path`, with a signature
 /// derived from the path so mismatched ordering is easy to spot in
 /// a failing assertion.
@@ -56,6 +66,14 @@ fn candidate(path: &str) -> ResolvedSymbol {
         signature: format!("fn helper() // {path}"),
         path: path.to_string(),
         container: None,
+    }
+}
+
+/// Builds a `ResolvedSymbol` candidate at `path` nested in `container`.
+fn candidate_with_container(path: &str, container: &str) -> ResolvedSymbol {
+    ResolvedSymbol {
+        container: Some(container.to_string()),
+        ..candidate(path)
     }
 }
 
@@ -281,6 +299,129 @@ fn should_keep_dependency_when_diff_symbol_shares_name_and_path_but_differs_in_c
     let actual = resolve_dependencies(files, &resolver);
 
     assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_drop_contained_candidate_when_reference_is_bare() {
+    // "use_foo" bare-references "Foo" (`referenced_names`), which
+    // cannot syntactically denote a symbol nested inside an unrelated
+    // container (ADR 0068's rule, mirrored here for dependency
+    // candidates per issue #227). The resolver returns a candidate
+    // nested in "class Baz"; it must not appear as a dependency.
+    let files = vec![FileReport {
+        path: "b.py".to_string(),
+        symbols: vec![symbol("use_foo", vec!["Foo"])],
+    }];
+    let resolver = FakeResolver {
+        matches: HashMap::from([("Foo", vec![candidate_with_container("a.py", "class Baz")])]),
+    };
+
+    let expected = vec![FileReport {
+        path: "b.py".to_string(),
+        symbols: vec![ExtractedSymbol {
+            dependencies: vec![],
+            ..symbol("use_foo", vec!["Foo"])
+        }],
+    }];
+    let actual = resolve_dependencies(files, &resolver);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_keep_contained_candidate_when_reference_is_a_method_reference() {
+    // Same shape as above, but the reference comes from
+    // `referenced_method_names` (a receiver-based call or method-spec
+    // name), which is unambiguous about targeting a contained symbol —
+    // container is not restricted for this set.
+    let files = vec![FileReport {
+        path: "b.rs".to_string(),
+        symbols: vec![symbol_with_method_reference("use_foo", vec!["foo"])],
+    }];
+    let resolver = FakeResolver {
+        matches: HashMap::from([("foo", vec![candidate_with_container("a.rs", "impl Baz")])]),
+    };
+
+    let expected = vec![FileReport {
+        path: "b.rs".to_string(),
+        symbols: vec![ExtractedSymbol {
+            dependencies: vec![candidate_with_container("a.rs", "impl Baz")],
+            ..symbol_with_method_reference("use_foo", vec!["foo"])
+        }],
+    }];
+    let actual = resolve_dependencies(files, &resolver);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_keep_contained_candidate_when_it_shares_the_referencing_symbols_container() {
+    // A bare reference from inside one container to a same-container
+    // sibling member is the one case a bare reference can legitimately
+    // denote a contained symbol (ADR 0068).
+    let files = vec![FileReport {
+        path: "a.py".to_string(),
+        symbols: vec![symbol_with_container("use_foo", "class Baz", vec!["foo"])],
+    }];
+    let resolver = FakeResolver {
+        matches: HashMap::from([("foo", vec![candidate_with_container("a.py", "class Baz")])]),
+    };
+
+    let expected = vec![FileReport {
+        path: "a.py".to_string(),
+        symbols: vec![ExtractedSymbol {
+            dependencies: vec![candidate_with_container("a.py", "class Baz")],
+            ..symbol_with_container("use_foo", "class Baz", vec!["foo"])
+        }],
+    }];
+    let actual = resolve_dependencies(files, &resolver);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_keep_top_level_candidate_when_reference_is_bare() {
+    // Baseline: a bare reference to a top-level (container `None`)
+    // candidate keeps matching, same as before this change.
+    let files = vec![FileReport {
+        path: "b.py".to_string(),
+        symbols: vec![symbol("use_foo", vec!["Foo"])],
+    }];
+    let resolver = FakeResolver {
+        matches: HashMap::from([("Foo", vec![candidate("a.py")])]),
+    };
+
+    let expected = vec![FileReport {
+        path: "b.py".to_string(),
+        symbols: vec![ExtractedSymbol {
+            dependencies: vec![candidate("a.py")],
+            ..symbol("use_foo", vec!["Foo"])
+        }],
+    }];
+    let actual = resolve_dependencies(files, &resolver);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_not_count_container_restricted_matches_in_omitted_dependency_matches() {
+    // A bare reference's container-restricted candidates are dropped
+    // before ranking/capping, not counted as "omitted" — omission is
+    // reserved for the cap (`MAX_MATCHES_PER_NAME`), a distinct reason
+    // from "this candidate's container makes it syntactically
+    // unreachable from a bare reference". `omitted_dependency_matches`
+    // must stay 0 when the only candidate is dropped this way.
+    let files = vec![FileReport {
+        path: "b.py".to_string(),
+        symbols: vec![symbol("use_foo", vec!["Foo"])],
+    }];
+    let resolver = FakeResolver {
+        matches: HashMap::from([("Foo", vec![candidate_with_container("a.py", "class Baz")])]),
+    };
+
+    let actual = resolve_dependencies(files, &resolver);
+
+    assert_eq!(0, actual[0].symbols[0].omitted_dependency_matches);
 }
 
 #[test]

--- a/rinkaku-core/src/deps_tests/resolve_dependencies.rs
+++ b/rinkaku-core/src/deps_tests/resolve_dependencies.rs
@@ -405,12 +405,9 @@ fn should_keep_top_level_candidate_when_reference_is_bare() {
 
 #[test]
 fn should_not_count_container_restricted_matches_in_omitted_dependency_matches() {
-    // A bare reference's container-restricted candidates are dropped
-    // before ranking/capping, not counted as "omitted" — omission is
-    // reserved for the cap (`MAX_MATCHES_PER_NAME`), a distinct reason
-    // from "this candidate's container makes it syntactically
-    // unreachable from a bare reference". `omitted_dependency_matches`
-    // must stay 0 when the only candidate is dropped this way.
+    // "Omitted" is reserved for the `MAX_MATCHES_PER_NAME` cap;
+    // container-restricted drops are a different reason and must not
+    // inflate it.
     let files = vec![FileReport {
         path: "b.py".to_string(),
         symbols: vec![symbol("use_foo", vec!["Foo"])],
@@ -419,9 +416,13 @@ fn should_not_count_container_restricted_matches_in_omitted_dependency_matches()
         matches: HashMap::from([("Foo", vec![candidate_with_container("a.py", "class Baz")])]),
     };
 
+    let expected = vec![FileReport {
+        path: "b.py".to_string(),
+        symbols: vec![symbol("use_foo", vec!["Foo"])],
+    }];
     let actual = resolve_dependencies(files, &resolver);
 
-    assert_eq!(0, actual[0].symbols[0].omitted_dependency_matches);
+    assert_eq!(expected, actual);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #227.

`deps::resolve_dependencies`'s "Depends on" candidate enumeration matched purely by name, with no container awareness — the same false-positive shape [ADR 0068](docs/adr/0068-container-aware-edge-matching-for-bare-references.md) fixed for `graph::collect_edges`'s change-graph edges, but deliberately left open for `deps.rs` as Decision point 5 (tracked as #227, since it changes a materially different output surface and deserved its own measurement).

- `resolve_dependencies` now applies the same `ContainerRule` distinction `collect_edges` uses: a `referenced_names` (bare) candidate is only kept if its container is `None` (top-level) or equal to the referencing symbol's own container; `referenced_method_names` candidates (receiver-based calls, method specs) are kept regardless of container, unchanged from before.
- Container-restricted-away candidates are dropped before ranking/capping and are **not** counted in `omitted_dependency_matches` — that count stays reserved for candidates cut by `MAX_MATCHES_PER_NAME`.
- ADR 0068 amended to record this follow-up as closed.

## Depends on output change (before/after)

Reproduction from the issue (`a.py` has a top-level `def Foo():` and an unrelated `class Baz: def Foo(self): ...`; `b.py::use_foo()` bare-calls `Foo()`):

**Before:**
```
Depends on:
- `a.py`: `def Foo():`
- `a.py`: `def Foo(self):`
```

**After:**
```
Depends on:
- `a.py`: `def Foo():`
```

Verified end-to-end against release binaries built from `main` (before) and this branch (after) on a scratch `git` repo reproducing the issue's scenario. Also verified a Rust `impl` method-call scenario (`b.foo()`, a `referenced_method_names` entry) still resolves across containers unrestricted, confirming the method-reference path is untouched.

## Test plan

- [x] `make test` (1104 tests, all passing)
- [x] `make lint` (fmt + clippy clean)
- [x] New unit tests in `rinkaku-core/src/deps_tests/resolve_dependencies.rs`: bare reference drops contained candidate, method reference keeps contained candidate, bare reference keeps same-container candidate, bare reference keeps top-level candidate, container-restricted candidates are excluded from `omitted_dependency_matches`
- [x] Manual e2e: Python bare-reference reproduction (before/after) and Rust method-reference regression check, both via built release binaries against scratch repos