### PR TITLE
fix: slice a reported container's signature to touched lines only

### DIFF
--- a/docs/adr/0071-slice-container-signatures-to-touched-lines.md
+++ b/docs/adr/0071-slice-container-signatures-to-touched-lines.md
@@ -1,0 +1,150 @@
+# 0071. Slice a reported container's signature to touched lines only
+
+- Status: accepted
+- Date: 2026-08-11
+- Relates to: [ADR 0014](0014-classify-symbol-changes-by-contract.md)
+  (comment-stripped signature comparison, whose comparison input this
+  decision changes), [ADR
+  0060](0060-preserve-line-structure-in-displayed-signatures.md)
+  (multi-line signature slicing this decision builds on)
+
+## Context
+
+Python and TypeScript classes are single tree-sitter nodes whose span
+covers the entire class body, methods included. When a changed line
+falls directly in the class's own body (a field, a class-level
+comment, the header/base-class list) rather than inside any nested
+method, `extract_changed_symbols`'s narrowest-enclosing-definition rule
+picks the class itself as the reported symbol, and `slice_signature`
+returns the whole class text with every method body stripped — but
+every method *signature* kept, touched or not.
+
+Reproduction: changing one field's value in a Python class with
+several unrelated methods —
+
+```python
+class Widget:
+    label = "a"          # only this line changes, "a" -> "b"
+
+    def move(self, dx, dy): ...
+    def scale(self, factor): ...
+```
+
+— reports `Widget`'s signature as the field plus both `move` and
+`scale` method signatures, neither of which changed. A reviewer (or an
+LLM consuming this output) sees two unrelated methods listed as part of
+"what changed" for a one-line edit.
+
+Go and Rust do not have this problem: a Go method is a sibling
+`method_declaration` node linked to its receiver type by field, not
+nested inside the receiver's own node, and Rust methods live in a
+separate `impl_item` node from the type they extend. Neither ever
+becomes "a container node whose body text embeds sibling method
+signatures," so this is a Python/TypeScript-specific (class-shaped)
+issue.
+
+### Constraint: classification must not be affected
+
+ADR 0014's `classify_symbols` compares each reported head-side symbol's
+`signature` against a matching base-side symbol's `signature`
+(byte-for-byte after whitespace normalization) to decide
+`Added`/`SignatureChanged`/`BodyOnly`. The base-side symbol always
+comes from `extract_all_symbols`, which indexes every definition in a
+file regardless of any diff and therefore has no notion of "touched
+lines" to slice by — its container signatures stay whole-class,
+unaffected by this decision.
+
+Naively slicing `ExtractedSymbol::signature` for containers inside
+`extract_changed_symbols` would make the head-side comparison input a
+touched-lines-only fragment while the base-side stays whole-class:
+even a container whose only actual change is a harmless reflow (no
+token-level difference) would compare unequal on size alone, turning
+what should classify `BodyOnly` into `SignatureChanged`. Classification
+must keep comparing whole-class text on both sides.
+
+## Decision
+
+Keep two signature values in play for a reported container symbol, but
+without adding a field to `ExtractedSymbol`:
+
+1. `extract_changed_symbols` (in the new `extract::container_slice`
+   module) narrows a reported container's `ExtractedSymbol::signature`
+   — the field callers render — to its header plus only the body-level
+   lines (member declarations, not member bodies) that overlap
+   `changed_ranges`. A member definition (method, nested class, ...)
+   with no overlapping line is dropped from the signature text
+   entirely, header-and-all; one with an overlapping line keeps
+   exactly as much of itself as the existing per-kind slicing already
+   produces (e.g. a touched method keeps its own signature line, body
+   still stripped).
+2. `classify_symbols` already receives `all_head_symbols` — the
+   complete, un-narrowed symbol set for the head file (added by the
+   "container falsely reported removed" fix this ADR's context section
+   above builds on) — precisely to judge container survival against
+   the whole file rather than the diff-narrowed `head_symbols` list.
+   The signature comparison now also looks up each head symbol's
+   `(name, container)` identity in `all_head_symbols` and compares
+   *that* whole-class signature against the base side, falling back to
+   the (already-whole, for every non-container kind) `head_symbols`
+   signature when no `all_head_symbols` entry exists. This keeps every
+   classification decision comparing whole-class text on both sides,
+   identical to today's comparison, while `ExtractedSymbol::signature`
+   itself is free to carry the narrower, touched-lines-only text for
+   display.
+3. The member-vs-container distinction is expressed generically: a
+   member is any `@definition`-query-captured node that is a
+   descendant of the reported container node. No per-language special
+   case — the same code path narrows a Python class and a TypeScript
+   class identically.
+
+## Alternatives
+
+- **Show elided members as a placeholder line** (e.g. `# ... 2 more
+  methods unchanged`): rejected for v1 — it requires deciding how to
+  count/name elided members across arbitrarily nested containers
+  (nested classes, class-field arrow functions) for a benefit
+  (explicitly signaling "there was more here") that is secondary to
+  the noise this ADR removes. Can be added later as a rendering-layer
+  concern without changing the extraction contract this ADR sets.
+- **Add a second field to `ExtractedSymbol`** (e.g.
+  `comparison_signature`) carrying the whole-class text alongside the
+  narrowed `signature`: rejected — `ExtractedSymbol` already has two
+  fields serving an analogous split-purpose role
+  (`referenced_names`/`referenced_method_names`, both `#[serde(skip)]`
+  intermediate artifacts), and each past addition required touching
+  every one of this struct's ~160 test-literal construction sites
+  across the repo (see ADR 0068's Consequences). Reusing
+  `all_head_symbols`, which `classify_symbols` already receives for an
+  adjacent reason, avoids that repo-wide mechanical churn for a
+  same-shaped problem.
+- **Slice in `pipeline.rs` after classification runs, using a
+  re-parse**: rejected — the touched-lines slice needs the AST node
+  boundaries of each member inside the container, and
+  `extract_changed_symbols`'s tree-sitter `Node` values are
+  intentionally scoped to `with_definition_nodes`'s callback and never
+  escape it (see that function's doc comment); re-parsing in
+  `pipeline.rs` to regain node access would duplicate the parse this
+  ADR's approach avoids.
+
+## Consequences
+
+- `ExtractedSymbol::signature` for a container reported because of a
+  body-level (not nested-member) touched line now omits every
+  untouched member's signature — output shape unchanged (still a
+  `String`), but shorter/narrower content for this case. Renderers
+  (Markdown/JSON/digest) need no changes; they already just print
+  whatever `signature` holds.
+- Classification (`Added`/`SignatureChanged`/`BodyOnly`) is unaffected
+  by this decision for every symbol kind, containers included — pinned
+  by regression tests comparing classification output before and
+  after this change on the same inputs.
+- **Known limitation, out of scope for this decision**: if a diff
+  changes both a container's own body-level line (e.g. an attribute)
+  *and* one of its methods in the same hunk set, the narrowest-
+  enclosing-definition rule (unchanged by this ADR) still suppresses
+  the container in favor of the touched method as the reported symbol
+  — the attribute change becomes invisible to this diff's output. This
+  pre-existing behavior is not something this ADR's touched-lines
+  slicing introduces or fixes; addressing it would mean changing which
+  symbol gets reported, not how a reported container's signature is
+  sliced.

--- a/rinkaku-core/src/extract/container_slice.rs
+++ b/rinkaku-core/src/extract/container_slice.rs
@@ -29,18 +29,68 @@ use super::{LineRange, is_descendant_of, node_to_line_range, overlaps_any};
 /// outside it (e.g. TypeScript's `abstract_method_signature` excludes its
 /// own trailing `;`), so removing only the bare node span would leave a
 /// stray `;` and blank indentation behind.
+///
+/// The widened ranges are then merged ([`merge_adjacent_ranges`]) before
+/// being returned: when two or more untouched members share the same
+/// physical line (e.g. `abstract area(): number; abstract perimeter():
+/// number;`), each member's own node span stops right before the next
+/// member's text starts, so widening the first member's range forward
+/// only reaches as far as its own `;` — it cannot "see" the second
+/// member's trailing `;` to widen into, since that byte range is already
+/// claimed by the second member's own (separately widened) range. Merging
+/// closes that gap instead of leaving each member to widen in isolation.
 pub(super) fn untouched_member_ranges<'a>(
     container: tree_sitter::Node<'a>,
     all_definition_nodes: &[tree_sitter::Node<'a>],
     changed_ranges: &[LineRange],
     source: &[u8],
 ) -> Vec<std::ops::Range<usize>> {
-    all_definition_nodes
+    let widened: Vec<std::ops::Range<usize>> = all_definition_nodes
         .iter()
         .filter(|node| is_descendant_of(**node, container))
         .filter(|node| !overlaps_any(node_to_line_range(**node), changed_ranges))
         .map(|node| widen_to_whole_line(node.start_byte()..node.end_byte(), source))
-        .collect()
+        .collect();
+    merge_adjacent_ranges(widened, source)
+}
+
+/// Sorts `ranges` by start position and merges any two that overlap or are
+/// separated only by bytes [`widen_to_whole_line`] would itself have
+/// widened across (horizontal whitespace and/or a single `;`) — i.e. the
+/// gap between them contains nothing worth keeping. This is what lets two
+/// untouched members sharing one physical line be removed as a single
+/// span instead of each stopping short at the other's boundary.
+fn merge_adjacent_ranges(
+    mut ranges: Vec<std::ops::Range<usize>>,
+    source: &[u8],
+) -> Vec<std::ops::Range<usize>> {
+    ranges.sort_by_key(|r| r.start);
+
+    let mut merged: Vec<std::ops::Range<usize>> = Vec::with_capacity(ranges.len());
+    for range in ranges {
+        match merged.last_mut() {
+            Some(last) if is_only_gap_filler(&source[last.end.min(range.start)..range.start]) => {
+                last.end = last.end.max(range.end);
+            }
+            _ => merged.push(range),
+        }
+    }
+    merged
+}
+
+/// Whether `gap` contains only bytes that are safe to fold into a merged
+/// removal: horizontal whitespace and/or a single leading `;`. Mirrors
+/// what [`widen_to_whole_line`] itself would strip, so merging two ranges
+/// across such a gap never removes anything [`widen_to_whole_line`]
+/// wouldn't already have removed had the gap not been claimed by another
+/// range first.
+fn is_only_gap_filler(gap: &[u8]) -> bool {
+    let after_semicolon = if gap.first() == Some(&b';') {
+        &gap[1..]
+    } else {
+        gap
+    };
+    after_semicolon.iter().all(|&b| b == b' ' || b == b'\t')
 }
 
 /// Extends `range` to cover its whole source line: backward past leading

--- a/rinkaku-core/src/extract/container_slice.rs
+++ b/rinkaku-core/src/extract/container_slice.rs
@@ -1,0 +1,86 @@
+//! Narrows a reported container's signature down to its header plus only
+//! the member lines a diff actually touched (ADR 0071).
+//!
+//! A container node (Python/TypeScript `class`) is reported as a symbol
+//! in its own right when a changed line falls directly in the class's
+//! own body — not inside any nested member — and `slice_signature`
+//! otherwise keeps every member's *signature* even when only one member
+//! (or a plain field) actually changed. This module computes the extra
+//! byte ranges to strip so untouched members disappear from the
+//! rendered signature entirely, while `slice_signature`'s existing
+//! method-body/comment stripping still applies to whatever remains.
+
+use super::{LineRange, is_descendant_of, node_to_line_range, overlaps_any};
+
+/// The byte ranges of every member definition inside `container` that
+/// does *not* overlap `changed_ranges` — i.e. every member whose entire
+/// span should be dropped from `container`'s signature, header and all.
+///
+/// A member is any node in `all_definition_nodes` that is strictly
+/// nested inside `container` — the same language-neutral "descendant of
+/// a captured `@definition` node" notion the narrowest-enclosing-
+/// definition rule already uses — so this applies identically to a
+/// Python class method, a TypeScript class method, or a class nested
+/// inside another class, with no per-language node-kind matching.
+///
+/// Each member's own node span is widened to its whole source line
+/// ([`widen_to_whole_line`]) before being returned: a captured definition
+/// node's span does not include a trailing terminator some grammars place
+/// outside it (e.g. TypeScript's `abstract_method_signature` excludes its
+/// own trailing `;`), so removing only the bare node span would leave a
+/// stray `;` and blank indentation behind.
+pub(super) fn untouched_member_ranges<'a>(
+    container: tree_sitter::Node<'a>,
+    all_definition_nodes: &[tree_sitter::Node<'a>],
+    changed_ranges: &[LineRange],
+    source: &[u8],
+) -> Vec<std::ops::Range<usize>> {
+    all_definition_nodes
+        .iter()
+        .filter(|node| is_descendant_of(**node, container))
+        .filter(|node| !overlaps_any(node_to_line_range(**node), changed_ranges))
+        .map(|node| widen_to_whole_line(node.start_byte()..node.end_byte(), source))
+        .collect()
+}
+
+/// Extends `range` to cover its whole source line: backward past leading
+/// horizontal whitespace to (not including) the previous newline, when
+/// that whitespace is the only thing between the previous newline and
+/// `range`'s start; forward past a single trailing `;` and any horizontal
+/// whitespace up to (not including) the next newline, when that is the
+/// only thing between `range`'s end and the next newline. Either side is
+/// widened independently — a member that shares its line with other kept
+/// content on one side only still gets the other side trimmed.
+fn widen_to_whole_line(range: std::ops::Range<usize>, source: &[u8]) -> std::ops::Range<usize> {
+    let line_start = source[..range.start]
+        .iter()
+        .rposition(|&b| b == b'\n')
+        .map_or(0, |pos| pos + 1);
+    let start = if source[line_start..range.start]
+        .iter()
+        .all(|&b| b == b' ' || b == b'\t')
+    {
+        line_start
+    } else {
+        range.start
+    };
+
+    let mut after = range.end;
+    if source.get(after) == Some(&b';') {
+        after += 1;
+    }
+    let line_end = source[after..]
+        .iter()
+        .position(|&b| b == b'\n')
+        .map_or(source.len(), |offset| after + offset);
+    let end = if source[after..line_end]
+        .iter()
+        .all(|&b| b == b' ' || b == b'\t')
+    {
+        line_end
+    } else {
+        range.end
+    };
+
+    start..end
+}

--- a/rinkaku-core/src/extract/hcl.rs
+++ b/rinkaku-core/src/extract/hcl.rs
@@ -87,7 +87,7 @@ pub(super) fn build_hcl_locals_symbols(
                 id: String::new(),
                 name: format!("local.{name}"),
                 kind: super::SymbolKind::Block,
-                signature: super::slice_signature(attribute, source),
+                signature: super::slice_signature(attribute, source, None),
                 range: super::node_to_line_range(attribute),
                 container: None,
                 referenced_names: references.bare,

--- a/rinkaku-core/src/extract/mod.rs
+++ b/rinkaku-core/src/extract/mod.rs
@@ -7,14 +7,29 @@
 
 use crate::diff::LineRange;
 use crate::language::LanguageSupport;
+use container_slice::untouched_member_ranges;
 use hcl::{build_hcl_locals_symbols, hcl_block_name, hcl_block_type};
 use references::collect_referenced_names;
 use serde::Serialize;
 use std::collections::HashMap;
 use tree_sitter::StreamingIterator;
 
+mod container_slice;
 mod hcl;
 mod references;
+
+/// Threaded through `build_symbols`/`build_symbol`/`slice_signature` only
+/// by `extract_changed_symbols` (ADR 0071) — `extract_all_symbols` and HCL
+/// `locals` expansion pass `None`, keeping their signatures whole
+/// regardless of any diff, since neither has a "this diff's touched lines"
+/// concept to narrow by (see [`untouched_member_ranges`]'s doc comment for
+/// why: `extract_all_symbols` indexes every definition in a file
+/// independent of any diff).
+#[derive(Clone, Copy)]
+struct TouchedContext<'a> {
+    all_definition_nodes: &'a [tree_sitter::Node<'a>],
+    changed_ranges: &'a [LineRange],
+}
 
 /// The kind of symbol a definition node represents, expressed in
 /// language-neutral terms so callers don't need to match on
@@ -207,6 +222,10 @@ pub fn extract_changed_symbols(
             .copied()
             .filter(|node| overlaps_any(node_to_line_range(*node), changed_ranges))
             .collect();
+        let touched_context = TouchedContext {
+            all_definition_nodes: all_nodes,
+            changed_ranges,
+        };
 
         touched_nodes
             .iter()
@@ -225,7 +244,15 @@ pub fn extract_changed_symbols(
                     .iter()
                     .any(|other| other != *node && is_descendant_of(*other, **node))
             })
-            .flat_map(|node| build_symbols(*node, source_bytes, reference_query, lang))
+            .flat_map(|node| {
+                build_symbols(
+                    *node,
+                    source_bytes,
+                    reference_query,
+                    lang,
+                    Some(touched_context),
+                )
+            })
             .filter(|symbol| overlaps_any(symbol.range, changed_ranges))
             .collect()
     })
@@ -247,7 +274,7 @@ pub fn extract_all_symbols(source: &str, lang: &dyn LanguageSupport) -> Vec<Extr
     with_definition_nodes(source, lang, |all_nodes, source_bytes, reference_query| {
         all_nodes
             .iter()
-            .flat_map(|node| build_symbols(*node, source_bytes, reference_query, lang))
+            .flat_map(|node| build_symbols(*node, source_bytes, reference_query, lang, None))
             .collect()
     })
 }
@@ -317,6 +344,19 @@ pub struct RemovedSymbol {
 /// reflow-only difference (indentation, line wrapping) must be normalized
 /// away here to avoid a false `SignatureChanged`, same as ADR 0014 already
 /// required before display signatures went multi-line.
+///
+/// A head symbol's own `signature` is not necessarily what gets compared:
+/// a reported container's `signature` may be narrowed to only its touched
+/// member lines (ADR 0071), which would never textually match a
+/// same-container base symbol's always-whole-class signature even when
+/// nothing else about the class actually changed. The comparison instead
+/// looks up each head symbol's `(name, container)` identity in
+/// `all_head_symbols` — the file's complete, un-narrowed symbol set
+/// already threaded through for the removal check above — and compares
+/// *that* signature, falling back to `symbol.signature` itself when no
+/// `all_head_symbols` entry exists (defensive; every `head_symbols` entry
+/// is expected to have one, since it is by construction a subset of the
+/// same file's complete symbol set).
 pub fn classify_symbols(
     head_symbols: &mut [ExtractedSymbol],
     base_symbols: &[ExtractedSymbol],
@@ -328,6 +368,10 @@ pub fn classify_symbols(
         .iter()
         .map(|s| ((s.name.as_str(), s.container.as_deref()), s))
         .collect();
+    let all_head_by_identity: HashMap<(&str, Option<&str>), &ExtractedSymbol> = all_head_symbols
+        .iter()
+        .map(|s| ((s.name.as_str(), s.container.as_deref()), s))
+        .collect();
 
     for symbol in head_symbols.iter_mut() {
         let identity = (symbol.name.as_str(), symbol.container.as_deref());
@@ -336,8 +380,11 @@ pub fn classify_symbols(
                 symbol.classification = Some(Classification::Added);
             }
             Some(base_symbol) => {
+                let comparison_signature = all_head_by_identity
+                    .get(&identity)
+                    .map_or(symbol.signature.as_str(), |s| s.signature.as_str());
                 if normalize_for_comparison(&base_symbol.signature)
-                    == normalize_for_comparison(&symbol.signature)
+                    == normalize_for_comparison(comparison_signature)
                 {
                     symbol.classification = Some(Classification::BodyOnly);
                 } else {
@@ -424,7 +471,7 @@ fn with_definition_nodes<T>(
 }
 
 /// Whether `node` is strictly nested inside `ancestor` in the syntax tree.
-fn is_descendant_of(node: tree_sitter::Node, ancestor: tree_sitter::Node) -> bool {
+pub(super) fn is_descendant_of(node: tree_sitter::Node, ancestor: tree_sitter::Node) -> bool {
     let mut current = node.parent();
     while let Some(parent) = current {
         if parent == ancestor {
@@ -438,7 +485,7 @@ fn is_descendant_of(node: tree_sitter::Node, ancestor: tree_sitter::Node) -> boo
 /// Converts a tree-sitter node's byte-oriented row span into a 1-based
 /// inclusive [`LineRange`], matching the convention `diff::parse_unified_diff`
 /// uses for new-side line numbers.
-fn node_to_line_range(node: tree_sitter::Node) -> LineRange {
+pub(super) fn node_to_line_range(node: tree_sitter::Node) -> LineRange {
     LineRange {
         start: node.start_position().row + 1,
         end: node.end_position().row + 1,
@@ -446,7 +493,7 @@ fn node_to_line_range(node: tree_sitter::Node) -> LineRange {
 }
 
 /// Whether `range` shares at least one line with any range in `others`.
-fn overlaps_any(range: LineRange, others: &[LineRange]) -> bool {
+pub(super) fn overlaps_any(range: LineRange, others: &[LineRange]) -> bool {
     others
         .iter()
         .any(|other| range.start <= other.end && other.start <= range.end)
@@ -465,12 +512,13 @@ fn build_symbols(
     source: &[u8],
     reference_query: &tree_sitter::Query,
     lang: &dyn LanguageSupport,
+    touched: Option<TouchedContext>,
 ) -> Vec<ExtractedSymbol> {
     if node.kind() == "block" && hcl_block_type(node, source).as_deref() == Some("locals") {
         return build_hcl_locals_symbols(node, source, reference_query, lang);
     }
 
-    build_symbol(node, source, reference_query, lang)
+    build_symbol(node, source, reference_query, lang, touched)
         .into_iter()
         .collect()
 }
@@ -484,10 +532,11 @@ fn build_symbol(
     source: &[u8],
     reference_query: &tree_sitter::Query,
     lang: &dyn LanguageSupport,
+    touched: Option<TouchedContext>,
 ) -> Option<ExtractedSymbol> {
     let kind = symbol_kind(node, source)?;
     let name = definition_name(node, source)?;
-    let signature = slice_signature(node, source);
+    let signature = slice_signature(node, source, touched);
     let container = find_container(node, source);
     let references = collect_referenced_names(node, source, reference_query);
     let is_test = lang.is_test_definition(node, source);
@@ -606,16 +655,19 @@ fn definition_name(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
 ///   implementation sense — their fields/variants/method signatures *are*
 ///   the API surface — so the whole node text is kept.
 /// - `class_definition` (Python), `class_declaration` /
-///   `abstract_class_declaration` (TS): the whole class text is kept
-///   (field/method signatures are the API surface, same as
-///   struct/interface), but nested method *bodies* — including a class
-///   field whose value is an arrow function, e.g. `area = (): number => {
-///   ... }` — are stripped so a class reads as a list of member signatures
-///   rather than full implementations. A per-method signature listing
-///   (rather than "whole class minus method bodies") would be more precise
-///   but adds real complexity — e.g. reconciling which subset of members to
-///   show when only one changed — that v1 defers; see the module-level
-///   rationale in `language/python.rs` and `language/typescript.rs`.
+///   `abstract_class_declaration` (TS): the class header plus member
+///   signatures are kept (field/method signatures are the API surface,
+///   same as struct/interface), but nested method *bodies* — including a
+///   class field whose value is an arrow function, e.g. `area = (): number
+///   => { ... }` — are stripped so a class reads as a list of member
+///   signatures rather than full implementations. When `touched` is
+///   `Some` (only `extract_changed_symbols` passes this — see
+///   [`TouchedContext`]), a member with no line overlapping
+///   `TouchedContext::changed_ranges` is dropped from the signature
+///   entirely, header and all (ADR 0071): a container is only ever
+///   reported as a symbol because some body-level line of its own was
+///   touched, so an unrelated, untouched method or nested class adds
+///   nothing but noise to that report.
 ///
 /// Comment nodes (`line_comment`/`block_comment` in Rust, `comment` in
 /// Go/Python/TypeScript — see [`is_comment_node`]) inside the kept range are
@@ -625,7 +677,11 @@ fn definition_name(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
 /// signature-string equality fire incorrectly. This is a pre-1.0 output
 /// change sanctioned by the ADR — some previously-reported signature strings
 /// that contained inline comments now omit them.
-fn slice_signature(node: tree_sitter::Node, source: &[u8]) -> String {
+fn slice_signature(
+    node: tree_sitter::Node,
+    source: &[u8],
+    touched: Option<TouchedContext>,
+) -> String {
     let first_line_column = node.start_position().column;
 
     if matches!(
@@ -634,6 +690,14 @@ fn slice_signature(node: tree_sitter::Node, source: &[u8]) -> String {
     ) {
         let mut removed_ranges: Vec<std::ops::Range<usize>> = Vec::new();
         collect_method_body_ranges(node, &mut removed_ranges);
+        if let Some(touched) = touched {
+            removed_ranges.extend(untouched_member_ranges(
+                node,
+                touched.all_definition_nodes,
+                touched.changed_ranges,
+                source,
+            ));
+        }
         collect_comment_ranges(node, source, &removed_ranges.clone(), &mut removed_ranges);
         return tidy_signature_lines(
             &text_with_ranges_removed(node, source, removed_ranges),

--- a/rinkaku-core/src/extract_tests/classification.rs
+++ b/rinkaku-core/src/extract_tests/classification.rs
@@ -5,7 +5,10 @@
 //! [`super::Classification::SignatureChanged`] /
 //! [`super::Classification::BodyOnly`]) and returns any base-only
 //! symbols whose base-side range overlaps `old_changed_ranges` as
-//! [`super::RemovedSymbol`]s.
+//! [`super::RemovedSymbol`]s. Also pins ADR 0071's `all_head_symbols`
+//! comparison lookup, which keeps classification correct when a
+//! container's own `signature` has been narrowed to its touched member
+//! lines.
 
 use super::*;
 use pretty_assertions::assert_eq;
@@ -58,6 +61,86 @@ fn should_classify_as_added_when_no_base_side_match_exists() {
         LineRange { start: 1, end: 3 },
     )];
     expected[0].classification = Some(Classification::Added);
+    let expected_removed: Vec<RemovedSymbol> = Vec::new();
+
+    assert_eq!(expected, head);
+    assert_eq!(expected_removed, removed);
+}
+
+// ADR 0071: a reported container's own `signature` may be narrowed to
+// only its touched member lines, but `all_head_symbols` still carries
+// that same symbol's whole, un-narrowed signature (as `extract_all_symbols`
+// always produces). Classification must compare the whole-class text
+// from `all_head_symbols`, not `head`'s own narrowed `signature` field —
+// otherwise a container whose base-side counterpart's whole-class text is
+// identical would spuriously classify `SignatureChanged` purely because
+// the head-side display text is shorter.
+#[test]
+fn should_classify_as_body_only_using_all_head_symbols_whole_signature_when_head_signature_is_narrowed()
+ {
+    let mut head = vec![symbol(
+        "Widget",
+        None,
+        // The narrowed, touched-lines-only display signature ADR 0071
+        // produces for a container — deliberately missing `move`'s
+        // signature line that both `all_head`/`base` still carry.
+        "class Widget:\n    label = \"a\"",
+        LineRange { start: 1, end: 6 },
+    )];
+    let all_head = vec![symbol(
+        "Widget",
+        None,
+        "class Widget:\n    label = \"a\"\n\n    def move(self, dx, dy):",
+        LineRange { start: 1, end: 6 },
+    )];
+    let base = vec![symbol(
+        "Widget",
+        None,
+        "class Widget:\n    label = \"a\"\n\n    def move(self, dx, dy):",
+        LineRange { start: 1, end: 6 },
+    )];
+
+    let removed = classify_symbols(&mut head, &base, &all_head, &[], "widget.py");
+
+    let mut expected = head.clone();
+    expected[0].classification = Some(Classification::BodyOnly);
+    let expected_removed: Vec<RemovedSymbol> = Vec::new();
+
+    assert_eq!(expected, head);
+    assert_eq!(expected_removed, removed);
+}
+
+// Companion: when the whole-class text in `all_head_symbols` actually
+// differs from the base side (not just narrower for display), the real
+// difference must still surface as `SignatureChanged`.
+#[test]
+fn should_classify_as_signature_changed_using_all_head_symbols_whole_signature_when_it_actually_differs()
+ {
+    let mut head = vec![symbol(
+        "Widget",
+        None,
+        "class Widget:\n    label = \"b\"",
+        LineRange { start: 1, end: 6 },
+    )];
+    let all_head = vec![symbol(
+        "Widget",
+        None,
+        "class Widget:\n    label = \"b\"\n\n    def move(self, dx, dy):",
+        LineRange { start: 1, end: 6 },
+    )];
+    let base = vec![symbol(
+        "Widget",
+        None,
+        "class Widget:\n    label = \"a\"\n\n    def move(self, dx, dy):",
+        LineRange { start: 1, end: 6 },
+    )];
+
+    let removed = classify_symbols(&mut head, &base, &all_head, &[], "widget.py");
+
+    let mut expected = head.clone();
+    expected[0].classification = Some(Classification::SignatureChanged);
+    expected[0].previous_signature =
+        Some("class Widget:\n    label = \"a\"\n\n    def move(self, dx, dy):".to_string());
     let expected_removed: Vec<RemovedSymbol> = Vec::new();
 
     assert_eq!(expected, head);

--- a/rinkaku-core/src/extract_tests/python.rs
+++ b/rinkaku-core/src/extract_tests/python.rs
@@ -189,6 +189,9 @@ def decorated(a):
     assert_eq!(expected, actual);
 }
 
+// NOTE: in both tests below, `__init__` is untouched by the diff and is
+// dropped from the reported class signature entirely, body and
+// signature line alike (ADR 0071).
 #[test]
 fn should_extract_class_signature_with_untouched_method_dropped_when_field_changed() {
     let source = "\
@@ -209,10 +212,6 @@ class Point:
         id: String::new(),
         name: "Point".to_string(),
         kind: SymbolKind::Class,
-        // `__init__` never touched by this diff, so its signature
-        // line is dropped entirely along with its body (ADR 0071)
-        // rather than kept the way `slice_signature` used to keep
-        // every member unconditionally.
         signature: "class Point:\n    x: int\n    y: int".to_string(),
         range: LineRange { start: 1, end: 7 },
         container: None,
@@ -253,8 +252,6 @@ class Point:
         id: String::new(),
         name: "Point".to_string(),
         kind: SymbolKind::Class,
-        // `__init__` untouched by this diff, dropped along with the
-        // comment (ADR 0071).
         signature: "class Point:\n\n    x: int\n    y: int".to_string(),
         range: LineRange { start: 1, end: 8 },
         container: None,

--- a/rinkaku-core/src/extract_tests/python.rs
+++ b/rinkaku-core/src/extract_tests/python.rs
@@ -190,7 +190,7 @@ def decorated(a):
 }
 
 #[test]
-fn should_extract_class_signature_with_method_bodies_stripped_when_field_changed() {
+fn should_extract_class_signature_with_untouched_method_dropped_when_field_changed() {
     let source = "\
 class Point:
     x: int
@@ -209,8 +209,11 @@ class Point:
         id: String::new(),
         name: "Point".to_string(),
         kind: SymbolKind::Class,
-        signature: "class Point:\n    x: int\n    y: int\n\n    def __init__(self, x, y):"
-            .to_string(),
+        // `__init__` never touched by this diff, so its signature
+        // line is dropped entirely along with its body (ADR 0071)
+        // rather than kept the way `slice_signature` used to keep
+        // every member unconditionally.
+        signature: "class Point:\n    x: int\n    y: int".to_string(),
         range: LineRange { start: 1, end: 7 },
         container: None,
         // "int" is the shared field-annotation type of both `x`
@@ -250,8 +253,9 @@ class Point:
         id: String::new(),
         name: "Point".to_string(),
         kind: SymbolKind::Class,
-        signature: "class Point:\n\n    x: int\n    y: int\n\n    def __init__(self, x, y):"
-            .to_string(),
+        // `__init__` untouched by this diff, dropped along with the
+        // comment (ADR 0071).
+        signature: "class Point:\n\n    x: int\n    y: int".to_string(),
         range: LineRange { start: 1, end: 8 },
         container: None,
         referenced_names: vec!["int".to_string()],

--- a/rinkaku-core/src/extract_tests/typescript.rs
+++ b/rinkaku-core/src/extract_tests/typescript.rs
@@ -340,7 +340,7 @@ enum Color {
 }
 
 #[test]
-fn should_extract_class_signature_with_method_bodies_stripped_when_field_changed() {
+fn should_extract_class_signature_with_untouched_method_dropped_when_field_changed() {
     let source = "\
 class Circle {
     radius: number;
@@ -359,7 +359,10 @@ class Circle {
         id: String::new(),
         name: "Circle".to_string(),
         kind: SymbolKind::Class,
-        signature: "class Circle {\n    radius: number;\n\n    area(): number\n}".to_string(),
+        // `area` never touched by this diff, dropped entirely along
+        // with its body (ADR 0071) rather than kept as a bare
+        // signature line.
+        signature: "class Circle {\n    radius: number;\n\n}".to_string(),
         range: LineRange { start: 1, end: 7 },
         container: None,
         referenced_names: vec!["Circle".to_string()],
@@ -397,7 +400,9 @@ class Circle {
         id: String::new(),
         name: "Circle".to_string(),
         kind: SymbolKind::Class,
-        signature: "class Circle {\n\n    radius: number;\n\n    area(): number\n}".to_string(),
+        // `area` never touched by this diff, dropped along with the
+        // comments (ADR 0071).
+        signature: "class Circle {\n\n    radius: number;\n\n}".to_string(),
         range: LineRange { start: 1, end: 8 },
         container: None,
         referenced_names: vec!["Circle".to_string()],
@@ -624,7 +629,7 @@ abstract class Shape {
 }
 
 #[test]
-fn should_extract_abstract_class_signature_when_no_member_line_specifically_changed() {
+fn should_extract_abstract_class_header_only_when_no_member_line_specifically_changed() {
     let source = "\
 abstract class Shape {
     abstract area(): number;
@@ -640,9 +645,9 @@ abstract class Shape {
         id: String::new(),
         name: "Shape".to_string(),
         kind: SymbolKind::Class,
-        signature:
-            "abstract class Shape {\n    abstract area(): number;\n    abstract perimeter(): number;\n}"
-                .to_string(),
+        // Neither member overlaps the touched line, so both are
+        // dropped (ADR 0071), leaving only the header.
+        signature: "abstract class Shape {\n\n}".to_string(),
         range: LineRange { start: 1, end: 4 },
         container: None,
         referenced_names: vec!["Shape".to_string()],

--- a/rinkaku-core/src/extract_tests/typescript.rs
+++ b/rinkaku-core/src/extract_tests/typescript.rs
@@ -339,6 +339,9 @@ enum Color {
     assert_eq!(expected, actual);
 }
 
+// NOTE: in both tests below, `area` is untouched by the diff and is
+// dropped from the reported class signature entirely, body and
+// signature line alike (ADR 0071).
 #[test]
 fn should_extract_class_signature_with_untouched_method_dropped_when_field_changed() {
     let source = "\
@@ -359,9 +362,6 @@ class Circle {
         id: String::new(),
         name: "Circle".to_string(),
         kind: SymbolKind::Class,
-        // `area` never touched by this diff, dropped entirely along
-        // with its body (ADR 0071) rather than kept as a bare
-        // signature line.
         signature: "class Circle {\n    radius: number;\n\n}".to_string(),
         range: LineRange { start: 1, end: 7 },
         container: None,
@@ -400,8 +400,6 @@ class Circle {
         id: String::new(),
         name: "Circle".to_string(),
         kind: SymbolKind::Class,
-        // `area` never touched by this diff, dropped along with the
-        // comments (ADR 0071).
         signature: "class Circle {\n\n    radius: number;\n\n}".to_string(),
         range: LineRange { start: 1, end: 8 },
         container: None,
@@ -645,8 +643,7 @@ abstract class Shape {
         id: String::new(),
         name: "Shape".to_string(),
         kind: SymbolKind::Class,
-        // Neither member overlaps the touched line, so both are
-        // dropped (ADR 0071), leaving only the header.
+        // Neither member overlaps the touched line (ADR 0071).
         signature: "abstract class Shape {\n\n}".to_string(),
         range: LineRange { start: 1, end: 4 },
         container: None,
@@ -738,6 +735,73 @@ const Component = () => {
         previous_signature: None,
     }];
     let actual = extract_changed_symbols(source, lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+// NOTE: in both tests below, `string` is TypeScript's built-in
+// `predefined_type`, not captured by the reference query (same as
+// `number` in sibling tests above).
+#[test]
+fn should_drop_two_untouched_same_line_abstract_methods_when_field_changed() {
+    let source = "\
+abstract class Shape {
+    label: string;
+
+    abstract area(): number; abstract perimeter(): number;
+}
+";
+    let lang = TypeScriptSupport;
+    let changed_ranges = vec![LineRange { start: 2, end: 2 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Shape".to_string(),
+        kind: SymbolKind::Class,
+        signature: "abstract class Shape {\n    label: string;\n\n}".to_string(),
+        range: LineRange { start: 1, end: 5 },
+        container: None,
+        referenced_names: vec!["Shape".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_drop_three_untouched_same_line_abstract_methods_when_field_changed() {
+    let source = "\
+abstract class Shape {
+    label: string;
+
+    abstract area(): number; abstract perimeter(): number; abstract volume(): number;
+}
+";
+    let lang = TypeScriptSupport;
+    let changed_ranges = vec![LineRange { start: 2, end: 2 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Shape".to_string(),
+        kind: SymbolKind::Class,
+        signature: "abstract class Shape {\n    label: string;\n\n}".to_string(),
+        range: LineRange { start: 1, end: 5 },
+        container: None,
+        referenced_names: vec!["Shape".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
     assert_eq!(expected, actual);
 }

--- a/rinkaku-core/src/pipeline_tests/container_slice_regression.rs
+++ b/rinkaku-core/src/pipeline_tests/container_slice_regression.rs
@@ -1,0 +1,145 @@
+//! ADR 0071 end-to-end: a reported container's signature narrows to its
+//! touched member lines, and this narrowing must not change ADR 0014
+//! classification — `classify_symbols` compares against `all_head_symbols`'
+//! always-whole-class signature, not the narrowed `head_symbols` one (see
+//! `extract::classify_symbols`'s doc comment).
+//!
+//! NOTE: asserts individual fields of the reported symbol rather than the
+//! whole `ExtractedSymbol`, matching the established partial-assert style
+//! of the sibling `classification_wiring` module this test's shape
+//! mirrors — the fields not asserted here (`id`, `range`,
+//! `referenced_names`, `dependencies`, ...) are irrelevant to the
+//! narrowing/classification interaction under test.
+
+use super::fake_reader;
+use crate::extract::Classification;
+use crate::pipeline::analyze_diff;
+use pretty_assertions::assert_eq;
+use std::collections::{HashMap, HashSet};
+
+// A field-only edit inside a Python class with an unrelated, untouched
+// method: the reported `Widget` signature must drop `move`/`scale`
+// entirely, and — despite the head-side signature being narrower than
+// the base-side's whole-class signature — still classify `BodyOnly`,
+// exactly as it did before ADR 0071 narrowed the displayed signature
+// (the class's own touched line changed value only, not shape).
+#[test]
+fn should_drop_untouched_methods_from_reported_class_signature_when_only_a_field_changed() {
+    let diff = "\
+diff --git a/widget.py b/widget.py
+index 57b03c6..75530be 100644
+--- a/widget.py
++++ b/widget.py
+@@ -1,7 +1,7 @@
+ class Widget:
+-    label = \"a\"
++    label = \"a\"
+
+     def move(self, dx, dy):
+         return dx + dy
+
+     def scale(self, factor):
+         return factor
+";
+    let base_source = "\
+class Widget:
+    label = \"a\"
+
+    def move(self, dx, dy):
+        return dx + dy
+
+    def scale(self, factor):
+        return factor
+";
+    let head_source = base_source;
+    let read_file = fake_reader(HashMap::from([("widget.py", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("widget.py", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    let symbol = &report.files[0].symbols[0];
+    assert_eq!("Widget", symbol.name);
+    assert_eq!("class Widget:\n    label = \"a\"", symbol.signature);
+    assert_eq!(Some(Classification::BodyOnly), symbol.classification);
+}
+
+// Companion case: the touched field's *value* actually changes. The
+// narrowed signature differs from the base's whole-class signature
+// for a real reason (the field's own text), so classification must
+// still correctly report `SignatureChanged` — narrowing the displayed
+// signature must not turn a real change into a false `BodyOnly` either.
+#[test]
+fn should_classify_signature_changed_when_a_touched_field_value_actually_differs() {
+    let diff = "\
+diff --git a/widget.py b/widget.py
+index 57b03c6..8b34e01 100644
+--- a/widget.py
++++ b/widget.py
+@@ -1,7 +1,7 @@
+ class Widget:
+-    label = \"a\"
++    label = \"b\"
+
+     def move(self, dx, dy):
+         return dx + dy
+
+     def scale(self, factor):
+         return factor
+";
+    let base_source = "\
+class Widget:
+    label = \"a\"
+
+    def move(self, dx, dy):
+        return dx + dy
+
+    def scale(self, factor):
+        return factor
+";
+    let head_source = "\
+class Widget:
+    label = \"b\"
+
+    def move(self, dx, dy):
+        return dx + dy
+
+    def scale(self, factor):
+        return factor
+";
+    let read_file = fake_reader(HashMap::from([("widget.py", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("widget.py", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    let symbol = &report.files[0].symbols[0];
+    assert_eq!("Widget", symbol.name);
+    assert_eq!("class Widget:\n    label = \"b\"", symbol.signature);
+    assert_eq!(
+        Some(Classification::SignatureChanged),
+        symbol.classification
+    );
+    assert_eq!(
+        Some("class Widget:\n    label = \"a\"\n\n    def move(self, dx, dy):\n\n    def scale(self, factor):".to_string()),
+        symbol.previous_signature
+    );
+}

--- a/rinkaku-core/src/pipeline_tests/mod.rs
+++ b/rinkaku-core/src/pipeline_tests/mod.rs
@@ -57,6 +57,11 @@
 //!   stoplisted receiver call creates no graph edge while the same-named
 //!   trait method spec still links to its implementation via
 //!   `referenced_method_names`.
+//! - [`container_slice_regression`] — ADR 0071 end-to-end: a reported
+//!   container's signature narrows to touched member lines, and ADR 0014
+//!   classification (`BodyOnly`/`SignatureChanged`) stays correct despite
+//!   the head-side signature no longer matching the base side's shape
+//!   byte-for-byte.
 
 use std::collections::HashMap;
 
@@ -64,6 +69,7 @@ mod analyze_diff;
 mod analyze_repo;
 mod classification_wiring;
 mod collect_referenced_names;
+mod container_slice_regression;
 mod file_size_warnings;
 mod generated_exclusion;
 mod go_receiver_regression;


### PR DESCRIPTION
## Summary

Python and TypeScript classes are single tree-sitter nodes whose span covers the entire class body, methods included. When a diff touches only a class-level line (a field, a class-level comment) rather than any nested method, the previously reported signature kept every method's signature line whether or not it was touched — a one-line field edit surfaced unrelated methods as "what changed," adding noise to Definitions output.

This PR narrows a reported container's signature down to its header plus only the touched member lines, dropping untouched member definitions entirely. See ADR 0071 for the full context and decision rationale.

## Classification safety

Slicing is a display-only change. `classify_symbols`'s `Added`/`SignatureChanged`/`BodyOnly` classification still compares each head symbol's **whole-class** signature (looked up via `all_head_symbols`, not the narrowed `signature` field) against the base side, so classification behavior is unaffected. This is pinned by regression tests in `pipeline_tests/container_slice_regression.rs` comparing classification output before and after this change on the same inputs.

## Blocker fix in this PR

Dynamic verification during review found that `untouched_member_ranges` widened each untouched member's byte range independently ([`widen_to_whole_line`]). When two or more untouched members share the same physical line — e.g. TypeScript's `abstract_method_signature`, whose node span excludes its own trailing `;` — `abstract area(): number; abstract perimeter(): number;` on one line, each member's widen-forward pass stopped right at the next member's boundary, since that byte range was already claimed by the next member's own widened range. The result was a stray `;` (or `; ;` for three siblings) leaking into the output.

Fixed by sorting and merging overlapping/adjacent widened ranges (`merge_adjacent_ranges` in `container_slice.rs`) before removal, so same-line untouched siblings are removed as a single span. Covered by two new regression tests (`should_drop_two_untouched_same_line_abstract_methods_when_field_changed`, `should_drop_three_untouched_same_line_abstract_methods_when_field_changed`) in `extract_tests/typescript.rs`.

## Known limitation

If a diff changes both a container's own body-level line (e.g. an attribute) *and* one of its methods in the same hunk set, the pre-existing narrowest-enclosing-definition rule still suppresses the container in favor of the touched method as the reported symbol — the attribute change becomes invisible to this diff's output. Not introduced or fixed by this change; see ADR 0071's Consequences section.

## Review note

Reviewed with both a static (map-assisted) pass and dynamic verification (building and running the changed extraction path against hand-crafted fixtures). The same-line-sibling `;` leak found during dynamic verification is fixed in this PR, not deferred.

## File size

`extract/mod.rs` was already over the warn threshold before this change; ADR 0071's `TouchedContext` plumbing adds ~30 lines to existing functions rather than new surface. A split is tracked as a follow-up, not addressed in this PR.

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] New regression tests reproduce the same-line sibling `;` leak before the fix and pass after