### PR TITLE
fix: stop reporting a live container as removed when only a member changed

### DIFF
--- a/docs/adr/0014-classify-symbol-changes-by-contract.md
+++ b/docs/adr/0014-classify-symbol-changes-by-contract.md
@@ -105,3 +105,29 @@ additive fields on the symbol; `removed` is a new top-level array.
 - Stripping comment nodes changes existing signature strings shown in
   output — another pre-1.0 output-format change, consistent with prior
   ADRs (0008, 0009, 0012).
+
+## Amendment (2026-08-07, fix/false-removed-container-on-member-edit)
+
+Found via dogfooding: editing only a nested member of an otherwise
+untouched Python/TypeScript class reported the enclosing class itself as
+`removed`, alongside the member's own (correct) classification —
+contradictory output in the same report. Root cause: `extract_changed_symbols`
+suppresses a container in favor of its narrowest touched member (so the
+Change graph doesn't report both the member and its enclosing class), but
+`classify_symbols`'s removal check compared the base side against that
+same narrowed `head_symbols` list rather than against the head file's
+complete symbol set — a still-alive container whose own line range was
+never directly touched would never appear in `head_symbols`, so it looked
+"gone" by the same test a genuinely deleted symbol would fail.
+
+Rust and Go were structurally immune: an `impl` block is never itself a
+reported symbol, and a Go method never nests inside its receiver's node,
+so neither language's containers are ever suppressed this way.
+
+Fix: `classify_symbols` now takes the head file's complete symbol set
+(`extract_all_symbols`'s output) as a separate parameter from
+`head_symbols`, and judges removal against that complete set instead.
+`pipeline::analyze_diff` threads this through, reading head-side content
+lazily in the empty-`changed_ranges` branch (a whole-symbol-deletion hunk)
+where it previously skipped that read entirely, since removal there can
+no longer be judged from `old_changed_ranges` overlap alone.

--- a/rinkaku-core/src/extract/mod.rs
+++ b/rinkaku-core/src/extract/mod.rs
@@ -284,14 +284,28 @@ pub struct RemovedSymbol {
 ///   with `previous_signature` set to the base signature.
 /// - A head symbol with a base-side match whose signature is identical →
 ///   [`Classification::BodyOnly`].
-/// - A base symbol with no head-side match, whose base-side range overlaps
-///   `old_changed_ranges` (the diff's old-side hunk ranges for this file) →
-///   returned as a [`RemovedSymbol`]. A base-only symbol *outside* every
-///   changed range is not reported: nothing in the diff actually touched
-///   it, so it is unrelated to this change (e.g. a symbol that merely moved
-///   later in the file because of an unrelated edit above it) — restricting
-///   to overlapping ranges is what keeps this from flooding output on a
-///   diff that only touches a small part of a large file.
+/// - A base symbol absent from `head_file_identities` (i.e. gone from the
+///   head file entirely, not merely absent from `head_symbols`), whose
+///   base-side range overlaps `old_changed_ranges` (the diff's old-side
+///   hunk ranges for this file) → returned as a [`RemovedSymbol`]. A
+///   base-only symbol *outside* every changed range is not reported:
+///   nothing in the diff actually touched it, so it is unrelated to this
+///   change (e.g. a symbol that merely moved later in the file because of
+///   an unrelated edit above it) — restricting to overlapping ranges is
+///   what keeps this from flooding output on a diff that only touches a
+///   small part of a large file.
+///
+/// `all_head_symbols` is deliberately a separate parameter from
+/// `head_symbols`: `head_symbols` only carries the *narrowest* enclosing
+/// definition touched by the diff (`extract_changed_symbols` suppresses a
+/// container whose own member was the thing actually touched, so the
+/// Change graph doesn't report both), so a still-alive container would
+/// never appear in `head_symbols` when only one of its members changed —
+/// checking removal against `head_symbols` alone would misreport that
+/// container as removed. `all_head_symbols` instead is the head file's
+/// *complete* symbol set (typically `extract_all_symbols`'s output), so a
+/// container's continued existence is judged against the whole file, not
+/// against the subset the diff happens to surface.
 ///
 /// Pure: takes both sides' already-extracted symbol lists and matches them
 /// in memory, no IO. `lang` is not needed here — `head_symbols` and
@@ -306,6 +320,7 @@ pub struct RemovedSymbol {
 pub fn classify_symbols(
     head_symbols: &mut [ExtractedSymbol],
     base_symbols: &[ExtractedSymbol],
+    all_head_symbols: &[ExtractedSymbol],
     old_changed_ranges: &[LineRange],
     path: &str,
 ) -> Vec<RemovedSymbol> {
@@ -314,9 +329,6 @@ pub fn classify_symbols(
         .map(|s| ((s.name.as_str(), s.container.as_deref()), s))
         .collect();
 
-    let mut matched_base_identities: std::collections::HashSet<(&str, Option<&str>)> =
-        std::collections::HashSet::new();
-
     for symbol in head_symbols.iter_mut() {
         let identity = (symbol.name.as_str(), symbol.container.as_deref());
         match base_by_identity.get(&identity) {
@@ -324,7 +336,6 @@ pub fn classify_symbols(
                 symbol.classification = Some(Classification::Added);
             }
             Some(base_symbol) => {
-                matched_base_identities.insert(identity);
                 if normalize_for_comparison(&base_symbol.signature)
                     == normalize_for_comparison(&symbol.signature)
                 {
@@ -337,11 +348,16 @@ pub fn classify_symbols(
         }
     }
 
+    let head_file_identities: std::collections::HashSet<(&str, Option<&str>)> = all_head_symbols
+        .iter()
+        .map(|s| (s.name.as_str(), s.container.as_deref()))
+        .collect();
+
     base_symbols
         .iter()
         .filter(|base_symbol| {
             let identity = (base_symbol.name.as_str(), base_symbol.container.as_deref());
-            !matched_base_identities.contains(&identity)
+            !head_file_identities.contains(&identity)
         })
         .filter(|base_symbol| overlaps_any(base_symbol.range, old_changed_ranges))
         .map(|base_symbol| RemovedSymbol {

--- a/rinkaku-core/src/extract_tests/classification.rs
+++ b/rinkaku-core/src/extract_tests/classification.rs
@@ -48,7 +48,8 @@ fn should_classify_as_added_when_no_base_side_match_exists() {
     )];
     let base: Vec<ExtractedSymbol> = vec![];
 
-    let removed = classify_symbols(&mut head, &base, &[], "src/lib.rs");
+    let all_head = head.clone();
+    let removed = classify_symbols(&mut head, &base, &all_head, &[], "src/lib.rs");
 
     let mut expected = vec![symbol(
         "foo",
@@ -88,7 +89,8 @@ fn should_classify_as_body_only_when_reflow_inserts_newline_right_after_opening_
         LineRange { start: 1, end: 1 },
     )];
 
-    let removed = classify_symbols(&mut head, &base, &[], "src/lib.go");
+    let all_head = head.clone();
+    let removed = classify_symbols(&mut head, &base, &all_head, &[], "src/lib.go");
 
     let mut expected = head.clone();
     expected[0].classification = Some(Classification::BodyOnly);
@@ -118,7 +120,8 @@ fn should_classify_as_body_only_when_reflow_inserts_newline_right_after_comma() 
         LineRange { start: 1, end: 1 },
     )];
 
-    let removed = classify_symbols(&mut head, &base, &[], "src/lib.rs");
+    let all_head = head.clone();
+    let removed = classify_symbols(&mut head, &base, &all_head, &[], "src/lib.rs");
 
     let mut expected = head.clone();
     expected[0].classification = Some(Classification::BodyOnly);
@@ -149,7 +152,8 @@ fn should_classify_as_signature_changed_when_reflow_adds_a_trailing_comma() {
         LineRange { start: 1, end: 1 },
     )];
 
-    let removed = classify_symbols(&mut head, &base, &[], "src/lib.rs");
+    let all_head = head.clone();
+    let removed = classify_symbols(&mut head, &base, &all_head, &[], "src/lib.rs");
 
     let mut expected = head.clone();
     expected[0].classification = Some(Classification::SignatureChanged);
@@ -179,7 +183,8 @@ fn should_classify_as_signature_changed_when_signatures_differ_only_by_a_word_bo
         LineRange { start: 1, end: 1 },
     )];
 
-    let removed = classify_symbols(&mut head, &base, &[], "src/lib.go");
+    let all_head = head.clone();
+    let removed = classify_symbols(&mut head, &base, &all_head, &[], "src/lib.go");
 
     let mut expected = head.clone();
     expected[0].classification = Some(Classification::SignatureChanged);
@@ -205,7 +210,8 @@ fn should_classify_as_signature_changed_when_base_signature_differs() {
         LineRange { start: 1, end: 3 },
     )];
 
-    let removed = classify_symbols(&mut head, &base, &[], "src/lib.rs");
+    let all_head = head.clone();
+    let removed = classify_symbols(&mut head, &base, &all_head, &[], "src/lib.rs");
 
     let mut expected = vec![symbol(
         "foo",
@@ -236,7 +242,8 @@ fn should_classify_as_body_only_when_base_signature_is_identical() {
         LineRange { start: 1, end: 3 },
     )];
 
-    let removed = classify_symbols(&mut head, &base, &[], "src/lib.rs");
+    let all_head = head.clone();
+    let removed = classify_symbols(&mut head, &base, &all_head, &[], "src/lib.rs");
 
     let mut expected = vec![symbol(
         "foo",
@@ -270,7 +277,8 @@ fn should_classify_as_added_when_base_match_has_different_container() {
         LineRange { start: 1, end: 3 },
     )];
 
-    let removed = classify_symbols(&mut head, &base, &[], "src/lib.rs");
+    let all_head = head.clone();
+    let removed = classify_symbols(&mut head, &base, &all_head, &[], "src/lib.rs");
 
     let mut expected = vec![symbol(
         "save",
@@ -301,7 +309,14 @@ fn should_report_removed_when_base_only_symbol_overlaps_old_changed_ranges() {
     )];
     let old_changed_ranges = vec![LineRange { start: 6, end: 6 }];
 
-    let removed = classify_symbols(&mut head, &base, &old_changed_ranges, "src/lib.rs");
+    let all_head = head.clone();
+    let removed = classify_symbols(
+        &mut head,
+        &base,
+        &all_head,
+        &old_changed_ranges,
+        "src/lib.rs",
+    );
 
     let expected_head: Vec<ExtractedSymbol> = vec![];
     let expected_removed = vec![RemovedSymbol {
@@ -329,7 +344,14 @@ fn should_not_report_removed_when_base_only_symbol_does_not_overlap_old_changed_
     // make every other base-only symbol show up as "removed".
     let old_changed_ranges = vec![LineRange { start: 6, end: 6 }];
 
-    let removed = classify_symbols(&mut head, &base, &old_changed_ranges, "src/lib.rs");
+    let all_head = head.clone();
+    let removed = classify_symbols(
+        &mut head,
+        &base,
+        &all_head,
+        &old_changed_ranges,
+        "src/lib.rs",
+    );
 
     let expected_removed: Vec<RemovedSymbol> = Vec::new();
     assert_eq!(expected_removed, removed);
@@ -367,7 +389,14 @@ fn should_report_removed_when_a_second_base_symbol_of_same_name_has_no_head_matc
     ];
     let old_changed_ranges = vec![LineRange { start: 11, end: 11 }];
 
-    let removed = classify_symbols(&mut head, &base, &old_changed_ranges, "src/lib.rs");
+    let all_head = head.clone();
+    let removed = classify_symbols(
+        &mut head,
+        &base,
+        &all_head,
+        &old_changed_ranges,
+        "src/lib.rs",
+    );
 
     let mut expected_head = vec![symbol(
         "helper",

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -238,16 +238,23 @@ pub fn analyze_diff(
             // rename, a mode-change-only diff, or — ADR 0014's case — a hunk
             // that only *removes* lines with nothing added back):
             // extract_changed_symbols would return no symbols for an empty
-            // changed_ranges anyway, so the head-side read is skipped entirely
-            // rather than paying IO for a result already known to be empty.
-            // `old_changed_ranges` can still be non-empty in the removal case,
-            // though, so classification against the base side still runs when
-            // a base reader is available — a whole-function deletion is
-            // exactly the case ADR 0014's `removed` classification exists for.
+            // changed_ranges anyway. `old_changed_ranges` can still be
+            // non-empty in the removal case, though, so classification
+            // against the base side still runs when a base reader is
+            // available — a whole-function deletion is exactly the case ADR
+            // 0014's `removed` classification exists for. The head-side file
+            // still needs reading in that case (`classify_against_base`
+            // reads it lazily, only when `old_changed_ranges` is non-empty)
+            // so removal can be judged against what the file *still*
+            // contains, not just the empty `head_symbols` this branch
+            // produces by construction — e.g. a whole-member deletion inside
+            // a class that otherwise survives.
             if changed_file.changed_ranges.is_empty() {
                 let mut no_head_symbols: Vec<ExtractedSymbol> = Vec::new();
                 removed.extend(classify_against_base(
                     &mut no_head_symbols,
+                    None,
+                    &read_file,
                     read_base_file,
                     lang,
                     changed_file.kind,
@@ -291,6 +298,8 @@ pub fn analyze_diff(
             // `read_base_file` is absent or its call fails for this file.
             removed.extend(classify_against_base(
                 &mut symbols,
+                Some(&source),
+                &read_file,
                 read_base_file,
                 lang,
                 changed_file.kind,
@@ -590,6 +599,22 @@ pub fn analyze_repo(
 /// reviewer looking at this diff actually has open — not the path history
 /// happens to read the comparison content from.
 ///
+/// `head_source`, when `Some`, is the caller's already-read head-side
+/// content for `report_path` (the ordinary case, which read it to run
+/// `extract_changed_symbols` anyway); `None` in the removal-only-hunk case,
+/// where the caller skipped that read since `head_symbols` is empty by
+/// construction. `classify_symbols` needs a *complete* head-side symbol set
+/// to judge removal correctly (a container whose only touched line was a
+/// member's — e.g. a class with one edited method — is never itself in
+/// `head_symbols`, since `extract_changed_symbols` suppresses a container in
+/// favor of its narrowest touched member; checking removal against
+/// `head_symbols` alone would misreport that container as gone). When
+/// `head_source` is `None` and `old_changed_ranges` is non-empty (something
+/// could actually be reported removed), this function reads `report_path`
+/// itself via `read_file` to build that complete set — still lazily, so a
+/// mode-change-only diff (`old_changed_ranges` also empty) pays no IO at
+/// all.
+///
 /// For every non-`Added` kind, a `read_base_file` call failing (`None` port,
 /// or an `Err` result — e.g. a transient git failure, or a rename/copy
 /// resolving to a base path this repository never actually had) leaves
@@ -606,6 +631,8 @@ pub fn analyze_repo(
 #[allow(clippy::too_many_arguments)]
 fn classify_against_base(
     head_symbols: &mut [ExtractedSymbol],
+    head_source: Option<&str>,
+    read_file: impl Fn(&str) -> std::io::Result<String>,
     read_base_file: Option<ReadBaseFile>,
     lang: &dyn LanguageSupport,
     kind: ChangeKind,
@@ -630,7 +657,30 @@ fn classify_against_base(
         return Vec::new();
     };
     let base_symbols = extract_all_symbols(&base_source, lang);
-    classify_symbols(head_symbols, &base_symbols, old_changed_ranges, report_path)
+
+    let owned_head_source;
+    let head_source = match head_source {
+        Some(source) => Some(source),
+        None if !old_changed_ranges.is_empty() => match read_file(report_path) {
+            Ok(source) => {
+                owned_head_source = source;
+                Some(owned_head_source.as_str())
+            }
+            Err(_) => None,
+        },
+        None => None,
+    };
+    let all_head_symbols = head_source
+        .map(|source| extract_all_symbols(source, lang))
+        .unwrap_or_default();
+
+    classify_symbols(
+        head_symbols,
+        &base_symbols,
+        &all_head_symbols,
+        old_changed_ranges,
+        report_path,
+    )
 }
 
 /// Every base-side symbol of a whole-file deletion, as [`RemovedSymbol`]s

--- a/rinkaku-core/src/pipeline_tests/classification_wiring.rs
+++ b/rinkaku-core/src/pipeline_tests/classification_wiring.rs
@@ -3,6 +3,11 @@
 //! `read_base_file: None` "not attempted" contract, base-path routing
 //! for renamed files, and the "never call `read_base_file` for an
 //! `Added` file" contract.
+//!
+//! See sibling module [`super::removed_container_regression`] for the
+//! regression where a still-alive container (Python/TypeScript `class`)
+//! was misreported as `removed` when only one of its nested members
+//! changed.
 
 use super::fake_reader;
 use crate::extract::{Classification, RemovedSymbol};

--- a/rinkaku-core/src/pipeline_tests/mod.rs
+++ b/rinkaku-core/src/pipeline_tests/mod.rs
@@ -37,6 +37,10 @@
 //! - [`parallel_determinism`] — ADR 0029 regression: `analyze_repo`'s
 //!   rayon-driven per-file loop must produce byte-identical, source-order
 //!   `Report`s across repeated calls.
+//! - [`removed_container_regression`] — a still-alive container
+//!   (Python/TypeScript `class`) misreported as `removed` when only a
+//!   nested member changed, since `extract_changed_symbols` suppresses a
+//!   container in favor of its narrowest touched member.
 
 use std::collections::HashMap;
 
@@ -48,6 +52,7 @@ mod file_size_warnings;
 mod generated_exclusion;
 mod is_generated_content;
 mod parallel_determinism;
+mod removed_container_regression;
 mod test_symbol_exclusion;
 
 /// Builds a `read_file` port backed by an in-memory map, so tests never

--- a/rinkaku-core/src/pipeline_tests/removed_container_regression.rs
+++ b/rinkaku-core/src/pipeline_tests/removed_container_regression.rs
@@ -1,0 +1,386 @@
+//! Regression: a still-alive container (Python `class` / TypeScript
+//! `class`) was misreported as `removed` when only one of its nested
+//! members changed. `extract_changed_symbols` suppresses a container in
+//! favor of its narrowest touched member (the "narrowest enclosing
+//! definition" rule, so the Change graph doesn't report both the member
+//! and its enclosing class), so `classify_symbols` must judge removal
+//! against the head file's *complete* symbol set, not against that
+//! narrowed `head_symbols` list — see [`crate::extract::classify_symbols`]'s
+//! `all_head_symbols` parameter.
+
+use super::fake_reader;
+use crate::extract::{Classification, RemovedSymbol};
+use crate::pipeline::analyze_diff;
+use pretty_assertions::assert_eq;
+use std::collections::{HashMap, HashSet};
+
+// Regression: editing only a nested member's *body* (no signature change)
+// inside an otherwise-untouched Python class must not report the class
+// itself as removed.
+#[test]
+fn should_not_report_container_as_removed_when_only_a_nested_member_body_changed_python() {
+    let diff = "\
+diff --git a/foo.py b/foo.py
+index 57b03c6..75530be 100644
+--- a/foo.py
++++ b/foo.py
+@@ -1,6 +1,6 @@
+ class Foo:
+     def __init__(self):
+-        self.x = 1
++        self.x = 2
+
+     def bar(self):
+         return self.x
+";
+    let base_source = "\
+class Foo:
+    def __init__(self):
+        self.x = 1
+
+    def bar(self):
+        return self.x
+";
+    let head_source = "\
+class Foo:
+    def __init__(self):
+        self.x = 2
+
+    def bar(self):
+        return self.x
+";
+    let read_file = fake_reader(HashMap::from([("foo.py", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.py", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}
+
+// Same regression, TypeScript: a class field/method body edit must not
+// report the enclosing `class` as removed.
+#[test]
+fn should_not_report_container_as_removed_when_only_a_nested_member_body_changed_typescript() {
+    let diff = "\
+diff --git a/foo.ts b/foo.ts
+index 1f05983..c7fbb49 100644
+--- a/foo.ts
++++ b/foo.ts
+@@ -2,6 +2,6 @@ class Foo {
+     x: number = 1;
+
+     bar(): number {
+-        return this.x;
++        return this.x + 1;
+     }
+ }
+";
+    let base_source = "\
+class Foo {
+    x: number = 1;
+
+    bar(): number {
+        return this.x;
+    }
+}
+";
+    let head_source = "\
+class Foo {
+    x: number = 1;
+
+    bar(): number {
+        return this.x + 1;
+    }
+}
+";
+    let read_file = fake_reader(HashMap::from([("foo.ts", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.ts", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}
+
+// Companion to the body-only case: a nested member's *signature* change
+// must still classify that member `SignatureChanged` while leaving the
+// still-alive container out of `removed` — the two facts are not in
+// tension, but before the fix they contradicted each other in the same
+// report (`bar` shown as changed while `class Foo` was also reported
+// gone).
+#[test]
+fn should_not_report_container_as_removed_when_a_nested_member_signature_changed() {
+    let diff = "\
+diff --git a/foo.py b/foo.py
+index 57b03c6..5084600 100644
+--- a/foo.py
++++ b/foo.py
+@@ -2,5 +2,5 @@ class Foo:
+     def __init__(self):
+         self.x = 1
+
+-    def bar(self):
+-        return self.x
++    def bar(self, y):
++        return self.x + y
+";
+    let base_source = "\
+class Foo:
+    def __init__(self):
+        self.x = 1
+
+    def bar(self):
+        return self.x
+";
+    let head_source = "\
+class Foo:
+    def __init__(self):
+        self.x = 1
+
+    def bar(self, y):
+        return self.x + y
+";
+    let read_file = fake_reader(HashMap::from([("foo.py", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.py", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    let symbol = &report.files[0].symbols[0];
+    assert_eq!("bar", symbol.name);
+    assert_eq!(
+        Some(Classification::SignatureChanged),
+        symbol.classification
+    );
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}
+
+// Regression guard: adding a brand-new method to an existing class is
+// already handled correctly today (the class was never suppressed as
+// "removed" in this case, since the new method has no base-side
+// counterpart at all) — pinned here so a future change to the removal
+// check cannot silently break this adjacent case while fixing the one
+// above.
+#[test]
+fn should_not_report_container_as_removed_when_a_new_method_is_added_to_an_existing_class() {
+    let diff = "\
+diff --git a/foo.py b/foo.py
+index 57b03c6..ea46dfd 100644
+--- a/foo.py
++++ b/foo.py
+@@ -4,3 +4,6 @@ class Foo:
+
+     def bar(self):
+         return self.x
++
++    def baz(self):
++        return self.x * 2
+";
+    let base_source = "\
+class Foo:
+    def __init__(self):
+        self.x = 1
+
+    def bar(self):
+        return self.x
+";
+    let head_source = "\
+class Foo:
+    def __init__(self):
+        self.x = 1
+
+    def bar(self):
+        return self.x
+
+    def baz(self):
+        return self.x * 2
+";
+    let read_file = fake_reader(HashMap::from([("foo.py", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.py", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    let symbol = &report.files[0].symbols[0];
+    assert_eq!("baz", symbol.name);
+    assert_eq!(Some(Classification::Added), symbol.classification);
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}
+
+// Sibling case: when the *whole* class is actually deleted (but the file
+// itself survives with other content), it and its members must still be
+// reported removed — the fix must not overcorrect into never reporting a
+// container removed at all. This diff hunk has no `+` lines at all (a
+// pure deletion), exercising `analyze_diff`'s empty-`changed_ranges`
+// branch, which now also needs to read head-side content lazily to tell
+// "class truly gone" apart from "class survived, only a member changed".
+#[test]
+fn should_report_class_and_members_as_removed_when_whole_class_deleted_from_a_still_alive_file() {
+    let diff = "\
+diff --git a/foo.py b/foo.py
+index a483def..c961442 100644
+--- a/foo.py
++++ b/foo.py
+@@ -1,10 +1,2 @@
+-class Foo:
+-    def __init__(self):
+-        self.x = 1
+-
+-    def bar(self):
+-        return self.x
+-
+-
+ def helper():
+     return 42
+";
+    let base_source = "\
+class Foo:
+    def __init__(self):
+        self.x = 1
+
+    def bar(self):
+        return self.x
+
+
+def helper():
+    return 42
+";
+    let head_source = "\
+def helper():
+    return 42
+";
+    let read_file = fake_reader(HashMap::from([("foo.py", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.py", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    let mut removed = report.removed.clone();
+    removed.sort_by(|a, b| a.name.cmp(&b.name));
+    let mut expected = vec![
+        RemovedSymbol {
+            name: "Foo".to_string(),
+            kind: crate::extract::SymbolKind::Class,
+            path: "foo.py".to_string(),
+            signature: "class Foo:\n    def __init__(self):\n\n    def bar(self):".to_string(),
+        },
+        RemovedSymbol {
+            name: "__init__".to_string(),
+            kind: crate::extract::SymbolKind::Function,
+            path: "foo.py".to_string(),
+            signature: "def __init__(self):".to_string(),
+        },
+        RemovedSymbol {
+            name: "bar".to_string(),
+            kind: crate::extract::SymbolKind::Function,
+            path: "foo.py".to_string(),
+            signature: "def bar(self):".to_string(),
+        },
+    ];
+    expected.sort_by(|a, b| a.name.cmp(&b.name));
+    // `expected` is exhaustive (fully qualified assert): if `helper` —
+    // the still-alive free function — were ever wrongly swept in, this
+    // comparison would fail on its own without a separate assertion.
+    assert_eq!(expected, removed);
+}
+
+// Guards the container-identity boundary: a free function and a class
+// method sharing the same bare name ("helper") must be told apart by
+// `(name, container)` identity, not name alone — editing only the
+// method's body must not make the unrelated free function of the same
+// name look removed, and vice versa.
+#[test]
+fn should_not_report_free_function_as_removed_when_only_a_same_named_method_changed() {
+    let diff = "\
+diff --git a/foo.py b/foo.py
+index deacb04..2bf7031 100644
+--- a/foo.py
++++ b/foo.py
+@@ -4,4 +4,4 @@ def helper():
+
+ class Foo:
+     def helper(self):
+-        return 2
++        return 3
+";
+    let base_source = "\
+def helper():
+    return 1
+
+
+class Foo:
+    def helper(self):
+        return 2
+";
+    let head_source = "\
+def helper():
+    return 1
+
+
+class Foo:
+    def helper(self):
+        return 3
+";
+    let read_file = fake_reader(HashMap::from([("foo.py", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.py", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}


### PR DESCRIPTION
## Summary

Editing only a nested member of an otherwise-untouched Python/TypeScript
class (method body, dunder, or method signature) caused the enclosing
class to be incorrectly reported in `## Removed symbols`, even though
the class is still alive — and even while the member itself was
correctly shown as changed in the same report. Minimal repro:

```python
# base
class Foo:
    def __init__(self):
        self.x = 1
    def bar(self):
        return self.x
# head: only __init__'s body changes
```

`rinkaku --base` on this diff reported `class Foo — removed` alongside
the (correct) `fn __init__` entry — a self-contradictory output.

## Root cause

`extract_changed_symbols` suppresses a container (impl/class) as a
symbol in its own right when one of its nested members is itself
touched — the "narrowest enclosing definition" rule, so the Change
graph reports the member, not both the member and its enclosing class.

`classify_symbols`'s removal check compared the base side against
that same narrowed `head_symbols` list. A still-alive class whose own
line range was never *directly* touched (only a member's range was)
never appears in `head_symbols`, so it looked "gone" by the exact same
test a genuinely deleted symbol would fail.

Rust and Go are structurally immune: an `impl` block is never itself a
reported symbol, and a Go method never nests inside its receiver
type's node, so neither language's containers are ever suppressed
this way in the first place.

## Fix

`classify_symbols` now takes the head file's *complete* symbol set
(typically `extract_all_symbols`'s output) as a separate parameter
from `head_symbols`, and judges removal against that instead of the
diff-narrowed list. `pipeline::analyze_diff` threads this through both
call sites, including the empty-`changed_ranges` branch (a
whole-symbol-deletion hunk), which previously skipped reading
head-side content entirely — it now does so lazily, only when
something could actually be reported removed.

ADR 0014 amended with a short note recording the root cause and fix.

## Test plan

- [x] `make test` (1104 tests, 6 new regression tests, all green)
- [x] `make lint`
- [x] e2e before/after with real `git` fixtures across Python,
      TypeScript, Go: body-only member edit, signature-changed member
      edit, new-method-added (regression guard, unaffected), whole-class
      deletion from a still-alive file (still correctly reported
      removed), same-name free-function/method disambiguation, and Go
      (structurally unaffected, confirmed no diff before/after)