### PR TITLE
fix: scope ubiquitous-method-name stoplist to receiver-call captures

### DIFF
--- a/docs/adr/0064-scoped-and-method-call-references.md
+++ b/docs/adr/0064-scoped-and-method-call-references.md
@@ -108,3 +108,46 @@ ambiguity):
   whose tests exist but lie outside the diff, so the marker would
   still fire falsely on routine PRs. Re-evaluate if a future change
   closes the diff-scope gap.
+
+## Amendment (2026-08-07, fix/scope-stoplist-to-receiver-calls)
+
+ADR 0068 reclassified Go's interface method-spec capture and
+TypeScript's interface method-signature capture from `@reference.call`
+to `@reference.method` (and gave Rust's pre-existing trait-method
+captures the same name), so all three started routing through this
+ADR's stoplist alongside Rust's receiver-call capture. ADR 0068's
+Consequences section flagged this as an accepted-but-unmeasured
+tradeoff and deferred a fix to
+[issue #230](https://github.com/hiro-o918/rinkaku/issues/230), since
+the stoplist's membership criterion and its 138/143-referrer
+measurements (this ADR's Context table) were taken purely on Rust's
+`x.get()`/`x.clone()` receiver calls — a name-only match against a
+same-named repo symbol is more likely wrong than right precisely
+because a receiver call site is common. An interface/trait method
+*spec* is the opposite shape: a declaration, occurring once per method
+per container, with a deliberate spec-to-implementation link (ADR
+0012) the stoplist was never measured against and has no rationale to
+suppress.
+
+Change: the receiver-call capture keeps the `@reference.method` name
+this ADR defined and stays behind the stoplist. The three
+container-declaring captures ADR 0068 introduced or renamed — Go's
+`interface_type (method_elem ...)`, TypeScript's `interface_declaration
+... (method_signature ...)`, and Rust's `trait_item`-scoped
+`function_signature_item`/`function_item` — move to a new
+`@reference.methodspec` capture name, which `extract::references::
+collect_referenced_names` still merges into `referenced_method_names`
+(ADR 0068's edge-matching rule is unchanged; only the stoplist's
+capture-name test narrows from `@reference.method` to exactly
+`@reference.method`, now excluding `@reference.methodspec`). No output
+shape changes: `referenced_method_names` was and remains
+`#[serde(skip)]`.
+
+Exposure before this fix, per ADR 0068's Consequences section: Go is
+largely shielded (the stoplist is all-lowercase, exported interface
+methods are capitalized), TypeScript is the most exposed (idiomatic
+lowercase method names like `get`/`set`/`has`/`delete`/`clear` are all
+stoplist entries), and Rust's own trait methods were exposed too
+though less visibly documented. This amendment restores the
+spec-to-implementation edge in all three cases; a receiver call on a
+stoplisted name (`x.get()`) is unaffected and stays filtered.

--- a/rinkaku-core/src/extract/mod.rs
+++ b/rinkaku-core/src/extract/mod.rs
@@ -123,11 +123,12 @@ pub struct ExtractedSymbol {
     #[serde(skip)]
     pub referenced_names: Vec<String>,
     /// Names this definition references via a receiver or method-spec
-    /// position — `@reference.method` captures: Rust's `x.foo()` calls and
-    /// trait method names, Go's interface method-spec names, TypeScript's
-    /// interface method-signature names (ADR 0068, extending ADR 0064's
-    /// `@reference.method` capture to the container-referring captures ADR
-    /// 0012 introduced). Unlike `referenced_names`, these may legitimately
+    /// position — `@reference.method` (Rust's `x.foo()` receiver calls,
+    /// ADR 0064) plus `@reference.methodspec` (Rust trait method names,
+    /// Go interface method-spec names, TypeScript interface
+    /// method-signature names — the container-referring captures ADR 0012
+    /// introduced, split out so only receiver calls pass the ADR 0064
+    /// stoplist; ADR 0068). Unlike `referenced_names`, these may legitimately
     /// denote a symbol nested inside any container, so
     /// `crate::graph::collect_edges` matches them without the
     /// same-container restriction. Same "intermediate pipeline artifact"

--- a/rinkaku-core/src/extract/references.rs
+++ b/rinkaku-core/src/extract/references.rs
@@ -18,10 +18,15 @@ pub(super) struct ReferencedNames {
     /// every non-query code walk below): cannot syntactically name a
     /// contained symbol in Python/Go/TypeScript.
     pub bare: Vec<String>,
-    /// `@reference.method` captures: Rust's receiver-based method calls
-    /// and trait method names, Go's interface method-spec names, and
-    /// TypeScript's interface method-signature names — all of which may
-    /// legitimately denote a symbol nested inside a container.
+    /// `@reference.method` and `@reference.methodspec` captures: Rust's
+    /// receiver-based method calls (`@reference.method`), plus Rust's
+    /// trait method names, Go's interface method-spec names, and
+    /// TypeScript's interface method-signature names
+    /// (`@reference.methodspec`) — all of which may legitimately denote a
+    /// symbol nested inside a container. Merged into one set here since
+    /// `graph::collect_edges` treats them identically (ADR 0068); the two
+    /// capture names exist only so [`is_ubiquitous_method_name`]'s
+    /// stoplist can apply to the former and not the latter (issue #230).
     pub method: Vec<String>,
 }
 
@@ -72,7 +77,7 @@ pub(super) fn collect_referenced_names(
                 && !is_noise_name(text)
                 && !(capture_name == "reference.method" && is_ubiquitous_method_name(text))
             {
-                if capture_name == "reference.method" {
+                if capture_name == "reference.method" || capture_name == "reference.methodspec" {
                     method.insert(text.to_string());
                 } else {
                     bare.insert(text.to_string());
@@ -173,8 +178,13 @@ fn hcl_traversal_name(variable_expr: tree_sitter::Node, source: &[u8]) -> Option
 /// same-named repo symbol is more likely wrong than right: one repo `fn
 /// clone` drew 143 referrers, a `fn get` 138, when method captures ran
 /// unfiltered (ADR 0064's measurements). Applied only to
-/// `@reference.method` captures — the same name called as a free function
-/// (`get(x)`) or defined as a symbol stays fully visible.
+/// `@reference.method` captures — Rust's receiver-based method calls
+/// (`x.get()`), the shape those measurements were taken on. Not applied to
+/// `@reference.methodspec` captures (interface/trait method declarations):
+/// a spec name is a rare, deliberate declaration, not a high-fan-in call
+/// site, so the stoplist's rationale does not transfer (ADR 0064
+/// amendment, issue #230). The same name called as a free function
+/// (`get(x)`) or defined as a symbol stays fully visible regardless.
 ///
 /// The criterion for membership is "belongs to a std trait or ubiquitous
 /// std method idiom", not "observed colliding here" — pollution appears

--- a/rinkaku-core/src/extract_tests/go.rs
+++ b/rinkaku-core/src/extract_tests/go.rs
@@ -178,7 +178,7 @@ type Fetcher interface {
         // and its referenced parameter/return types (bare type
         // references). "Fetch" is the interface's own method spec
         // name (ADR 0012 decision 2), captured under
-        // `@reference.method` (ADR 0068) since it may denote a
+        // `@reference.methodspec` (ADR 0068) since it may denote a
         // symbol nested inside a container (a receiver method).
         referenced_names: vec![
             "Fetcher".to_string(),
@@ -225,6 +225,43 @@ type Repo interface {
             "string".to_string(),
         ],
         referenced_method_names: vec!["Delete".to_string(), "Save".to_string()],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_keep_stoplisted_interface_method_name_in_referenced_method_names() {
+    // Unexported (lowercase) interface method names are the case Go
+    // exposes to the ADR 0064 stoplist: the stoplist is scoped to
+    // receiver-call captures (issue #230), so a method spec still keeps
+    // its spec-to-implementation edge even when its name collides
+    // (`get`).
+    let source = "\
+package main
+
+type cache interface {
+	get(key string) string
+}
+";
+    let lang = GoSupport;
+    let changed_ranges = vec![LineRange { start: 4, end: 4 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "cache".to_string(),
+        kind: SymbolKind::Interface,
+        signature: "cache interface {\n\tget(key string) string\n}".to_string(),
+        range: LineRange { start: 3, end: 5 },
+        container: None,
+        referenced_names: vec!["cache".to_string(), "string".to_string()],
+        referenced_method_names: vec!["get".to_string()],
         dependencies: vec![],
         omitted_dependency_matches: 0,
         is_test: false,

--- a/rinkaku-core/src/extract_tests/rust.rs
+++ b/rinkaku-core/src/extract_tests/rust.rs
@@ -554,7 +554,7 @@ trait Greeter {
         // The trait's own name and the referenced `String` return
         // type of its method signature are bare references. Its
         // "greet" method name (ADR 0012 decision 2) is captured
-        // under `@reference.method` (ADR 0068), since a trait method
+        // under `@reference.methodspec` (ADR 0068), since a trait method
         // name may denote a symbol nested inside a container (an
         // impl method).
         referenced_names: vec!["Greeter".to_string(), "String".to_string()],
@@ -601,7 +601,7 @@ trait Repo {
         // grammar, not `type_identifier`, so it is not captured at
         // all — see REFERENCE_QUERY's doc comment). Both the
         // bodiless `save` signature and the default-body `label`
-        // method contribute their names under `@reference.method`
+        // method contribute their names under `@reference.methodspec`
         // (ADR 0012 decision 2, ADR 0068).
         referenced_names: vec!["Repo".to_string(), "String".to_string()],
         referenced_method_names: vec!["label".to_string(), "save".to_string()],

--- a/rinkaku-core/src/extract_tests/rust_references.rs
+++ b/rinkaku-core/src/extract_tests/rust_references.rs
@@ -202,6 +202,64 @@ fn should_collect_scoped_and_method_call_references(
     assert_eq!(expected, actual);
 }
 
+#[test]
+fn should_keep_stoplisted_trait_method_name_but_still_drop_it_from_a_receiver_call() {
+    // Contrasts the two `@reference.method`-family captures on the same
+    // stoplisted name (`get`, issue #230): a trait method spec is a
+    // declaration and keeps its edge, while a receiver call on the same
+    // name stays filtered by the ADR 0064 stoplist — scoping the filter
+    // to receiver-call captures only.
+    let source = "\
+trait Cache {
+    fn get(&self) -> Format;
+}
+fn build() -> Format {
+    state.get()
+}
+";
+    let lang = RustSupport;
+    let changed_ranges = vec![
+        LineRange { start: 1, end: 1 },
+        LineRange { start: 4, end: 4 },
+    ];
+
+    let expected = vec![
+        ExtractedSymbol {
+            id: String::new(),
+            name: "Cache".to_string(),
+            kind: SymbolKind::Trait,
+            signature: "trait Cache {\n    fn get(&self) -> Format;\n}".to_string(),
+            range: LineRange { start: 1, end: 3 },
+            container: None,
+            referenced_names: vec!["Cache".to_string(), "Format".to_string()],
+            referenced_method_names: vec!["get".to_string()],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        },
+        ExtractedSymbol {
+            id: String::new(),
+            name: "build".to_string(),
+            kind: SymbolKind::Function,
+            signature: "fn build() -> Format".to_string(),
+            range: LineRange { start: 4, end: 6 },
+            container: None,
+            referenced_names: vec!["Format".to_string()],
+            referenced_method_names: vec![],
+            dependencies: vec![],
+            omitted_dependency_matches: 0,
+            is_test: false,
+            classification: None,
+            previous_signature: None,
+        },
+    ];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
 #[rstest]
 #[case::should_collect_call_and_path_identifiers_inside_macro_body(
     "\

--- a/rinkaku-core/src/extract_tests/typescript.rs
+++ b/rinkaku-core/src/extract_tests/typescript.rs
@@ -205,10 +205,11 @@ interface Repo {
 }
 
 #[test]
-fn should_drop_stoplisted_interface_method_name_from_referenced_method_names() {
-    // Pins ADR 0068's disclosed tradeoff (tracked in issue #230):
-    // routing interface method specs through the ADR 0064 stoplist
-    // costs the spec-to-implementation edge for names like `get`.
+fn should_keep_stoplisted_interface_method_name_in_referenced_method_names() {
+    // The ADR 0064 stoplist is scoped to receiver-call captures
+    // (issue #230): an interface method spec is a declaration, not a
+    // high-fan-in call site, so a name colliding with the stoplist
+    // (`get`) still keeps its spec-to-implementation edge.
     let source = "\
 interface Cache {
     get(key: string): string;
@@ -227,7 +228,7 @@ interface Cache {
         range: LineRange { start: 1, end: 4 },
         container: None,
         referenced_names: vec!["Cache".to_string()],
-        referenced_method_names: vec!["store".to_string()],
+        referenced_method_names: vec!["get".to_string(), "store".to_string()],
         dependencies: vec![],
         omitted_dependency_matches: 0,
         is_test: false,

--- a/rinkaku-core/src/extract_tests/typescript.rs
+++ b/rinkaku-core/src/extract_tests/typescript.rs
@@ -146,7 +146,7 @@ interface Shape {
         // TypeScript's built-in `predefined_type`, a distinct node
         // kind the reference query does not capture.
         // `area`/`perimeter` are its method signature names (ADR
-        // 0012 decision 2), captured under `@reference.method` (ADR
+        // 0012 decision 2), captured under `@reference.methodspec` (ADR
         // 0068) since a method signature name may denote a symbol
         // nested inside a container (a class method).
         referenced_names: vec!["Shape".to_string()],
@@ -189,7 +189,7 @@ interface Repo {
         container: None,
         // "id" (a `property_signature` name) is deliberately
         // excluded; only "save" (a `method_signature` name) is
-        // captured, under `@reference.method` (ADR 0068) alongside
+        // captured, under `@reference.methodspec` (ADR 0068) alongside
         // the interface's own name in `referenced_names`.
         referenced_names: vec!["Repo".to_string()],
         referenced_method_names: vec!["save".to_string()],

--- a/rinkaku-core/src/language/go.rs
+++ b/rinkaku-core/src/language/go.rs
@@ -47,26 +47,30 @@ const DEFINITION_QUERY: &str = "\
 ///   (see the trait doc comment on `reference_query`).
 /// - `interface_type (method_elem name: (field_identifier))` captures each
 ///   method spec's name inside an interface body (ADR 0012 decision 2)
-///   under `@reference.method` (ADR 0068): feeding these into the
-///   interface symbol's `referenced_method_names` makes
-///   `graph::collect_edges`'s name-based matching link the interface to a
-///   same-named changed receiver method, so the two stop appearing as
-///   independent roots in the change graph. Scoped to `interface_type`'s
-///   own `method_elem` children (rather than a bare `(method_elem name:
-///   (field_identifier) @reference.method)` pattern) so this cannot match
-///   anything else — `method_elem` only ever occurs inside an
-///   `interface_type` in this grammar, but the explicit parent keeps the
-///   intent legible. Captured under `reference.method`, not
-///   `reference.call`, since — unlike a free function call — a method
-///   spec name may denote a symbol nested inside a container (a receiver
-///   method), which `graph::collect_edges` matches without a
-///   same-container restriction (ADR 0068); a bare `reference.call` name
-///   cannot.
+///   under `@reference.methodspec` (ADR 0068, ADR 0064 amendment):
+///   feeding these into the interface symbol's `referenced_method_names`
+///   makes `graph::collect_edges`'s name-based matching link the
+///   interface to a same-named changed receiver method, so the two stop
+///   appearing as independent roots in the change graph. Scoped to
+///   `interface_type`'s own `method_elem` children (rather than a bare
+///   `(method_elem name: (field_identifier) @reference.methodspec)`
+///   pattern) so this cannot match anything else — `method_elem` only
+///   ever occurs inside an `interface_type` in this grammar, but the
+///   explicit parent keeps the intent legible. Captured under
+///   `reference.methodspec`, not `reference.call`, since — unlike a free
+///   function call — a method spec name may denote a symbol nested
+///   inside a container (a receiver method), which
+///   `graph::collect_edges` matches without a same-container restriction
+///   (ADR 0068); a bare `reference.call` name cannot. Kept distinct from
+///   Rust's receiver-call `@reference.method` capture so the ADR 0064
+///   ubiquitous-name stoplist — measured against high-fan-in receiver
+///   calls — does not also apply to this rare, declarative capture (ADR
+///   0064 amendment, issue #230).
 const REFERENCE_QUERY: &str = "\
 [
   (call_expression function: (identifier) @reference.call)
   (type_identifier) @reference.type
-  (interface_type (method_elem name: (field_identifier) @reference.method))
+  (interface_type (method_elem name: (field_identifier) @reference.methodspec))
 ]";
 
 pub struct GoSupport;

--- a/rinkaku-core/src/language/rust.rs
+++ b/rinkaku-core/src/language/rust.rs
@@ -57,14 +57,16 @@ const DEFINITION_QUERY: &str = "\
 ///   (identifier)))` and the same shape for `function_item` capture a
 ///   trait's method names — both the common bodiless `fn name(...);` form
 ///   and a default-body `fn name(...) { ... }` form (ADR 0012 decision 2)
-///   — under `@reference.method` (ADR 0068, not a new capture prefix: a
-///   trait method name plays the same "may denote a container member"
-///   role as a receiver-based method call). Feeding these into the trait
-///   symbol's `referenced_method_names` makes `graph::collect_edges`'s
-///   name-based matching link the trait to a same-named changed impl
-///   method, so the two stop appearing as independent roots in the change
-///   graph. Scoped to a `trait_item`'s own `body` field (rather than
-///   matching `function_signature_item`/`function_item` anywhere) so an
+///   — under `@reference.methodspec` (ADR 0068: a trait method name plays
+///   the same "may denote a container member" role as a receiver-based
+///   method call, but is captured under a distinct name so the ADR 0064
+///   stoplist below does not apply to it — ADR 0064 amendment, issue
+///   #230). Feeding these into the trait symbol's
+///   `referenced_method_names` makes `graph::collect_edges`'s name-based
+///   matching link the trait to a same-named changed impl method, so the
+///   two stop appearing as independent roots in the change graph. Scoped
+///   to a `trait_item`'s own `body` field (rather than matching
+///   `function_signature_item`/`function_item` anywhere) so an
 ///   `impl_item`'s or free function's name is never captured this way —
 ///   those are already covered by `definition_query` capturing the
 ///   function/method itself, not via this path.
@@ -74,8 +76,8 @@ const REFERENCE_QUERY: &str = "\
   (call_expression function: (field_expression field: (field_identifier) @reference.method))
   (type_identifier) @reference.type
   (scoped_identifier path: (identifier) @reference.type)
-  (trait_item body: (declaration_list (function_signature_item name: (identifier) @reference.method)))
-  (trait_item body: (declaration_list (function_item name: (identifier) @reference.method)))
+  (trait_item body: (declaration_list (function_signature_item name: (identifier) @reference.methodspec)))
+  (trait_item body: (declaration_list (function_item name: (identifier) @reference.methodspec)))
 ]";
 
 pub struct RustSupport;

--- a/rinkaku-core/src/language/typescript.rs
+++ b/rinkaku-core/src/language/typescript.rs
@@ -68,26 +68,32 @@ const DEFINITION_QUERY: &str = "\
 ///   exclusion list.
 /// - `interface_declaration body: (interface_body (method_signature name:
 ///   (property_identifier)))` captures an interface's method signature
-///   names (ADR 0012 decision 2) under `@reference.method` (ADR 0068):
-///   feeding these into the interface symbol's `referenced_method_names`
-///   makes `graph::collect_edges`'s name-based matching link the
-///   interface to a same-named changed class method, so the two stop
-///   appearing as independent roots in the change graph. Deliberately
-///   `method_signature` only, not `property_signature` — a plain data
-///   field is not a method spec, and including it would pull unrelated
-///   same-named symbols into the interface's edges without the "this is a
-///   method the interface declares" justification method specs have.
-///   Captured under `reference.method`, not `reference.call`, since —
-///   unlike a free function call — a method signature name may denote a
-///   symbol nested inside a container (a class method), which
-///   `graph::collect_edges` matches without a same-container restriction
-///   (ADR 0068); a bare `reference.call` name cannot.
+///   names (ADR 0012 decision 2) under `@reference.methodspec` (ADR 0068,
+///   ADR 0064 amendment): feeding these into the interface symbol's
+///   `referenced_method_names` makes `graph::collect_edges`'s name-based
+///   matching link the interface to a same-named changed class method,
+///   so the two stop appearing as independent roots in the change graph.
+///   Deliberately `method_signature` only, not `property_signature` — a
+///   plain data field is not a method spec, and including it would pull
+///   unrelated same-named symbols into the interface's edges without the
+///   "this is a method the interface declares" justification method
+///   specs have. Captured under `reference.methodspec`, not
+///   `reference.call`, since — unlike a free function call — a method
+///   signature name may denote a symbol nested inside a container (a
+///   class method), which `graph::collect_edges` matches without a
+///   same-container restriction (ADR 0068); a bare `reference.call` name
+///   cannot. Kept distinct from Rust's receiver-call `@reference.method`
+///   capture so the ADR 0064 ubiquitous-name stoplist — measured against
+///   high-fan-in receiver calls — does not also apply to this rare,
+///   declarative capture (ADR 0064 amendment, issue #230); TypeScript's
+///   idiomatic lowercase method names (`get`, `set`, `has`, `delete`,
+///   `clear`) are the case this matters most for.
 const REFERENCE_QUERY: &str = "\
 [
   (call_expression function: (identifier) @reference.call)
   (new_expression constructor: (identifier) @reference.call)
   (type_identifier) @reference.type
-  (interface_declaration body: (interface_body (method_signature name: (property_identifier) @reference.method)))
+  (interface_declaration body: (interface_body (method_signature name: (property_identifier) @reference.methodspec)))
 ]";
 
 pub struct TypeScriptSupport;


### PR DESCRIPTION
## Summary

ADR 0068 reclassified Go's interface `method_elem` capture and TypeScript's interface `method_signature` capture from `@reference.call` to `@reference.method` (and gave Rust's pre-existing trait-method captures the same name). This unintentionally routed all three through the ADR 0064 ubiquitous-method-name stoplist, which was measured and designed for high-fan-in *receiver-call* sites (`x.get()`, `x.clone()`), not one-off method *declarations*.

Net effect before this fix: an interface/trait method spec whose name collides with the stoplist (`get`, `set`, `has`, `delete`, `clear`, ...) lost its spec-to-implementation edge in the change graph. TypeScript was most exposed (idiomatic lowercase method names), Go was largely shielded (stoplist is all-lowercase, exported methods are capitalized), Rust trait methods were exposed too.

## Changes

- Split the container-declaring captures into a new `@reference.methodspec` capture name, distinct from Rust's receiver-call `@reference.method` capture:
  - Go: `interface_type (method_elem ...)`
  - TypeScript: `interface_declaration ... (method_signature ...)`
  - Rust: `trait_item`-scoped `function_signature_item`/`function_item`
- `extract::references::collect_referenced_names` merges both capture names into `referenced_method_names` identically (ADR 0068's graph-edge matching rule is unchanged) — only `is_ubiquitous_method_name`'s stoplist check narrows to exactly `@reference.method`, now excluding `@reference.methodspec`.
- No output shape change: `referenced_method_names` was and remains `#[serde(skip)]`.
- Scope deliberately excludes `deps.rs`/`graph.rs` (ADR 0068 decision point 5's known gap, tracked separately as #227) to avoid touching files under parallel work.
- ADR 0064 gets an amendment recording this narrowing; ADR 0068 itself is untouched.

## Test plan

- [x] `make test` (1104 core/tui tests pass)
- [x] `make lint`
- [x] New/updated unit tests:
  - TS: `should_keep_stoplisted_interface_method_name_in_referenced_method_names` (was `should_drop_...`, now asserts `get` is kept)
  - Go: `should_keep_stoplisted_interface_method_name_in_referenced_method_names` (new, unexported `cache.get`)
  - Rust: `should_keep_stoplisted_trait_method_name_but_still_drop_it_from_a_receiver_call` (new, contrasts trait spec vs. `x.get()` receiver call on the same name)
- [x] End-to-end verification: built `rinkaku` from this branch and from `origin/main`, ran both against scratch git repos with `--base HEAD~1 --format json`:
  - TS `interface Cache { get }` + `class MemCache implements Cache { get }`, both changed: main → no edge; this branch → `cache.ts::Cache -> mem_cache.ts::get` edge, `Cache` as sole graph root.
  - Rust `trait Cache { fn get }` + `impl Cache for MemCache { fn get }`, both changed: main → no edge; this branch → `lib.rs::Cache -> lib.rs::get` edge.
  - Rust receiver call `cache.get()` on a stoplisted name: no edge on either branch (unaffected, as intended).

Closes #230