### PR TITLE
test: pin symbol-disappearance regression matrix in pipeline_tests

### DIFF
--- a/rinkaku-core/src/pipeline_tests/go_receiver_regression.rs
+++ b/rinkaku-core/src/pipeline_tests/go_receiver_regression.rs
@@ -1,0 +1,78 @@
+//! Regression: a Go receiver method changing alone — its struct entirely
+//! untouched by the diff, unlike
+//! `removed_container_regression`'s Python/TypeScript cases where the
+//! container line range is present in the diff's hunk context — must
+//! still be reported under its struct container, and the struct itself
+//! must not be misreported as `removed` (ADR 0012 decision 2 for
+//! container naming; PR #237's `all_head_symbols` fix for the removal
+//! check).
+
+use super::fake_reader;
+use crate::extract::{Classification, RemovedSymbol};
+use crate::pipeline::analyze_diff;
+use pretty_assertions::assert_eq;
+use std::collections::{HashMap, HashSet};
+
+#[test]
+fn should_report_receiver_method_under_its_container_without_a_false_removed_struct() {
+    let diff = "\
+diff --git a/repo.go b/repo.go
+index 57b03c6..1e5c9a1 100644
+--- a/repo.go
++++ b/repo.go
+@@ -8,5 +8,5 @@ type Repo struct {
+ }
+
+ func (r *Repo) Save(id string) error {
+-\treturn errors.New(\"not implemented\")
++\treturn nil
+ }
+";
+    let base_source = "\
+package main
+
+import \"errors\"
+
+type Repo struct {
+\tName string
+}
+
+func (r *Repo) Save(id string) error {
+\treturn errors.New(\"not implemented\")
+}
+";
+    let head_source = "\
+package main
+
+import \"errors\"
+
+type Repo struct {
+\tName string
+}
+
+func (r *Repo) Save(id string) error {
+\treturn nil
+}
+";
+    let read_file = fake_reader(HashMap::from([("repo.go", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("repo.go", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(1, report.files[0].symbols.len());
+    let symbol = &report.files[0].symbols[0];
+    assert_eq!("Save", symbol.name);
+    assert_eq!(Some("Repo".to_string()), symbol.container);
+    assert_eq!(Some(Classification::BodyOnly), symbol.classification);
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}

--- a/rinkaku-core/src/pipeline_tests/hcl_regression.rs
+++ b/rinkaku-core/src/pipeline_tests/hcl_regression.rs
@@ -1,0 +1,177 @@
+//! HCL/Terraform end-to-end regression matrix via [`analyze_diff`]: a
+//! deleted `resource` block is reported `removed`; a label rename shows
+//! up as an `Added`/`removed` pair rather than a signature change (HCL
+//! block identity is `(block_type, ...labels)`-based, per
+//! [`crate::language::hcl`]); and editing one `locals` attribute leaves
+//! its untouched sibling attributes out of both the changed-symbol list
+//! and `removed`, mirroring `locals`' per-attribute expansion pinned at
+//! the extract level in `extract_tests::hcl`.
+
+use super::fake_reader;
+use crate::extract::{Classification, RemovedSymbol, SymbolKind};
+use crate::pipeline::analyze_diff;
+use pretty_assertions::assert_eq;
+use std::collections::{HashMap, HashSet};
+
+#[test]
+fn should_report_resource_as_removed_when_block_deleted_from_a_still_alive_file() {
+    let diff = "\
+diff --git a/main.tf b/main.tf
+index 57b03c6..1e5c9a1 100644
+--- a/main.tf
++++ b/main.tf
+@@ -1,7 +1,3 @@
+-resource \"aws_instance\" \"web\" {
+-  ami           = \"ami-123\"
+-  instance_type = \"t3.micro\"
+-}
+-
+ resource \"aws_instance\" \"other\" {
+   ami = \"ami-456\"
+ }
+";
+    let base_source = "\
+resource \"aws_instance\" \"web\" {
+  ami           = \"ami-123\"
+  instance_type = \"t3.micro\"
+}
+
+resource \"aws_instance\" \"other\" {
+  ami = \"ami-456\"
+}
+";
+    let head_source = "\
+resource \"aws_instance\" \"other\" {
+  ami = \"ami-456\"
+}
+";
+    let read_file = fake_reader(HashMap::from([("main.tf", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("main.tf", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    let expected = vec![RemovedSymbol {
+        name: "aws_instance.web".to_string(),
+        kind: SymbolKind::Block,
+        path: "main.tf".to_string(),
+        signature: "resource \"aws_instance\" \"web\"".to_string(),
+    }];
+    assert_eq!(expected, report.removed);
+}
+
+// A label rename changes the block's identity (`(block_type, labels)`,
+// per crate::language::hcl), so it is not a signature change on the same
+// symbol — the old label must show up removed and the new label added,
+// not merged into one SignatureChanged entry.
+#[test]
+fn should_report_added_and_removed_pair_when_resource_label_renamed() {
+    let diff = "\
+diff --git a/main.tf b/main.tf
+index 57b03c6..1e5c9a1 100644
+--- a/main.tf
++++ b/main.tf
+@@ -1,3 +1,3 @@
+-resource \"aws_instance\" \"web\" {
++resource \"aws_instance\" \"frontend\" {
+   ami = \"ami-123\"
+ }
+";
+    let base_source = "\
+resource \"aws_instance\" \"web\" {
+  ami = \"ami-123\"
+}
+";
+    let head_source = "\
+resource \"aws_instance\" \"frontend\" {
+  ami = \"ami-123\"
+}
+";
+    let read_file = fake_reader(HashMap::from([("main.tf", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("main.tf", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(1, report.files[0].symbols.len());
+    let symbol = &report.files[0].symbols[0];
+    assert_eq!("aws_instance.frontend", symbol.name);
+    assert_eq!(Some(Classification::Added), symbol.classification);
+
+    let expected_removed = vec![RemovedSymbol {
+        name: "aws_instance.web".to_string(),
+        kind: SymbolKind::Block,
+        path: "main.tf".to_string(),
+        signature: "resource \"aws_instance\" \"web\"".to_string(),
+    }];
+    assert_eq!(expected_removed, report.removed);
+}
+
+#[test]
+fn should_report_only_the_changed_locals_attribute_when_a_sibling_attribute_is_untouched() {
+    let diff = "\
+diff --git a/main.tf b/main.tf
+index 57b03c6..1e5c9a1 100644
+--- a/main.tf
++++ b/main.tf
+@@ -1,4 +1,4 @@
+ locals {
+-  name_prefix = \"demo\"
++  name_prefix = \"prod\"
+   port        = 8080
+ }
+";
+    let base_source = "\
+locals {
+  name_prefix = \"demo\"
+  port        = 8080
+}
+";
+    let head_source = "\
+locals {
+  name_prefix = \"prod\"
+  port        = 8080
+}
+";
+    let read_file = fake_reader(HashMap::from([("main.tf", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("main.tf", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(1, report.files[0].symbols.len());
+    let symbol = &report.files[0].symbols[0];
+    assert_eq!("local.name_prefix", symbol.name);
+    assert_eq!(
+        Some(Classification::SignatureChanged),
+        symbol.classification
+    );
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}

--- a/rinkaku-core/src/pipeline_tests/import_only_changes.rs
+++ b/rinkaku-core/src/pipeline_tests/import_only_changes.rs
@@ -1,0 +1,370 @@
+//! Regression: a diff touching only import/`use` lines must produce no
+//! changed symbols and no false `removed` entries, across every
+//! import-bearing built-in language. Import statements sit outside every
+//! language's `definition_query`, so `extract_changed_symbols` already
+//! returns empty for them (see each language's
+//! `should_return_empty_vec_when_changed_line_is_outside_any_definition`
+//! extract-level test) — this module pins the same guarantee end-to-end
+//! through [`analyze_diff`], including the base-comparison path
+//! (`read_base_file: Some`), where an import-line rewrite still produces
+//! non-empty `old_changed_ranges` but must not make `classify_symbols`
+//! misreport anything as removed, since no definition's range overlaps an
+//! import line.
+
+use super::fake_reader;
+use crate::extract::RemovedSymbol;
+use crate::pipeline::analyze_diff;
+use pretty_assertions::assert_eq;
+use std::collections::{HashMap, HashSet};
+
+#[test]
+fn should_report_no_symbols_when_python_diff_only_adds_an_import() {
+    let diff = "\
+diff --git a/foo.py b/foo.py
+index 57b03c6..1e5c9a1 100644
+--- a/foo.py
++++ b/foo.py
+@@ -1,2 +1,3 @@
++import os
+ def helper():
+     return 1
+";
+    let base_source = "\
+def helper():
+    return 1
+";
+    let head_source = "\
+import os
+def helper():
+    return 1
+";
+    let read_file = fake_reader(HashMap::from([("foo.py", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.py", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(
+        Vec::<crate::extract::ExtractedSymbol>::new(),
+        report.files[0].symbols
+    );
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}
+
+#[test]
+fn should_report_no_symbols_when_python_diff_rewrites_an_import_line() {
+    let diff = "\
+diff --git a/foo.py b/foo.py
+index 57b03c6..1e5c9a1 100644
+--- a/foo.py
++++ b/foo.py
+@@ -1,3 +1,3 @@
+-import os
++import sys
+ def helper():
+     return 1
+";
+    let base_source = "\
+import os
+def helper():
+    return 1
+";
+    let head_source = "\
+import sys
+def helper():
+    return 1
+";
+    let read_file = fake_reader(HashMap::from([("foo.py", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.py", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(
+        Vec::<crate::extract::ExtractedSymbol>::new(),
+        report.files[0].symbols
+    );
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}
+
+#[test]
+fn should_report_no_symbols_when_rust_diff_only_changes_a_use_line() {
+    let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index 57b03c6..1e5c9a1 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,4 +1,4 @@
+-use std::collections::HashMap;
++use std::collections::HashSet;
+ fn helper() -> i32 {
+     1
+ }
+";
+    let base_source = "\
+use std::collections::HashMap;
+fn helper() -> i32 {
+    1
+}
+";
+    let head_source = "\
+use std::collections::HashSet;
+fn helper() -> i32 {
+    1
+}
+";
+    let read_file = fake_reader(HashMap::from([("src/lib.rs", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("src/lib.rs", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(
+        Vec::<crate::extract::ExtractedSymbol>::new(),
+        report.files[0].symbols
+    );
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}
+
+#[test]
+fn should_report_no_symbols_when_go_diff_removes_an_import() {
+    let diff = "\
+diff --git a/foo.go b/foo.go
+index 57b03c6..1e5c9a1 100644
+--- a/foo.go
++++ b/foo.go
+@@ -1,7 +1,6 @@
+ package main
+
+ import (
+-\t\"fmt\"
+ \t\"os\"
+ )
+
+";
+    let base_source = "\
+package main
+
+import (
+\t\"fmt\"
+\t\"os\"
+)
+
+func helper() int {
+\treturn 1
+}
+";
+    let head_source = "\
+package main
+
+import (
+\t\"os\"
+)
+
+func helper() int {
+\treturn 1
+}
+";
+    let read_file = fake_reader(HashMap::from([("foo.go", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.go", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(
+        Vec::<crate::extract::ExtractedSymbol>::new(),
+        report.files[0].symbols
+    );
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}
+
+#[test]
+fn should_report_no_symbols_when_typescript_diff_renames_an_import_alias() {
+    let diff = "\
+diff --git a/foo.ts b/foo.ts
+index 57b03c6..1e5c9a1 100644
+--- a/foo.ts
++++ b/foo.ts
+@@ -1,4 +1,4 @@
+-import { helper as h } from \"./helper\";
++import { helper as helperFn } from \"./helper\";
+ function useHelper(): number {
+     return 1;
+ }
+";
+    let base_source = "\
+import { helper as h } from \"./helper\";
+function useHelper(): number {
+    return 1;
+}
+";
+    let head_source = "\
+import { helper as helperFn } from \"./helper\";
+function useHelper(): number {
+    return 1;
+}
+";
+    let read_file = fake_reader(HashMap::from([("foo.ts", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.ts", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(
+        Vec::<crate::extract::ExtractedSymbol>::new(),
+        report.files[0].symbols
+    );
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}
+
+// Compound case (item 2 of the disappearance-regression matrix): an
+// import rewrite in the same diff as a real usage-site change must still
+// surface the function whose body actually changed, not get swallowed by
+// the no-op import edit sitting in the same hunk range.
+#[test]
+fn should_report_the_changed_function_when_python_diff_combines_an_import_rewrite_with_a_usage_change()
+ {
+    let diff = "\
+diff --git a/foo.py b/foo.py
+index 57b03c6..1e5c9a1 100644
+--- a/foo.py
++++ b/foo.py
+@@ -1,3 +1,3 @@
+-import json
++import orjson as json
+ def load(raw):
+-    return json.loads(raw)
++    return json.loads(raw, strict=False)
+";
+    let base_source = "\
+import json
+def load(raw):
+    return json.loads(raw)
+";
+    let head_source = "\
+import orjson as json
+def load(raw):
+    return json.loads(raw, strict=False)
+";
+    let read_file = fake_reader(HashMap::from([("foo.py", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.py", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(1, report.files[0].symbols.len());
+    let symbol = &report.files[0].symbols[0];
+    assert_eq!("load", symbol.name);
+    assert_eq!(
+        Some(crate::extract::Classification::BodyOnly),
+        symbol.classification
+    );
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}
+
+#[test]
+fn should_report_the_changed_function_when_typescript_diff_combines_an_import_rewrite_with_a_usage_change()
+ {
+    let diff = "\
+diff --git a/foo.ts b/foo.ts
+index 57b03c6..1e5c9a1 100644
+--- a/foo.ts
++++ b/foo.ts
+@@ -1,4 +1,4 @@
+-import { parse } from \"./parser\";
++import { parse as parseInput } from \"./parser\";
+ function load(raw: string): unknown {
+-    return parse(raw);
++    return parseInput(raw, { strict: false });
+ }
+";
+    let base_source = "\
+import { parse } from \"./parser\";
+function load(raw: string): unknown {
+    return parse(raw);
+}
+";
+    let head_source = "\
+import { parse as parseInput } from \"./parser\";
+function load(raw: string): unknown {
+    return parseInput(raw, { strict: false });
+}
+";
+    let read_file = fake_reader(HashMap::from([("foo.ts", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("foo.ts", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(1, report.files[0].symbols.len());
+    let symbol = &report.files[0].symbols[0];
+    assert_eq!("load", symbol.name);
+    assert_eq!(
+        Some(crate::extract::Classification::BodyOnly),
+        symbol.classification
+    );
+    assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}

--- a/rinkaku-core/src/pipeline_tests/mod.rs
+++ b/rinkaku-core/src/pipeline_tests/mod.rs
@@ -41,6 +41,22 @@
 //!   (Python/TypeScript `class`) misreported as `removed` when only a
 //!   nested member changed, since `extract_changed_symbols` suppresses a
 //!   container in favor of its narrowest touched member.
+//! - [`import_only_changes`] — import/`use`-only diffs (Python, Rust, Go,
+//!   TypeScript) produce no changed symbols and no false `removed`
+//!   entries, including the base-comparison path where an import-line
+//!   rewrite still yields non-empty `old_changed_ranges`; and the
+//!   compound case where an import rewrite shares a diff with a real
+//!   usage-site change.
+//! - [`hcl_regression`] — HCL/Terraform `resource` block deletion and
+//!   label rename via `analyze_diff`, and `locals` sibling-attribute
+//!   isolation end-to-end.
+//! - [`go_receiver_regression`] — a Go receiver method changing alone,
+//!   with its struct untouched by the diff, is reported under its
+//!   container without a false `removed` entry for the struct.
+//! - [`rust_stoplist_regression`] — ADR 0064/#236 pinned end-to-end: a
+//!   stoplisted receiver call creates no graph edge while the same-named
+//!   trait method spec still links to its implementation via
+//!   `referenced_method_names`.
 
 use std::collections::HashMap;
 
@@ -50,9 +66,13 @@ mod classification_wiring;
 mod collect_referenced_names;
 mod file_size_warnings;
 mod generated_exclusion;
+mod go_receiver_regression;
+mod hcl_regression;
+mod import_only_changes;
 mod is_generated_content;
 mod parallel_determinism;
 mod removed_container_regression;
+mod rust_stoplist_regression;
 mod test_symbol_exclusion;
 
 /// Builds a `read_file` port backed by an in-memory map, so tests never

--- a/rinkaku-core/src/pipeline_tests/rust_stoplist_regression.rs
+++ b/rinkaku-core/src/pipeline_tests/rust_stoplist_regression.rs
@@ -1,0 +1,120 @@
+//! End-to-end pin for ADR 0064 (amended by #236, issue #230): a
+//! stoplisted receiver call (`state.get()`) must create no graph edge,
+//! while the same-named trait method spec (`fn get(&self) -> i32;`)
+//! still feeds `referenced_method_names` and links to its implementation
+//! — through the full [`analyze_diff`] pipeline, not just
+//! `extract_changed_symbols` (already pinned at the extract level by
+//! `extract_tests::rust_references::should_keep_stoplisted_trait_method_name_but_still_drop_it_from_a_receiver_call`).
+
+use super::fake_reader;
+use crate::pipeline::analyze_diff;
+use std::collections::{HashMap, HashSet};
+
+#[test]
+fn should_link_trait_methodspec_to_impl_but_not_a_stoplisted_receiver_call_on_the_same_name() {
+    let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index 57b03c6..1e5c9a1 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,15 +1,15 @@
+-trait Cache {
++pub trait Cache {
+     fn get(&self) -> i32;
+ }
+
+ struct Store;
+
+ impl Cache for Store {
+-    fn get(&self) -> i32 {
+-        0
++    fn get(&self) -> i32 {
++        1
+     }
+ }
+
+ fn build(state: Store) -> i32 {
+-    state.get()
++    state.get() as i32
+ }
+";
+    let source = "\
+pub trait Cache {
+    fn get(&self) -> i32;
+}
+
+struct Store;
+
+impl Cache for Store {
+    fn get(&self) -> i32 {
+        1
+    }
+}
+
+fn build(state: Store) -> i32 {
+    state.get() as i32
+}
+";
+    let read_file = fake_reader(HashMap::from([("src/lib.rs", source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    // The trait's own declaration line changed, so the whole trait —
+    // not just its inner `get` method spec — is the extracted symbol
+    // (the "narrowest enclosing definition" rule, same as
+    // extract_tests::rust::should_extract_trait_signature_when_no_method_line_specifically_changed).
+    let trait_node = report
+        .graph
+        .nodes
+        .iter()
+        .find(|n| n.name == "Cache")
+        .expect("Cache trait node should exist");
+    let impl_get_node = report
+        .graph
+        .nodes
+        .iter()
+        .find(|n| n.name == "get" && n.container.as_deref() == Some("impl Store"))
+        .expect("impl Store's get node should exist");
+    let build_node = report
+        .graph
+        .nodes
+        .iter()
+        .find(|n| n.name == "build")
+        .expect("build node should exist");
+
+    let has_edge = |from: &str, to: &str| {
+        report
+            .graph
+            .edges
+            .iter()
+            .any(|e| e.from == from && e.to == to)
+    };
+
+    // The trait method spec's `get` still links to the impl's `get` —
+    // ContainerRule::Any for referenced_method_names is unaffected by the
+    // stoplist, which only scopes to receiver-call captures.
+    assert!(
+        has_edge(&trait_node.id, &impl_get_node.id),
+        "expected an edge from the trait method spec to its impl"
+    );
+    // The stoplisted receiver call `state.get()` must not create an edge
+    // from `build` to either `get` node.
+    assert!(
+        !has_edge(&build_node.id, &impl_get_node.id),
+        "expected no edge from a stoplisted receiver call to the impl method"
+    );
+    assert!(
+        !has_edge(&build_node.id, &trait_node.id),
+        "expected no edge from a stoplisted receiver call to the trait"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to the 2026-08-07 symbol-disappearance investigation, which
reproduced a matrix of scenarios across all built-in languages and fixed
three bugs (#228, #235, #237). This PR adds permanent `analyze_diff`
end-to-end regression tests for the matrix rows that were already
passing but had no dedicated coverage — so a future regression on any of
them fails loudly instead of silently.

Test-only change; no production code touched.

## Coverage added (all pass against current `main`)

| # | Scenario | Languages | File |
|---|---|---|---|
| 1 | import/`use`-only diff → empty symbols, empty `removed` (including the base-comparison path, where an import-line rewrite still yields non-empty `old_changed_ranges`) | Python, Rust, Go, TypeScript | `import_only_changes.rs` |
| 2 | import rewrite + real usage-site change in the same diff → the used function still shows up correctly classified | Python, TypeScript | `import_only_changes.rs` |
| 3 | HCL `resource` block deletion → `removed`; label rename → `Added`/`removed` pair (not a signature change, since HCL block identity includes labels) | HCL | `hcl_regression.rs` |
| 4 | HCL `locals` single-attribute edit → untouched sibling attribute stays out of both the changed-symbol list and `removed` | HCL | `hcl_regression.rs` |
| 5 | Go receiver method change alone, with its struct entirely untouched by the diff (not just present-but-unchanged in the diff's hunk context) → correct container, no false `removed` struct entry (PR #237's `all_head_symbols` fix) | Go | `go_receiver_regression.rs` |
| 6 | ADR 0064/#236 (issue #230) end-to-end: a stoplisted receiver call (`state.get()`) creates no graph edge, while the same-named trait method spec still links to its implementation via `referenced_method_names` | Rust | `rust_stoplist_regression.rs` |

Items 5 and 6 already had extract-level unit coverage
(`extract_tests::go`, `extract_tests::rust_references`); these add the
missing pipeline-level (`analyze_diff` end-to-end) pin.

No test in this matrix failed against current `main` — nothing here
uncovered a new bug.

## Test plan

- [x] `make test` — 1104 workspace tests pass (527 in `rinkaku-core`,
      12 new vs. the 515 on `main`)
- [x] `make lint` — clean
- [x] Confirmed no production code changed (`git diff --stat` against
      `main` touches only `rinkaku-core/src/pipeline_tests/`)