### PR TITLE
feat: annotate Other changed files with non-symbol changed-line counts

### DIFF
--- a/docs/adr/0070-annotate-non-symbol-changed-line-counts.md
+++ b/docs/adr/0070-annotate-non-symbol-changed-line-counts.md
@@ -1,0 +1,156 @@
+# 0070. Annotate "Other changed files" with non-symbol changed-line counts
+
+- Status: accepted
+- Date: 2026-08-08
+
+## Context
+
+Dogfooding rinkaku against two external repositories surfaced the same
+gap from two different angles:
+
+- A real bugfix in `swr` changed a field on a top-level `const` object.
+  No function/class signature changed, so rinkaku's Change graph and
+  Definitions sections had nothing to show; the file appeared only as
+  a bare path under "## Other changed files".
+- A Python SDK change extended `__all__` to export a new name — a
+  genuine public-API change — with the same result: the file that
+  carries the public surface change is indistinguishable, in rinkaku's
+  own output, from a file whose only change was a comment tweak or a
+  trailing-whitespace fix.
+
+Every built-in `LanguageSupport`'s `definition_query` targets
+function/class/struct-shaped definitions; top-level `const`/`var`
+bindings, import statements, and Python's `__all__` list sit outside
+that query by design (`import_only_changes.rs` pins the same
+guarantee for import lines). `extract_changed_symbols` correctly
+returns no symbols for these files — nothing here challenges that
+extraction boundary. But `render_markdown`'s "Other changed files"
+section then reduces every such file to a single line with no signal
+about *how much* changed or *how confident* a reader should be that
+skipping it is safe. A 2-line `__all__` addition and a 200-line
+non-symbol rewrite of the same file currently render identically.
+
+## Decision
+
+Add a changed-line-count annotation to each "Other changed files"
+entry in Markdown, and the equivalent data to JSON, computed from data
+the pipeline already holds — no new IO, no new parsing pass.
+
+Concretely:
+
+- `pipeline::analyze_diff` already iterates `changed_file.changed_ranges`
+  (`Vec<LineRange>`, merged and non-overlapping — see
+  `merge_adjacent_ranges`) for every file it builds a `FileReport` for.
+  When that file's `symbols` end up empty (the "Other changed files"
+  case), sum `end - start + 1` across `changed_ranges` to get the
+  file's total new-side changed-line count, and collect
+  `(path, changed_line_count)` pairs alongside the existing
+  `sized_files` collection (ADR 0028's pattern).
+- A new pure function in `rinkaku-core` (mirroring
+  `file_size::compute_file_size_bands`) turns those pairs into a new
+  `Vec<NonSymbolChange>` — `struct NonSymbolChange { path: String,
+  changed_line_count: usize }` — exposed as a new `Report` field,
+  `non_symbol_changes`.
+- `render_markdown` looks up each "Other changed files" path in this
+  new field and renders:
+
+  ```
+  - src/index.ts (12 changed lines outside any definition)
+  ```
+
+  A path with no matching entry (should not occur in practice, since
+  every `files_with_no_symbols` path is produced by the same loop that
+  collects the pairs) falls back to the current bare-path line rather
+  than panicking.
+- JSON gets the new `non_symbol_changes` array as an additional
+  top-level field, additive and always present (empty array when
+  `files` has no symbol-less entries), matching `file_size_bands`'
+  precedent rather than `fan_ins`' file-size-warning-only subset.
+
+### Why a new `Report` field, not a field on `FileReport`
+
+`FileReport { path, symbols }` is constructed at 6 production call
+sites and 100+ test-fixture call sites across `rinkaku-core` and
+`rinkaku-tui` (Rust's exhaustive struct-literal syntax means every one
+would need updating for a new field). `Report` itself already carries
+several derived-but-parallel `Vec`s keyed by path or id
+(`file_size_warnings`, `file_size_bands`, `test_coverage`) for exactly
+this reason: adding a sibling `Vec<NonSymbolChange>` keyed by `path`
+costs the same ~85-site mechanical fixture churn `file_size_bands`
+already paid (PR that introduced it: `f83d232`), not the ~100+-site
+churn a `FileReport` field would add on top. This also keeps
+`resolve_dependencies` and `partition_test_symbols` — both of which
+already reconstruct `FileReport` — untouched.
+
+### Scope: only files with zero symbols
+
+This ADR's fix targets `render_markdown`'s "Other changed files"
+section specifically — a file already covered by "## Definitions"
+that *also* has an unrelated non-symbol change (e.g. an import edit
+sitting next to a changed function) is unaffected: that file's
+non-symbol edit stays invisible, same as today. Extending
+`non_symbol_changes` to cover symbol-bearing files too is future work
+(see Consequences).
+
+### `analyze_repo` (whole-repo outline mode)
+
+Not affected. `analyze_repo` already drops a file from `files`
+entirely once its post-filter symbol list is empty (no diff, so no
+"pure rename with nothing to report but still worth noting" case per
+its own doc comment) — there is no "Other changed files" section in
+outline mode and no `changed_ranges` concept to measure from, so
+`non_symbol_changes` is always empty for `ReportOrigin::RepoOutline`.
+
+### Digest output
+
+Not affected. `render_digest` only iterates `file.symbols` per file
+and has no per-file "nothing to show" branch at all — a symbol-less
+file already contributes nothing to the digest, and this ADR does not
+change that; a digest line for a non-symbol change is future work if
+it turns out to matter in practice.
+
+### TUI
+
+Not affected in this PR. `rinkaku-tui`'s tree already renders a
+symbol-less `FileReport` as a childless `File` node with zero badges
+(`tree/mod.rs`'s `build_tree` doc comment) — there is no
+"Other changed files"-shaped section to annotate the same way
+Markdown's is. Surfacing `non_symbol_changes` there (e.g. a badge on
+the file row) is left as follow-up; `Report` gaining a field that TUI
+doesn't yet consume is normal and already true of several existing
+fields.
+
+## Alternatives considered
+
+1. **Promote top-level bindings/imports to lightweight symbols.**
+   Would make these changes fully visible (signature, dependencies,
+   Change graph placement) rather than just a line count, but expands
+   every `LanguageSupport`'s `definition_query` and signature-slicing
+   rule, likely doubling "Other changed files" noise for the common
+   case (an import reordered by a formatter) that this ADR is not
+   trying to surface. Deferred — worth a dedicated ADR if a concrete
+   need for full symbol treatment (dependency edges into a changed
+   `const`, e.g.) shows up.
+2. **Do nothing — leave the file un-annotated.** Rejected: both
+   dogfooding examples were real, user-relevant changes that a
+   reviewer skimming rinkaku's output would have missed entirely with
+   no hint that anything worth checking was there.
+
+## Consequences
+
+- Markdown: "Other changed files" entries change shape (additive
+  suffix); existing snapshot-style tests pinning the old bare-path
+  line (`empty_and_ordering.rs`, `sections_skipped_fan_in_filesize.rs`
+  precedent) are updated as part of this change, since the changed
+  wording is this ADR's intended effect, not an accidental
+  regression.
+- JSON: new always-present top-level `non_symbol_changes` field;
+  every existing field's shape and every existing key's value are
+  unchanged.
+- `pipeline_tests`: an import-only-change scenario (already covered by
+  `import_only_changes.rs` at the `analyze_diff`/`FileReport` level)
+  gains an assertion that `Report.non_symbol_changes` carries the
+  expected count for at least one representative language.
+- Future work, explicitly deferred rather than folded into this PR:
+  symbol-bearing files with additional non-symbol edits, TUI badge
+  surfacing, and digest-format inclusion.

--- a/rinkaku-core/src/lib.rs
+++ b/rinkaku-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod extract;
 pub mod file_size;
 pub mod graph;
 pub mod language;
+pub mod non_symbol_changes;
 pub mod pipeline;
 pub mod progress;
 pub mod render;

--- a/rinkaku-core/src/non_symbol_changes.rs
+++ b/rinkaku-core/src/non_symbol_changes.rs
@@ -1,0 +1,92 @@
+//! Changed-line counts for files with no changed symbol (ADR 0070).
+//!
+//! Pure over `(path, changed_line_count)` pairs — [`crate::pipeline`]
+//! collects the pairs while it already holds each file's `changed_ranges`
+//! in scope (a file only contributes a pair here when its `FileReport`
+//! ends up with an empty `symbols` list; see `analyze_diff`'s doc
+//! comment). This mirrors [`crate::file_size`]'s pair-in,
+//! `Vec<Entry>`-out shape.
+
+use serde::Serialize;
+
+/// One file's total changed-line count, for a file whose diff produced no
+/// changed symbol (ADR 0070) — reported on
+/// [`crate::render::Report::non_symbol_changes`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NonSymbolChange {
+    pub path: String,
+    pub changed_line_count: usize,
+}
+
+/// Builds a [`NonSymbolChange`] per `(path, changed_line_count)` pair,
+/// sorted by `path` ascending — matching
+/// [`crate::file_size::compute_file_size_bands`]'s ordering rationale:
+/// there is no "most attention-worthy first" ranking here, just a
+/// complete per-file listing in a stable order.
+pub fn compute_non_symbol_changes(files: &[(String, usize)]) -> Vec<NonSymbolChange> {
+    let mut entries: Vec<NonSymbolChange> = files
+        .iter()
+        .map(|(path, changed_line_count)| NonSymbolChange {
+            path: path.clone(),
+            changed_line_count: *changed_line_count,
+        })
+        .collect();
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_return_empty_when_no_files_given() {
+        let files: Vec<(String, usize)> = vec![];
+
+        let expected: Vec<NonSymbolChange> = vec![];
+        let actual = compute_non_symbol_changes(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_build_one_entry_per_file() {
+        let files = vec![("src/index.ts".to_string(), 12)];
+
+        let expected = vec![NonSymbolChange {
+            path: "src/index.ts".to_string(),
+            changed_line_count: 12,
+        }];
+        let actual = compute_non_symbol_changes(&files);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn should_sort_entries_by_path_ascending() {
+        let files = vec![
+            ("z.py".to_string(), 3),
+            ("a.py".to_string(), 5),
+            ("m.py".to_string(), 1),
+        ];
+
+        let expected = vec![
+            NonSymbolChange {
+                path: "a.py".to_string(),
+                changed_line_count: 5,
+            },
+            NonSymbolChange {
+                path: "m.py".to_string(),
+                changed_line_count: 1,
+            },
+            NonSymbolChange {
+                path: "z.py".to_string(),
+                changed_line_count: 3,
+            },
+        ];
+        let actual = compute_non_symbol_changes(&files);
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/rinkaku-core/src/pipeline.rs
+++ b/rinkaku-core/src/pipeline.rs
@@ -17,6 +17,7 @@ use crate::extract::{
 use crate::file_size::{compute_file_size_bands, compute_file_size_warnings};
 use crate::graph::{build_graph, compute_fan_ins, compute_test_coverage, stamp_ids};
 use crate::language::{LanguageSupport, language_for_path};
+use crate::non_symbol_changes::compute_non_symbol_changes;
 use crate::progress::{OnProgress, should_report_progress};
 use crate::render::{FileReport, Report, ReportOrigin, SkipReason, SkippedFile, TestFileSummary};
 use rayon::prelude::*;
@@ -178,6 +179,13 @@ pub fn analyze_diff(
     // excluded by construction — they have no content to measure, or are
     // explicitly outside rinkaku's concern.
     let mut sized_files: Vec<(String, usize)> = Vec::new();
+    // ADR 0070: `(path, changed_line_count)` for every file whose
+    // `FileReport` ends up with an empty `symbols` list despite having
+    // non-empty `changed_ranges` — i.e. a diff that touched only
+    // non-symbol content (a top-level `const`, an import, Python's
+    // `__all__`). Collected here, where `changed_ranges` is already in
+    // scope, rather than recomputed at render time.
+    let mut non_symbol_changed_files: Vec<(String, usize)> = Vec::new();
 
     for changed_file in changed_files {
         // ADR 0033 (amended): the per-file body is wrapped in a labeled
@@ -308,6 +316,14 @@ pub fn analyze_diff(
                 &changed_file.old_changed_ranges,
             ));
 
+            if symbols.is_empty() {
+                let changed_line_count: usize = changed_file
+                    .changed_ranges
+                    .iter()
+                    .map(|range| range.end - range.start + 1)
+                    .sum();
+                non_symbol_changed_files.push((changed_file.path.clone(), changed_line_count));
+            }
             files.push(FileReport {
                 path: changed_file.path,
                 symbols,
@@ -350,6 +366,9 @@ pub fn analyze_diff(
     let file_size_warnings = compute_file_size_warnings(&sized_files);
     // ADR 0028 amendment: every file's band, from the same pairs.
     let file_size_bands = compute_file_size_bands(&sized_files);
+    // ADR 0070: changed-line counts for symbol-less files, from the pairs
+    // collected inline above during the per-file loop.
+    let non_symbol_changes = compute_non_symbol_changes(&non_symbol_changed_files);
 
     Ok(Report {
         origin: ReportOrigin::Diff,
@@ -362,6 +381,7 @@ pub fn analyze_diff(
         file_size_warnings,
         file_size_bands,
         removed,
+        non_symbol_changes,
     })
 }
 
@@ -571,6 +591,7 @@ pub fn analyze_repo(
         file_size_warnings,
         file_size_bands,
         removed: Vec::new(),
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-core/src/pipeline_tests/analyze_diff.rs
+++ b/rinkaku-core/src/pipeline_tests/analyze_diff.rs
@@ -31,6 +31,7 @@ fn should_return_empty_report_when_diff_is_empty() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff("", read_file, None, None, true, &HashSet::new(), true, None)
         .expect("analyze should succeed");
@@ -100,6 +101,7 @@ fn foo(a: i32) -> i32 {
             band: FileSizeBand::Normal,
         }],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff(
         diff,
@@ -146,6 +148,7 @@ index 4b825dc..0000000
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff(
         diff,
@@ -185,6 +188,7 @@ Binary files a/assets/logo.png and b/assets/logo.png differ
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff(
         diff,
@@ -232,6 +236,7 @@ index e69de29..4b825dc 100644
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff(
         diff,
@@ -283,6 +288,7 @@ rename to src/new_name.rs
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff(
         diff,
@@ -424,6 +430,7 @@ index e69de29..4b825dc 100644
             band: FileSizeBand::Normal,
         }],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff(
         diff,

--- a/rinkaku-core/src/pipeline_tests/analyze_repo.rs
+++ b/rinkaku-core/src/pipeline_tests/analyze_repo.rs
@@ -28,6 +28,7 @@ fn should_return_empty_report_when_paths_is_empty() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_repo(&[], read_file, true, &HashSet::new(), true, None);
 
@@ -123,6 +124,7 @@ struct Point {
             band: FileSizeBand::Normal,
         }],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
 
@@ -166,6 +168,7 @@ fn should_skip_path_without_registered_language_support() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
 
@@ -191,6 +194,7 @@ fn should_skip_path_when_read_file_fails() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), true, None);
 
@@ -220,6 +224,7 @@ fn should_skip_path_in_generated_paths_set_without_reading_it() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_repo(&paths, read_file, true, &generated_paths, true, None);
 
@@ -243,6 +248,7 @@ fn should_skip_file_with_generated_content_marker_when_include_generated_is_fals
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_repo(&paths, read_file, true, &HashSet::new(), false, None);
 
@@ -283,6 +289,7 @@ func TestFoo(t *testing.T) {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_repo(&paths, read_file, false, &HashSet::new(), true, None);
 

--- a/rinkaku-core/src/pipeline_tests/generated_exclusion.rs
+++ b/rinkaku-core/src/pipeline_tests/generated_exclusion.rs
@@ -303,6 +303,7 @@ func Foo() int { return 2 }
             band: FileSizeBand::Normal,
         }],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff(
         diff,
@@ -381,6 +382,7 @@ fn foo(a: i32) -> i32 {
             band: FileSizeBand::Normal,
         }],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff(
         diff,
@@ -469,6 +471,7 @@ index e69de29..4b825dc 100644
             band: FileSizeBand::Normal,
         }],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff(
         diff,

--- a/rinkaku-core/src/pipeline_tests/import_only_changes.rs
+++ b/rinkaku-core/src/pipeline_tests/import_only_changes.rs
@@ -13,6 +13,7 @@
 
 use super::fake_reader;
 use crate::extract::RemovedSymbol;
+use crate::non_symbol_changes::NonSymbolChange;
 use crate::pipeline::analyze_diff;
 use pretty_assertions::assert_eq;
 use std::collections::{HashMap, HashSet};
@@ -58,6 +59,52 @@ def helper():
         report.files[0].symbols
     );
     assert_eq!(Vec::<RemovedSymbol>::new(), report.removed);
+}
+
+// ADR 0070: a symbol-less file's `Report.non_symbol_changes` carries the
+// changed-line count `render_markdown`'s "Other changed files" annotation
+// is built from — the same import-only diff as
+// `should_report_no_symbols_when_python_diff_only_adds_an_import`, this
+// time asserting the sibling field that guarantee's regression coverage
+// didn't previously touch.
+#[test]
+fn should_report_non_symbol_change_line_count_when_python_diff_only_adds_an_import() {
+    let diff = "\
+diff --git a/foo.py b/foo.py
+index 57b03c6..1e5c9a1 100644
+--- a/foo.py
++++ b/foo.py
+@@ -1,2 +1,3 @@
++import os
+ def helper():
+     return 1
+";
+    let head_source = "\
+import os
+def helper():
+    return 1
+";
+    let read_file = fake_reader(HashMap::from([("foo.py", head_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        None,
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    assert_eq!(
+        vec![NonSymbolChange {
+            path: "foo.py".to_string(),
+            changed_line_count: 1,
+        }],
+        report.non_symbol_changes
+    );
 }
 
 #[test]

--- a/rinkaku-core/src/pipeline_tests/test_symbol_exclusion.rs
+++ b/rinkaku-core/src/pipeline_tests/test_symbol_exclusion.rs
@@ -119,6 +119,7 @@ fn should_add_two_numbers() {
             band: FileSizeBand::Normal,
         }],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff(
         diff,
@@ -305,6 +306,7 @@ mod tests {
             band: FileSizeBand::Normal,
         }],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let actual = analyze_diff(
         diff,

--- a/rinkaku-core/src/render/digest.rs
+++ b/rinkaku-core/src/render/digest.rs
@@ -198,6 +198,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed,
+            non_symbol_changes: vec![],
         }
     }
 

--- a/rinkaku-core/src/render/markdown.rs
+++ b/rinkaku-core/src/render/markdown.rs
@@ -21,8 +21,9 @@ use std::fmt::Write as _;
 /// symbol's signature in the same tree order; a "Tests" section
 /// summarizing excluded test symbols per file (ADR 0009); an "Other changed
 /// files" section for files that were analyzed but contributed no symbol
-/// (e.g. a pure rename — see `pipeline::analyze_diff`'s doc comment); and a
-/// list of skipped files.
+/// (e.g. a pure rename — see `pipeline::analyze_diff`'s doc comment),
+/// annotated with a changed-line count when the file's diff touched
+/// content outside any definition (ADR 0070); and a list of skipped files.
 ///
 /// `SkipReason::Generated` entries are omitted from "Skipped files"
 /// entirely, however the file was detected as generated — either an
@@ -214,10 +215,32 @@ pub(super) fn render_markdown(report: &Report) -> Result<String, RenderError> {
     }
 
     if !files_with_no_symbols.is_empty() {
+        // ADR 0070: a path with no matching entry (should not occur — every
+        // `files_with_no_symbols` path is produced by the same pipeline
+        // loop that collects `non_symbol_changes`) falls back to the bare
+        // path rather than panicking.
+        let non_symbol_change_by_path: HashMap<&str, usize> = report
+            .non_symbol_changes
+            .iter()
+            .map(|change| (change.path.as_str(), change.changed_line_count))
+            .collect();
         writeln!(out, "## Other changed files")?;
         writeln!(out)?;
         for path in &files_with_no_symbols {
-            writeln!(out, "- {path}")?;
+            match non_symbol_change_by_path.get(path) {
+                Some(changed_line_count) => {
+                    let noun = if *changed_line_count == 1 {
+                        "line"
+                    } else {
+                        "lines"
+                    };
+                    writeln!(
+                        out,
+                        "- {path} ({changed_line_count} changed {noun} outside any definition)"
+                    )?;
+                }
+                None => writeln!(out, "- {path}")?,
+            }
         }
         writeln!(out)?;
     }

--- a/rinkaku-core/src/render/markdown_tests/change_graph_fold.rs
+++ b/rinkaku-core/src/render/markdown_tests/change_graph_fold.rs
@@ -81,6 +81,7 @@ fn should_inline_two_leaf_struct_children_as_uses_annotation_on_method_line() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -180,6 +181,7 @@ fn should_disambiguate_folded_names_when_duplicate_symbols_fold_under_same_paren
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -266,6 +268,7 @@ fn should_repeat_folded_struct_annotation_on_every_referencing_parent() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -360,6 +363,7 @@ fn should_fold_hcl_block_dependency_repeated_across_multiple_parents() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -427,6 +431,7 @@ fn should_render_childless_non_function_root_as_top_level_line_when_it_would_oth
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -507,6 +512,7 @@ fn should_render_nested_line_when_non_function_child_has_its_own_children() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -591,6 +597,7 @@ fn should_not_fold_non_function_child_when_its_only_children_are_cycle_edges() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\

--- a/rinkaku-core/src/render/markdown_tests/change_graph_summary.rs
+++ b/rinkaku-core/src/render/markdown_tests/change_graph_summary.rs
@@ -35,6 +35,7 @@ fn should_render_change_graph_and_definitions_when_report_has_one_symbol() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -91,6 +92,7 @@ fn should_render_summary_with_hotspot_when_report_has_multiple_symbols_and_files
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -143,6 +145,7 @@ fn should_render_repository_graph_heading_and_drop_changed_wording_when_origin_i
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -183,6 +186,7 @@ fn should_omit_hotspot_suffix_when_all_symbols_are_in_one_file() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -231,6 +235,7 @@ fn should_break_hotspot_tie_by_first_seen_path_order_when_counts_are_equal() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -299,6 +304,7 @@ fn should_include_start_line_in_label_when_node_id_is_disambiguated_by_line() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\

--- a/rinkaku-core/src/render/markdown_tests/change_graph_tree.rs
+++ b/rinkaku-core/src/render/markdown_tests/change_graph_tree.rs
@@ -53,6 +53,7 @@ fn should_nest_callee_under_caller_in_change_graph_when_symbol_references_anothe
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -139,6 +140,7 @@ fn should_order_definitions_in_true_pre_order_when_first_child_has_its_own_child
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -231,6 +233,7 @@ fn should_mark_see_above_when_symbol_reachable_from_multiple_roots() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -303,6 +306,7 @@ fn should_render_cycle_warning_when_edge_is_marked_as_cycle() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -417,6 +421,7 @@ fn should_render_full_cycle_example_with_two_root_functions_and_a_dependency_cyc
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\

--- a/rinkaku-core/src/render/markdown_tests/classification_and_removed.rs
+++ b/rinkaku-core/src/render/markdown_tests/classification_and_removed.rs
@@ -36,6 +36,7 @@ fn should_append_new_marker_to_tree_and_definition_when_symbol_is_added() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -88,6 +89,7 @@ fn should_render_diff_block_and_marker_when_symbol_is_signature_changed() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -145,6 +147,7 @@ fn should_render_line_based_diff_block_when_multiline_signature_changed() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -208,6 +211,7 @@ fn should_render_container_comment_above_diff_lines_when_signature_changed_symbo
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -261,6 +265,7 @@ fn should_render_unmarked_tree_and_definition(#[case] classification: Option<Cla
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -318,6 +323,7 @@ fn should_append_marker_to_fan_in_line_before_used_by() {
         file_size_bands: vec![],
         removed: vec![],
         test_coverage: vec![],
+        non_symbol_changes: vec![],
     };
 
     let markdown = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
@@ -371,6 +377,7 @@ fn should_render_removed_symbols_section_between_definitions_and_tests() {
             path: "src/lib.rs".to_string(),
             signature: "fn old_helper()".to_string(),
         }],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -432,6 +439,7 @@ fn should_render_removed_symbols_section_alone_when_graph_is_empty() {
             path: "src/lib.rs".to_string(),
             signature: "fn old_helper()".to_string(),
         }],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -493,6 +501,7 @@ fn should_deduplicate_identical_removed_symbol_lines() {
                 signature: "fn save(&self, id: &str)".to_string(),
             },
         ],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -533,6 +542,7 @@ fn should_omit_removed_symbols_section_when_removed_is_empty() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let markdown = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
@@ -576,6 +586,7 @@ fn should_widen_fence_when_previous_signature_contains_a_backtick_run() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\

--- a/rinkaku-core/src/render/markdown_tests/definition_body.rs
+++ b/rinkaku-core/src/render/markdown_tests/definition_body.rs
@@ -38,6 +38,7 @@ fn should_render_container_comment_when_symbol_has_container() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -95,6 +96,7 @@ fn should_render_depends_on_list_when_symbol_has_dependencies() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -158,6 +160,7 @@ fn should_collapse_multiline_dependency_signature_to_one_line() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -224,6 +227,7 @@ fn should_render_multiple_depends_on_entries_when_symbol_has_several_dependencie
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -285,6 +289,7 @@ fn should_render_omitted_matches_note_when_dependency_matches_were_capped() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -347,6 +352,7 @@ fn should_widen_fence_when_signature_contains_a_backtick_run() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -402,6 +408,7 @@ fn should_widen_fence_when_container_contains_a_backtick_run() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -462,6 +469,7 @@ fn should_render_zero_tests_line_when_symbol_has_no_covering_tests() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -537,6 +545,7 @@ fn should_render_covering_test_names_when_symbol_has_tests() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -615,6 +624,7 @@ fn should_cap_covering_test_names_when_symbol_has_more_than_the_listed_maximum()
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\

--- a/rinkaku-core/src/render/markdown_tests/depends_on_collapse.rs
+++ b/rinkaku-core/src/render/markdown_tests/depends_on_collapse.rs
@@ -69,6 +69,7 @@ fn should_collapse_depends_on_when_identical_to_an_earlier_sibling() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -164,6 +165,7 @@ fn should_not_collapse_depends_on_when_lists_differ() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -251,6 +253,7 @@ fn should_not_collapse_across_files() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -340,6 +343,7 @@ fn should_not_collapse_when_omitted_dependency_matches_differ() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -448,6 +452,7 @@ fn should_not_collapse_against_an_older_match_when_a_differing_list_interposes()
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\

--- a/rinkaku-core/src/render/markdown_tests/empty_and_ordering.rs
+++ b/rinkaku-core/src/render/markdown_tests/empty_and_ordering.rs
@@ -6,6 +6,7 @@
 
 use super::*;
 use crate::extract::SymbolKind;
+use crate::non_symbol_changes::NonSymbolChange;
 use crate::render::report::{FileReport, ReportOrigin, SkipReason, SkippedFile};
 use crate::render::{OutputFormat, render};
 use pretty_assertions::assert_eq;
@@ -27,6 +28,7 @@ fn should_render_empty_markdown_when_report_has_no_files_and_no_skips() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "".to_string();
@@ -64,6 +66,125 @@ fn should_list_file_with_no_symbols_under_other_changed_files_when_report_has_no
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
+    };
+
+    let expected = "\
+## Other changed files
+
+- src/new_name.rs
+
+"
+    .to_string();
+    let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+// ADR 0070: when `Report.non_symbol_changes` carries an entry for a
+// symbol-less file, "Other changed files" annotates it with the changed
+// line count instead of a bare path.
+#[test]
+fn should_annotate_other_changed_file_with_non_symbol_changed_line_count() {
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/index.ts".to_string(),
+            symbols: vec![],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        test_coverage: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+        non_symbol_changes: vec![NonSymbolChange {
+            path: "src/index.ts".to_string(),
+            changed_line_count: 12,
+        }],
+    };
+
+    let expected = "\
+## Other changed files
+
+- src/index.ts (12 changed lines outside any definition)
+
+"
+    .to_string();
+    let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_use_singular_line_wording_when_non_symbol_change_is_exactly_one_line() {
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "foo.py".to_string(),
+            symbols: vec![],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        test_coverage: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+        non_symbol_changes: vec![NonSymbolChange {
+            path: "foo.py".to_string(),
+            changed_line_count: 1,
+        }],
+    };
+
+    let expected = "\
+## Other changed files
+
+- foo.py (1 changed line outside any definition)
+
+"
+    .to_string();
+    let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
+
+    assert_eq!(expected, actual);
+}
+
+// A path with no matching `non_symbol_changes` entry falls back to the
+// bare-path line rather than panicking — should not occur in practice
+// (see `render_markdown`'s doc comment), but the lookup is a `HashMap`
+// miss, not an indexing operation, so this is a real reachable branch.
+#[test]
+fn should_fall_back_to_bare_path_when_non_symbol_changes_has_no_matching_entry() {
+    let report = Report {
+        origin: ReportOrigin::Diff,
+        files: vec![FileReport {
+            path: "src/new_name.rs".to_string(),
+            symbols: vec![],
+        }],
+        skipped: vec![],
+        graph: SymbolGraph {
+            nodes: vec![],
+            edges: vec![],
+            roots: vec![],
+        },
+        tests: vec![],
+        fan_ins: vec![],
+        test_coverage: vec![],
+        file_size_warnings: vec![],
+        file_size_bands: vec![],
+        removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -113,6 +234,7 @@ fn should_list_file_with_no_symbols_after_definitions_when_report_has_graph_node
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -164,6 +286,7 @@ fn should_render_other_changed_files_before_skipped_files_when_report_has_both()
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -201,6 +324,7 @@ fn should_render_tests_section_with_singular_symbol_noun_when_count_is_one() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -235,6 +359,7 @@ fn should_render_tests_section_with_plural_symbols_noun_when_count_is_greater_th
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -278,6 +403,7 @@ fn should_render_tests_section_between_definitions_and_other_changed_files_when_
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -334,6 +460,7 @@ fn should_omit_generated_skip_entry_from_markdown_output() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "".to_string();
@@ -371,6 +498,7 @@ fn should_omit_only_generated_entries_when_skipped_has_other_reasons_too() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\

--- a/rinkaku-core/src/render/markdown_tests/lookup_miss_defenses.rs
+++ b/rinkaku-core/src/render/markdown_tests/lookup_miss_defenses.rs
@@ -36,6 +36,7 @@ fn should_skip_definitions_entry_when_visit_order_id_has_no_matching_symbol() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -74,6 +75,7 @@ fn should_render_nothing_for_root_when_root_id_has_no_matching_symbol() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -130,6 +132,7 @@ fn should_omit_cycle_warning_line_when_cycle_target_id_has_no_matching_symbol() 
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\

--- a/rinkaku-core/src/render/markdown_tests/sections_skipped_fan_in_filesize.rs
+++ b/rinkaku-core/src/render/markdown_tests/sections_skipped_fan_in_filesize.rs
@@ -42,6 +42,7 @@ fn should_render_skipped_files_section_when_report_has_skips() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -85,6 +86,7 @@ fn should_render_change_graph_then_skipped_section_when_report_has_both() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -137,6 +139,7 @@ fn should_omit_high_fan_in_symbols_section_when_fan_ins_is_empty() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -235,6 +238,7 @@ fn should_render_high_fan_in_symbols_section_between_change_graph_and_definition
         file_size_bands: vec![],
         removed: vec![],
         test_coverage: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -309,6 +313,7 @@ fn should_render_fan_in_line_for_symbol_with_no_matching_definition() {
         file_size_bands: vec![],
         removed: vec![],
         test_coverage: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -376,6 +381,7 @@ fn should_render_file_sizes_section_in_report_order_across_all_bands() {
             },
         ],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -432,6 +438,7 @@ fn should_omit_file_sizes_section_when_report_has_no_bands() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let actual = render(&report, OutputFormat::Markdown).expect("markdown render succeeds");
@@ -509,6 +516,7 @@ fn should_place_file_sizes_between_high_fan_in_symbols_and_definitions() {
         }],
         removed: vec![],
         test_coverage: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -586,6 +594,7 @@ fn should_include_file_size_warnings_in_json_output() {
         ],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -613,7 +622,8 @@ fn should_include_file_size_warnings_in_json_output() {
     }
   ],
   \"file_size_bands\": [],
-  \"removed\": []
+  \"removed\": [],
+  \"non_symbol_changes\": []
 }"
     .to_string();
     let actual = render(&report, OutputFormat::Json).expect("json render succeeds");

--- a/rinkaku-core/src/render/markdown_tests/untested_changes.rs
+++ b/rinkaku-core/src/render/markdown_tests/untested_changes.rs
@@ -36,6 +36,7 @@ fn should_omit_no_referencing_tests_section_when_test_coverage_is_empty() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -91,6 +92,7 @@ fn should_omit_no_referencing_tests_section_when_every_symbol_has_coverage() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -186,6 +188,7 @@ fn should_render_no_referencing_tests_section_between_high_fan_in_symbols_and_fi
             band: crate::file_size::FileSizeBand::Normal,
         }],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\
@@ -279,6 +282,7 @@ fn should_render_repo_outline_heading_when_origin_is_repo_outline() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = "\

--- a/rinkaku-core/src/render/mermaid_tests/class_styling.rs
+++ b/rinkaku-core/src/render/mermaid_tests/class_styling.rs
@@ -201,6 +201,7 @@ fn should_append_fan_in_count_suffix_to_label_when_node_is_high_fan_in() {
         file_size_bands: vec![],
         removed: vec![],
         test_coverage: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = concat!(
@@ -250,6 +251,7 @@ fn should_prefer_fan_in_class_over_changed_class_when_node_is_both() {
         file_size_bands: vec![],
         removed: vec![],
         test_coverage: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = concat!(
@@ -303,6 +305,7 @@ fn should_prefer_fan_in_class_over_added_class_when_a_new_symbol_has_high_fan_in
         file_size_bands: vec![],
         removed: vec![],
         test_coverage: vec![],
+        non_symbol_changes: vec![],
     };
 
     let expected = concat!(

--- a/rinkaku-core/src/render/mermaid_tests/mod.rs
+++ b/rinkaku-core/src/render/mermaid_tests/mod.rs
@@ -76,6 +76,7 @@ fn empty_report(graph: SymbolGraph, files: Vec<FileReport>) -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-core/src/render/mermaid_tests/removed_symbols.rs
+++ b/rinkaku-core/src/render/mermaid_tests/removed_symbols.rs
@@ -154,6 +154,7 @@ fn should_render_removed_only_file_as_removed_node_when_fallback_fires() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![removed_symbol("old_only", "src/gone.rs")],
+        non_symbol_changes: vec![],
     };
 
     let expected = concat!(

--- a/rinkaku-core/src/render/report.rs
+++ b/rinkaku-core/src/render/report.rs
@@ -85,6 +85,14 @@ pub struct Report {
     /// [`crate::pipeline::analyze_diff`]'s `read_base_file` parameter),
     /// same as every symbol's `classification` staying `None` in that case.
     pub removed: Vec<RemovedSymbol>,
+    /// Changed-line counts for files whose `FileReport` in `files` has an
+    /// empty `symbols` list (ADR 0070) — the data behind Markdown's
+    /// "Other changed files" annotation. One entry per such file, sorted
+    /// by path ascending (see
+    /// [`crate::non_symbol_changes::compute_non_symbol_changes`]). Always
+    /// empty for [`ReportOrigin::RepoOutline`], which never produces an
+    /// empty-`symbols` `FileReport` in the first place.
+    pub non_symbol_changes: Vec<crate::non_symbol_changes::NonSymbolChange>,
 }
 
 /// Which pipeline entry point produced a [`Report`] (ADR 0017). `Default`
@@ -232,6 +240,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         };
 
         let expected = "\
@@ -253,7 +262,8 @@ mod tests {
   \"test_coverage\": [],
   \"file_size_warnings\": [],
   \"file_size_bands\": [],
-  \"removed\": []
+  \"removed\": [],
+  \"non_symbol_changes\": []
 }"
         .to_string();
         let actual = render(&report, OutputFormat::Json).expect("json render succeeds");
@@ -285,6 +295,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         };
 
         let expected = "\
@@ -302,7 +313,8 @@ mod tests {
   \"test_coverage\": [],
   \"file_size_warnings\": [],
   \"file_size_bands\": [],
-  \"removed\": []
+  \"removed\": [],
+  \"non_symbol_changes\": []
 }"
         .to_string();
         let actual = render(&report, OutputFormat::Json).expect("json render succeeds");
@@ -338,6 +350,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         };
 
         let expected = "\
@@ -386,7 +399,8 @@ mod tests {
   \"test_coverage\": [],
   \"file_size_warnings\": [],
   \"file_size_bands\": [],
-  \"removed\": []
+  \"removed\": [],
+  \"non_symbol_changes\": []
 }"
         .to_string();
         let actual = render(&report, OutputFormat::Json).expect("json render succeeds");
@@ -427,6 +441,7 @@ mod tests {
                 path: "src/lib.rs".to_string(),
                 signature: "fn old_helper()".to_string(),
             }],
+            non_symbol_changes: vec![],
         };
 
         let expected = "\
@@ -479,7 +494,8 @@ mod tests {
       \"path\": \"src/lib.rs\",
       \"signature\": \"fn old_helper()\"
     }
-  ]
+  ],
+  \"non_symbol_changes\": []
 }"
         .to_string();
         let actual = render(&report, OutputFormat::Json).expect("json render succeeds");
@@ -516,6 +532,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         };
 
         let expected = "\
@@ -559,7 +576,8 @@ mod tests {
   \"test_coverage\": [],
   \"file_size_warnings\": [],
   \"file_size_bands\": [],
-  \"removed\": []
+  \"removed\": [],
+  \"non_symbol_changes\": []
 }"
         .to_string();
         let actual = render(&report, OutputFormat::Json).expect("json render succeeds");

--- a/rinkaku-tui/src/app/tests/mod.rs
+++ b/rinkaku-tui/src/app/tests/mod.rs
@@ -90,6 +90,7 @@ pub(super) fn empty_report() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-tui/src/blast_radius.rs
+++ b/rinkaku-tui/src/blast_radius.rs
@@ -294,6 +294,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         }
     }
 

--- a/rinkaku-tui/src/detail_tests/mod.rs
+++ b/rinkaku-tui/src/detail_tests/mod.rs
@@ -66,5 +66,6 @@ pub(super) fn empty_report() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }

--- a/rinkaku-tui/src/diff_shape_tests/mod.rs
+++ b/rinkaku-tui/src/diff_shape_tests/mod.rs
@@ -64,6 +64,7 @@ pub(super) fn empty_report() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-tui/src/event_loop/tests.rs
+++ b/rinkaku-tui/src/event_loop/tests.rs
@@ -32,6 +32,7 @@ pub(super) fn empty_report() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-tui/src/input_translate_tests/mod.rs
+++ b/rinkaku-tui/src/input_translate_tests/mod.rs
@@ -34,6 +34,7 @@ pub(super) fn empty_report() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-tui/src/order/rank_tests/mod.rs
+++ b/rinkaku-tui/src/order/rank_tests/mod.rs
@@ -63,6 +63,7 @@ pub(super) fn report_with_graph(nodes: Vec<Node>, edges: Vec<Edge>) -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-tui/src/order/sort_tests/mod.rs
+++ b/rinkaku-tui/src/order/sort_tests/mod.rs
@@ -36,6 +36,7 @@ pub(super) fn report_with_graph(nodes: Vec<Node>, edges: Vec<Edge>) -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-tui/src/review_flow_tests/mod.rs
+++ b/rinkaku-tui/src/review_flow_tests/mod.rs
@@ -63,6 +63,7 @@ pub(super) fn empty_report() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-tui/src/source.rs
+++ b/rinkaku-tui/src/source.rs
@@ -356,6 +356,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         }
     }
 

--- a/rinkaku-tui/src/tree/tree_tests/mod.rs
+++ b/rinkaku-tui/src/tree/tree_tests/mod.rs
@@ -69,5 +69,6 @@ pub(super) fn empty_report() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }

--- a/rinkaku-tui/src/ui/blast_radius.rs
+++ b/rinkaku-tui/src/ui/blast_radius.rs
@@ -163,6 +163,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         }
     }
 

--- a/rinkaku-tui/src/ui/detail_pane_tests/content_by_row_kind.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/content_by_row_kind.rs
@@ -17,6 +17,7 @@ fn should_draw_placeholder_message_when_there_are_no_rows_at_all() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     // ADR 0020 defaults the right pane to Diff, whose own placeholder
     // text differs ("select a symbol or file row..."); `ToggleDiff`
@@ -65,6 +66,7 @@ fn should_draw_dir_detail_content_when_cursor_is_on_a_directory_row() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     // ADR 0020 defaults the right pane to Diff; `ToggleDiff` switches to
     // Detail, which is what this test actually exercises. (A directory
@@ -123,6 +125,7 @@ fn should_draw_symbols_label_without_changed_wording_when_origin_is_repo_outline
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     // See the sibling test above for why `ToggleDiff` is needed to
     // reach the Detail pane this test actually exercises.
@@ -257,6 +260,7 @@ fn should_draw_both_test_note_and_real_symbols_in_detail_pane_when_file_is_mixed
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     // Row 0 is the "app.rs" file row itself.
     let app = App::new(&report).handle_key(crate::app::InputKey::ToggleDiff);

--- a/rinkaku-tui/src/ui/detail_pane_tests/mod.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/mod.rs
@@ -79,6 +79,7 @@ pub(super) fn report_with_one_symbol() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 
@@ -117,6 +118,7 @@ pub(super) fn report_with_one_skipped_file() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 
@@ -141,6 +143,7 @@ pub(super) fn report_with_one_test_file() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 
@@ -172,5 +175,6 @@ pub(super) fn report_with_many_symbols(count: usize) -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }

--- a/rinkaku-tui/src/ui/detail_pane_tests/tab_expansion.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/tab_expansion.rs
@@ -33,6 +33,7 @@ fn draw_detail_for_signature(signature: &str, previous_signature: Option<&str>) 
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let app = App::new(&report)
         .handle_key(crate::app::InputKey::Down)

--- a/rinkaku-tui/src/ui/detail_pane_tests/wrap_reachability.rs
+++ b/rinkaku-tui/src/ui/detail_pane_tests/wrap_reachability.rs
@@ -31,6 +31,7 @@ fn should_reach_the_last_wrapped_line_of_content_via_scrolling_when_a_logical_li
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     // ADR 0020 defaults the right pane to Diff, whose own placeholder
     // text also happens to embed the file path (`"(no diff hunks found
@@ -96,6 +97,7 @@ fn should_report_indicator_total_as_wrapped_row_count_not_logical_line_count_whe
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     // ADR 0020 defaults the right pane to Diff; `ToggleDiff` switches to
     // Detail, which is what this test actually exercises.

--- a/rinkaku-tui/src/ui/diff_pane_tests/mod.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/mod.rs
@@ -70,6 +70,7 @@ pub(super) fn report_with_one_symbol() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-tui/src/ui/diff_pane_tests/row_kinds.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/row_kinds.rs
@@ -72,6 +72,7 @@ fn should_draw_diff_pane_with_hunk_lines_when_toggled_on_a_skipped_file_row() {
         file_size_bands: vec![],
         removed: vec![],
         files: vec![],
+        non_symbol_changes: vec![],
     };
     // Row 0 is the collapsing "assets" dir; row 1 is the skipped file.
     // ADR 0020 defaults the right pane to Diff already, so no
@@ -141,6 +142,7 @@ fn should_draw_diff_pane_with_hunk_lines_for_an_unsupported_language_skipped_fil
         file_size_bands: vec![],
         removed: vec![],
         files: vec![],
+        non_symbol_changes: vec![],
     };
     // Row 0 is the collapsing "vendor" dir; row 1 is the skipped file.
     // ADR 0020 defaults the right pane to Diff already, so no
@@ -212,6 +214,7 @@ fn should_draw_per_symbol_section_headers_when_diff_pane_shows_a_file_selection(
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let app = App::new(&report);
     let diff_text = "\
@@ -280,6 +283,7 @@ fn should_draw_contract_header_before_hunks_when_symbol_signature_changed() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     // Row 0 is the "lib.rs" file row, row 1 is the "foo" symbol.
     let app = App::new(&report).handle_key(crate::app::InputKey::Down);

--- a/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/split_view.rs
@@ -201,6 +201,7 @@ fn should_draw_old_and_new_signature_side_by_side_when_symbol_signature_changed(
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     // Row 0 is the "lib.rs" file row, row 1 is the "foo" symbol. ADR 0044
     // amendment: split is now the default `DiffViewMode`, so no

--- a/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/styling.rs
@@ -279,6 +279,7 @@ fn should_fall_back_to_plain_diff_style_when_file_extension_is_unrecognized() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     // ADR 0020 defaults the right pane to Diff already, so no
     // `ToggleDiff` press is needed to reach it here.

--- a/rinkaku-tui/src/ui/diff_pane_tests/tab_expansion.rs
+++ b/rinkaku-tui/src/ui/diff_pane_tests/tab_expansion.rs
@@ -22,6 +22,7 @@ fn go_report() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 
@@ -149,6 +150,7 @@ fn should_expand_tabs_on_the_unhighlighted_path_when_extension_is_unknown() {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let app = App::new(&report).handle_key(crate::app::InputKey::Down);
     let diff_text = "\

--- a/rinkaku-tui/src/ui/entry.rs
+++ b/rinkaku-tui/src/ui/entry.rs
@@ -213,6 +213,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         }
     }
 
@@ -237,6 +238,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         }
     }
 
@@ -497,6 +499,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         }
     }
 

--- a/rinkaku-tui/src/ui/help_overlay/tests.rs
+++ b/rinkaku-tui/src/ui/help_overlay/tests.rs
@@ -283,6 +283,7 @@ fn report_with_one_symbol() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-tui/src/ui/overlay.rs
+++ b/rinkaku-tui/src/ui/overlay.rs
@@ -187,6 +187,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         }
     }
 

--- a/rinkaku-tui/src/ui/review_overlay_tests.rs
+++ b/rinkaku-tui/src/ui/review_overlay_tests.rs
@@ -46,6 +46,7 @@ fn report_with_one_symbol() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-tui/src/ui/source_screen_tests/highlighting.rs
+++ b/rinkaku-tui/src/ui/source_screen_tests/highlighting.rs
@@ -27,6 +27,7 @@ fn should_apply_keyword_foreground_and_symbol_range_background_in_source_screen(
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let app = App::new(&report)
         .handle_key(crate::app::InputKey::Down)
@@ -102,6 +103,7 @@ fn should_fall_back_to_plain_source_style_when_file_extension_is_unrecognized() 
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let app = App::new(&report)
         .handle_key(crate::app::InputKey::Down)

--- a/rinkaku-tui/src/ui/source_screen_tests/mod.rs
+++ b/rinkaku-tui/src/ui/source_screen_tests/mod.rs
@@ -67,6 +67,7 @@ pub(super) fn report_with_one_symbol() -> Report {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     }
 }
 

--- a/rinkaku-tui/src/ui/source_screen_tests/tab_expansion.rs
+++ b/rinkaku-tui/src/ui/source_screen_tests/tab_expansion.rs
@@ -28,6 +28,7 @@ fn draw_source(path: &str, contents: &str) -> Terminal<TestBackend> {
         file_size_warnings: vec![],
         file_size_bands: vec![],
         removed: vec![],
+        non_symbol_changes: vec![],
     };
     let app = App::new(&report)
         .handle_key(crate::app::InputKey::Down)

--- a/rinkaku-tui/src/ui/status.rs
+++ b/rinkaku-tui/src/ui/status.rs
@@ -216,6 +216,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         }
     }
 
@@ -248,6 +249,7 @@ mod tests {
             file_size_warnings: vec![],
             file_size_bands: vec![],
             removed: vec![],
+            non_symbol_changes: vec![],
         }
     }
 

--- a/rinkaku/src/notes.rs
+++ b/rinkaku/src/notes.rs
@@ -118,6 +118,7 @@ mod tests {
                 file_size_warnings: vec![],
                 file_size_bands: vec![],
                 removed: vec![],
+                non_symbol_changes: vec![],
             }
         }
 
@@ -136,6 +137,7 @@ mod tests {
                 file_size_warnings: vec![],
                 file_size_bands: vec![],
                 removed: vec![],
+                non_symbol_changes: vec![],
             }
         }
 
@@ -186,6 +188,7 @@ mod tests {
                 file_size_warnings: vec![],
                 file_size_bands: vec![],
                 removed: vec![],
+                non_symbol_changes: vec![],
             };
 
             let actual = garbage_input_note("some diff text", &report);
@@ -215,6 +218,7 @@ mod tests {
                 file_size_warnings: vec![],
                 file_size_bands: vec![],
                 removed: vec![],
+                non_symbol_changes: vec![],
             };
 
             let actual = garbage_input_note("some diff text", &report);
@@ -256,6 +260,7 @@ mod tests {
                 file_size_warnings: vec![],
                 file_size_bands: vec![],
                 removed: vec![],
+                non_symbol_changes: vec![],
             };
 
             let actual = garbage_input_note("some diff text", &report);
@@ -318,6 +323,7 @@ mod tests {
                 file_size_warnings: vec![],
                 file_size_bands: vec![],
                 removed: vec![],
+                non_symbol_changes: vec![],
             }
         }
 
@@ -379,6 +385,7 @@ mod tests {
                 file_size_warnings: vec![],
                 file_size_bands: vec![],
                 removed: vec![],
+                non_symbol_changes: vec![],
             };
 
             let actual = entry_pivot_empty_note(&report, "src/api");
@@ -411,6 +418,7 @@ mod tests {
                 file_size_warnings: vec![],
                 file_size_bands: vec![],
                 removed: vec![],
+                non_symbol_changes: vec![],
             }
         }
 

--- a/rinkaku/src/pipeline.rs
+++ b/rinkaku/src/pipeline.rs
@@ -50,6 +50,7 @@ pub(crate) fn run_base_pipeline(
                 file_size_warnings: Vec::new(),
                 file_size_bands: vec![],
                 removed: Vec::new(),
+                non_symbol_changes: vec![],
             },
             diff_text,
         ));
@@ -348,6 +349,7 @@ mod tests {
                 file_size_warnings: Vec::new(),
                 file_size_bands: vec![],
                 removed: Vec::new(),
+                non_symbol_changes: vec![],
             },
             actual_report
         );
@@ -529,6 +531,62 @@ fn should_add_two_numbers() {
         assert_eq!(
             Some("fn foo(a: i32) -> i32".to_string()),
             symbol.previous_signature
+        );
+    }
+
+    // ADR 0070 end-to-end: a real git repository where a commit only
+    // extends Python's `__all__` (a public-API change with no touched
+    // function/class definition) must produce a `non_symbol_changes` entry
+    // through the full `--base`/`--pr` pipeline — not just through
+    // `analyze_diff` called directly with fake readers (already covered by
+    // `pipeline_tests::import_only_changes`).
+    #[test]
+    fn should_report_non_symbol_change_via_real_base_commit_when_diff_only_extends_dunder_all() {
+        let dir = tempfile::TempDir::new().expect("create tempdir");
+        run_git(dir.path(), &["init", "--initial-branch=main"]);
+        run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+        run_git(dir.path(), &["config", "user.name", "Test"]);
+        std::fs::write(
+            dir.path().join("foo.py"),
+            "__all__ = [\"helper\"]\n\n\ndef helper():\n    return 1\n",
+        )
+        .expect("write foo.py");
+        run_git(dir.path(), &["add", "foo.py"]);
+        run_git(dir.path(), &["commit", "-m", "initial commit"]);
+
+        std::fs::write(
+            dir.path().join("foo.py"),
+            "__all__ = [\"helper\", \"other\"]\n\n\ndef helper():\n    return 1\n",
+        )
+        .expect("edit foo.py");
+        run_git(dir.path(), &["add", "foo.py"]);
+        run_git(dir.path(), &["commit", "-m", "export other from foo"]);
+
+        let cli = Cli {
+            command: None,
+            base: None,
+            head: "HEAD".to_string(),
+            pr: None,
+            format: None,
+            deps: 0,
+            exclude_tests: false,
+            include_generated: false,
+            entry: None,
+            tui: false,
+        };
+        let spinner = Spinner::start("test");
+        let (actual, _diff_text) =
+            run_base_pipeline(&cli, "HEAD~1", "HEAD", Some(dir.path()), &spinner)
+                .expect("run_base_pipeline should succeed");
+
+        let expected_symbols: Vec<rinkaku_core::extract::ExtractedSymbol> = Vec::new();
+        assert_eq!(expected_symbols, actual.files[0].symbols);
+        assert_eq!(
+            vec![rinkaku_core::non_symbol_changes::NonSymbolChange {
+                path: "foo.py".to_string(),
+                changed_line_count: 1,
+            }],
+            actual.non_symbol_changes
         );
     }
 


### PR DESCRIPTION
## Summary

Dogfooding rinkaku against two external repositories found the same gap
from two angles: a real `swr` bugfix that changed a field on a top-level
`const` object, and a Python SDK change that extended `__all__` to export
a new public name. Neither touches a function/class signature, so both
files rendered as a bare path under "## Other changed files" —
indistinguishable from a whitespace-only change.

- `Report` gains a new field, `non_symbol_changes: Vec<NonSymbolChange>`
  (`{ path, changed_line_count }`), populated in `analyze_diff` from each
  file's already-collected `changed_ranges` — no new IO, no new parsing
  pass.
- `render_markdown` annotates each "Other changed files" entry with its
  changed-line count when an entry exists:
  `- src/index.ts (12 changed lines outside any definition)`.
- JSON gets the same data as an always-present top-level array.

New data lives as a sibling `Report` field (mirroring `file_size_bands`)
rather than a field on `FileReport`, which would have required updating
100+ test-fixture call sites instead of ~55 — see ADR 0070 for the full
rationale, scope (symbol-less files only; a symbol-bearing file with an
*additional* unrelated non-symbol edit is unaffected), and deferred
alternatives (promoting bindings/imports to lightweight symbols).

## Before / after

```
- foo.py                                          # before
- foo.py (1 changed line outside any definition)  # after
```

Verified with release builds of both `origin/main` and this branch
against a `git init` demo repo with a Python `__all__`-only commit.

## Test plan

- [x] `make test` (rinkaku-core: 546, rinkaku: 210, rinkaku-tui: 1104 —
      all passing)
- [x] `make lint` (fmt + clippy, clean)
- [x] New unit tests: `non_symbol_changes.rs` (pure function), a pipeline
      test asserting `Report.non_symbol_changes` for an import-only Python
      diff, four Markdown-rendering tests (annotated, singular "line"
      wording, HashMap-miss fallback, ordering), and an end-to-end test in
      `rinkaku/src/pipeline.rs` driving `run_base_pipeline` against a real
      git repository with a `__all__`-only commit.
- [x] Manual dogfooding: built release binaries from both `origin/main`
      and this branch, ran both against demo repos covering an
      `__all__`-only Python change, a multi-line TypeScript `const`-only
      change, a real symbol-signature change (regression check — no
      "Other changed files" section, unaffected), and a pure file rename
      (regression check — stays unannotated, since there are no changed
      lines to count).
- [x] Ran this branch's own build against its own PR diff (`--base
      origin/main --head HEAD`) — the tool correctly annotates its own
      `rinkaku-core/src/lib.rs` one-line change.

https://claude.ai/code/session_01WKvqieuGphKNwDXPLcZNhq