### PR TITLE
fix: strip whole comment lines including indentation from signatures

### DIFF
--- a/rinkaku-core/src/extract/mod.rs
+++ b/rinkaku-core/src/extract/mod.rs
@@ -634,7 +634,7 @@ fn slice_signature(node: tree_sitter::Node, source: &[u8]) -> String {
     ) {
         let mut removed_ranges: Vec<std::ops::Range<usize>> = Vec::new();
         collect_method_body_ranges(node, &mut removed_ranges);
-        collect_comment_ranges(node, &removed_ranges.clone(), &mut removed_ranges);
+        collect_comment_ranges(node, source, &removed_ranges.clone(), &mut removed_ranges);
         return tidy_signature_lines(
             &text_with_ranges_removed(node, source, removed_ranges),
             first_line_column,
@@ -675,7 +675,7 @@ fn slice_signature(node: tree_sitter::Node, source: &[u8]) -> String {
         .map(|body| body.start_byte())
         .unwrap_or(node.end_byte());
     let mut comment_ranges: Vec<std::ops::Range<usize>> = Vec::new();
-    collect_comment_ranges(node, &[], &mut comment_ranges);
+    collect_comment_ranges(node, source, &[], &mut comment_ranges);
     // Comments at/after `text_end` fall inside the body, which is dropped
     // wholesale below anyway — only ones inside the kept declaration prefix
     // need to be individually removed.
@@ -760,13 +760,21 @@ fn collect_method_body_ranges(node: tree_sitter::Node, ranges: &mut Vec<std::ops
 /// would still handle an overlapping range correctly (it clamps against
 /// `cursor`), but skipping it here keeps `ranges` a non-overlapping set,
 /// matching that function's stated "not expected in practice" assumption.
+///
+/// Each comment's own range is widened by [`widen_to_whole_line_comment`]
+/// before being pushed, so a whole-line comment's leading indentation is
+/// removed along with it.
 fn collect_comment_ranges(
     node: tree_sitter::Node,
+    source: &[u8],
     already_removed: &[std::ops::Range<usize>],
     ranges: &mut Vec<std::ops::Range<usize>>,
 ) {
     if is_comment_node(node) {
-        ranges.push(node.start_byte()..node.end_byte());
+        ranges.push(widen_to_whole_line_comment(
+            node.start_byte()..node.end_byte(),
+            source,
+        ));
         return; // A comment node has no children worth descending into.
     }
     if already_removed
@@ -777,7 +785,38 @@ fn collect_comment_ranges(
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_comment_ranges(child, already_removed, ranges);
+        collect_comment_ranges(child, source, already_removed, ranges);
+    }
+}
+
+/// Extends a comment node's own byte range to also cover its leading
+/// horizontal whitespace back to (not including) the previous newline,
+/// when that whitespace is the only thing between the previous newline
+/// and the comment — i.e. the comment is the whole line's content.
+///
+/// Whether a grammar's comment token span includes its own trailing
+/// newline is not uniform (tree-sitter-rust's outer/inner line doc
+/// comments, `///`/`//!`, include it; every other comment kind this
+/// module handles does not), so leaving the leading indent out of the
+/// removed range is only safe for the grammars that exclude the
+/// newline. Folding the indent into the range here makes the result the
+/// same either way, without branching on which grammar produced the
+/// node.
+fn widen_to_whole_line_comment(
+    range: std::ops::Range<usize>,
+    source: &[u8],
+) -> std::ops::Range<usize> {
+    let line_start = source[..range.start]
+        .iter()
+        .rposition(|&b| b == b'\n')
+        .map_or(0, |pos| pos + 1);
+    if source[line_start..range.start]
+        .iter()
+        .all(|&b| b == b' ' || b == b'\t')
+    {
+        line_start..range.end
+    } else {
+        range
     }
 }
 

--- a/rinkaku-core/src/extract_tests/go.rs
+++ b/rinkaku-core/src/extract_tests/go.rs
@@ -11,6 +11,42 @@ use crate::language::go::GoSupport;
 use pretty_assertions::assert_eq;
 
 #[test]
+fn should_dedent_field_after_consecutive_comments() {
+    let source = "\
+package main
+
+type Foo struct {
+	// one
+	// two
+	// three
+	A string
+	B string
+}
+";
+    let lang = GoSupport;
+    let changed_ranges = vec![LineRange { start: 7, end: 7 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Foo".to_string(),
+        kind: SymbolKind::Struct,
+        signature: "Foo struct {\n\n\tA string\n\tB string\n}".to_string(),
+        range: LineRange { start: 3, end: 9 },
+        container: None,
+        referenced_names: vec!["Foo".to_string(), "string".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn should_extract_function_signature_when_body_line_changed() {
     let source = "\
 package main

--- a/rinkaku-core/src/extract_tests/hcl.rs
+++ b/rinkaku-core/src/extract_tests/hcl.rs
@@ -9,6 +9,41 @@ use crate::language::hcl::HclSupport;
 use pretty_assertions::assert_eq;
 
 #[test]
+fn should_dedent_attribute_after_consecutive_comments() {
+    let source = "\
+variable \"region\" {
+  # one
+  # two
+  # three
+  type    = string
+  default = \"us-east-1\"
+}
+";
+    let lang = HclSupport;
+    let changed_ranges = vec![LineRange { start: 5, end: 5 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "var.region".to_string(),
+        kind: SymbolKind::Block,
+        signature: "variable \"region\" {\n\n  type    = string\n  default = \"us-east-1\"\n}"
+            .to_string(),
+        range: LineRange { start: 1, end: 7 },
+        container: None,
+        referenced_names: vec![],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn should_extract_resource_header_signature_when_body_line_changed() {
     let source = "\
 resource \"aws_instance\" \"web\" {

--- a/rinkaku-core/src/extract_tests/python.rs
+++ b/rinkaku-core/src/extract_tests/python.rs
@@ -11,6 +11,39 @@ use crate::language::python::PythonSupport;
 use pretty_assertions::assert_eq;
 
 #[test]
+fn should_dedent_field_after_consecutive_comments() {
+    let source = "\
+class Foo:
+    # one
+    # two
+    # three
+    a: str
+    b: str
+";
+    let lang = PythonSupport;
+    let changed_ranges = vec![LineRange { start: 5, end: 5 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Foo".to_string(),
+        kind: SymbolKind::Class,
+        signature: "class Foo:\n\n    a: str\n    b: str".to_string(),
+        range: LineRange { start: 1, end: 6 },
+        container: None,
+        referenced_names: vec!["str".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn should_extract_function_signature_when_body_line_changed() {
     let source = "\
 def foo(a):

--- a/rinkaku-core/src/extract_tests/rust.rs
+++ b/rinkaku-core/src/extract_tests/rust.rs
@@ -348,6 +348,112 @@ fn foo(/* count */ a: i32) -> i32 {
     assert_eq!(expected, actual);
 }
 
+// tree-sitter-rust's `///`/`//!` doc comment tokens include their own
+// trailing newline in the node's byte range, unlike a plain `//` or block
+// comment. Stripping only the token left the leading indentation behind
+// with no newline after it, so it accumulated onto the next kept line.
+
+#[test]
+fn should_dedent_field_after_consecutive_doc_comments() {
+    let source = "\
+pub struct Foo {
+    /// one
+    /// two
+    /// three
+    pub a: String,
+    pub b: String,
+}
+";
+    let lang = RustSupport;
+    let changed_ranges = vec![LineRange { start: 5, end: 5 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Foo".to_string(),
+        kind: SymbolKind::Struct,
+        signature: "pub struct Foo {\n    pub a: String,\n    pub b: String,\n}".to_string(),
+        range: LineRange { start: 1, end: 7 },
+        container: None,
+        referenced_names: vec!["Foo".to_string(), "String".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_dedent_field_after_single_doc_comment() {
+    let source = "\
+pub struct Foo {
+    /// one
+    pub a: String,
+    pub b: String,
+}
+";
+    let lang = RustSupport;
+    let changed_ranges = vec![LineRange { start: 4, end: 4 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Foo".to_string(),
+        kind: SymbolKind::Struct,
+        signature: "pub struct Foo {\n    pub a: String,\n    pub b: String,\n}".to_string(),
+        range: LineRange { start: 1, end: 5 },
+        container: None,
+        referenced_names: vec!["Foo".to_string(), "String".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+// Pins the pre-existing (unchanged by this fix) behavior for a comment
+// that shares its line with kept code: only the comment token is
+// stripped, leaving the code and the line's own newline intact.
+
+#[test]
+fn should_keep_line_when_trailing_comment_shares_it_with_code() {
+    let source = "\
+struct Point {
+    x: i32, // trailing note
+    y: i32,
+}
+";
+    let lang = RustSupport;
+    let changed_ranges = vec![LineRange { start: 4, end: 4 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Point".to_string(),
+        kind: SymbolKind::Struct,
+        signature: "struct Point {\n    x: i32,\n    y: i32,\n}".to_string(),
+        range: LineRange { start: 1, end: 4 },
+        container: None,
+        referenced_names: vec!["Point".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
 #[test]
 fn should_set_container_when_method_inside_impl_block_changed() {
     let source = "\

--- a/rinkaku-core/src/extract_tests/typescript.rs
+++ b/rinkaku-core/src/extract_tests/typescript.rs
@@ -11,6 +11,40 @@ use crate::language::typescript::TypeScriptSupport;
 use pretty_assertions::assert_eq;
 
 #[test]
+fn should_dedent_field_after_consecutive_comments() {
+    let source = "\
+interface Foo {
+    // one
+    // two
+    // three
+    a: string;
+    b: string;
+}
+";
+    let lang = TypeScriptSupport;
+    let changed_ranges = vec![LineRange { start: 5, end: 5 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Foo".to_string(),
+        kind: SymbolKind::Interface,
+        signature: "interface Foo {\n\n    a: string;\n    b: string;\n}".to_string(),
+        range: LineRange { start: 1, end: 7 },
+        container: None,
+        referenced_names: vec!["Foo".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn should_extract_function_signature_when_body_line_changed() {
     let source = "\
 function foo(a: number): number {


### PR DESCRIPTION
## Summary

`collect_comment_ranges` (in `rinkaku-core/src/extract/mod.rs`) only
removed a comment node's own byte span when stripping comments from a
kept signature, never its leading indentation. That's normally fine —
the leading indent collapses to a blank line via
`tidy_signature_lines`'s dedent/blank-line-collapse logic — but
tree-sitter-rust's outer/inner line doc comment tokens (`///`, `//!`)
include their own trailing newline in that span, unlike a plain `//`
comment or a block comment. Removing just the token in that case left
the leading indentation behind with **no newline after it**, so it
concatenated directly onto the next kept line instead of collapsing to
a blank line. Consecutive doc-commented fields each contributed their
own indentation to the pile-up.

Repro:

```rust
pub struct Foo {
    /// one
    /// two
    /// three
    pub a: String,
    pub b: String,
}
```

produced a signature with `pub a: String,` indented 16 spaces (4
per stripped `///` line) instead of 4. `rinkaku-core`'s own
`ExtractedSymbol` struct hits this for real — its `id` field follows a
6-line doc comment — and the corruption is visible in recent PR
digests (e.g. #228's).

### Before (this repo's own `ExtractedSymbol`, from PR #228's diff)

```
pub struct ExtractedSymbol {
                                pub id: String,
    pub name: String,
    pub kind: SymbolKind,
            pub signature: String,
                pub range: LineRange,
                pub container: Option<String>,
                                                           #[serde(skip)]
    pub referenced_names: Vec<String>,
    ...
```

### After

```
pub struct ExtractedSymbol {
    pub id: String,
    pub name: String,
    pub kind: SymbolKind,
    pub signature: String,
    pub range: LineRange,
    pub container: Option<String>,
    #[serde(skip)]
    pub referenced_names: Vec<String>,
    ...
```

## Fix

Widen each comment's removed range to also cover its leading
horizontal whitespace back to the previous newline, when the comment
is the whole line's content (`widen_to_whole_line_comment`). This
makes the outcome the same regardless of whether a grammar's comment
token happens to include its own trailing newline, instead of
special-casing per grammar. A trailing same-line comment (`x: i32, //
note`) is unaffected — its line has kept content before it, so the
widening is a no-op.

Go/Python/TypeScript/HCL comment tokens don't include the trailing
newline and were already producing the correct one-blank-line-per-
removed-comment output; I added regression tests there too, pinning
that this change doesn't alter their behavior.

## Scope note

`extract/mod.rs` crosses the 1000-line warn threshold in rinkaku's own
file-size check after this change (1008 lines, was 969/watch). The
signature-slicing cluster this fix touches (`slice_signature` onward)
looks like an independent, splittable responsibility, but doing that
split is out of scope for this bug-fix PR — filing it as a follow-up
instead of mixing a structural refactor into a behavior fix.

## Test plan

- [x] `should_dedent_field_after_consecutive_doc_comments` /
      `should_dedent_field_after_single_doc_comment` (Rust): pin the
      fix for the exact regression shape.
- [x] `should_keep_line_when_trailing_comment_shares_it_with_code`
      (Rust): pins the pre-existing trailing-comment behavior as
      unchanged.
- [x] One `should_dedent_field_after_consecutive_comments` /
      `should_dedent_attribute_after_consecutive_comments` regression
      test per remaining language (Go, Python, TypeScript, HCL),
      confirming the fix doesn't change their already-correct output.
- [x] `make test` (1104 tests) and `make lint` pass.
- [x] Dynamic verification: built the CLI before and after the fix and
      ran it on PR #228's real diff (`git diff 2242a0b^1...2242a0b |
      rinkaku`), confirming the `ExtractedSymbol` struct signature in
      the digest output goes from corrupted indentation to clean
      4-space indentation (excerpt above).
