### PR TITLE
refactor: consolidate backtick fence computation in render module

### DIFF
--- a/rinkaku-core/src/render/digest.rs
+++ b/rinkaku-core/src/render/digest.rs
@@ -10,6 +10,7 @@
 
 use crate::extract::{Classification, ExtractedSymbol, RemovedSymbol};
 use crate::render::report::Report;
+use crate::render::shared::backtick_fence;
 use std::fmt::Write as _;
 
 /// `name (path)` — matches `render_markdown`'s `tree_label`/
@@ -126,27 +127,14 @@ fn removed_line(removed: &RemovedSymbol) -> String {
 /// `text` can't prematurely close it (mirrors `render_markdown`'s
 /// `fence_for`).
 fn fence_for(text: &str) -> String {
-    "`".repeat((longest_backtick_run(text).unwrap_or(0) + 1).max(1))
+    backtick_fence([text], 1)
 }
 
 /// [`fence_for`]'s sibling for a ` ```diff ` fenced block: widens against
 /// both the previous and current signature text, mirroring
 /// `render_markdown`'s `fence_for_diff`.
 fn fence_for_diff(previous_signature: &str, signature: &str) -> String {
-    let longest_run = [previous_signature, signature]
-        .iter()
-        .flat_map(|text| longest_backtick_run(text))
-        .max()
-        .unwrap_or(0);
-    "`".repeat((longest_run + 1).max(3))
-}
-
-/// Length of the longest run of consecutive `` ` `` characters in `text`.
-fn longest_backtick_run(text: &str) -> Option<usize> {
-    text.split(|c| c != '`')
-        .map(str::len)
-        .filter(|&len| len > 0)
-        .max()
+    backtick_fence([previous_signature, signature], 3)
 }
 
 #[cfg(test)]

--- a/rinkaku-core/src/render/markdown.rs
+++ b/rinkaku-core/src/render/markdown.rs
@@ -12,7 +12,7 @@ use crate::file_size::{FileSizeBand, FileSizeEntry};
 use crate::graph::{FanIn, Node, NodeId, SymbolGraph, TestCoverage};
 use crate::render::RenderError;
 use crate::render::report::{Report, ReportOrigin, SkipReason, SkippedFile, skip_reason_label};
-use crate::render::shared::SymbolLookup;
+use crate::render::shared::{SymbolLookup, backtick_fence};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
@@ -489,6 +489,17 @@ fn render_definition(
     writeln!(out, "### {}", labeled_with_marker(path, symbol))?;
     writeln!(out)?;
 
+    render_signature(out, symbol)?;
+
+    if let Some(coverage) = test_coverage {
+        writeln!(out, "{}", test_coverage_line(coverage, lookup))?;
+        writeln!(out)?;
+    }
+
+    render_dependencies(out, symbol, same_as_above)
+}
+
+fn render_signature(out: &mut String, symbol: &ExtractedSymbol) -> Result<(), RenderError> {
     let container_line = symbol.container.as_deref().map(|c| format!("// {c}"));
     match (symbol.classification, &symbol.previous_signature) {
         (Some(Classification::SignatureChanged), Some(previous_signature)) => {
@@ -520,12 +531,14 @@ fn render_definition(
         }
     }
     writeln!(out)?;
+    Ok(())
+}
 
-    if let Some(coverage) = test_coverage {
-        writeln!(out, "{}", test_coverage_line(coverage, lookup))?;
-        writeln!(out)?;
-    }
-
+fn render_dependencies(
+    out: &mut String,
+    symbol: &ExtractedSymbol,
+    same_as_above: Option<&str>,
+) -> Result<(), RenderError> {
     if !symbol.dependencies.is_empty() || symbol.omitted_dependency_matches > 0 {
         if let Some(label) = same_as_above {
             writeln!(out, "Depends on: same as `{label}` above")?;
@@ -534,16 +547,6 @@ fn render_definition(
         }
         writeln!(out, "Depends on:")?;
         for dependency in &symbol.dependencies {
-            // Inline code spans (not a fenced block): a dependency list
-            // entry is one line per dependency, so a fence per entry would
-            // be noisy. Path and signature are not hardened against
-            // embedded backticks the way the fenced blocks above are — a
-            // signature is unlikely to contain a backtick run long enough
-            // to break out of a single backtick span, and this is a
-            // cosmetic-only failure mode (unlike the fenced blocks, which
-            // without widening could make later content render as code).
-            // A multi-line dependency signature (ADR 0060) is collapsed to
-            // one line here, since this list's shape is one entry per line.
             writeln!(
                 out,
                 "- `{}`: `{}`",
@@ -848,12 +851,7 @@ fn visit_from(
 /// of consecutive backticks in `content`, with a floor of 3 (the minimum
 /// valid Markdown fence).
 fn fence_for(container_line: Option<&str>, signature: &str) -> String {
-    let longest_run = [container_line.unwrap_or(""), signature]
-        .iter()
-        .flat_map(|text| longest_backtick_run(text))
-        .max()
-        .unwrap_or(0);
-    "`".repeat((longest_run + 1).max(3))
+    backtick_fence([container_line.unwrap_or(""), signature], 3)
 }
 
 /// [`fence_for`]'s sibling for a `signature_changed` symbol's ` ```diff `
@@ -865,20 +863,10 @@ fn fence_for_diff(
     previous_signature: &str,
     signature: &str,
 ) -> String {
-    let longest_run = [container_line.unwrap_or(""), previous_signature, signature]
-        .iter()
-        .flat_map(|text| longest_backtick_run(text))
-        .max()
-        .unwrap_or(0);
-    "`".repeat((longest_run + 1).max(3))
-}
-
-/// Length of the longest run of consecutive `` ` `` characters in `text`.
-fn longest_backtick_run(text: &str) -> Option<usize> {
-    text.split(|c| c != '`')
-        .map(str::len)
-        .filter(|&len| len > 0)
-        .max()
+    backtick_fence(
+        [container_line.unwrap_or(""), previous_signature, signature],
+        3,
+    )
 }
 
 /// Collapses a possibly multi-line signature (ADR 0060) into one line for

--- a/rinkaku-core/src/render/shared.rs
+++ b/rinkaku-core/src/render/shared.rs
@@ -20,7 +20,8 @@ pub(super) struct SymbolLookup<'a> {
 
 impl<'a> SymbolLookup<'a> {
     pub(super) fn build(files: &'a [FileReport]) -> Self {
-        let mut by_id = HashMap::new();
+        let symbol_count = files.iter().map(|file| file.symbols.len()).sum();
+        let mut by_id = HashMap::with_capacity(symbol_count);
         for file in files {
             for symbol in &file.symbols {
                 by_id.insert(symbol.id.as_str(), (file.path.as_str(), symbol));
@@ -32,4 +33,23 @@ impl<'a> SymbolLookup<'a> {
     pub(super) fn get(&self, id: &str) -> Option<(&'a str, &'a ExtractedSymbol)> {
         self.by_id.get(id).copied()
     }
+}
+
+pub(super) fn backtick_fence<'a>(
+    contents: impl IntoIterator<Item = &'a str>,
+    minimum_length: usize,
+) -> String {
+    let longest_run = contents
+        .into_iter()
+        .flat_map(longest_backtick_run)
+        .max()
+        .unwrap_or(0);
+    "`".repeat((longest_run + 1).max(minimum_length))
+}
+
+fn longest_backtick_run(text: &str) -> Option<usize> {
+    text.split(|character| character != '`')
+        .map(str::len)
+        .filter(|&length| length > 0)
+        .max()
 }


### PR DESCRIPTION
## Summary

- Consolidate the duplicated longest-backtick-run / fence-width logic from `markdown.rs` and `digest.rs` into a shared `backtick_fence` helper in `shared.rs`, parameterizing the minimum fence width (3 for block fences, 1 for inline spans) so per-format behavior is preserved
- Split `render_definition` in `markdown.rs` into signature and dependency helpers
- Pre-size the symbol lookup map with the total symbol count to avoid rehashing

No observable behavior change.

## Validation

- `make test` — all tests pass
- `make lint` — fmt and clippy clean

https://claude.ai/code/session_01P47C6duMHcas2HJ7hXwZdp