### PR TITLE
feat: collapse repeated Depends on lists in Markdown Definitions

### DIFF
--- a/docs/adr/0069-collapse-repeated-depends-on-lists.md
+++ b/docs/adr/0069-collapse-repeated-depends-on-lists.md
@@ -1,0 +1,99 @@
+# 0069. Collapse repeated "Depends on" lists in Markdown Definitions
+
+- Status: accepted
+- Date: 2026-08-08
+
+## Context
+
+Dogfooding PR #237's diff (`rinkaku --base 3c5ecf7 --head d8b810f`)
+showed the `## Definitions` section repeating the same `Depends on:`
+list verbatim across sibling symbols: 7 of the 11 test functions in
+`rinkaku-core/src/extract_tests/classification.rs` share an identical
+set of helper/type dependencies (`Classification`, `LineRange`,
+`RemovedSymbol`, three same-named `symbol` helpers, and the
+`(+26 more definitions matched by name)` note), so the same ~7-line
+block is printed 7 times in a row.
+
+The "Change graph" tree already solves the analogous problem for
+shared subtrees: `render_tree_node` prints a node in full only once
+and every later occurrence as a one-line `(see above)` reference (ADR
+0008, condensed further by ADR 0012). `render_definition`'s `Depends
+on:` list has no equivalent — each symbol's dependency list is
+rendered independently of what came before it in the same document.
+
+## Decision
+
+In `render_markdown`, before rendering `## Definitions`, track, per
+file, the most recently rendered non-empty `dependencies` list (using
+`ExtractedSymbol::dependencies`' derived `PartialEq`, list order and
+all). When a symbol's `dependencies` list exactly equals the tracked
+list for its own file, `render_definition` emits one reference line
+instead of repeating the list, pointing at the *nearest* earlier match
+(not necessarily the first occurrence in the file) so the reference is
+always as close by as possible:
+
+```
+Depends on: same as `fn should_classify_as_added_when_no_base_side_match_exists` above
+```
+
+Design choices, narrower than the tree's collapse:
+
+- **Exact match only.** No near-identical merging (e.g. subset/superset
+  folding) — that would drop information a reader might need, unlike
+  the tree's `(see above)`, which never loses a name (the full list is
+  still under `## Definitions` for the first occurrence). A collapsed
+  `Depends on:` line still points at a real prior entry that has the
+  complete list.
+- **`omitted_dependency_matches` participates in the comparison
+  implicitly** by being rendered as part of the same list check: two
+  symbols with identical `dependencies` but a different omitted-count
+  are treated as different lists (the omitted-count line is part of
+  what "the same Depends on block" means here), so the collapse never
+  hides a differing "+N more" note.
+- **Scoped to the same file, not the whole report.** Two unrelated
+  files can coincidentally define a same-shaped dependency (or, more
+  commonly, both have an empty list), and a cross-file "same as X
+  above" reference would send a reader jumping between files to
+  confirm a coincidence instead of an intentional shared block. Diffs
+  also commonly cluster same-file test siblings next to each other
+  (as in the PR #237 example), so same-file scoping already catches
+  the common case without a cross-file reference's extra cognitive
+  cost.
+- **JSON output is unaffected.** JSON serializes `Report`/
+  `ExtractedSymbol` directly; a machine consumer parsing
+  `dependencies` has no volume problem and no compaction is warranted.
+  `digest` output already omits dependencies entirely and stays
+  untouched.
+- **Empty lists are never collapsed.** `render_definition` already
+  skips the whole `Depends on:` block when a symbol has no
+  dependencies and no omitted matches, so there is nothing to
+  reference.
+
+## Alternatives
+
+- **Cross-file scoping**: catches more repeats (e.g. two files with
+  the same single dependency) but trades a within-file glance for a
+  jump to another file's heading; rejected per PR #237's dogfooding
+  example, where every repeat was already same-file.
+- **Near-identical merging (e.g. collapse when lists share N of M
+  entries)**: strictly more information loss for a fuzzier win; the
+  observed case is exact-match repetition, so exact match already
+  captures the value without the risk.
+- **Deduplicate by content hash across the whole document into a
+  shared "Common dependencies" appendix**: bigger restructuring of the
+  `## Definitions` section for a gain the observed case does not need;
+  the per-symbol reference line keeps the existing one-entry-per-
+  symbol shape intact.
+
+## Consequences
+
+- `## Definitions` shrinks materially on diffs with repeated sibling
+  dependency shapes (the PR #237 example: 7 duplicate ~7-line blocks
+  become 7 one-line references) with no information loss — the full
+  list remains readable at the first occurrence.
+- Another Markdown-only formatting change (JSON untouched), consistent
+  with the ADR 0010/0012 precedent of keeping JSON as the raw,
+  uncondensed shape.
+- The collapse reference names the earlier symbol by its label (same
+  format as tree/heading labels), so a reader can locate it either by
+  scrolling up or by search.

--- a/rinkaku-core/src/render/markdown.rs
+++ b/rinkaku-core/src/render/markdown.rs
@@ -137,17 +137,39 @@ pub(super) fn render_markdown(report: &Report) -> Result<String, RenderError> {
 
         writeln!(out, "## Definitions")?;
         writeln!(out)?;
+        let mut last_depends_on_by_file: HashMap<
+            &str,
+            (&[crate::deps::ResolvedSymbol], usize, String),
+        > = HashMap::new();
         for id in &visit_order {
             let Some((path, symbol)) = lookup.get(id) else {
                 continue;
             };
+            let same_as_above = last_depends_on_by_file
+                .get(path)
+                .filter(|(dependencies, omitted, _)| {
+                    *dependencies == symbol.dependencies.as_slice()
+                        && *omitted == symbol.omitted_dependency_matches
+                })
+                .map(|(_, _, label)| label.as_str());
             render_definition(
                 &mut out,
                 path,
                 symbol,
                 test_coverage_by_id.get(id.as_str()).copied(),
                 &lookup,
+                same_as_above,
             )?;
+            if !symbol.dependencies.is_empty() || symbol.omitted_dependency_matches > 0 {
+                last_depends_on_by_file.insert(
+                    path,
+                    (
+                        symbol.dependencies.as_slice(),
+                        symbol.omitted_dependency_matches,
+                        labeled_with_marker(path, symbol),
+                    ),
+                );
+            }
         }
     }
 
@@ -449,12 +471,20 @@ fn render_tree_node(
 /// produced an entry for (a test symbol rendered as its own Definitions
 /// entry — coverage is not a meaningful question to ask of a test), in
 /// which case no "Tests:" line is emitted at all.
+///
+/// `same_as_above`, when `Some(label)`, means the caller (`render_markdown`)
+/// already found an earlier same-file symbol whose `dependencies` and
+/// `omitted_dependency_matches` are identical to this symbol's — the
+/// "Depends on:" list is then replaced with a one-line
+/// `Depends on: same as \`label\` above` reference to that symbol instead of
+/// repeating the list (ADR 0069).
 fn render_definition(
     out: &mut String,
     path: &str,
     symbol: &ExtractedSymbol,
     test_coverage: Option<&TestCoverage>,
     lookup: &SymbolLookup,
+    same_as_above: Option<&str>,
 ) -> Result<(), RenderError> {
     writeln!(out, "### {}", labeled_with_marker(path, symbol))?;
     writeln!(out)?;
@@ -497,6 +527,11 @@ fn render_definition(
     }
 
     if !symbol.dependencies.is_empty() || symbol.omitted_dependency_matches > 0 {
+        if let Some(label) = same_as_above {
+            writeln!(out, "Depends on: same as `{label}` above")?;
+            writeln!(out)?;
+            return Ok(());
+        }
         writeln!(out, "Depends on:")?;
         for dependency in &symbol.dependencies {
             // Inline code spans (not a fenced block): a dependency list

--- a/rinkaku-core/src/render/markdown_tests/depends_on_collapse.rs
+++ b/rinkaku-core/src/render/markdown_tests/depends_on_collapse.rs
@@ -1,0 +1,380 @@
+//! ADR 0069: collapsing a `Depends on:` list into a `same as ... above`
+//! reference when it exactly repeats an earlier symbol's list in the same
+//! file.
+
+use super::*;
+use crate::extract::{ExtractedSymbol, SymbolKind};
+use crate::render::report::{FileReport, ReportOrigin};
+use crate::render::{OutputFormat, render};
+use pretty_assertions::assert_eq;
+
+#[test]
+fn should_collapse_depends_on_when_identical_to_an_earlier_sibling() {
+    let dependency = crate::deps::ResolvedSymbol {
+        signature: "struct Point { x: i32 }".to_string(),
+        path: "src/point.rs".to_string(),
+        container: None,
+    };
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    dependencies: vec![dependency.clone()],
+                    ..symbol(
+                        "src/lib.rs::foo",
+                        "foo",
+                        SymbolKind::Function,
+                        "fn foo(p: Point) -> i32",
+                    )
+                },
+                ExtractedSymbol {
+                    dependencies: vec![dependency.clone()],
+                    ..symbol(
+                        "src/lib.rs::bar",
+                        "bar",
+                        SymbolKind::Function,
+                        "fn bar(p: Point) -> i32",
+                    )
+                },
+                ExtractedSymbol {
+                    dependencies: vec![dependency],
+                    ..symbol(
+                        "src/lib.rs::baz",
+                        "baz",
+                        SymbolKind::Function,
+                        "fn baz(p: Point) -> i32",
+                    )
+                },
+            ],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![
+                node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                node("src/lib.rs::bar", "src/lib.rs", "bar"),
+                node("src/lib.rs::baz", "src/lib.rs", "baz"),
+            ],
+            edges: vec![],
+            roots: vec![
+                "src/lib.rs::foo".to_string(),
+                "src/lib.rs::bar".to_string(),
+                "src/lib.rs::baz".to_string(),
+            ],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        test_coverage: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+
+    let expected = "\
+## Change graph
+
+3 changed symbols in 1 file
+
+- fn foo (src/lib.rs)
+- fn bar (src/lib.rs)
+- fn baz (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo(p: Point) -> i32
+```
+
+Depends on:
+- `src/point.rs`: `struct Point { x: i32 }`
+
+### fn bar (src/lib.rs)
+
+```
+fn bar(p: Point) -> i32
+```
+
+Depends on: same as `fn foo (src/lib.rs)` above
+
+### fn baz (src/lib.rs)
+
+```
+fn baz(p: Point) -> i32
+```
+
+Depends on: same as `fn bar (src/lib.rs)` above
+
+"
+    .to_string();
+    let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_not_collapse_depends_on_when_lists_differ() {
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    dependencies: vec![crate::deps::ResolvedSymbol {
+                        signature: "struct Point { x: i32 }".to_string(),
+                        path: "src/point.rs".to_string(),
+                        container: None,
+                    }],
+                    ..symbol(
+                        "src/lib.rs::foo",
+                        "foo",
+                        SymbolKind::Function,
+                        "fn foo(p: Point) -> i32",
+                    )
+                },
+                ExtractedSymbol {
+                    dependencies: vec![crate::deps::ResolvedSymbol {
+                        signature: "struct Line { a: Point, b: Point }".to_string(),
+                        path: "src/line.rs".to_string(),
+                        container: None,
+                    }],
+                    ..symbol(
+                        "src/lib.rs::bar",
+                        "bar",
+                        SymbolKind::Function,
+                        "fn bar(l: Line) -> i32",
+                    )
+                },
+            ],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![
+                node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                node("src/lib.rs::bar", "src/lib.rs", "bar"),
+            ],
+            edges: vec![],
+            roots: vec!["src/lib.rs::foo".to_string(), "src/lib.rs::bar".to_string()],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        test_coverage: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+
+    let expected = "\
+## Change graph
+
+2 changed symbols in 1 file
+
+- fn foo (src/lib.rs)
+- fn bar (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo(p: Point) -> i32
+```
+
+Depends on:
+- `src/point.rs`: `struct Point { x: i32 }`
+
+### fn bar (src/lib.rs)
+
+```
+fn bar(l: Line) -> i32
+```
+
+Depends on:
+- `src/line.rs`: `struct Line { a: Point, b: Point }`
+
+"
+    .to_string();
+    let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_not_collapse_across_files() {
+    let dependency = crate::deps::ResolvedSymbol {
+        signature: "struct Point { x: i32 }".to_string(),
+        path: "src/point.rs".to_string(),
+        container: None,
+    };
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![
+            FileReport {
+                path: "src/a.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    dependencies: vec![dependency.clone()],
+                    ..symbol(
+                        "src/a.rs::foo",
+                        "foo",
+                        SymbolKind::Function,
+                        "fn foo(p: Point) -> i32",
+                    )
+                }],
+            },
+            FileReport {
+                path: "src/b.rs".to_string(),
+                symbols: vec![ExtractedSymbol {
+                    dependencies: vec![dependency],
+                    ..symbol(
+                        "src/b.rs::bar",
+                        "bar",
+                        SymbolKind::Function,
+                        "fn bar(p: Point) -> i32",
+                    )
+                }],
+            },
+        ],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![
+                node("src/a.rs::foo", "src/a.rs", "foo"),
+                node("src/b.rs::bar", "src/b.rs", "bar"),
+            ],
+            edges: vec![],
+            roots: vec!["src/a.rs::foo".to_string(), "src/b.rs::bar".to_string()],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        test_coverage: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+
+    let expected = "\
+## Change graph
+
+2 changed symbols in 2 files — most in src/a.rs (1)
+
+- fn foo (src/a.rs)
+- fn bar (src/b.rs)
+
+## Definitions
+
+### fn foo (src/a.rs)
+
+```
+fn foo(p: Point) -> i32
+```
+
+Depends on:
+- `src/point.rs`: `struct Point { x: i32 }`
+
+### fn bar (src/b.rs)
+
+```
+fn bar(p: Point) -> i32
+```
+
+Depends on:
+- `src/point.rs`: `struct Point { x: i32 }`
+
+"
+    .to_string();
+    let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+// The omitted-matches note is part of what "the same Depends on block"
+// means (ADR 0069), so a differing note must prevent collapse even when
+// the resolved `dependencies` list itself is identical.
+#[test]
+fn should_not_collapse_when_omitted_dependency_matches_differ() {
+    let dependency = crate::deps::ResolvedSymbol {
+        signature: "struct Point { x: i32 }".to_string(),
+        path: "src/point.rs".to_string(),
+        container: None,
+    };
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    dependencies: vec![dependency.clone()],
+                    omitted_dependency_matches: 1,
+                    ..symbol(
+                        "src/lib.rs::foo",
+                        "foo",
+                        SymbolKind::Function,
+                        "fn foo(p: Point) -> i32",
+                    )
+                },
+                ExtractedSymbol {
+                    dependencies: vec![dependency],
+                    omitted_dependency_matches: 2,
+                    ..symbol(
+                        "src/lib.rs::bar",
+                        "bar",
+                        SymbolKind::Function,
+                        "fn bar(p: Point) -> i32",
+                    )
+                },
+            ],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![
+                node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                node("src/lib.rs::bar", "src/lib.rs", "bar"),
+            ],
+            edges: vec![],
+            roots: vec!["src/lib.rs::foo".to_string(), "src/lib.rs::bar".to_string()],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        test_coverage: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+
+    let expected = "\
+## Change graph
+
+2 changed symbols in 1 file
+
+- fn foo (src/lib.rs)
+- fn bar (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo(p: Point) -> i32
+```
+
+Depends on:
+- `src/point.rs`: `struct Point { x: i32 }`
+- (+1 more definitions matched by name)
+
+### fn bar (src/lib.rs)
+
+```
+fn bar(p: Point) -> i32
+```
+
+Depends on:
+- `src/point.rs`: `struct Point { x: i32 }`
+- (+2 more definitions matched by name)
+
+"
+    .to_string();
+    let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+    assert_eq!(expected, actual);
+}

--- a/rinkaku-core/src/render/markdown_tests/depends_on_collapse.rs
+++ b/rinkaku-core/src/render/markdown_tests/depends_on_collapse.rs
@@ -378,3 +378,119 @@ Depends on:
 
     assert_eq!(expected, actual);
 }
+
+#[test]
+fn should_not_collapse_against_an_older_match_when_a_differing_list_interposes() {
+    // Pins the single-slot "nearest earlier match" tracker (ADR 0069):
+    // an interposed differing list overwrites it, so an older identical
+    // list is no longer a collapse target.
+    let point = crate::deps::ResolvedSymbol {
+        signature: "struct Point { x: i32 }".to_string(),
+        path: "src/point.rs".to_string(),
+        container: None,
+    };
+    let line = crate::deps::ResolvedSymbol {
+        signature: "struct Line { a: Point, b: Point }".to_string(),
+        path: "src/line.rs".to_string(),
+        container: None,
+    };
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/lib.rs".to_string(),
+            symbols: vec![
+                ExtractedSymbol {
+                    dependencies: vec![point.clone()],
+                    ..symbol(
+                        "src/lib.rs::foo",
+                        "foo",
+                        SymbolKind::Function,
+                        "fn foo(p: Point) -> i32",
+                    )
+                },
+                ExtractedSymbol {
+                    dependencies: vec![line],
+                    ..symbol(
+                        "src/lib.rs::bar",
+                        "bar",
+                        SymbolKind::Function,
+                        "fn bar(l: Line) -> i32",
+                    )
+                },
+                ExtractedSymbol {
+                    dependencies: vec![point],
+                    ..symbol(
+                        "src/lib.rs::baz",
+                        "baz",
+                        SymbolKind::Function,
+                        "fn baz(p: Point) -> i32",
+                    )
+                },
+            ],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![
+                node("src/lib.rs::foo", "src/lib.rs", "foo"),
+                node("src/lib.rs::bar", "src/lib.rs", "bar"),
+                node("src/lib.rs::baz", "src/lib.rs", "baz"),
+            ],
+            edges: vec![],
+            roots: vec![
+                "src/lib.rs::foo".to_string(),
+                "src/lib.rs::bar".to_string(),
+                "src/lib.rs::baz".to_string(),
+            ],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        test_coverage: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+    };
+
+    let expected = "\
+## Change graph
+
+3 changed symbols in 1 file
+
+- fn foo (src/lib.rs)
+- fn bar (src/lib.rs)
+- fn baz (src/lib.rs)
+
+## Definitions
+
+### fn foo (src/lib.rs)
+
+```
+fn foo(p: Point) -> i32
+```
+
+Depends on:
+- `src/point.rs`: `struct Point { x: i32 }`
+
+### fn bar (src/lib.rs)
+
+```
+fn bar(l: Line) -> i32
+```
+
+Depends on:
+- `src/line.rs`: `struct Line { a: Point, b: Point }`
+
+### fn baz (src/lib.rs)
+
+```
+fn baz(p: Point) -> i32
+```
+
+Depends on:
+- `src/point.rs`: `struct Point { x: i32 }`
+
+"
+    .to_string();
+    let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+    assert_eq!(expected, actual);
+}

--- a/rinkaku-core/src/render/markdown_tests/mod.rs
+++ b/rinkaku-core/src/render/markdown_tests/mod.rs
@@ -12,6 +12,9 @@
 //!   `(see above)` for functions, and cycle warnings.
 //! - [`definition_body`] — one symbol's "### ..." entry: container
 //!   comment, `Depends on:` list, and the fence-widening rules.
+//! - [`depends_on_collapse`] — ADR 0069's `Depends on:` collapse into a
+//!   `same as ... above` reference for an exact-match repeat within the
+//!   same file.
 //! - [`sections_skipped_fan_in_filesize`] — the "Skipped files",
 //!   "High fan-in symbols", and "File sizes" sections plus the
 //!   ADR 0028 JSON shape.
@@ -33,6 +36,7 @@ mod change_graph_summary;
 mod change_graph_tree;
 mod classification_and_removed;
 mod definition_body;
+mod depends_on_collapse;
 mod empty_and_ordering;
 mod lookup_miss_defenses;
 mod sections_skipped_fan_in_filesize;


### PR DESCRIPTION
## Summary

Dogfooding PR #237's diff (`rinkaku --base 3c5ecf7 --head d8b810f`) showed the `## Definitions` section repeating an identical `Depends on:` block across sibling symbols with no information gain — 7 of 11 test functions in one file printed the same ~7-line dependency list back to back.

The "Change graph" tree already solves this for shared subtrees via `(see above)`. This PR adds the same idea to `Depends on:` lists:

- When a symbol's `dependencies` (and `omitted_dependency_matches`) exactly match the *nearest earlier* same-file symbol's, the list is replaced with one line: `Depends on: same as \`<label>\` above`.
- **Exact match only** — no near-identical/subset merging, so nothing is silently dropped; the full list stays intact at the first occurrence.
- **Scoped to the same file** — a cross-file coincidental match is not collapsed, since that would send a reader jumping files to confirm a coincidence rather than an intentional repeat.
- **JSON and `digest` output are unaffected** — this is a Markdown-only formatting change, consistent with the ADR 0010/0012 precedent.

Design rationale and alternatives considered are recorded in `docs/adr/0069-collapse-repeated-depends-on-lists.md`.

## Before / after (PR #237's diff)

Rendered Markdown output: **423 lines -> 364 lines** (14% smaller), with zero information loss.

```
### fn should_classify_as_body_only_when_reflow_inserts_newline_right_after_comma (...)

Depends on: same as `fn should_classify_as_body_only_when_reflow_inserts_newline_right_after_opening_paren (...)` above
```

## Test plan

- [x] `make test` (all workspace crates green)
- [x] `make lint`
- [x] New tests in `rinkaku-core/src/render/markdown_tests/depends_on_collapse.rs`:
  - `should_collapse_depends_on_when_identical_to_an_earlier_sibling`
  - `should_not_collapse_depends_on_when_lists_differ`
  - `should_not_collapse_across_files`
  - `should_not_collapse_when_omitted_dependency_matches_differ`
- [x] Manually re-ran `rinkaku --base 3c5ecf7 --head d8b810f --format md` before/after the change to confirm the real-world reduction and that no dependency information was lost

https://claude.ai/code/session_01WKvqieuGphKNwDXPLcZNhq