### PR TITLE
fix: include leading decorators and attributes in definition spans

### DIFF
--- a/docs/adr/0073-include-decorators-and-attributes-in-definition-span.md
+++ b/docs/adr/0073-include-decorators-and-attributes-in-definition-span.md
@@ -79,11 +79,11 @@ override it:
 
 `with_definition_nodes` (`extract/mod.rs`) computes each captured
 node's extended span once, right after the query match, and wraps the
-result in a small value type (`extract::definition_span::Definition`)
-carrying the original node plus the span's start byte/row. Every
+result in a small value type (`extract::definition_span::DefinitionNode`)
+carrying the original node plus the span's start byte/row/column. Every
 downstream consumer that today reads a bare node's own
 `start_byte()`/`start_position()` for range or slicing purposes reads
-the `Definition`'s span-start instead:
+the `DefinitionNode`'s span-start instead:
 
 - the touched/overlap check (`node_to_line_range`, feeding
   `extract_changed_symbols`'s filter)
@@ -97,13 +97,21 @@ the `Definition`'s span-start instead:
   decorator.
 
 `collect_referenced_names` (`extract/references.rs`) is **not**
-changed — it still walks the inner (undecorated) node's subtree only.
-A decorator/attribute's own arguments (`@app.route("/x")`,
-`#[serde(rename = "y")]`) are not scanned for references; this is
-deliberately deferred, not silently dropped, since decorator arguments
-are a distinct, lower-confidence reference shape (often configuration
-values, not symbol names) that deserves its own decision if it turns
-out to matter in practice.
+changed — it is still called with the original (unwidened) node, so a
+Python decorator or Rust attribute — sitting outside that node's own
+subtree — contributes nothing to `referenced_names`/
+`referenced_method_names` either before or after this decision. A
+decorator/attribute's own arguments (`@app.route("/x")`,
+`#[serde(rename = "y")]`) are not scanned for references for these two
+languages; this is deliberately deferred, not silently dropped, since
+decorator arguments are a distinct, lower-confidence reference shape
+(often configuration values, not symbol names) that deserves its own
+decision if it turns out to matter in practice. TypeScript already
+diverges from this by construction and is unaffected: its decorator
+sits *inside* `class_declaration`'s own subtree (the same grammar
+accident this ADR's Context section describes), so `Component` in
+`@Component() class Widget {}` was already collected as a reference
+before this decision and continues to be.
 
 ## Alternatives
 

--- a/docs/adr/0073-include-decorators-and-attributes-in-definition-span.md
+++ b/docs/adr/0073-include-decorators-and-attributes-in-definition-span.md
@@ -1,0 +1,169 @@
+# 0073. Include decorators and attributes in a definition's span
+
+- Status: accepted
+- Date: 2026-08-11
+- Relates to: [ADR 0071](0071-slice-container-signatures-to-touched-lines.md)
+  (the untouched-member removal this decision's extended span also
+  feeds into)
+
+## Context
+
+A Python `@decorator` and a Rust `#[attribute]` both sit outside the
+tree-sitter node `definition_query` captures for the definition they
+annotate:
+
+- Python: `function_definition`/`class_definition` is wrapped in a
+  `decorated_definition` node once any decorator is present; the query
+  captures the inner node directly, not the wrapper (see
+  `language/python.rs`'s `DEFINITION_QUERY` doc comment).
+- Rust: an `attribute_item` (`#[derive(...)]`, `#[allow(...)]`, ...) is
+  a preceding *sibling* of the item it annotates, not a child, and
+  `definition_query` never walks siblings to include it (see
+  `language/rust.rs`'s `has_test_attribute`, which already performs
+  this walk for a different purpose: test-attribute detection).
+
+Consequently, a diff that touches only a decorator/attribute line —
+adding `@dataclass`, changing `#[derive(Debug)]` to
+`#[derive(Debug, Clone)]` — is invisible to rinkaku: the changed line
+falls outside every reported definition's row range, so
+`extract_changed_symbols` reports nothing, and the definition's
+signature (when it *is* reported for some other reason) never includes
+the decorator/attribute text.
+
+TypeScript does not have this problem, but not by design: its grammar
+attaches a decorator as a child of `class_declaration` itself
+(`(decorator) (class) name: (type_identifier) ...`), so it is already
+inside the captured node's row range and already inside the text
+`slice_signature` keeps. This is a grammar-shape accident, not a
+deliberate choice recorded anywhere — Python and Rust's current
+"decorator-blind" behavior is the actual v1 simplification (Python's
+`DEFINITION_QUERY` doc comment says so explicitly), and this ADR closes
+that gap so all three languages behave the same way.
+
+## Decision
+
+Add one method to `LanguageSupport`:
+
+```rust
+fn definition_span_start<'a>(&self, node: Node<'a>) -> Node<'a> {
+    node
+}
+```
+
+Default implementation returns `node` unchanged — Go, TypeScript, and
+HCL keep exactly today's behavior with zero code. Python and Rust
+override it:
+
+- **Python**: if `node`'s parent is `decorated_definition`, return that
+  parent. This also covers a class method's own decorator, since
+  `decorated_definition` wraps a nested `function_definition` the same
+  way it wraps a top-level one (verified against the grammar: a
+  decorated method inside a class body is `block ->
+  decorated_definition -> function_definition`, structurally identical
+  to the top-level case).
+- **Rust**: walk backward through `node`'s preceding siblings,
+  extending across consecutive `attribute_item` nodes, and return the
+  earliest one found (or `node` itself if there are none). The walk
+  stops — does not extend across — a `line_comment`/`block_comment`
+  sibling: a comment sitting between an attribute and its item is
+  common (a doc comment describing why the attribute is there), and if
+  the span extended through it, a comment-only line edit would make the
+  whole definition register as touched, which is not this ADR's goal.
+  This intentionally diverges from `has_test_attribute`'s sibling walk
+  (`is_skippable_between_attribute_and_item`), which *does* skip over
+  comments — that walk answers "is this item test-attributed at all",
+  where a comment in between is irrelevant to the yes/no answer; this
+  walk instead answers "which lines belong to this definition", where
+  a comment in between is content that must stay outside the span for
+  the pin above to hold.
+
+`with_definition_nodes` (`extract/mod.rs`) computes each captured
+node's extended span once, right after the query match, and wraps the
+result in a small value type (`extract::definition_span::Definition`)
+carrying the original node plus the span's start byte/row. Every
+downstream consumer that today reads a bare node's own
+`start_byte()`/`start_position()` for range or slicing purposes reads
+the `Definition`'s span-start instead:
+
+- the touched/overlap check (`node_to_line_range`, feeding
+  `extract_changed_symbols`'s filter)
+- `ExtractedSymbol::range`
+- `slice_signature`'s declaration-prefix and class-header start (so a
+  decorator/attribute is included in the signature text, not only in
+  the touched-range check)
+- ADR 0071's untouched-member removal (`container_slice.rs`): a
+  member's widened removal range now starts at the member's own
+  decorator/attribute, so dropping an untouched method also drops its
+  decorator.
+
+`collect_referenced_names` (`extract/references.rs`) is **not**
+changed — it still walks the inner (undecorated) node's subtree only.
+A decorator/attribute's own arguments (`@app.route("/x")`,
+`#[serde(rename = "y")]`) are not scanned for references; this is
+deliberately deferred, not silently dropped, since decorator arguments
+are a distinct, lower-confidence reference shape (often configuration
+values, not symbol names) that deserves its own decision if it turns
+out to matter in practice.
+
+## Alternatives
+
+- **Widen the tree-sitter query itself** (capture
+  `decorated_definition`/a synthetic attribute-inclusive span directly
+  in `DEFINITION_QUERY`): rejected for Rust — there is no single Rust
+  grammar node spanning an attribute plus the item it annotates (they
+  are siblings, not parent/child), so the query language cannot express
+  this; a post-query widening step is required regardless, and reusing
+  the same mechanism for Python keeps the two languages' handling
+  symmetric instead of one being query-based and the other
+  procedural.
+- **Only extend the touched-range check, leave `slice_signature`
+  reading the bare node**: rejected — a decorator-only change would
+  then be *detected* but the reported signature would still omit the
+  decorator that changed, which is the same "hides the actual edit"
+  problem this ADR exists to fix, just moved one step later.
+- **Keep `with_definition_nodes` returning bare `Node`s and recompute
+  the span start at each call site**: rejected — every call site would
+  need its own `lang.definition_span_start(node)` call and the same
+  per-node tree walk repeated (once per touched-range check, once for
+  `range`, once for `slice_signature`, once per container-slice
+  member); computing it once in `with_definition_nodes` and passing a
+  small struct is cheaper and removes the chance of one call site
+  silently reading the un-widened node.
+
+## Consequences
+
+- A decorator/attribute-only change is now detected as
+  `SignatureChanged` (base and head both slice the same way, so the
+  comparison stays symmetric) instead of being invisible.
+- A reported symbol's signature now includes its decorator(s)/
+  attribute(s) even when the diff that triggered the report touched
+  only the `def`/`class`/`fn`/`struct` line itself, not the
+  decorator — this widens what today's tests pin as the expected
+  signature text for every decorated/attributed Python and Rust
+  fixture, a deliberate, one-time output-shape change accepted as part
+  of this ADR (not something call sites need to opt into).
+- A Python class method's decorator-only change now surfaces the
+  method itself as the narrowest touched definition (per the existing
+  narrowest-enclosing-definition rule), not the whole enclosing class —
+  previously neither was reported at all, so this is a strict
+  improvement, not a behavior this ADR needs to choose between.
+- `symbol.range` for a decorated/attributed symbol now starts at the
+  decorator/attribute line, not the `def`/`fn` line — this is
+  serialized in JSON output and consumed by `rinkaku-tui` for
+  highlighting; both already treat `range` as "the symbol's full
+  extent" and need no code change, only wider highlighted spans for
+  decorated symbols.
+- Rust's `#[test]`/`#[rstest]`/`#[cfg(test)]`-style attributes are
+  ordinary `attribute_item` siblings under this mechanism, so a test
+  function's reported `range` now also starts at its test attribute
+  line — `is_test_definition`'s own detection logic is unaffected (it
+  inspects the node's siblings directly, independent of
+  `definition_span_start`), only the reported range/signature text
+  shifts.
+- **Deferred, not fixed by this decision**: the existing gap where a
+  diff touching both a container's own body-level line and one of its
+  members in the same hunk set still suppresses the container in favor
+  of the member (ADR 0071's Consequences) is unchanged — a decorator on
+  the *container itself*, changed alongside a member change, remains
+  subject to that same pre-existing suppression rule, not a new gap
+  this ADR introduces.

--- a/docs/adr/0073-include-decorators-and-attributes-in-definition-span.md
+++ b/docs/adr/0073-include-decorators-and-attributes-in-definition-span.md
@@ -30,15 +30,26 @@ falls outside every reported definition's row range, so
 signature (when it *is* reported for some other reason) never includes
 the decorator/attribute text.
 
-TypeScript does not have this problem, but not by design: its grammar
-attaches a decorator as a child of `class_declaration` itself
-(`(decorator) (class) name: (type_identifier) ...`), so it is already
-inside the captured node's row range and already inside the text
-`slice_signature` keeps. This is a grammar-shape accident, not a
-deliberate choice recorded anywhere — Python and Rust's current
-"decorator-blind" behavior is the actual v1 simplification (Python's
-`DEFINITION_QUERY` doc comment says so explicitly), and this ADR closes
-that gap so all three languages behave the same way.
+A non-exported TypeScript class does not have this problem, but not by
+design: its grammar attaches a decorator as a child of
+`class_declaration` itself (`(decorator) (class) name:
+(type_identifier) ...`), so it is already inside the captured node's
+row range and already inside the text `slice_signature` keeps. This is
+a grammar-shape accident, not a deliberate choice recorded anywhere —
+Python and Rust's current "decorator-blind" behavior is the actual v1
+simplification (Python's `DEFINITION_QUERY` doc comment says so
+explicitly), and this ADR closes that gap so all three languages behave
+the same way.
+
+An `export`ed TypeScript class does *not* share this accident: the
+grammar instead attaches the decorator to the enclosing
+`export_statement` (`(export_statement decorator: (decorator ...)
+declaration: (class_declaration ...))`), one level higher than the
+`class_declaration` node `DEFINITION_QUERY` captures. `export class Foo
+{}` is the common case in Angular/NestJS-style decorated classes, so
+this is not a corner case — a decorator-only change on an exported
+class was invisible in the same way Python/Rust's was, and needs the
+same widening `PythonSupport`/`RustSupport` already have.
 
 ## Decision
 
@@ -50,9 +61,9 @@ fn definition_span_start<'a>(&self, node: Node<'a>) -> Node<'a> {
 }
 ```
 
-Default implementation returns `node` unchanged — Go, TypeScript, and
-HCL keep exactly today's behavior with zero code. Python and Rust
-override it:
+Default implementation returns `node` unchanged — Go and HCL keep
+exactly today's behavior with zero code (neither has decorator/attribute
+syntax at all). Python, Rust, and TypeScript override it:
 
 - **Python**: if `node`'s parent is `decorated_definition`, return that
   parent. This also covers a class method's own decorator, since
@@ -76,6 +87,19 @@ override it:
   walk instead answers "which lines belong to this definition", where
   a comment in between is content that must stay outside the span for
   the pin above to hold.
+- **TypeScript**: if `node`'s parent is `export_statement` and it has a
+  `decorator` field, return the earliest decorator (`export_statement`'s
+  `decorator` field is `multiple: true` for stacked decorators, and
+  `child_by_field_name` already returns the first one in source order).
+  Returns `node` unchanged when the parent is an `export_statement` with
+  no `decorator` field — an undecorated `export class Foo {}` must not
+  pull the `export` keyword into the span, since it belongs to
+  `export_statement`, not to `class_declaration` itself. A non-exported
+  decorated class, or the `export @Dec() class Foo {}` ordering (the
+  grammar accepts the decorator either before or after `export`), needs
+  no override at all: both put the decorator inside
+  `class_declaration`'s own span already, per the grammar-accident
+  behavior described above.
 
 `with_definition_nodes` (`extract/mod.rs`) computes each captured
 node's extended span once, right after the query match, and wraps the
@@ -106,12 +130,16 @@ decorator/attribute's own arguments (`@app.route("/x")`,
 languages; this is deliberately deferred, not silently dropped, since
 decorator arguments are a distinct, lower-confidence reference shape
 (often configuration values, not symbol names) that deserves its own
-decision if it turns out to matter in practice. TypeScript already
-diverges from this by construction and is unaffected: its decorator
-sits *inside* `class_declaration`'s own subtree (the same grammar
-accident this ADR's Context section describes), so `Component` in
-`@Component() class Widget {}` was already collected as a reference
-before this decision and continues to be.
+decision if it turns out to matter in practice. A non-exported
+TypeScript class's decorator already diverges from this by construction
+and is unaffected: it sits *inside* `class_declaration`'s own subtree
+(the same grammar accident this ADR's Context section describes), so
+`Component` in `@Component() class Widget {}` was already collected as
+a reference before this decision and continues to be. An exported
+class's decorator (`@Component()\nexport class Widget {}`) sits outside
+`class_declaration`'s subtree the same way Python/Rust's do, so it is
+subject to the same deferral: `Component` is not collected as a
+reference for the exported form, unlike the non-exported form.
 
 ## Alternatives
 
@@ -147,9 +175,10 @@ before this decision and continues to be.
   attribute(s) even when the diff that triggered the report touched
   only the `def`/`class`/`fn`/`struct` line itself, not the
   decorator — this widens what today's tests pin as the expected
-  signature text for every decorated/attributed Python and Rust
-  fixture, a deliberate, one-time output-shape change accepted as part
-  of this ADR (not something call sites need to opt into).
+  signature text for every decorated/attributed Python, Rust, and
+  exported-TypeScript-class fixture, a deliberate, one-time
+  output-shape change accepted as part of this ADR (not something call
+  sites need to opt into).
 - A Python class method's decorator-only change now surfaces the
   method itself as the narrowest touched definition (per the existing
   narrowest-enclosing-definition rule), not the whole enclosing class —

--- a/rinkaku-core/src/extract/container_slice.rs
+++ b/rinkaku-core/src/extract/container_slice.rs
@@ -10,7 +10,8 @@
 //! rendered signature entirely, while `slice_signature`'s existing
 //! method-body/comment stripping still applies to whatever remains.
 
-use super::{LineRange, is_descendant_of, node_to_line_range, overlaps_any};
+use super::{LineRange, is_descendant_of, overlaps_any};
+use crate::extract::definition_span::DefinitionNode;
 
 /// The byte ranges of every member definition inside `container` that
 /// does *not* overlap `changed_ranges` — i.e. every member whose entire
@@ -23,12 +24,16 @@ use super::{LineRange, is_descendant_of, node_to_line_range, overlaps_any};
 /// Python class method, a TypeScript class method, or a class nested
 /// inside another class, with no per-language node-kind matching.
 ///
-/// Each member's own node span is widened to its whole source line
+/// Each member's own widened span (ADR 0073: decorator/attribute
+/// inclusive) is further widened to its whole source line
 /// ([`widen_to_whole_line`]) before being returned: a captured definition
 /// node's span does not include a trailing terminator some grammars place
 /// outside it (e.g. TypeScript's `abstract_method_signature` excludes its
 /// own trailing `;`), so removing only the bare node span would leave a
-/// stray `;` and blank indentation behind.
+/// stray `;` and blank indentation behind. Starting from the member's
+/// decorator/attribute rather than its bare node also means an untouched
+/// member's decorator is dropped along with the rest of it, not left
+/// behind as an orphaned line.
 ///
 /// The widened ranges are then merged ([`merge_adjacent_ranges`]) before
 /// being returned: when two or more untouched members share the same
@@ -41,15 +46,20 @@ use super::{LineRange, is_descendant_of, node_to_line_range, overlaps_any};
 /// closes that gap instead of leaving each member to widen in isolation.
 pub(super) fn untouched_member_ranges<'a>(
     container: tree_sitter::Node<'a>,
-    all_definition_nodes: &[tree_sitter::Node<'a>],
+    all_definition_nodes: &[DefinitionNode<'a>],
     changed_ranges: &[LineRange],
     source: &[u8],
 ) -> Vec<std::ops::Range<usize>> {
     let widened: Vec<std::ops::Range<usize>> = all_definition_nodes
         .iter()
-        .filter(|node| is_descendant_of(**node, container))
-        .filter(|node| !overlaps_any(node_to_line_range(**node), changed_ranges))
-        .map(|node| widen_to_whole_line(node.start_byte()..node.end_byte(), source))
+        .filter(|definition| is_descendant_of(definition.node, container))
+        .filter(|definition| !overlaps_any(definition.line_range(), changed_ranges))
+        .map(|definition| {
+            widen_to_whole_line(
+                definition.span_start_byte()..definition.node.end_byte(),
+                source,
+            )
+        })
         .collect();
     merge_adjacent_ranges(widened, source)
 }

--- a/rinkaku-core/src/extract/definition_span.rs
+++ b/rinkaku-core/src/extract/definition_span.rs
@@ -71,6 +71,7 @@ mod tests {
     use super::*;
     use crate::language::python::PythonSupport;
     use crate::language::rust::RustSupport;
+    use crate::language::typescript::TypeScriptSupport;
     use pretty_assertions::assert_eq;
 
     fn parse<'a>(
@@ -146,8 +147,40 @@ mod tests {
 
         let actual = DefinitionNode::new(struct_node, &lang);
 
-        // Line 2 is the `#[derive(Debug)]` line — the comment on line 1
-        // must stay outside the span.
         assert_eq!(LineRange { start: 2, end: 5 }, actual.line_range());
+    }
+
+    #[test]
+    fn should_widen_span_to_decorator_when_typescript_exported_class_is_decorated() {
+        let source = "@Component()\nexport class Widget {\n    label: string;\n}\n";
+        let mut parser = tree_sitter::Parser::new();
+        let lang = TypeScriptSupport;
+        let tree = parse(&mut parser, lang.grammar(), source);
+        let export_statement = tree.root_node().named_child(0).unwrap();
+        assert_eq!("export_statement", export_statement.kind());
+        let class_node = export_statement.child_by_field_name("declaration").unwrap();
+        assert_eq!("class_declaration", class_node.kind());
+
+        let actual = DefinitionNode::new(class_node, &lang);
+
+        assert_eq!(0, actual.span_start_byte());
+        assert_eq!(LineRange { start: 1, end: 4 }, actual.line_range());
+    }
+
+    #[test]
+    fn should_not_widen_span_when_typescript_exported_class_is_undecorated() {
+        let source = "export class Widget {\n    label: string;\n}\n";
+        let mut parser = tree_sitter::Parser::new();
+        let lang = TypeScriptSupport;
+        let tree = parse(&mut parser, lang.grammar(), source);
+        let export_statement = tree.root_node().named_child(0).unwrap();
+        assert_eq!("export_statement", export_statement.kind());
+        let class_node = export_statement.child_by_field_name("declaration").unwrap();
+        assert_eq!("class_declaration", class_node.kind());
+
+        let actual = DefinitionNode::new(class_node, &lang);
+
+        assert_eq!(class_node.start_byte(), actual.span_start_byte());
+        assert_eq!(LineRange { start: 1, end: 3 }, actual.line_range());
     }
 }

--- a/rinkaku-core/src/extract/definition_span.rs
+++ b/rinkaku-core/src/extract/definition_span.rs
@@ -1,0 +1,153 @@
+//! Widens a captured `@definition` node's span to include any
+//! decorator/attribute annotating it (ADR 0073).
+//!
+//! [`LanguageSupport::definition_span_start`] locates where a definition's
+//! span should actually begin (a Python `decorated_definition` wrapper, the
+//! earliest of a run of Rust `attribute_item` siblings, or the node itself
+//! for languages with no such wrapping). This module computes that once per
+//! captured node — right after the query match, in
+//! [`super::with_definition_nodes`] — and carries the result alongside the
+//! original node so every downstream consumer (touched-range checks,
+//! `ExtractedSymbol::range`, signature slicing, untouched-member removal)
+//! reads the same widened span instead of each re-deriving it.
+
+use super::LineRange;
+use crate::language::LanguageSupport;
+
+/// A captured `@definition` node plus the byte/row position its span
+/// actually starts at once any decorator/attribute is folded in. `node`
+/// itself is kept (not just the span start) because most tree-sitter
+/// operations — walking children, finding the `body` field, and so on —
+/// still need the original definition node, not its widened span; AST
+/// nesting checks ([`super::is_descendant_of`]) also deliberately use
+/// `node` rather than the span, since a decorator/attribute is never
+/// itself an ancestor/descendant of anything.
+#[derive(Clone, Copy)]
+pub(super) struct DefinitionNode<'a> {
+    pub(super) node: tree_sitter::Node<'a>,
+    span_start_byte: usize,
+    span_start_row: usize,
+    span_start_column: usize,
+}
+
+impl<'a> DefinitionNode<'a> {
+    pub(super) fn new(node: tree_sitter::Node<'a>, lang: &dyn LanguageSupport) -> Self {
+        let span_start = lang.definition_span_start(node);
+        Self {
+            node,
+            span_start_byte: span_start.start_byte(),
+            span_start_row: span_start.start_position().row,
+            span_start_column: span_start.start_position().column,
+        }
+    }
+
+    pub(super) fn span_start_byte(&self) -> usize {
+        self.span_start_byte
+    }
+
+    /// The widened span's starting column — the dedent baseline
+    /// `tidy_signature_lines` needs (see `first_line_column`'s doc comment
+    /// there), taken from the decorator/attribute's own indentation when
+    /// present rather than the inner definition's, since the decorator line
+    /// is now the signature's actual first line.
+    pub(super) fn span_start_column(&self) -> usize {
+        self.span_start_column
+    }
+
+    /// The widened span as a 1-based inclusive [`LineRange`]: starts at the
+    /// decorator/attribute line when present, ends at `node`'s own last
+    /// line (a decorator/attribute never extends the *end* of a
+    /// definition, only its start).
+    pub(super) fn line_range(&self) -> LineRange {
+        LineRange {
+            start: self.span_start_row + 1,
+            end: self.node.end_position().row + 1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language::python::PythonSupport;
+    use crate::language::rust::RustSupport;
+    use pretty_assertions::assert_eq;
+
+    fn parse<'a>(
+        parser: &'a mut tree_sitter::Parser,
+        grammar: tree_sitter::Language,
+        source: &'a str,
+    ) -> tree_sitter::Tree {
+        parser.set_language(&grammar).unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
+    #[test]
+    fn should_widen_span_to_decorator_when_python_function_is_decorated() {
+        let source = "@decorator\ndef foo(a):\n    return a\n";
+        let mut parser = tree_sitter::Parser::new();
+        let lang = PythonSupport;
+        let tree = parse(&mut parser, lang.grammar(), source);
+        let function_node = tree.root_node().named_child(0).unwrap();
+        assert_eq!("decorated_definition", function_node.kind());
+        let inner = function_node.named_child(1).unwrap();
+        assert_eq!("function_definition", inner.kind());
+
+        let actual = DefinitionNode::new(inner, &lang);
+
+        assert_eq!(0, actual.span_start_byte());
+        assert_eq!(LineRange { start: 1, end: 3 }, actual.line_range());
+    }
+
+    #[test]
+    fn should_not_widen_span_when_python_function_is_undecorated() {
+        let source = "def foo(a):\n    return a\n";
+        let mut parser = tree_sitter::Parser::new();
+        let lang = PythonSupport;
+        let tree = parse(&mut parser, lang.grammar(), source);
+        let function_node = tree.root_node().named_child(0).unwrap();
+        assert_eq!("function_definition", function_node.kind());
+
+        let actual = DefinitionNode::new(function_node, &lang);
+
+        assert_eq!(function_node.start_byte(), actual.span_start_byte());
+        assert_eq!(LineRange { start: 1, end: 2 }, actual.line_range());
+    }
+
+    #[test]
+    fn should_widen_span_to_earliest_attribute_when_rust_item_has_stacked_attributes() {
+        let source = "#[allow(dead_code)]\n#[derive(Debug)]\nstruct Foo {\n    x: i32,\n}\n";
+        let mut parser = tree_sitter::Parser::new();
+        let lang = RustSupport;
+        let tree = parse(&mut parser, lang.grammar(), source);
+        let struct_node = tree
+            .root_node()
+            .named_children(&mut tree.root_node().walk())
+            .find(|n| n.kind() == "struct_item")
+            .unwrap();
+
+        let actual = DefinitionNode::new(struct_node, &lang);
+
+        assert_eq!(0, actual.span_start_byte());
+        assert_eq!(LineRange { start: 1, end: 5 }, actual.line_range());
+    }
+
+    #[test]
+    fn should_not_widen_span_past_comment_when_rust_attribute_is_separated_by_comment() {
+        let source = "// a comment\n#[derive(Debug)]\nstruct Foo {\n    x: i32,\n}\n";
+        let mut parser = tree_sitter::Parser::new();
+        let lang = RustSupport;
+        let tree = parse(&mut parser, lang.grammar(), source);
+        let struct_node = tree
+            .root_node()
+            .named_children(&mut tree.root_node().walk())
+            .find(|n| n.kind() == "struct_item")
+            .unwrap();
+
+        let actual = DefinitionNode::new(struct_node, &lang);
+
+        // Line 2 is the `#[derive(Debug)]` line — the comment on line 1
+        // must stay outside the span.
+        assert_eq!(LineRange { start: 2, end: 5 }, actual.line_range());
+    }
+}

--- a/rinkaku-core/src/extract/hcl.rs
+++ b/rinkaku-core/src/extract/hcl.rs
@@ -4,6 +4,7 @@
 //! (ADR 0028) when the HCL arms pushed it over the warn threshold —
 //! the same split `references.rs` got for the language-specific walks.
 
+use crate::extract::definition_span::DefinitionNode;
 use crate::language::LanguageSupport;
 
 /// The block-type keyword of an HCL `block` node — the text of its
@@ -83,12 +84,13 @@ pub(super) fn build_hcl_locals_symbols(
             let name = name_node.utf8_text(source).ok()?;
             let references =
                 super::references::collect_referenced_names(attribute, source, reference_query);
+            let definition = DefinitionNode::new(attribute, lang);
             Some(super::ExtractedSymbol {
                 id: String::new(),
                 name: format!("local.{name}"),
                 kind: super::SymbolKind::Block,
-                signature: super::slice_signature(attribute, source, None),
-                range: super::node_to_line_range(attribute),
+                signature: super::slice_signature(definition, source, None),
+                range: definition.line_range(),
                 container: None,
                 referenced_names: references.bare,
                 referenced_method_names: references.method,

--- a/rinkaku-core/src/extract/mod.rs
+++ b/rinkaku-core/src/extract/mod.rs
@@ -8,6 +8,7 @@
 use crate::diff::LineRange;
 use crate::language::LanguageSupport;
 use container_slice::untouched_member_ranges;
+use definition_span::DefinitionNode;
 use hcl::{build_hcl_locals_symbols, hcl_block_name, hcl_block_type};
 use references::collect_referenced_names;
 use serde::Serialize;
@@ -15,6 +16,7 @@ use std::collections::HashMap;
 use tree_sitter::StreamingIterator;
 
 mod container_slice;
+mod definition_span;
 mod hcl;
 mod references;
 
@@ -27,7 +29,7 @@ mod references;
 /// independent of any diff).
 #[derive(Clone, Copy)]
 struct TouchedContext<'a> {
-    all_definition_nodes: &'a [tree_sitter::Node<'a>],
+    all_definition_nodes: &'a [DefinitionNode<'a>],
     changed_ranges: &'a [LineRange],
 }
 
@@ -217,10 +219,10 @@ pub fn extract_changed_symbols(
     }
 
     with_definition_nodes(source, lang, |all_nodes, source_bytes, reference_query| {
-        let touched_nodes: Vec<tree_sitter::Node> = all_nodes
+        let touched_nodes: Vec<DefinitionNode> = all_nodes
             .iter()
             .copied()
-            .filter(|node| overlaps_any(node_to_line_range(*node), changed_ranges))
+            .filter(|node| overlaps_any(node.line_range(), changed_ranges))
             .collect();
         let touched_context = TouchedContext {
             all_definition_nodes: all_nodes,
@@ -242,7 +244,7 @@ pub fn extract_changed_symbols(
                 // situation cannot arise for Go structs.
                 !touched_nodes
                     .iter()
-                    .any(|other| other != *node && is_descendant_of(*other, **node))
+                    .any(|other| other.node != node.node && is_descendant_of(other.node, node.node))
             })
             .flat_map(|node| {
                 build_symbols(
@@ -417,14 +419,15 @@ pub fn classify_symbols(
 }
 
 /// Parses `source`, runs `lang`'s `definition_query` to find every
-/// `@definition` node, and hands the resulting nodes (plus the source
-/// bytes they borrow from, and a compiled `reference_query`) to `f`. Node
-/// values borrow from the parsed tree, so this scoped-callback shape —
-/// rather than returning `Vec<Node>` directly — keeps the tree alive
-/// exactly as long as needed without leaking it or threading a `Tree`
-/// value out through every caller. Shared by `extract_changed_symbols`
-/// and `extract_all_symbols`, which differ only in how they filter/use
-/// the node list.
+/// `@definition` node, widens each one's span to include any
+/// decorator/attribute ([`DefinitionNode`], ADR 0073), and hands the
+/// resulting list (plus the source bytes they borrow from, and a compiled
+/// `reference_query`) to `f`. Node values borrow from the parsed tree, so
+/// this scoped-callback shape — rather than returning `Vec<DefinitionNode>`
+/// directly — keeps the tree alive exactly as long as needed without
+/// leaking it or threading a `Tree` value out through every caller. Shared
+/// by `extract_changed_symbols` and `extract_all_symbols`, which differ
+/// only in how they filter/use the node list.
 ///
 /// `reference_query` is compiled once here (file granularity) rather than
 /// once per definition node: `Query::new` takes ~1ms, and a repo-wide
@@ -437,7 +440,7 @@ pub fn classify_symbols(
 fn with_definition_nodes<T>(
     source: &str,
     lang: &dyn LanguageSupport,
-    f: impl FnOnce(&[tree_sitter::Node], &[u8], &tree_sitter::Query) -> T,
+    f: impl FnOnce(&[DefinitionNode], &[u8], &tree_sitter::Query) -> T,
 ) -> T {
     let mut parser = tree_sitter::Parser::new();
     parser
@@ -463,7 +466,7 @@ fn with_definition_nodes<T>(
     while let Some(m) = matches.next() {
         for capture in m.captures {
             if capture.index == definition_capture_index {
-                nodes.push(capture.node);
+                nodes.push(DefinitionNode::new(capture.node, lang));
             }
         }
     }
@@ -482,16 +485,6 @@ pub(super) fn is_descendant_of(node: tree_sitter::Node, ancestor: tree_sitter::N
     false
 }
 
-/// Converts a tree-sitter node's byte-oriented row span into a 1-based
-/// inclusive [`LineRange`], matching the convention `diff::parse_unified_diff`
-/// uses for new-side line numbers.
-pub(super) fn node_to_line_range(node: tree_sitter::Node) -> LineRange {
-    LineRange {
-        start: node.start_position().row + 1,
-        end: node.end_position().row + 1,
-    }
-}
-
 /// Whether `range` shares at least one line with any range in `others`.
 pub(super) fn overlaps_any(range: LineRange, others: &[LineRange]) -> bool {
     others
@@ -508,17 +501,18 @@ pub(super) fn overlaps_any(range: LineRange, others: &[LineRange]) -> bool {
 /// overlap — a no-op for single-node symbols, whose range is the
 /// already-touched captured node's own.
 fn build_symbols(
-    node: tree_sitter::Node,
+    definition: DefinitionNode,
     source: &[u8],
     reference_query: &tree_sitter::Query,
     lang: &dyn LanguageSupport,
     touched: Option<TouchedContext>,
 ) -> Vec<ExtractedSymbol> {
+    let node = definition.node;
     if node.kind() == "block" && hcl_block_type(node, source).as_deref() == Some("locals") {
         return build_hcl_locals_symbols(node, source, reference_query, lang);
     }
 
-    build_symbol(node, source, reference_query, lang, touched)
+    build_symbol(definition, source, reference_query, lang, touched)
         .into_iter()
         .collect()
 }
@@ -528,15 +522,16 @@ fn build_symbols(
 /// (defensive default for query/grammar drift, not expected in practice
 /// given `definition_query` only captures known kinds).
 fn build_symbol(
-    node: tree_sitter::Node,
+    definition: DefinitionNode,
     source: &[u8],
     reference_query: &tree_sitter::Query,
     lang: &dyn LanguageSupport,
     touched: Option<TouchedContext>,
 ) -> Option<ExtractedSymbol> {
+    let node = definition.node;
     let kind = symbol_kind(node, source)?;
     let name = definition_name(node, source)?;
-    let signature = slice_signature(node, source, touched);
+    let signature = slice_signature(definition, source, touched);
     let container = find_container(node, source);
     let references = collect_referenced_names(node, source, reference_query);
     let is_test = lang.is_test_definition(node, source);
@@ -548,7 +543,7 @@ fn build_symbol(
         name,
         kind,
         signature,
-        range: node_to_line_range(node),
+        range: definition.line_range(),
         container,
         referenced_names: references.bare,
         referenced_method_names: references.method,
@@ -678,11 +673,12 @@ fn definition_name(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
 /// change sanctioned by the ADR — some previously-reported signature strings
 /// that contained inline comments now omit them.
 fn slice_signature(
-    node: tree_sitter::Node,
+    definition: DefinitionNode,
     source: &[u8],
     touched: Option<TouchedContext>,
 ) -> String {
-    let first_line_column = node.start_position().column;
+    let node = definition.node;
+    let first_line_column = definition.span_start_column();
 
     if matches!(
         node.kind(),
@@ -700,7 +696,7 @@ fn slice_signature(
         }
         collect_comment_ranges(node, source, &removed_ranges.clone(), &mut removed_ranges);
         return tidy_signature_lines(
-            &text_with_ranges_removed(node, source, removed_ranges),
+            &text_with_ranges_removed(node, definition.span_start_byte(), source, removed_ranges),
             first_line_column,
         );
     }
@@ -750,30 +746,31 @@ fn slice_signature(
         removed_ranges.push(body.start_byte()..node.end_byte());
     }
 
-    let raw = text_with_ranges_removed(node, source, removed_ranges);
+    let raw = text_with_ranges_removed(node, definition.span_start_byte(), source, removed_ranges);
     tidy_signature_lines(&raw, first_line_column)
 }
 
-/// Removes every byte range in `ranges` from `node`'s own text (`node`'s
-/// full span, not just the declaration prefix — callers that only want a
-/// prefix pre-truncate `ranges` to stop at that boundary), returning the
-/// remainder as a `String`. Ranges are sorted and removed front-to-back,
-/// advancing a `cursor` past each removed range in turn, so earlier
-/// removals naturally narrow what later ones can still remove; if a range
-/// starts before the current `cursor` (overlapping ranges, defensively not
-/// expected in practice) *that one range's removal* is skipped — its own
-/// iteration does nothing and `cursor` is left wherever the previous
-/// iteration advanced it to — rather than the whole function panicking on
-/// an invalid slice.
+/// Removes every byte range in `ranges` from the `span_start_byte..
+/// node.end_byte()` text (the definition's full widened span, not just the
+/// declaration prefix — callers that only want a prefix pre-truncate
+/// `ranges` to stop at that boundary), returning the remainder as a
+/// `String`. Ranges are sorted and removed front-to-back, advancing a
+/// `cursor` past each removed range in turn, so earlier removals naturally
+/// narrow what later ones can still remove; if a range starts before the
+/// current `cursor` (overlapping ranges, defensively not expected in
+/// practice) *that one range's removal* is skipped — its own iteration does
+/// nothing and `cursor` is left wherever the previous iteration advanced it
+/// to — rather than the whole function panicking on an invalid slice.
 fn text_with_ranges_removed(
     node: tree_sitter::Node,
+    span_start_byte: usize,
     source: &[u8],
     mut ranges: Vec<std::ops::Range<usize>>,
 ) -> String {
     ranges.sort_by_key(|r| r.start);
 
     let mut result = Vec::with_capacity(source.len());
-    let mut cursor = node.start_byte();
+    let mut cursor = span_start_byte;
     for range in &ranges {
         if range.start < cursor {
             continue; // Defensive: overlapping ranges should not occur.

--- a/rinkaku-core/src/extract_tests/python.rs
+++ b/rinkaku-core/src/extract_tests/python.rs
@@ -1,8 +1,8 @@
 //! Tests pinning [`super::extract_changed_symbols`] and
 //! [`super::extract_all_symbols`] behavior on Python sources: function
 //! and class signatures with nested method bodies stripped, decorator
-//! and nested-function edge cases (decorators do not extend a
-//! definition's range up to the decorator line), comment stripping
+//! and nested-function edge cases (a decorator extends a definition's
+//! span up to the decorator line itself — ADR 0073), comment stripping
 //! inside class signatures, and the Python end-to-end path via
 //! `parse_unified_diff` + `language_for_path`.
 
@@ -141,19 +141,35 @@ def top_level(a, b):
 }
 
 #[test]
-fn should_not_detect_change_when_only_decorator_line_changed() {
+fn should_detect_change_when_only_decorator_line_changed() {
     let source = "\
 @decorator_v2
 def decorated(a):
     return a
 ";
     let lang = PythonSupport;
-    // Line 1 is the decorator, outside `function_definition`'s own
-    // row range (see the doc comment on `DEFINITION_QUERY` in
-    // language/python.rs) — a deliberate v1 simplification.
+    // Line 1 is the decorator — `PythonSupport::definition_span_start`
+    // widens `function_definition`'s span to include its
+    // `decorated_definition` wrapper (ADR 0073), so a decorator-only
+    // change is detected and the decorator is included in the reported
+    // signature.
     let changed_ranges = vec![LineRange { start: 1, end: 1 }];
 
-    let expected: Vec<ExtractedSymbol> = Vec::new();
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "decorated".to_string(),
+        kind: SymbolKind::Function,
+        signature: "@decorator_v2\ndef decorated(a):".to_string(),
+        range: LineRange { start: 1, end: 3 },
+        container: None,
+        referenced_names: vec![],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
     let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
     assert_eq!(expected, actual);
@@ -173,8 +189,111 @@ def decorated(a):
         id: String::new(),
         name: "decorated".to_string(),
         kind: SymbolKind::Function,
-        signature: "def decorated(a):".to_string(),
-        range: LineRange { start: 2, end: 3 },
+        // The decorator is included in the signature (ADR 0073) even
+        // though only the body line changed: the reported span always
+        // starts at the decorator once one is present.
+        signature: "@decorator\ndef decorated(a):".to_string(),
+        range: LineRange { start: 1, end: 3 },
+        container: None,
+        referenced_names: vec![],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_detect_change_when_only_class_decorator_line_changed() {
+    let source = "\
+@dataclass
+class Point:
+    x: int
+    y: int
+";
+    let lang = PythonSupport;
+    let changed_ranges = vec![LineRange { start: 1, end: 1 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Point".to_string(),
+        kind: SymbolKind::Class,
+        signature: "@dataclass\nclass Point:\n    x: int\n    y: int".to_string(),
+        range: LineRange { start: 1, end: 4 },
+        container: None,
+        referenced_names: vec!["int".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+// A decorator on a class *method* is covered by the same
+// `decorated_definition`-parent check as a top-level function (ADR
+// 0073) — the method itself, not the enclosing class, is reported as
+// the narrowest touched definition.
+#[test]
+fn should_report_only_the_method_when_only_a_class_methods_decorator_line_changed() {
+    let source = "\
+class Widget:
+    @property
+    def label(self):
+        return self._label
+";
+    let lang = PythonSupport;
+    let changed_ranges = vec![LineRange { start: 2, end: 2 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "label".to_string(),
+        kind: SymbolKind::Function,
+        signature: "@property\ndef label(self):".to_string(),
+        range: LineRange { start: 2, end: 4 },
+        container: Some("class Widget".to_string()),
+        referenced_names: vec![],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_detect_change_when_a_decorator_is_newly_added() {
+    let source = "\
+@decorator
+def foo(a):
+    return a
+";
+    let lang = PythonSupport;
+    // Diff-line-count semantics: an added decorator shifts the
+    // definition's own diff-reported start down by one line versus the
+    // undecorated base, but the changed range here is simply the new
+    // decorator line itself.
+    let changed_ranges = vec![LineRange { start: 1, end: 1 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "foo".to_string(),
+        kind: SymbolKind::Function,
+        signature: "@decorator\ndef foo(a):".to_string(),
+        range: LineRange { start: 1, end: 3 },
         container: None,
         referenced_names: vec![],
         referenced_method_names: vec![],
@@ -398,6 +517,80 @@ class Point:
         // — see REFERENCE_QUERY's doc comment in
         // language/python.rs).
         referenced_names: vec!["str".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+// ADR 0071 + ADR 0073: when the container itself is reported (a
+// body-level line touched, not any member), an untouched decorated
+// method is dropped from the signature decorator and all — not left
+// behind as an orphaned `@property` line.
+#[test]
+fn should_drop_untouched_decorated_members_decorator_from_container_signature() {
+    let source = "\
+class Widget:
+    label = \"a\"
+
+    @property
+    def untouched(self):
+        return self._untouched
+";
+    let lang = PythonSupport;
+    // Line 2 (`label = \"a\"`) is a body-level line, not inside any
+    // method, so the class itself is the narrowest touched definition.
+    let changed_ranges = vec![LineRange { start: 2, end: 2 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Widget".to_string(),
+        kind: SymbolKind::Class,
+        signature: "class Widget:\n    label = \"a\"".to_string(),
+        range: LineRange { start: 1, end: 6 },
+        container: None,
+        referenced_names: vec![],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+// A decorated method whose own body line is touched is reported on its
+// own (narrowest-enclosing-definition rule), and its decorator is kept
+// as part of that reported signature (ADR 0073) — the container is
+// never reported in this case, so container-slicing does not apply.
+#[test]
+fn should_keep_touched_members_decorator_when_member_itself_is_reported() {
+    let source = "\
+class Widget:
+    @property
+    def touched(self):
+        return self._touched
+";
+    let lang = PythonSupport;
+    let changed_ranges = vec![LineRange { start: 4, end: 4 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "touched".to_string(),
+        kind: SymbolKind::Function,
+        signature: "@property\ndef touched(self):".to_string(),
+        range: LineRange { start: 2, end: 4 },
+        container: Some("class Widget".to_string()),
+        referenced_names: vec![],
         referenced_method_names: vec![],
         dependencies: vec![],
         omitted_dependency_matches: 0,

--- a/rinkaku-core/src/extract_tests/rust.rs
+++ b/rinkaku-core/src/extract_tests/rust.rs
@@ -117,12 +117,11 @@ fn should_add_two_numbers() {
         id: String::new(),
         name: "should_add_two_numbers".to_string(),
         kind: SymbolKind::Function,
-        signature: "fn should_add_two_numbers()".to_string(),
-        // Note: the `function_item` node's own range starts at the
-        // `fn` line, not the `#[test]` attribute line above it — same
-        // convention as Python's decorator handling (see
-        // `should_not_detect_change_when_only_decorator_line_changed`).
-        range: LineRange { start: 2, end: 4 },
+        // The `#[test]` attribute is included in the signature and the
+        // reported range starts at its line, not the `fn` line below it
+        // (ADR 0073) — same convention as Python's decorator handling.
+        signature: "#[test]\nfn should_add_two_numbers()".to_string(),
+        range: LineRange { start: 1, end: 4 },
         container: None,
         referenced_names: vec![],
         referenced_method_names: vec![],
@@ -174,6 +173,128 @@ fn should_return_empty_vec_when_source_has_no_definitions() {
 
     let expected: Vec<ExtractedSymbol> = Vec::new();
     let actual = extract_all_symbols(source, &lang);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_detect_change_when_only_derive_attribute_line_changed() {
+    let source = "\
+#[derive(Debug, Clone)]
+struct Point {
+    x: i32,
+}
+";
+    let lang = RustSupport;
+    // Line 1 is the attribute — `RustSupport::definition_span_start`
+    // widens `struct_item`'s span to include its preceding
+    // `attribute_item` sibling (ADR 0073), so an attribute-only change
+    // is detected and included in the reported signature.
+    let changed_ranges = vec![LineRange { start: 1, end: 1 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Point".to_string(),
+        kind: SymbolKind::Struct,
+        signature: "#[derive(Debug, Clone)]\nstruct Point {\n    x: i32,\n}".to_string(),
+        range: LineRange { start: 1, end: 4 },
+        container: None,
+        referenced_names: vec!["Point".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn should_detect_change_when_only_a_functions_attribute_line_changed() {
+    let source = "\
+#[inline]
+fn helper(x: i32) -> i32 {
+    x
+}
+";
+    let lang = RustSupport;
+    let changed_ranges = vec![LineRange { start: 1, end: 1 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "helper".to_string(),
+        kind: SymbolKind::Function,
+        signature: "#[inline]\nfn helper(x: i32) -> i32".to_string(),
+        range: LineRange { start: 1, end: 4 },
+        container: None,
+        referenced_names: vec![],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+// ADR 0073: a comment between an attribute and the item it annotates
+// stops the span-widening walk, so a comment-only line change does not
+// make the definition register as touched.
+#[test]
+fn should_not_detect_change_when_only_a_comment_between_attribute_and_item_changed() {
+    let source = "\
+#[derive(Debug)]
+// a comment
+struct Point {
+    x: i32,
+}
+";
+    let lang = RustSupport;
+    let changed_ranges = vec![LineRange { start: 2, end: 2 }];
+
+    let expected: Vec<ExtractedSymbol> = Vec::new();
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+// The attribute above the comment is still outside the span too, since
+// the walk stops at the first non-attribute sibling it meets going
+// backward from the item.
+#[test]
+fn should_not_include_attribute_separated_by_comment_in_signature() {
+    let source = "\
+#[derive(Debug)]
+// a comment
+struct Point {
+    x: i32,
+}
+";
+    let lang = RustSupport;
+    let changed_ranges = vec![LineRange { start: 3, end: 3 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Point".to_string(),
+        kind: SymbolKind::Struct,
+        signature: "struct Point {\n    x: i32,\n}".to_string(),
+        range: LineRange { start: 3, end: 5 },
+        container: None,
+        referenced_names: vec!["Point".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
 
     assert_eq!(expected, actual);
 }

--- a/rinkaku-core/src/extract_tests/rust_references.rs
+++ b/rinkaku-core/src/extract_tests/rust_references.rs
@@ -356,8 +356,12 @@ struct Point {
         id: String::new(),
         name: "Point".to_string(),
         kind: SymbolKind::Struct,
-        signature: "struct Point {\n    x: i32,\n}".to_string(),
-        range: LineRange { start: 2, end: 4 },
+        // The `#[derive(...)]` attribute is included in the signature
+        // and the reported range starts at its line (ADR 0073); its own
+        // arguments (`Debug`, `Clone`) are still not collected as
+        // references, which is what this test pins.
+        signature: "#[derive(Debug, Clone)]\nstruct Point {\n    x: i32,\n}".to_string(),
+        range: LineRange { start: 1, end: 4 },
         container: None,
         referenced_names: vec!["Point".to_string()],
         referenced_method_names: vec![],

--- a/rinkaku-core/src/extract_tests/typescript.rs
+++ b/rinkaku-core/src/extract_tests/typescript.rs
@@ -422,6 +422,115 @@ class Widget {
     assert_eq!(expected, actual);
 }
 
+// `export class` puts the decorator on the enclosing `export_statement`,
+// not on `class_declaration` itself (unlike the non-exported case pinned
+// above), so this needs `TypeScriptSupport`'s `definition_span_start`
+// override (ADR 0073) to be detected and included in the signature.
+#[test]
+fn should_detect_change_when_only_exported_class_decorator_line_changed() {
+    let source = "\
+@Component()
+export class Widget {
+    label: string;
+}
+";
+    let lang = TypeScriptSupport;
+    let changed_ranges = vec![LineRange { start: 1, end: 1 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Widget".to_string(),
+        kind: SymbolKind::Class,
+        signature: "@Component()\nexport class Widget {\n    label: string;\n}".to_string(),
+        range: LineRange { start: 1, end: 4 },
+        container: None,
+        referenced_names: vec!["Widget".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+// `export @Component() class` (decorator written after the `export`
+// keyword) parses the decorator as a child of `class_declaration` itself,
+// the same grammar shape as the non-exported case — already covered by
+// `definition_span_start`'s default (no widening needed), so this is
+// detected without going through `exported_decorator_span_start` at all.
+// `class_declaration`'s own span starts at the decorator, not at
+// `export`, so the leading `export` keyword is outside it and stays out
+// of the signature (unlike the `@dec\nexport class` ordering above, whose
+// decorator is truly outside the node and needs the override to be
+// included).
+#[test]
+fn should_detect_change_when_decorator_follows_export_keyword() {
+    let source = "\
+export @Component()
+class Widget {
+    label: string;
+}
+";
+    let lang = TypeScriptSupport;
+    let changed_ranges = vec![LineRange { start: 1, end: 1 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Widget".to_string(),
+        kind: SymbolKind::Class,
+        signature: "@Component()\nclass Widget {\n    label: string;\n}".to_string(),
+        range: LineRange { start: 1, end: 4 },
+        container: None,
+        referenced_names: vec!["Component".to_string(), "Widget".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
+// Pins that a plain `export class` (no decorator) keeps today's
+// signature text unchanged — `export` must not leak into the span start
+// just because the definition sits inside an `export_statement`.
+#[test]
+fn should_not_include_export_keyword_when_exported_class_has_no_decorator() {
+    let source = "\
+export class Widget {
+    label: string;
+}
+";
+    let lang = TypeScriptSupport;
+    let changed_ranges = vec![LineRange { start: 2, end: 2 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Widget".to_string(),
+        kind: SymbolKind::Class,
+        signature: "class Widget {\n    label: string;\n}".to_string(),
+        range: LineRange { start: 1, end: 3 },
+        container: None,
+        referenced_names: vec!["Widget".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
 // ADR 0014: both `//` and `/* */` comments in this grammar parse
 // under the same `comment` node kind (unlike Rust's split), and
 // both must be stripped from a class signature.

--- a/rinkaku-core/src/extract_tests/typescript.rs
+++ b/rinkaku-core/src/extract_tests/typescript.rs
@@ -378,6 +378,50 @@ class Circle {
     assert_eq!(expected, actual);
 }
 
+// TypeScript's grammar nests a decorator as a direct child of
+// `class_declaration` itself, so it is already inside the captured
+// node's own row range and signature text without any widening (ADR
+// 0073's `LanguageSupport::definition_span_start` default applies
+// here) — pinning this keeps Python/Rust's explicit widening and
+// TypeScript's pre-existing grammar-shape behavior symmetric.
+#[test]
+fn should_detect_change_when_only_class_decorator_line_changed() {
+    let source = "\
+@Component()
+class Widget {
+    label: string;
+}
+";
+    let lang = TypeScriptSupport;
+    let changed_ranges = vec![LineRange { start: 1, end: 1 }];
+
+    let expected = vec![ExtractedSymbol {
+        id: String::new(),
+        name: "Widget".to_string(),
+        kind: SymbolKind::Class,
+        signature: "@Component()\nclass Widget {\n    label: string;\n}".to_string(),
+        range: LineRange { start: 1, end: 4 },
+        container: None,
+        // `Component` (the decorator's own call) and `Widget` (the
+        // class's own self-reference — see the sibling
+        // `should_extract_class_signature_with_untouched_method_dropped_when_field_changed`
+        // test for why a class captures its own name) are both
+        // collected, since this module deliberately does not scope
+        // reference collection away from a decorator's own subtree
+        // (see `references.rs`).
+        referenced_names: vec!["Component".to_string(), "Widget".to_string()],
+        referenced_method_names: vec![],
+        dependencies: vec![],
+        omitted_dependency_matches: 0,
+        is_test: false,
+        classification: None,
+        previous_signature: None,
+    }];
+    let actual = extract_changed_symbols(source, &lang, &changed_ranges);
+
+    assert_eq!(expected, actual);
+}
+
 // ADR 0014: both `//` and `/* */` comments in this grammar parse
 // under the same `comment` node kind (unlike Rust's split), and
 // both must be stripped from a class signature.

--- a/rinkaku-core/src/language/mod.rs
+++ b/rinkaku-core/src/language/mod.rs
@@ -57,6 +57,18 @@ pub trait LanguageSupport {
     fn is_test_definition(&self, _node: tree_sitter::Node, _source: &[u8]) -> bool {
         false
     }
+
+    /// Widens a captured `@definition` node's span to include any
+    /// decorator/attribute annotating it (ADR 0073), so the touched-range
+    /// check, `ExtractedSymbol::range`, and the extracted signature text
+    /// all cover the decorator/attribute the same way they cover the
+    /// definition itself. Defaults to `node` unchanged: Go, TypeScript, and
+    /// HCL need no widening — TypeScript's grammar already nests a
+    /// decorator inside `class_declaration`, and Go/HCL have no decorator
+    /// syntax at all.
+    fn definition_span_start<'a>(&self, node: tree_sitter::Node<'a>) -> tree_sitter::Node<'a> {
+        node
+    }
 }
 
 /// Looks up the `LanguageSupport` registered for a file path, based on

--- a/rinkaku-core/src/language/python.rs
+++ b/rinkaku-core/src/language/python.rs
@@ -10,13 +10,11 @@ use super::LanguageSupport;
 /// another `function_definition`, not a class) and classes.
 ///
 /// `function_definition`/`class_definition` are captured directly rather
-/// than their enclosing `decorated_definition` wrapper. This means a
-/// decorator-only line change (with the `def`/`class` line itself
-/// untouched) is not detected as touching the definition — a deliberate
-/// v1 simplification consistent with "only symbol-level changes are
-/// surfaced" (see `extract_changed_symbols`'s module doc); decorators are
-/// also never included in the extracted signature text for the same
-/// reason a Rust definition's attributes aren't.
+/// than their enclosing `decorated_definition` wrapper — `PythonSupport`'s
+/// `definition_span_start` widens the captured node back out to that
+/// wrapper when present (ADR 0073), so a decorator-only change is still
+/// detected and included in the extracted signature, without needing the
+/// query itself to capture the wrapper node.
 const DEFINITION_QUERY: &str = "\
 [
   (function_definition) @definition.function
@@ -73,6 +71,19 @@ impl LanguageSupport for PythonSupport {
     /// match the filename pattern (e.g. `tests/factories.py`).
     fn is_test_path(&self, path: &str) -> bool {
         is_in_tests_dir(path) || is_python_test_filename(path)
+    }
+
+    /// A decorated function/class's `decorated_definition` wrapper is its
+    /// direct parent — true whether the definition is top-level or nested
+    /// inside a class body (a decorated method's parent chain is `block ->
+    /// decorated_definition -> function_definition`, the same shape as the
+    /// top-level case), so a class method's own decorator is covered
+    /// without any container-specific handling.
+    fn definition_span_start<'a>(&self, node: tree_sitter::Node<'a>) -> tree_sitter::Node<'a> {
+        match node.parent() {
+            Some(parent) if parent.kind() == "decorated_definition" => parent,
+            _ => node,
+        }
     }
 }
 

--- a/rinkaku-core/src/language/rust.rs
+++ b/rinkaku-core/src/language/rust.rs
@@ -130,6 +130,26 @@ impl LanguageSupport for RustSupport {
         }
         false
     }
+
+    /// Walks backward through `node`'s preceding siblings across
+    /// consecutive `attribute_item`s (ADR 0073), returning the earliest one
+    /// found. Stops at (does not extend across) a comment sibling — unlike
+    /// `has_test_attribute`'s walk, which skips comments because it only
+    /// needs a yes/no answer, this walk determines which lines belong to
+    /// the definition, so a comment between an attribute and its item must
+    /// stay outside the span.
+    fn definition_span_start<'a>(&self, node: tree_sitter::Node<'a>) -> tree_sitter::Node<'a> {
+        let mut span_start = node;
+        let mut sibling = node.prev_sibling();
+        while let Some(candidate) = sibling {
+            if candidate.kind() != "attribute_item" {
+                break;
+            }
+            span_start = candidate;
+            sibling = candidate.prev_sibling();
+        }
+        span_start
+    }
 }
 
 /// Whether `node` is preceded by a `#[test]`, `#[rstest]`, or

--- a/rinkaku-core/src/language/typescript.rs
+++ b/rinkaku-core/src/language/typescript.rs
@@ -118,6 +118,10 @@ impl LanguageSupport for TypeScriptSupport {
     fn is_test_path(&self, path: &str) -> bool {
         is_test_path(path)
     }
+
+    fn definition_span_start<'a>(&self, node: tree_sitter::Node<'a>) -> tree_sitter::Node<'a> {
+        exported_decorator_span_start(node)
+    }
 }
 
 /// Common test-file convention checked by both grammars: `.test.ts(x)` /
@@ -158,6 +162,32 @@ impl LanguageSupport for TsxSupport {
 
     fn is_test_path(&self, path: &str) -> bool {
         is_test_path(path)
+    }
+
+    fn definition_span_start<'a>(&self, node: tree_sitter::Node<'a>) -> tree_sitter::Node<'a> {
+        exported_decorator_span_start(node)
+    }
+}
+
+/// Widens `node`'s span to its enclosing `export_statement`'s earliest
+/// `decorator` field when present (ADR 0073 amendment): unlike a
+/// non-exported `class_declaration`, whose decorator is grammar-nested as
+/// its own child and thus already inside its span, `export class Foo {}`
+/// attaches the decorator to the *`export_statement`* wrapper instead, so
+/// it falls outside `class_declaration`'s span the same way Python's
+/// `decorated_definition` wrapper does. Returns `node` unchanged when the
+/// parent is an `export_statement` with no decorator — an export with no
+/// decorator must not pull the `export` keyword into the signature.
+fn exported_decorator_span_start(node: tree_sitter::Node) -> tree_sitter::Node {
+    let Some(parent) = node.parent() else {
+        return node;
+    };
+    if parent.kind() != "export_statement" {
+        return node;
+    }
+    match parent.child_by_field_name("decorator") {
+        Some(decorator) => decorator,
+        None => node,
     }
 }
 

--- a/rinkaku-core/src/pipeline_tests/decorator_attribute_span_regression.rs
+++ b/rinkaku-core/src/pipeline_tests/decorator_attribute_span_regression.rs
@@ -1,0 +1,126 @@
+//! ADR 0073 end-to-end: a diff touching only a decorator (Python) or
+//! attribute (Rust) line is detected via `analyze_diff` and classified
+//! against the base side, exercising the full pipeline path
+//! (`extract_changed_symbols` -> `classify_symbols`) rather than just
+//! `extract_changed_symbols` in isolation like `extract_tests/`.
+//!
+//! NOTE: asserts individual fields of the reported symbol rather than the
+//! whole `ExtractedSymbol`, matching the established partial-assert style
+//! of the sibling `container_slice_regression`/`classification_wiring`
+//! modules this test's shape mirrors — the fields not asserted here
+//! (`id`, `referenced_names`, `dependencies`, ...) are irrelevant to the
+//! span-widening/classification interaction under test.
+
+use super::fake_reader;
+use crate::extract::Classification;
+use crate::pipeline::analyze_diff;
+use pretty_assertions::assert_eq;
+use std::collections::{HashMap, HashSet};
+
+#[test]
+fn should_classify_signature_changed_when_only_a_python_decorator_line_changed() {
+    let diff = "\
+diff --git a/widget.py b/widget.py
+index 57b03c6..75530be 100644
+--- a/widget.py
++++ b/widget.py
+@@ -1,3 +1,3 @@
+-@decorator_v1
++@decorator_v2
+ def handler(a):
+     return a
+";
+    let base_source = "\
+@decorator_v1
+def handler(a):
+    return a
+";
+    let head_source = "\
+@decorator_v2
+def handler(a):
+    return a
+";
+    let read_file = fake_reader(HashMap::from([("widget.py", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("widget.py", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    let symbol = &report.files[0].symbols[0];
+    assert_eq!("handler", symbol.name);
+    assert_eq!("@decorator_v2\ndef handler(a):", symbol.signature);
+    assert_eq!(
+        Some(Classification::SignatureChanged),
+        symbol.classification
+    );
+    assert_eq!(
+        Some("@decorator_v1\ndef handler(a):".to_string()),
+        symbol.previous_signature
+    );
+}
+
+#[test]
+fn should_classify_signature_changed_when_only_a_rust_derive_attribute_line_changed() {
+    let diff = "\
+diff --git a/point.rs b/point.rs
+index 57b03c6..75530be 100644
+--- a/point.rs
++++ b/point.rs
+@@ -1,4 +1,4 @@
+-#[derive(Debug)]
++#[derive(Debug, Clone)]
+ struct Point {
+     x: i32,
+ }
+";
+    let base_source = "\
+#[derive(Debug)]
+struct Point {
+    x: i32,
+}
+";
+    let head_source = "\
+#[derive(Debug, Clone)]
+struct Point {
+    x: i32,
+}
+";
+    let read_file = fake_reader(HashMap::from([("point.rs", head_source)]));
+    let read_base_file = fake_reader(HashMap::from([("point.rs", base_source)]));
+
+    let report = analyze_diff(
+        diff,
+        read_file,
+        Some(&read_base_file),
+        None,
+        true,
+        &HashSet::new(),
+        true,
+        None,
+    )
+    .expect("analyze should succeed");
+
+    let symbol = &report.files[0].symbols[0];
+    assert_eq!("Point", symbol.name);
+    assert_eq!(
+        "#[derive(Debug, Clone)]\nstruct Point {\n    x: i32,\n}",
+        symbol.signature
+    );
+    assert_eq!(
+        Some(Classification::SignatureChanged),
+        symbol.classification
+    );
+    assert_eq!(
+        Some("#[derive(Debug)]\nstruct Point {\n    x: i32,\n}".to_string()),
+        symbol.previous_signature
+    );
+}

--- a/rinkaku-core/src/pipeline_tests/mod.rs
+++ b/rinkaku-core/src/pipeline_tests/mod.rs
@@ -62,6 +62,9 @@
 //!   classification (`BodyOnly`/`SignatureChanged`) stays correct despite
 //!   the head-side signature no longer matching the base side's shape
 //!   byte-for-byte.
+//! - [`decorator_attribute_span_regression`] — ADR 0073 end-to-end: a
+//!   diff touching only a Python decorator or Rust attribute line is
+//!   detected and classified `SignatureChanged` via `analyze_diff`.
 
 use std::collections::HashMap;
 
@@ -70,6 +73,7 @@ mod analyze_repo;
 mod classification_wiring;
 mod collect_referenced_names;
 mod container_slice_regression;
+mod decorator_attribute_span_regression;
 mod file_size_warnings;
 mod generated_exclusion;
 mod go_receiver_regression;

--- a/rinkaku-core/src/pipeline_tests/test_symbol_exclusion.rs
+++ b/rinkaku-core/src/pipeline_tests/test_symbol_exclusion.rs
@@ -85,8 +85,10 @@ fn should_add_two_numbers() {
                 id: "src/lib.rs::should_add_two_numbers".to_string(),
                 name: "should_add_two_numbers".to_string(),
                 kind: SymbolKind::Function,
-                signature: "fn should_add_two_numbers()".to_string(),
-                range: LineRange { start: 2, end: 4 },
+                // The `#[test]` attribute is included in the signature
+                // and the reported range starts at its line (ADR 0073).
+                signature: "#[test]\nfn should_add_two_numbers()".to_string(),
+                range: LineRange { start: 1, end: 4 },
                 container: None,
                 referenced_names: vec![],
                 referenced_method_names: vec![],


### PR DESCRIPTION
## Summary

Python `@decorator` and Rust `#[attribute]` annotations sit outside the tree-sitter node rinkaku's `definition_query` captures, so a diff touching only a decorator/attribute line was invisible: the changed line fell outside every reported definition's row range. This PR (building on the preceding commits on this branch) closes that gap via `LanguageSupport::definition_span_start`, and extends the fix to a case found during review: a decorator on an `export class` in TypeScript.

TypeScript's grammar nests a non-exported class's decorator as a direct child of `class_declaration`, so that case already worked by accident. An `export class Foo {}`, however — the common shape for Angular/NestJS-style decorated classes — attaches the decorator to the enclosing `export_statement` instead, one level above the captured node, so it had the same "invisible decorator-only change" problem as Python/Rust. `TypeScriptSupport`/`TsxSupport::definition_span_start` now widens to the `export_statement`'s earliest `decorator` field when present, leaving the span untouched (no `export` keyword leakage) when there is none.

See [ADR 0073](docs/adr/0073-include-decorators-and-attributes-in-definition-span.md) for the full design, now corrected to describe the TypeScript `export_statement` case and its reference-collection consequence.

## Behavior changes

- A decorator/attribute-only change (Python, Rust, and now exported-TypeScript-class) is now classified as `SignatureChanged` instead of being invisible.
- A reported symbol's signature always includes its decorator(s)/attribute(s), even when the diff only touched the `def`/`class`/`fn`/`struct`/`export class` line itself.
- A decorated class method is reported standalone (the narrowest touched definition), not the whole enclosing class.
- `symbol.range` for a decorated/attributed symbol now starts at the decorator/attribute line, not the `def`/`class`/`fn` line.

## Out of scope

- Feeding decorator/attribute arguments into reference collection (`Depends on`) is deliberately deferred — see ADR 0073's "Decision" section.
- A separate, pre-existing gap where a pure-deletion hunk immediately preceding a surviving definition doesn't surface in `signature_changed`/`removed`/`non_symbol_changes` was found during dynamic verification. It predates this PR (rooted in `diff.rs`'s `parse_hunk`) and is not addressed here.

## Review note

This PR went through a map-assisted static review pass plus independent static review, and dynamic verification against the built binary (10 scenarios). The TypeScript `export class` gap above was found during that dynamic verification and is fixed in this PR, not left as a follow-up.

## Test plan

- [x] `make test` (1074 tests, including new TDD coverage for `export class` decorator/no-decorator/decorator-after-`export` cases)
- [x] `make lint`